### PR TITLE
1. Added copy constructor for TokenValidationParameters

### DIFF
--- a/src/Microsoft.IdentityModel.Protocol.Extensions/AudienceValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocol.Extensions/AudienceValidator.cs
@@ -44,12 +44,12 @@ namespace Microsoft.IdentityModel.Extensions
 
             if (audiences == null)
             {
-                throw new AudienceUriValidationFailedException(ErrorMessages.IDX10215);
+                throw new SecurityTokenInvalidAudienceException(ErrorMessages.IDX10215);
             }
 
             if (string.IsNullOrWhiteSpace(validationParameters.ValidAudience) && (validationParameters.ValidAudiences == null))
             {
-                throw new ArgumentException(ErrorMessages.IDX10208);
+                throw new SecurityTokenInvalidAudienceException(ErrorMessages.IDX10208);
             }
 
             foreach (string audience in audiences)

--- a/src/Microsoft.IdentityModel.Protocol.Extensions/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocol.Extensions/Saml2SecurityTokenHandler.cs
@@ -69,7 +69,7 @@ namespace Microsoft.IdentityModel.Extensions
         /// </summary>
         /// <param name="securityToken">The token string thats needs to be read.</param>
         /// <returns>'True' if the ReadToken method can parse the token string.</returns>
-        public virtual bool CanReadToken(string securityToken)
+        public override bool CanReadToken(string securityToken)
         {
             if (string.IsNullOrWhiteSpace(securityToken) || securityToken.Length > MaximumTokenSizeInBytes)
             {

--- a/src/Microsoft.IdentityModel.Protocol.Extensions/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocol.Extensions/SamlSecurityTokenHandler.cs
@@ -63,7 +63,7 @@ namespace Microsoft.IdentityModel.Extensions
         /// </summary>
         /// <param name="securityToken">The token string thats needs to be read.</param>
         /// <returns>'True' if the ReadToken method can parse the token string.</returns>
-        public virtual bool CanReadToken(string securityToken)
+        public override bool CanReadToken(string securityToken)
         {
             if (string.IsNullOrWhiteSpace(securityToken) || securityToken.Length > MaximumTokenSizeInBytes)
             {

--- a/src/System.IdentityModel.Tokens.Jwt/IExpirableNonceCache.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/IExpirableNonceCache.cs
@@ -1,0 +1,32 @@
+﻿
+namespace System.IdentityModel.Tokens
+{
+    // TODO - just added interface without any testing to get idea of how it fits
+    /// <summary>
+    /// Interface
+    /// </summary>
+    public interface IExpirableNonceCache
+    {
+        /// <summary>
+        /// Try to add nonce
+        /// </summary>
+        /// <param name="nonce"></param>
+        /// <param name="expiresAt"></param>
+        /// <returns></returns>
+        bool TryAdd(string nonce, DateTime expiresAt);
+
+        /// <summary>
+        /// Try to find nonce
+        /// </summary>
+        /// <param name="nonce"></param>
+        /// <returns></returns>
+        bool TryFind(string nonce);
+
+        /// <summary>
+        /// Try to Remove nonce
+        /// </summary>
+        /// <param name="nonce"></param>
+        /// <returns></returns>
+        bool TryRemove(string nonce);
+    }
+}

--- a/src/System.IdentityModel.Tokens.Jwt/System.IdentityModel.Tokens.Jwt.csproj
+++ b/src/System.IdentityModel.Tokens.Jwt/System.IdentityModel.Tokens.Jwt.csproj
@@ -66,6 +66,7 @@
     <Compile Include="DiagnosticUtility.cs" />
     <Compile Include="EpochTime.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="IExpirableNonceCache.cs" />
     <Compile Include="ISecurityTokenValidator.cs" />
     <Compile Include="JsonExtensions.cs" />
     <Compile Include="JwtConfigurationStrings.cs" />

--- a/src/System.IdentityModel.Tokens.Jwt/TokenValidationParameters.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/TokenValidationParameters.cs
@@ -28,6 +28,35 @@ namespace System.IdentityModel.Tokens
     public class TokenValidationParameters
     {
         /// <summary>
+        /// Copy constructor for <see cref="TokenValidationParameters"/>.
+        /// </summary>
+        public TokenValidationParameters(TokenValidationParameters other)
+        {
+            if (other == null)
+            {
+                return;
+            }
+
+            AudienceValidator = other.AudienceValidator;
+            IssuerSigningKey = other.IssuerSigningKey;
+            IssuerSigningKeyRetriever = other.IssuerSigningKeyRetriever;
+            IssuerSigningKeys = other.IssuerSigningKeys;
+            IssuerSigningToken = other.IssuerSigningToken;
+            IssuerSigningTokens = other.IssuerSigningTokens;
+            IssuerValidator = other.IssuerValidator;
+            LifetimeValidator = other.LifetimeValidator;
+            SaveSigninToken = other.SaveSigninToken;
+            TokenReplayCache = other.TokenReplayCache;
+            ValidateActor = other.ValidateActor;
+            ValidateAudience = other.ValidateAudience;
+            ValidateIssuer = other.ValidateIssuer;
+            ValidAudience = other.ValidAudience;
+            ValidAudiences = other.ValidAudiences;
+            ValidIssuer = other.ValidIssuer;
+            ValidIssuers = other.ValidIssuers;
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TokenValidationParameters"/> class.
         /// </summary>        
         public TokenValidationParameters()
@@ -119,6 +148,17 @@ namespace System.IdentityModel.Tokens
         [DefaultValue(false)]
         public bool SaveSigninToken
         {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or set the <see cref="IExpirableNonceCache"/> that will be checked to ensure that a token in not replayed.
+        /// </summary>
+        public IExpirableNonceCache TokenReplayCache
+        {
+            // TODO - just added member without any testing to get
+            // idea of how it fits
             get;
             set;
         }

--- a/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/CrossTokenTests.cs
+++ b/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/CrossTokenTests.cs
@@ -67,12 +67,12 @@ namespace Microsoft.IdentityModel.Test
             ClaimsPrincipal saml2Principal = ValidateToken(samlToken, IdentityUtilities.DefaultAsymmetricTokenValidationParameters, samlHandler, ExpectedException.NoExceptionExpected);
             ClaimsPrincipal samlPrincipal = ValidateToken(saml2Token, IdentityUtilities.DefaultAsymmetricTokenValidationParameters, saml2Handler, ExpectedException.NoExceptionExpected);
 
-            Assert.IsTrue(IdentityComparer.AreEqual(samlPrincipal, saml2Principal));
+            Assert.IsTrue(IdentityComparer.AreEqual<ClaimsPrincipal>(samlPrincipal, saml2Principal, new CompareContext { IgnoreSubject = true }));
 
             // false = ignore type of objects, we expect all objects in the principal to be of same type (no derived types)
             // true = ignore subject, claims have a backpointer to their ClaimsIdentity.  Most of the time this will be different as we are comparing two different ClaimsIdentities.
             // true = ignore properties of claims, any mapped claims short to long for JWT's will have a property that represents the short type.
-            Assert.IsTrue(IdentityComparer.AreEqual(jwtPrincipal, saml2Principal, false, true, true));
+            Assert.IsTrue(IdentityComparer.AreEqual<ClaimsPrincipal>(jwtPrincipal, saml2Principal, new CompareContext{IgnoreType = false, IgnoreSubject = true, IgnoreProperties=true}));
         }
 
         private ClaimsPrincipal ValidateToken(string securityToken, TokenValidationParameters validationParameters, ISecurityTokenValidator tokenValidator, ExpectedException expectedException)

--- a/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/JsonWebKeyTests.cs
+++ b/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/JsonWebKeyTests.cs
@@ -152,7 +152,7 @@ namespace Microsoft.IdentityModel.Test
                 jsonWebKey.X5c.Add(method);
             }
 
-            Assert.IsTrue(IdentityComparer.AreEqual(jsonWebKey.X5c, methods));
+            Assert.IsTrue(IdentityComparer.AreEqual<IEnumerable<string>>(jsonWebKey.X5c, methods, CompareContext.Default));
         }
 
         [TestMethod]

--- a/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/JsonWebKeysTests.cs
+++ b/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/JsonWebKeysTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.IdentityModel.Test
 
             if (compareTo != null)
             {
-                Assert.IsTrue(IdentityComparer.AreEqual(jsonWebKeys, compareTo), "jsonWebKeys created from: " + (obj == null ? "NULL" : obj.ToString() + " did not match expected."));
+                Assert.IsTrue(IdentityComparer.AreEqual<JsonWebKeys>(jsonWebKeys, compareTo, CompareContext.Default), "jsonWebKeys created from: " + (obj == null ? "NULL" : obj.ToString() + " did not match expected."));
             }
 
             return jsonWebKeys;

--- a/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/OpenIdConnectMetadataTests.cs
+++ b/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/OpenIdConnectMetadataTests.cs
@@ -149,7 +149,7 @@ namespace Microsoft.IdentityModel.Test
             Assert.AreEqual(metadata.Issuer, issuer);
             Assert.AreEqual(metadata.JwksUri, jwks_Uri);
             Assert.AreEqual(metadata.TokenEndpoint, token_Endpoint);
-            Assert.IsTrue(IdentityComparer.AreEqual(metadata.SigningKeys, securityKeys));
+            Assert.IsTrue(IdentityComparer.AreEqual<IEnumerable<SecurityKey>>(metadata.SigningKeys, securityKeys));
         }
 
         [TestMethod]

--- a/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/Saml2SecurityTokenHandlerTests.cs
+++ b/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/Saml2SecurityTokenHandlerTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.IdentityModel.Test
             expectedException = ExpectedException.SecurityTokenInvalidIssuerException( substringExpected: "IDX10211");
             ValidateIssuer(null, new TokenValidationParameters(), samlSecurityTokenHandler, expectedException);
 
-            expectedException = ExpectedException.SecurityTokenInvalidIssuerException(substringExpected: "IDX10205");
+            expectedException = ExpectedException.SecurityTokenInvalidIssuerException(substringExpected: "IDX10204");
             ValidateIssuer("bob", new TokenValidationParameters { }, samlSecurityTokenHandler, expectedException);
 
             expectedException = ExpectedException.NoExceptionExpected;
@@ -273,8 +273,9 @@ namespace Microsoft.IdentityModel.Test
             expectedException = ExpectedException.NoExceptionExpected;
             ValidateToken(securityToken: samlString, validationParameters: tokenValidationParameters, samlSecurityTokenHandler: samlSecurityTokenHandler, expectedException: expectedException);
 
+            // no valid audiences
             tokenValidationParameters.ValidateAudience = true;
-            expectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214");
+            expectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208");
             ValidateToken(securityToken: samlString, validationParameters: tokenValidationParameters, samlSecurityTokenHandler: samlSecurityTokenHandler, expectedException: expectedException);
 
             tokenValidationParameters.ValidateAudience = true;

--- a/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/SamlSecurityTokenHandlerTests.cs
+++ b/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/SamlSecurityTokenHandlerTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.IdentityModel.Test
             expectedException = ExpectedException.SecurityTokenInvalidIssuerException(substringExpected: "IDX10211");
             ValidateIssuer(null, new TokenValidationParameters(), samlSecurityTokenHandler, expectedException);
 
-            expectedException = ExpectedException.SecurityTokenInvalidIssuerException(substringExpected: "IDX10205");
+            expectedException = ExpectedException.SecurityTokenInvalidIssuerException(substringExpected: "IDX10204");
             ValidateIssuer("bob", new TokenValidationParameters { }, samlSecurityTokenHandler, expectedException);
 
             expectedException = ExpectedException.NoExceptionExpected;

--- a/tests/Shared/IdentityComparer.cs
+++ b/tests/Shared/IdentityComparer.cs
@@ -17,22 +17,111 @@
 //-----------------------------------------------------------------------
 
 using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Test;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens;
 using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
 
 namespace System.IdentityModel.Test
 {
+    public class CompareContext
+    {
+        public CompareContext()
+        {
+            IgnoreSubject = true;
+            StringComparison = System.StringComparison.Ordinal;
+        }
+
+        public static CompareContext Default = new CompareContext();
+
+        public bool ExpectRawData { get; set; }
+        public bool IgnoreProperties { get; set; }
+        public bool IgnoreSubject { get; set; }
+        public bool IgnoreType { get; set; }
+        public StringComparison StringComparison { get; set; }
+    }
+
     public class IdentityComparer
     {
-        public static bool AreEqual(IDictionary<string, string> dictionary1, IDictionary<string, string> dictionary2)
+        private static bool AreEnumsEqual<T>(IEnumerable<T> t1, IEnumerable<T> t2, CompareContext context, Func<T, T, CompareContext, bool> areEqual)
         {
-            if (dictionary1 == null && dictionary2 == null)
+            if (t1 == null && t2 == null)
                 return true;
 
-            if (dictionary1 == null || dictionary2 == null)
+            if (t1 == null || t2 == null)
                 return false;
 
+            if (object.ReferenceEquals(t1, t2))
+                return true;
+
+            int numToMatch = 0;
+            int numMatched = 0;
+
+            List<T> ts = new List<T>(t2);
+            foreach (var t in t1)
+            {
+                numToMatch++;
+                for (int i = 0; i < ts.Count; i++)
+                {
+                    if (areEqual(t, ts[i], context))
+                    {
+                        numMatched++;
+                        ts.RemoveAt(i);
+                    }
+                }
+            }
+
+            return (ts.Count == 0 && numMatched == numToMatch);
+        }
+
+        public static bool AreEqual<T>(T t1, T t2)
+        {
+            return AreEqual<T>(t1, t2, CompareContext.Default);
+        }
+
+        public static bool AreEqual<T>(T t1, T t2, CompareContext context)
+        {
+            if (t1 is TokenValidationParameters)
+                return AreEqual<TokenValidationParameters>(t1 as TokenValidationParameters, t2 as TokenValidationParameters, context, AreTokenValidationParametersEqual);
+            else if (t1 is JwtSecurityToken)
+                return AreEqual<JwtSecurityToken>(t1 as JwtSecurityToken, t2 as JwtSecurityToken, context, AreJwtSecurityTokensEqual);
+            else if (t1 is ClaimsIdentity)
+                return AreEqual<ClaimsIdentity>(t1 as ClaimsIdentity, t2 as ClaimsIdentity, context, AreClaimsIdentitiesEqual);
+            else if (t1 is ClaimsPrincipal)
+                return AreEqual<ClaimsPrincipal>(t1 as ClaimsPrincipal, t2 as ClaimsPrincipal, context, AreClaimsPrincipalsEqual);
+            else if (t1 is JsonWebKey)
+                return AreEqual<JsonWebKey>(t1 as JsonWebKey, t2 as JsonWebKey, context, AreJsonWebKeysEqual);
+            else if (t1 is JsonWebKeys)
+                return AreEqual<JsonWebKeys>(t1 as JsonWebKeys, t2 as JsonWebKeys, context, AreJsonWebKeyKeysEqual);
+            else if (t1 is OpenIdConnectMetadata)
+                return AreEqual<OpenIdConnectMetadata>(t1 as OpenIdConnectMetadata, t2 as OpenIdConnectMetadata, context, AreOpenIdConnectMetadataEqual);
+            if (t1 is IEnumerable<Claim>)
+                return AreEnumsEqual<Claim>(t1 as IEnumerable<Claim>, t2 as IEnumerable<Claim>, context, AreClaimsEqual);
+            else if (t1 is IEnumerable<string>)
+                return AreEnumsEqual<string>(t1 as IEnumerable<string>, t2 as IEnumerable<string>, context, AreStringsEqual);
+            else if (t1 is IEnumerable<SecurityKey>)
+                return AreEnumsEqual<SecurityKey>(t1 as IEnumerable<SecurityKey>, t2 as IEnumerable<SecurityKey>, context, AreSecurityKeysEqual);
+
+            throw new InvalidOperationException("type not known");
+        }
+
+        public static bool AreEqual<T>(T t1, T t2, CompareContext context, Func<T, T, CompareContext, bool> areEqual)
+        {
+            if (t1 == null && t2 == null)
+                return true;
+
+            if (t1 == null || t2 == null)
+                return false;
+
+            if (object.ReferenceEquals(t1, t2))
+                return true;
+
+            return areEqual(t1, t2, context);
+        }
+
+        private static bool AreDictionariesEqual(IDictionary<string, string> dictionary1, IDictionary<string, string> dictionary2, CompareContext context)
+        {
             if (dictionary1.Count != dictionary2.Count)
                 return false;
 
@@ -55,15 +144,8 @@ namespace System.IdentityModel.Test
             return numMatched == dictionary1.Count;
         }
 
-        public static bool AreEqual(Claim claim1, Claim claim2, bool ignoreSubject = true, bool ignoreProperties = false)
+        private static bool AreClaimsEqual(Claim claim1, Claim claim2, CompareContext context)
         {
-
-            if (claim1 == null && claim2 == null)
-                return true;
-
-            if (claim1 == null || claim2 == null)
-                return false;
-
             if (claim1.Type != claim2.Type)
                 return false;
 
@@ -73,8 +155,8 @@ namespace System.IdentityModel.Test
             if (claim1.OriginalIssuer != claim2.OriginalIssuer)
                 return false;
 
-            if (!ignoreProperties && !IdentityComparer.AreEqual(claim1.Properties, claim2.Properties))
-                    return false;
+            if (!context.IgnoreProperties && !AreEqual<IDictionary<string, string>>(claim1.Properties, claim2.Properties, context, AreDictionariesEqual))
+                return false;
 
             if (claim1.Value != claim2.Value)
                 return false;
@@ -82,49 +164,15 @@ namespace System.IdentityModel.Test
             if (claim1.ValueType != claim2.ValueType)
                 return false;
 
-            if (!ignoreSubject && !IdentityComparer.AreEqual(claim1.Subject, claim2.Subject))
-                    return false;
+            if (!context.IgnoreSubject && !AreEqual<ClaimsIdentity>(claim1.Subject, claim2.Subject, context, AreClaimsIdentitiesEqual))
+                return false;
 
             return true;
         }
 
-        public static bool AreEqual(IEnumerable<Claim> claims1, IEnumerable<Claim> claims2, bool ignoreSubject = true, bool ignoreProperties = false)
+        private static bool AreClaimsPrincipalsEqual(ClaimsPrincipal principal1, ClaimsPrincipal principal2, CompareContext context)
         {
-            if (claims1 == null && claims2 == null)
-                return true;
-
-            if (claims1 == null || claims2 == null)
-                return false;
-
-            int numMatched = 0;
-            int numToMatch = 0;
-            List<Claim> claims2Claims = new List<Claim>(claims2);
-            foreach (Claim claim in claims1)
-            {
-                numToMatch++;
-                for (int i = 0; i < claims2Claims.Count; i++)
-                {
-                    if (AreEqual(claim, claims2Claims[i], ignoreSubject, ignoreProperties))
-                    {
-                        numMatched++;
-                        claims2Claims.RemoveAt(i);
-                        break;
-                    }
-                }
-            }
-
-            return claims2Claims.Count == 0 && numToMatch == numMatched;
-        }
-
-        public static bool AreEqual(ClaimsPrincipal principal1, ClaimsPrincipal principal2, bool ignoreType = false, bool ignoreSubject = true, bool ignoreProperties = false)
-        {
-            if (principal1 == null && principal2 == null)
-                return true;
-
-            if (principal1 == null || principal2 == null)
-                return false;
-
-            if (!ignoreType)
+            if (!context.IgnoreType)
             {
                 if (principal1.GetType() != principal2.GetType())
                     return false;
@@ -133,12 +181,12 @@ namespace System.IdentityModel.Test
             int numMatched = 0;
             int numToMatch = 0;
             List<ClaimsIdentity> identities2 = new List<ClaimsIdentity>(principal2.Identities);
-            foreach(ClaimsIdentity identity in principal1.Identities)
+            foreach (ClaimsIdentity identity in principal1.Identities)
             {
                 numToMatch++;
-                for( int i = 0; i < identities2.Count; i++)
+                for (int i = 0; i < identities2.Count; i++)
                 {
-                    if(AreEqual(identity, identities2[i], ignoreType, ignoreSubject, ignoreProperties))
+                    if (AreEqual<ClaimsIdentity>(identity, identities2[i], context, AreClaimsIdentitiesEqual))
                     {
                         numMatched++;
                         identities2.RemoveAt(i);
@@ -150,242 +198,141 @@ namespace System.IdentityModel.Test
             return identities2.Count == 0 && numToMatch == numMatched;
         }
 
-        public static bool AreEqual(BootstrapContext bc1, BootstrapContext bc2)
+        private static bool AreBootstrapContextsEqual(BootstrapContext bc1, BootstrapContext bc2, CompareContext context)
         {
-            if(bc1 == null && bc2 == null)
-                return true;
-
-            if(bc1 == null || bc2 == null)
+            if (!AreEqual<SecurityToken>(bc1.SecurityToken, bc2.SecurityToken, context, AreSecurityTokensEqual))
                 return false;
 
-            if (bc1.SecurityToken == null && bc2.SecurityToken != null)
-            {
+            if (!AreEqual<string>(bc1.Token, bc2.Token, context, AreStringsEqual))
                 return false;
-            }
-
-            if (bc1.SecurityToken != null && bc2.SecurityToken == null)
-            {
-                return false;
-            }
-
-            if (bc1.SecurityToken != null && bc2.SecurityToken != null)
-            {
-                if (bc1.SecurityToken.GetType() != bc2.SecurityToken.GetType())
-                {
-                    return false;
-                }
-            }
-
-            if (bc1.Token == null && bc2.Token != null)
-            {
-                return false;
-            }
-
-            if (bc1.Token != null && bc2.Token == null)
-            {
-                return false;
-            }
-
-            if (bc1.Token != null && bc2.Token != null)
-            {
-                if (bc1.Token.GetType() != bc2.Token.GetType())
-                {
-                    return false;
-                }
-            }
 
             return true;
         }
 
-        public static bool AreEqual(ClaimsIdentity ci1, ClaimsIdentity ci2, bool ignoreType = false, bool ignoreSubject = true, bool ignoreProperties = false)
+        private static bool AreClaimsIdentitiesEqual(ClaimsIdentity ci1, ClaimsIdentity ci2, CompareContext compareContext)
         {
-            if (ci1 == null && ci2 == null)
-                return true;
-
-            if (ci1 == null || ci2 == null)
+            if (!string.Equals(ci1.AuthenticationType, ci2.AuthenticationType, compareContext.StringComparison))
                 return false;
 
-            if (!ignoreType)
-            {
-                if (ci1.GetType() != ci2.GetType())
-                    return false;
-            }
-
-            if (!IdentityComparer.AreEqual(ci1.Actor, ci2.Actor))
+            if (!string.Equals(ci1.Label, ci2.Label, compareContext.StringComparison))
                 return false;
 
-            if (StringComparer.OrdinalIgnoreCase.Compare(ci1.AuthenticationType, ci2.AuthenticationType) != 0)
+            if (!string.Equals(ci1.Name, ci2.Name, compareContext.StringComparison))
                 return false;
 
-            //if (!IdentityComparer45.AreEqual(ci1.BootstrapContext as ISerializable, ci2.BootstrapContext as ISerializable))
-            //    return false;
+            if (!string.Equals(ci1.NameClaimType, ci2.NameClaimType))
+                return false;
 
-            if (!IdentityComparer.AreEqual(ci1.Claims, ci2.Claims, ignoreSubject, ignoreProperties))
+            if (!string.Equals(ci1.RoleClaimType, ci2.RoleClaimType))
+                return false;
+
+            if (!AreEnumsEqual<Claim>(ci1.Claims, ci2.Claims, compareContext, AreClaimsEqual))
                 return false;
 
             if (ci1.IsAuthenticated != ci2.IsAuthenticated)
                 return false;
 
-            if (StringComparer.Ordinal.Compare(ci1.Label, ci2.Label) != 0)
+            if (!AreEqual<ClaimsIdentity>(ci1.Actor, ci2.Actor, compareContext, AreClaimsIdentitiesEqual))
                 return false;
 
-            if (StringComparer.Ordinal.Compare(ci1.Name, ci2.Name) != 0)
+            if (!compareContext.IgnoreType && (ci1.GetType() != ci2.GetType()))
                 return false;
 
-            if (StringComparer.OrdinalIgnoreCase.Compare(ci1.NameClaimType, ci2.NameClaimType) != 0)
-                return false;
-
-            if (StringComparer.OrdinalIgnoreCase.Compare(ci1.RoleClaimType, ci2.RoleClaimType) != 0)
-                return false;
+            // || TODO compare bootstrapcontext
 
             return true;
         }
 
-        public static bool AreEqual( JwtSecurityToken jwt1, JwtSecurityToken jwt2, bool expectRawData = false )
+        private static bool AreJwtSecurityTokensEqual(JwtSecurityToken jwt1, JwtSecurityToken jwt2, CompareContext compareContext)
         {
-            if ( jwt1 == null && jwt2 == null )
-            {
-                return true;
-            }
-
-            if ( null == jwt1 || null == jwt2 )
-            {
+            if (!AreEqual<JwtHeader>(jwt1.Header, jwt2.Header, compareContext, AreJwtHeadersEqual))
                 return false;
-            }
 
-            if ( !AreEqual( jwt1.Header, jwt2.Header ) )
-            {
+            if (!AreEqual<JwtPayload>(jwt1.Payload, jwt2.Payload, compareContext, AreJwtPayloadsEqual))
                 return false;
-            }
 
-            if ( !AreEqual( jwt1.Payload, jwt2.Payload ) )
-            {
+            if (!AreEnumsEqual<Claim>(jwt1.Claims, jwt2.Claims, compareContext, AreClaimsEqual))
                 return false;
-            }
 
-            if ( !IdentityComparer.AreEqual( jwt1.Claims, jwt2.Claims ) )
-            {
+            if (!string.Equals(jwt1.Actor, jwt2.Actor, compareContext.StringComparison))
                 return false;
-            }
 
-            if ( jwt1.Actor != jwt2.Actor )
-            {
+            if (!string.Equals(jwt1.Audience, jwt2.Audience, compareContext.StringComparison))
                 return false;
-            }
 
-            if ( !AreEqual( jwt1.Audience, jwt2.Audience ) )
-            {
+            if (!string.Equals(jwt1.Id, jwt2.Id, compareContext.StringComparison))
                 return false;
-            }
 
-            if ( !AreEqual( jwt1.Id, jwt2.Id ) )
-            {
+            if (!string.Equals(jwt1.Issuer, jwt2.Issuer, compareContext.StringComparison))
                 return false;
-            }
 
-            if ( !AreEqual( jwt1.Issuer, jwt2.Issuer ) )
-            {
+            if (compareContext.ExpectRawData && !string.Equals( jwt1.RawData, jwt2.RawData, compareContext.StringComparison))
                 return false;
-            }
 
-            if ( expectRawData && !AreEqual( jwt1.RawData, jwt2.RawData ) )
-            {
+            if (!string.Equals(jwt1.SignatureAlgorithm, jwt2.SignatureAlgorithm, compareContext.StringComparison))
                 return false;
-            }
 
-            if ( !AreEqual( jwt1.SignatureAlgorithm, jwt2.SignatureAlgorithm ) )
-            {
+            if (jwt1.ValidFrom != jwt2.ValidFrom)
                 return false;
-            }
 
-            if ( jwt1.ValidFrom != jwt2.ValidFrom )
-            {
+            if (jwt1.ValidTo != jwt2.ValidTo)
                 return false;
-            }
 
-            if ( jwt1.ValidTo != jwt2.ValidTo )
-            {
+            if (!AreEnumsEqual<SecurityKey>(jwt1.SecurityKeys, jwt2.SecurityKeys, compareContext, AreSecurityKeysEqual))
                 return false;
-            }
 
-            // no reason to check keys, as they are always empty.
+            // no reason to check keys, as they are always empty for now.
             //ReadOnlyCollection<SecurityKey> keys = jwt.SecurityKeys;
 
             return true;
         }
 
-        public static bool AreEqual( SecurityToken token1, SecurityToken token2 )
+        private static bool AreSecurityKeyIdentifiersEqual(SecurityKeyIdentifier ski1, SecurityKeyIdentifier ski2, CompareContext context)
         {
-            // null match and type
-            if ( token1 == null && token2 == null )
-            {
-                return true;
-            }
-
-            if ( null == token1 || null == token2 )
-            {
+            if (ski1.GetType() == ski1.GetType())
                 return false;
-            }
 
-            return token1.GetType() == token1.GetType();
+            if (ski1.Count != ski2.Count)
+                return false;
+
+            return true;
         }
 
-        public static bool AreEqual( SigningCredentials cred1, SigningCredentials cred2 )
+        private static bool AreSecurityTokensEqual(SecurityToken token1, SecurityToken token2, CompareContext context)
         {
-            // null match and type
-            if ( cred1 == null && cred2 == null )
-            {
-                return true;
-            }
-
-            if ( null == cred1 || null == cred2 )
-            {
+            if (token1.GetType() == token2.GetType())
                 return false;
-            }
 
-            if ( cred1.GetType() != cred2.GetType() )
-            {
+            if (!AreEnumsEqual<SecurityKey>(token1.SecurityKeys, token2.SecurityKeys, CompareContext.Default, AreSecurityKeysEqual))
                 return false;
-            }
 
-            if ( !string.Equals( cred1.DigestAlgorithm, cred2.DigestAlgorithm, StringComparison.Ordinal ) )
-            {
-                return false;
-            }
+            return true;
+        }
 
-            if ( !string.Equals( cred1.SignatureAlgorithm, cred2.SignatureAlgorithm, StringComparison.Ordinal ) )
-            {
+        private static bool AreSigningCredentialsEqual(SigningCredentials cred1, SigningCredentials cred2, CompareContext context)
+        {
+            if (cred1.GetType() != cred2.GetType())
                 return false;
-            }
+
+            if (!string.Equals(cred1.DigestAlgorithm, cred2.DigestAlgorithm, context.StringComparison))
+                return false;
+
+            if (!string.Equals(cred1.SignatureAlgorithm, cred2.SignatureAlgorithm, context.StringComparison))
+                return false;
 
             // SigningKey, null match and type
-            if ( cred1.SigningKey == null && cred2.SigningKey != null )
-            {
+            if (!AreEqual<SecurityKey>(cred1.SigningKey, cred2.SigningKey, context, AreSecurityKeysEqual))
                 return false;
-            }
 
-            if ( cred1.SigningKey != null && cred2.SigningKey == null )
-            {
+            if (!AreEqual<SecurityKeyIdentifier>(cred1.SigningKeyIdentifier, cred2.SigningKeyIdentifier, context, AreSecurityKeyIdentifiersEqual))
                 return false;
-            }
 
-            if ( cred1.SigningKey.GetType() != cred2.SigningKey.GetType() )
-            {
-                return false;
-            }
+            return true;
+        }
 
-            // SigningKeyIdentifier, null match and type
-            if ( cred1.SigningKeyIdentifier == null && cred2.SigningKeyIdentifier != null )
-            {
-                return false;
-            }
-
-            if ( cred1.SigningKeyIdentifier != null && cred2.SigningKeyIdentifier == null )
-            {
-                return false;
-            }
-
-            if ( cred1.SigningKeyIdentifier.GetType() != cred2.SigningKeyIdentifier.GetType() )
+        public static bool AreJwtHeadersEqual(JwtHeader header1, JwtHeader header2, CompareContext context)
+        {
+            if (header1.Count != header2.Count)
             {
                 return false;
             }
@@ -393,55 +340,14 @@ namespace System.IdentityModel.Test
             return true;
         }
 
-        public static bool AreEqual(IList<string> strings1, IList<string> strings2, StringComparison stringComparison = StringComparison.Ordinal)
+        public static bool AreJwtPayloadsEqual(JwtPayload payload1, JwtPayload payload2, CompareContext context)
         {
-            int numMatched = 0;
-            int numToMatch = 0;
-            List<string> strings = new List<string>(strings2);
-            foreach(string str in strings1)
-            {
-                numToMatch++;
-                for(int i = 0; i< strings.Count; i++)
-                {
-                    if(string.Equals(str, strings[i], stringComparison))
-                    {
-                        numMatched++;
-                        strings.RemoveAt(i);
-                    }
-                }
-            }
-
-            return strings.Count == 0 && numMatched == numToMatch;
-        }
-
-        public static bool AreEqual(string string1, string string2, StringComparison stringComparison = StringComparison.Ordinal)
-        {
-            if ( string1 == null && string2 == null )
-            {
-                return true;
-            }
-
-            if ( null == string1 || null == string2 )
+            if (payload1.Count != payload2.Count)
             {
                 return false;
             }
 
-            return string.Equals(string1, string2, stringComparison);
-        }
-
-        public static bool AreEqual( JwtHeader header1, JwtHeader header2 )
-        {
-            if ( header1 == null && header2 == null )
-            {
-                return true;
-            }
-
-            if ( null == header1 || null == header2 )
-            {
-                return false;
-            }
-
-            if ( header1.Count != header2.Count )
+            if (!AreEnumsEqual<Claim>(payload1.Claims, payload2.Claims, context, AreClaimsEqual))
             {
                 return false;
             }
@@ -449,24 +355,15 @@ namespace System.IdentityModel.Test
             return true;
         }
 
-        public static bool AreEqual( JwtPayload payload1, JwtPayload payload2 )
+        private static bool AreStringsEqual(string string1, string string2, CompareContext context)
         {
-            if ( payload1 == null && payload2 == null )
-            {
-                return true;
-            }
+            return string.Equals(string1, string2, context.StringComparison);
+        }
 
-            if ( null == payload1 || null == payload2 )
-            {
-                return false;
-            }
 
-            if ( payload1.Count != payload2.Count )
-            {
-                return false;
-            }
-
-            if ( !IdentityComparer.AreEqual( payload1.Claims, payload2.Claims ) )
+        private static bool AreJsonWebKeyKeysEqual(JsonWebKeys jsonWebkeys1, JsonWebKeys jsonWebkeys2, CompareContext compareContext)
+        {
+            if (!AreEnumsEqual<JsonWebKey>(jsonWebkeys1.Keys, jsonWebkeys2.Keys, compareContext, AreJsonWebKeysEqual))
             {
                 return false;
             }
@@ -474,213 +371,188 @@ namespace System.IdentityModel.Test
             return true;
         }
 
-        public static bool AreEqual(ICollection<SecurityKey> securityKeys1, ICollection<SecurityKey> securityKeys2)
+        private static bool AreJsonWebKeysEqual(JsonWebKey jsonWebkey1, JsonWebKey jsonWebkey2, CompareContext compareContext)
         {
-            if (securityKeys1 == null && securityKeys2 == null)
-            {
-                return true;
-            }
-
-            if (securityKeys1 == null || securityKeys2 == null)
-            {
+            if(!string.Equals(jsonWebkey1.Alg, jsonWebkey2.Alg, compareContext.StringComparison))
                 return false;
-            }
 
-            if (object.ReferenceEquals(securityKeys1, securityKeys2))
-            {
-                return true;
-            }
-
-            if (securityKeys1.Count != securityKeys2.Count)
-            {
+            if( !string.Equals(jsonWebkey1.KeyOps, jsonWebkey2.KeyOps, compareContext.StringComparison))
                 return false;
-            }
 
-            List<X509SecurityKey> keys1 = new List<X509SecurityKey>();
-            foreach (var key in securityKeys1)
-            {
-                if (key is X509SecurityKey)
-                {
-                    keys1.Add(key as X509SecurityKey);
-                }
-            }
+            if( !string.Equals(jsonWebkey1.Kid, jsonWebkey2.Kid, compareContext.StringComparison))
+                return false;
 
-            List<X509SecurityKey> keys2 = new List<X509SecurityKey>();
-            foreach (var key in securityKeys2)
-            {
-                if (key is X509SecurityKey)
-                {
-                    keys2.Add(key as X509SecurityKey);
-                }
-            }
+            if( !string.Equals(jsonWebkey1.Kty, jsonWebkey2.Kty, compareContext.StringComparison))
+                return false;
 
-            foreach (var key in keys1)
-            {
-                for (int i = 0; i < keys2.Count; i++)
-                {
-                    if (key.Certificate.Thumbprint == keys2[i].Certificate.Thumbprint)
-                    {
-                        keys2.RemoveAt(i);
-                    }
-                }
-            }
+            if( !string.Equals(jsonWebkey1.Use, jsonWebkey2.Use, compareContext.StringComparison))
+                return false;
 
-            return (keys2.Count == 0);
+            if (!string.Equals(jsonWebkey1.X5t, jsonWebkey2.X5t, compareContext.StringComparison))
+                return false;
+
+            if (!string.Equals(jsonWebkey1.X5u, jsonWebkey2.X5u, compareContext.StringComparison))
+                return false;
+
+            if (!AreEnumsEqual<string>(jsonWebkey1.X5c, jsonWebkey2.X5c, compareContext, AreStringsEqual))
+                return false;
+
+            return true;
         }
 
-        public static bool AreEqual(OpenIdConnectMetadata metadata1, OpenIdConnectMetadata metadata2)
+        private static bool AreBytesEqual(byte[] bytes1, byte[] bytes2)
         {
-            if (metadata1 == null && metadata2 == null)
-            {
-                return true;
-            }
-
-            if (metadata1 == null || metadata2 == null)
+            if (bytes1.Length != bytes2.Length)
             {
                 return false;
             }
 
-            if (object.ReferenceEquals(metadata1, metadata2))
+            for (int i = 0; i < bytes1.Length; i++)
             {
-                return true;
-            }
-
-            if (!IdentityComparer.AreEqual(metadata1.AuthorizationEndpoint, metadata2.AuthorizationEndpoint))
-            {
-                return false;
-            }
-
-            if (!IdentityComparer.AreEqual(metadata1.CheckSessionIframe, metadata2.CheckSessionIframe))
-            {
-                return false;
-            }
-
-            if (!IdentityComparer.AreEqual(metadata1.EndSessionEndpoint, metadata2.EndSessionEndpoint))
-            {
-                return false;
-            }
-
-            if (!IdentityComparer.AreEqual(metadata1.Issuer, metadata2.Issuer))
-            {
-                return false;
-            }
-
-            if (!IdentityComparer.AreEqual(metadata1.JwksUri, metadata2.JwksUri))
-            {
-                return false;
-            }
-
-            if (!AreEqual(metadata1.SigningKeys, metadata2.SigningKeys))
-            {
-                return false;
-            }
-
-            if (!IdentityComparer.AreEqual(metadata1.TokenEndpoint, metadata2.TokenEndpoint))
-            {
-                return false;
+                if (bytes1[i] != bytes2[i])
+                {
+                    return false;
+                }
             }
 
             return true;
         }
 
-        public static bool AreEqual( JsonWebKeys jsonWebkeys1, JsonWebKeys jsonWebkeys2)
+        private static bool AreOpenIdConnectMetadataEqual(OpenIdConnectMetadata metadata1, OpenIdConnectMetadata metadata2, CompareContext context)
         {
-            if (jsonWebkeys1 == null && jsonWebkeys2 == null)
-            {
-                return true;
-            }
+            if (!string.Equals(metadata1.AuthorizationEndpoint, metadata2.AuthorizationEndpoint, context.StringComparison))
+                return false;
 
-            if (null == jsonWebkeys1 || null == jsonWebkeys2)
+            if (!string.Equals(metadata1.CheckSessionIframe, metadata2.CheckSessionIframe, context.StringComparison))
+                return false;
+
+            if (!string.Equals(metadata1.EndSessionEndpoint, metadata2.EndSessionEndpoint, context.StringComparison))
+                return false;
+
+            if (!string.Equals(metadata1.Issuer, metadata2.Issuer, context.StringComparison))
+                return false;
+
+            if (!string.Equals(metadata1.JwksUri, metadata2.JwksUri, context.StringComparison))
+                return false;
+
+            if (!AreEnumsEqual<SecurityKey>(metadata1.SigningKeys, metadata2.SigningKeys, context, AreSecurityKeysEqual))
+                return false;
+
+            if (!string.Equals(metadata1.TokenEndpoint, metadata2.TokenEndpoint, context.StringComparison))
+                return false;
+
+            return true;
+        }
+
+        private static bool AreSecurityKeysEqual(SecurityKey securityKey1, SecurityKey securityKey2, CompareContext context)
+        {
+            if( !context.IgnoreType && (securityKey1.GetType() != securityKey2.GetType()))
+                return false;
+
+            // Check X509SecurityKey first so we don't have to use reflection to get cert.
+            X509SecurityKey x509Key1 = securityKey1 as X509SecurityKey;
+            if (x509Key1 != null)
             {
+                X509SecurityKey x509Key2 = securityKey2 as X509SecurityKey;
+                if (x509Key1.Certificate.Thumbprint == x509Key2.Certificate.Thumbprint)
+                {
+                    return true;
+                }
+
                 return false;
             }
 
-            if (!AreEqual(jsonWebkeys1.Keys, jsonWebkeys2.Keys))
+            X509AsymmetricSecurityKey x509AsymmKey1 = securityKey1 as X509AsymmetricSecurityKey;
+            if (x509AsymmKey1 != null)
             {
-                return false;
+                X509AsymmetricSecurityKey x509AsymmKey2 = securityKey2 as X509AsymmetricSecurityKey;
+                X509Certificate2 x509Cert1 = TestUtilities.GetProperty(x509AsymmKey1, "certificate") as X509Certificate2;
+                X509Certificate2 x509Cert2 = TestUtilities.GetProperty(x509AsymmKey2, "certificate") as X509Certificate2;
+                if (x509Cert1 == null && x509Cert2 == null)
+                {
+                    return true;
+                }
+
+                if (x509Cert1 != null || x509Cert2 != null)
+                {
+                    return false;
+                }
+
+                if (x509Cert1.Thumbprint != x509Cert2.Thumbprint)
+                {
+                    return false;
+                }
+            }
+
+            SymmetricSecurityKey symKey1 = securityKey1 as SymmetricSecurityKey;
+            if (symKey1 != null)
+            {
+                SymmetricSecurityKey symKey2 = securityKey2 as SymmetricSecurityKey;
+                if (!AreBytesEqual(symKey1.GetSymmetricKey(), symKey2.GetSymmetricKey()))
+                {
+                    return false;
+                }
             }
 
             return true;
         }
 
-        public static bool AreEqual(IList<JsonWebKey> jsonWebkeys1, IList<JsonWebKey> jsonWebkeys2)
+        private static bool AreKeyRetrieversEqual(Func<string, IEnumerable<SecurityKey>> keyRetrevier1, Func<string, IEnumerable<SecurityKey>> keyRetrevier2, CompareContext compareContext)
         {
-            if (jsonWebkeys1 == null && jsonWebkeys2 == null)
-            {
-                return true;
-            }
-
-            if (null == jsonWebkeys1 || null == jsonWebkeys2)
-            {
+            if (!AreEnumsEqual<SecurityKey>(keyRetrevier1("keys"), keyRetrevier2("keys"), compareContext, AreSecurityKeysEqual))
                 return false;
-            }
 
-            List<JsonWebKey> jsonWebKeys = new List<JsonWebKey>(jsonWebkeys2);
-            foreach(JsonWebKey webKey in jsonWebkeys1)
-            {
-                for( int i=0; i<jsonWebKeys.Count;i++)
-                {
-                    if(AreEqual(jsonWebKeys[i], webKey))
-                    {
-                        jsonWebKeys.RemoveAt(i);
-                    }
-                }
-            }
-
-            return jsonWebKeys.Count == 0;
+            return true;
         }
 
-        public static bool AreEqual(JsonWebKey jsonWebkey1, JsonWebKey jsonWebkey2)
+        private static bool AreValidatorsEqual(Func<string, SecurityToken, bool> validator1, Func<string, SecurityToken, bool> validator2, CompareContext compareContext)
         {
-            if (jsonWebkey1 == null && jsonWebkey2 == null)
-            {
-                return true;
-            }
-
-            if (null == jsonWebkey1 || null == jsonWebkey2)
-            {
+            if (validator1("str", null) != validator2("str", null))
                 return false;
-            }
 
-            if(!AreEqual(jsonWebkey1.Alg, jsonWebkey2.Alg))
-            {
-                return false;
-            }
+            return true;
+        }
 
-            if (!AreEqual(jsonWebkey1.KeyOps, jsonWebkey2.KeyOps))
-            {
+        private static bool AreTokenValidationParametersEqual(TokenValidationParameters validationParameters1, TokenValidationParameters validationParameters2, CompareContext compareContext)
+        {
+            if (!AreEqual<Func<string, SecurityToken, bool>>(validationParameters1.AudienceValidator, validationParameters2.AudienceValidator, compareContext, AreValidatorsEqual))
                 return false;
-            }
 
-            if (!AreEqual(jsonWebkey1.Kid, jsonWebkey2.Kid))
-            {
+            if (!AreEqual<Func<string, SecurityToken, bool>>(validationParameters1.IssuerValidator, validationParameters2.IssuerValidator, compareContext, AreValidatorsEqual))
                 return false;
-            }
 
-            if (!AreEqual(jsonWebkey1.Kty, jsonWebkey2.Kty))
-            {
+            if (!AreEqual<Func<string, SecurityToken, bool>>(validationParameters1.LifetimeValidator, validationParameters2.LifetimeValidator, compareContext, AreValidatorsEqual))
                 return false;
-            }
 
-            if (!AreEqual(jsonWebkey1.Use, jsonWebkey2.Use))
-            {
+            if (!AreEqual<Func<string, IEnumerable<SecurityKey>>>(validationParameters1.IssuerSigningKeyRetriever, validationParameters2.IssuerSigningKeyRetriever, compareContext, AreKeyRetrieversEqual))
                 return false;
-            }
 
-            if (!AreEqual(jsonWebkey1.X5c, jsonWebkey2.X5c))
-            {
+            if (!AreEqual<SecurityKey>(validationParameters1.IssuerSigningKey, validationParameters2.IssuerSigningKey, compareContext, AreSecurityKeysEqual))
                 return false;
-            }
 
-            if (!AreEqual(jsonWebkey1.X5t, jsonWebkey2.X5t))
-            {
+            if (!AreEnumsEqual<SecurityKey>(validationParameters1.IssuerSigningKeys, validationParameters2.IssuerSigningKeys, compareContext, AreSecurityKeysEqual))
                 return false;
-            }
 
-            if (!AreEqual(jsonWebkey1.X5u, jsonWebkey2.X5u))
-            {
+            if (validationParameters1.SaveSigninToken != validationParameters2.SaveSigninToken)
                 return false;
-            }
+
+            if (validationParameters1.ValidateAudience != validationParameters2.ValidateAudience)
+                return false;
+
+            if (validationParameters1.ValidateIssuer != validationParameters2.ValidateIssuer)
+                return false;
+
+            if (!String.Equals(validationParameters1.ValidAudience, validationParameters2.ValidAudience, StringComparison.Ordinal))
+                return false;
+
+            if (!AreEnumsEqual<string>(validationParameters1.ValidAudiences, validationParameters2.ValidAudiences, new CompareContext { StringComparison = System.StringComparison.Ordinal }, AreStringsEqual))
+                return false;
+
+            if (!String.Equals(validationParameters1.ValidIssuer, validationParameters2.ValidIssuer, StringComparison.Ordinal))
+                return false;
+
+            if (!AreEnumsEqual<string>(validationParameters1.ValidIssuers, validationParameters2.ValidIssuers, CompareContext.Default, AreStringsEqual))
+                return false;
 
             return true;
         }

--- a/tests/Shared/TestUtilities.cs
+++ b/tests/Shared/TestUtilities.cs
@@ -32,6 +32,23 @@ namespace Microsoft.IdentityModel.Test
     {
 
         /// <summary>
+        /// Gets a named property on an object
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="property"></param>
+        /// <param name="propertyValue"></param>
+        public static object GetProperty(object obj, string property)
+        {
+            Type type = obj.GetType();
+            PropertyInfo propertyInfo = type.GetProperty(property);
+
+            Assert.IsNotNull(propertyInfo, "property is not found: " + property + ", type: " + type.ToString());
+
+            return propertyInfo.GetValue(obj);
+        }
+
+
+        /// <summary>
         /// Set a named property on an object
         /// </summary>
         /// <param name="obj"></param>

--- a/tests/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
+++ b/tests/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
@@ -60,7 +60,7 @@ namespace System.IdentityModel.Test
             JwtSecurityTokenHandler handler = new JwtSecurityTokenHandler();
             string jwt = handler.WriteToken(new JwtSecurityToken("", ""));
             JwtSecurityToken token = new JwtSecurityToken(jwt);
-            Assert.IsTrue(IdentityComparer.AreEqual(token, new JwtSecurityToken("", ""), false));
+            Assert.IsTrue(IdentityComparer.AreEqual<JwtSecurityToken>(token, new JwtSecurityToken("", "")));
         }
 
         [TestMethod]
@@ -122,7 +122,7 @@ namespace System.IdentityModel.Test
             JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
             ClaimsPrincipal claimsPrincipal = tokenHandler.ValidateToken(encodedJwt, IdentityUtilities.DefaultSymmetricTokenValidationParameters);
 
-            Assert.IsTrue(IdentityComparer.AreEqual(claimsPrincipal.Claims, ClaimSets.DuplicateTypes(IdentityUtilities.DefaultIssuer, IdentityUtilities.DefaultIssuer), true, true));
+            Assert.IsTrue(IdentityComparer.AreEqual<IEnumerable<Claim>>(claimsPrincipal.Claims, ClaimSets.DuplicateTypes(IdentityUtilities.DefaultIssuer, IdentityUtilities.DefaultIssuer), new CompareContext { IgnoreProperties = true, IgnoreSubject = true }));
         }
 
         [TestMethod]

--- a/tests/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/tests/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -226,7 +226,7 @@ namespace System.IdentityModel.Test
                 ClaimsIdentity claimsIdentityValidated = claimsPrincipal.Identity as ClaimsIdentity;
                 ClaimsPrincipal actorClaimsPrincipal = tokendHandler.ValidateToken(actor, actorValidationParameters);
                 Assert.IsNotNull(claimsIdentityValidated.Actor);
-                Assert.IsTrue(IdentityComparer.AreEqual(claimsIdentityValidated.Actor, (actorClaimsPrincipal.Identity as ClaimsIdentity)));
+                Assert.IsTrue(IdentityComparer.AreEqual<ClaimsIdentity>(claimsIdentityValidated.Actor, (actorClaimsPrincipal.Identity as ClaimsIdentity)));
                 expectedException.ProcessNoException();
             }
             catch (Exception ex)
@@ -364,7 +364,7 @@ namespace System.IdentityModel.Test
                             IdentityUtilities.DefaultIssuer)));
 
                 // These should not be translated.            
-                Assert.IsTrue(IdentityComparer.AreEqual(jwt.Claims, inboundShortClaims));
+                Assert.IsTrue(IdentityComparer.AreEqual<IEnumerable<Claim>>(jwt.Claims, inboundShortClaims, CompareContext.Default));
 
                 var validationParameters = new TokenValidationParameters
                 {
@@ -883,7 +883,7 @@ namespace System.IdentityModel.Test
             string jwt = (tokenHandler.CreateToken(issuer: "http://www.GotJwt.com", audience: null) as JwtSecurityToken).RawData; 
             
             // validIssuer null, validIssuers null
-            ExpectedException ee = new ExpectedException(typeof(SecurityTokenInvalidIssuerException), substringExpected: "Jwt10311");
+            ExpectedException ee = new ExpectedException(typeof(SecurityTokenInvalidIssuerException), substringExpected: "Jwt10317");
             TokenValidationParameters validationParameters = new TokenValidationParameters() { ValidateAudience = false };
             CheckVariation(jwt, tokenHandler, validationParameters, ee);
 
@@ -984,7 +984,7 @@ namespace System.IdentityModel.Test
             CheckVariation(jwt, tokenHandler, validationParameters, ee);
 
             // "TokenValidationParameters.ValidAudience TokenValidationParameters.ValidAudiences both null"
-            ee = new ExpectedException(typeof(SecurityTokenInvalidAudienceException), substringExpected: "Jwt10303");
+            ee = new ExpectedException(typeof(SecurityTokenInvalidAudienceException), substringExpected: "Jwt10301");
             jwt = (tokenHandler.CreateToken(issuer: "http://www.GotJwt.com", audience: "http://www.GotJwt.com") as JwtSecurityToken).RawData;
             CheckVariation(jwt, tokenHandler, validationParameters, ee);
 

--- a/tests/System.IdentityModel.Tokens.Jwt.Tests/Tokens.cs
+++ b/tests/System.IdentityModel.Tokens.Jwt.Tests/Tokens.cs
@@ -40,9 +40,12 @@ namespace System.IdentityModel.Test
 
     public static class JwtTestTokens
     {
-        public static JwtSecurityToken Simple( string issuer, string originalIssuer )
+        public static JwtSecurityToken Simple( string issuer = null, string originalIssuer = null )
         {
-            return new JwtSecurityToken( issuer, "http://www.contoso.com", ClaimSets.Simple( issuer, originalIssuer ) );
+            string iss = issuer ?? IdentityUtilities.DefaultIssuer;
+            string originalIss = originalIssuer ?? IdentityUtilities.DefaultOriginalIssuer;
+
+            return new JwtSecurityToken( issuer, "http://www.contoso.com", ClaimSets.Simple( iss, originalIss ) );
         }
 
         public static JwtSecurityToken Create( string issuer, string originalIssuer, SigningCredentials signingCredentials )


### PR DESCRIPTION
1. Fixed broken tests
2. Modified IdentityComparer to reduce code redundancy
3. Saml1 and Saml2 ReadToken marked override rather than virtual
4. AudienceValidator throws SecurityTokenInvalidAudienceException
5. Added shell for IExpirableNonceCache
