### PR TITLE
Issue #48 Add support for userinfo_endpoint in OpenIdConnectConfiguratio...

### DIFF
--- a/src/Microsoft.IdentityModel.Protocol.Extensions/Configuration/OpenIdConnectConfiguration.cs
+++ b/src/Microsoft.IdentityModel.Protocol.Extensions/Configuration/OpenIdConnectConfiguration.cs
@@ -140,6 +140,15 @@ namespace Microsoft.IdentityModel.Protocols
                     TokenEndpoint = str;
                 }
             }
+
+            if (dictionary.TryGetValue(OpenIdProviderMetadataNames.UserInfoEndpoint, out obj))
+            {
+                str = obj as string;
+                if (str != null)
+                {
+                    UserInfoEndpoint = str;
+                }
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Protocol.Extensions/OpenIdConnectConstants.cs
+++ b/src/Microsoft.IdentityModel.Protocol.Extensions/OpenIdConnectConstants.cs
@@ -191,7 +191,7 @@ namespace Microsoft.IdentityModel.Protocols
         public const string SubjectTypesSupported = "subject_types_supported";
         public const string TokenEndpoint = "token_endpoint";
         public const string TokenEndpointAuthMethodsSupported = "token_endpoint_auth_methods_supported";
-        public const string UserInfoEndpoint = "user_info_endpoint";
+        public const string UserInfoEndpoint = "userinfo_endpoint";
         #pragma warning restore 1591
     }
 }

--- a/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/OpenIdConnectConfigurationRetrieverTests.cs
+++ b/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/OpenIdConnectConfigurationRetrieverTests.cs
@@ -82,6 +82,7 @@ namespace Microsoft.IdentityModel.Test
             OpenIdConnectConfiguration configuration;
 
             configuration = await GetConfigurationFromMixedAsync(OpenIdConfigData.OpenIdConnectMetadataPingString, expectedException: ExpectedException.NoExceptionExpected);
+            Assert.IsTrue(IdentityComparer.AreEqual(configuration, OpenIdConfigData.OpenIdConnectConfigurationPing));
 
             configuration = await GetConfigurationFromMixedAsync(OpenIdConfigData.OpenIdConnectMetadataPingLabsJWKSString, expectedException: ExpectedException.NoExceptionExpected);
             Assert.IsTrue(IdentityComparer.AreEqual(configuration, OpenIdConfigData.OpenIdConnectConfigurationPingLabsJWKS));
@@ -111,7 +112,7 @@ namespace Microsoft.IdentityModel.Test
             GetAndCheckConfiguration("end_session_endpoint", "EndSessionEndpoint");
             GetAndCheckConfiguration("jwks_uri", "JwksUri", OpenIdConfigData.AADCommonUrl);
             GetAndCheckConfiguration("token_endpoint", "TokenEndpoint");
-            GetAndCheckConfiguration("user_info_endpoint", "UserInfoEndpoint");
+            GetAndCheckConfiguration("userinfo_endpoint", "UserInfoEndpoint");
         }
 
         private async Task<OpenIdConnectConfiguration> GetConfigurationFromHttpAsync(string uri, ExpectedException expectedException, OpenIdConnectConfiguration expectedConfiguration = null)

--- a/tests/Shared/IdentityComparer.cs
+++ b/tests/Shared/IdentityComparer.cs
@@ -457,6 +457,9 @@ namespace System.IdentityModel.Test
             if (!string.Equals(configuration1.TokenEndpoint, configuraiton2.TokenEndpoint, context.StringComparison))
                 return false;
 
+            if (!string.Equals(configuration1.UserInfoEndpoint, configuraiton2.UserInfoEndpoint, context.StringComparison))
+                return false;
+
             return true;
         }
         

--- a/tests/Shared/OpenIdConfigData.cs
+++ b/tests/Shared/OpenIdConfigData.cs
@@ -162,6 +162,15 @@ namespace Microsoft.IdentityModel.Test
             string base64String3 = Convert.ToBase64String(Base64UrlEncoder.DecodeBytes(JsonWebKeyFromPingExpected3.N));
             rsa3.FromXmlString(string.Format(CultureInfo.InvariantCulture, rsaImportTemplate, base64String3, JsonWebKeyFromPingExpected3.E));
 
+            OpenIdConnectConfigurationPing =
+                new OpenIdConnectConfiguration()
+                {
+                    AuthorizationEndpoint = "https://connect-interop.pinglabs.org:9031/as/authorization.oauth2",
+                    Issuer = "https://connect-interop.pinglabs.org:9031",
+                    TokenEndpoint = "https://connect-interop.pinglabs.org:9031/as/token.oauth2",
+                    UserInfoEndpoint = "https://connect-interop.pinglabs.org:9031/idp/userinfo.openid"
+                };
+
             OpenIdConnectConfigurationPingLabsJWKS =
                 new OpenIdConnectConfiguration()
                 {
@@ -450,6 +459,7 @@ namespace Microsoft.IdentityModel.Test
         public static OpenIdConnectConfiguration OpenIdConnectConfigurationSingleX509Data1;
         public static OpenIdConnectConfiguration OpenIdConnectConfigurationWithKeys1;
         public static OpenIdConnectConfiguration OpenIdConnectConfigurationPingLabsJWKS;
+        public static OpenIdConnectConfiguration OpenIdConnectConfigurationPing;
         public static X509Certificate2 X509CertificateJsonWebKey1;
         public static X509Certificate2 X509CertificateJsonWebKey2;
         public static IDictionary<string, object> JsonWebKeyDictionary1;


### PR DESCRIPTION
Contains an enhancement to support the userinfo_endpoint value in OIDC Discovery.

Testing was achieved through existing fixture OpenIdConnectConfigurationRetrieverTests. Also, IdentityComparer.AreOpenIdConnectConfigurationEqual() was altered to examine the UserInfoEndpoint property. 

The IdentityComparer modification initially caused the existing test OpenIdConnectConfiguration_Properties to fail, before my changes were applied. I also modified existing test OpenIdConnectConfigurationRetriever_FromText() to compare a loaded configuration against the new OpenIdConfigData.OpenIdConnectConfigurationPing reference instance.

I can't think of any other tests that would add value. Basically, if the constructor's JSON parameter contains a userinfo_endpoint value, then the UserInfoEndpoint property is assigned - this is confirmed by the above two tests. Let me know if you can think of any other tests I should cover.

Thanks
Rich
