### PR TITLE
Fixing authenticationType on claimsIdentity generated by ValidateToken()

### DIFF
--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1437,7 +1437,7 @@ namespace System.IdentityModel.Tokens
                 roleClaimType = this.RoleClaimType;
             }
 
-            ClaimsIdentity identity = new ClaimsIdentity(AuthenticationTypes.Federation, nameClaimType, roleClaimType);
+            ClaimsIdentity identity = new ClaimsIdentity(AuthenticationType, nameClaimType, roleClaimType);
             if (saveBootstrapContext)
             {
                 if (jwt.RawData != null)


### PR DESCRIPTION
JwtSecurityTokenHandler has an AuthenticationType property that is meant to be used as the AuthenticationType on ClaimsIdentity generated by ValidateToken(). However, ValidateToken() hardcodes the authenticationType to "Federation". The fix is to use the AuthenticationType property instead of the hardcoded value.
