### PR TITLE
import DNX project types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.user
 *.sln.docstates
 
+# lock files
+project.lock.json
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/src/Microsoft.IdentityModel.Logging/Microsoft.IdentityModel.Logging.xproj
+++ b/src/Microsoft.IdentityModel.Logging/Microsoft.IdentityModel.Logging.xproj
@@ -4,7 +4,7 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>fe248334-75ac-4f60-9409-42a28c7a39aa</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -25,7 +25,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
   <ProjectExtensions>
     <VisualStudio>
       <UserProperties project_1json__JSONSchema="http://www.asp.net/media/4878834/project.json" />

--- a/src/Microsoft.IdentityModel.Protocol.Extensions/Microsoft.IdentityModel.Protocols.xproj
+++ b/src/Microsoft.IdentityModel.Protocol.Extensions/Microsoft.IdentityModel.Protocols.xproj
@@ -4,7 +4,7 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>B5416A2F-9918-44C0-9178-D25E89976A75</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -25,7 +25,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
   <ProjectExtensions>
     <VisualStudio>
       <UserProperties project_1json__JSONSchema="http://www.asp.net/media/4878834/project.json" />

--- a/src/Microsoft.IdentityModel.Protocol.Extensions/OpenIdConnectMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocol.Extensions/OpenIdConnectMessage.cs
@@ -96,7 +96,7 @@ namespace Microsoft.IdentityModel.Protocols
 
             foreach (KeyValuePair<string, string[]> keyValue in parameters)
             {
-                if (keyValue.Value != null)
+                if (keyValue.Value != null && !string.IsNullOrWhiteSpace(keyValue.Key))
                 {
                     foreach (string strValue in keyValue.Value)
                     {

--- a/src/Microsoft.IdentityModel.Protocol.Extensions/OpenIdConnectMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocol.Extensions/OpenIdConnectMessage.cs
@@ -100,7 +100,7 @@ namespace Microsoft.IdentityModel.Protocols
                 {
                     foreach (string strValue in keyValue.Value)
                     {
-                        if (strValue != null && keyValue.Key != null)
+                        if (strValue != null)
                         {
                             SetParameter(keyValue.Key, strValue);
                             break;

--- a/src/System.IdentityModel.Tokens/System.IdentityModel.Tokens.xproj
+++ b/src/System.IdentityModel.Tokens/System.IdentityModel.Tokens.xproj
@@ -4,7 +4,7 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>A0E7DD32-5189-439C-B460-5BA3B0561707</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -25,7 +25,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
   <ProjectExtensions>
     <VisualStudio>
       <UserProperties project_1json__JSONSchema="http://www.asp.net/media/4878834/project.json" />

--- a/tests/Microsoft.IdentityModel.Logging.Tests/Microsoft.IdentityModel.Logging.Tests.xproj
+++ b/tests/Microsoft.IdentityModel.Logging.Tests/Microsoft.IdentityModel.Logging.Tests.xproj
@@ -4,8 +4,7 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
-  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>7bb23627-58d2-41d5-b711-acc5d7f6654e</ProjectGuid>
     <RootNamespace>Microsoft.IdentityModel.Logging.Tests</RootNamespace>
@@ -16,5 +15,5 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/Microsoft.IdentityModel.Protocol.Extensions.Tests.xproj
+++ b/tests/Microsoft.IdentityModel.Protocol.Extensions.Tests/Microsoft.IdentityModel.Protocol.Extensions.Tests.xproj
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="__ToolsVersion__" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>CC665B24-9531-41B9-93C1-EF7F425AB33C</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -48,7 +48,7 @@
       <Link>Shared\TestUtilities.cs</Link>
     </Compile>
   </ItemGroup>
-  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
   <ProjectExtensions>
     <VisualStudio>
       <UserProperties project_1json__JSONSchema="http://www.asp.net/media/4878834/project.json" />

--- a/tests/System.IdentityModel.Tokens.Tests/System.IdentityModel.Tokens.Tests.xproj
+++ b/tests/System.IdentityModel.Tokens.Tests/System.IdentityModel.Tokens.Tests.xproj
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="__ToolsVersion__" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>b449c824-9d81-4588-a562-e61d9215c976</ProjectGuid>
     <OutputType>Library</OutputType>
@@ -45,7 +45,7 @@
       <Link>Shared\TestUtilities.cs</Link>
     </Compile>
   </ItemGroup>
-  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
   <ProjectExtensions>
     <VisualStudio>
       <UserProperties project_1json__JSONSchema="http://www.asp.net/media/4878834/project.json" />


### PR DESCRIPTION
Fixup project for dnx.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/115%23discussion_r28101323%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/115%23discussion_r28104193%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/115%23discussion_r28107269%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20d3562b29ac165ea7790bc90515d0f9ba22b48f03%20src/Microsoft.IdentityModel.Protocol.Extensions/OpenIdConnectMessage.cs%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/115%23discussion_r28101323%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Do%20we%20need%20this%20check%20here%3F%20Few%20lines%20below%20this%20line%20of%20code%2C%20we%20check%20for%20the%20null%20value.%20Does%20it%20have%20any%20perf%20benefit%20checking%20it%20here%3F%20If%20so%2C%20we%20should%20remove%20the%20check%20from%20the%20other%20line.%22%2C%20%22created_at%22%3A%20%222015-04-09T20%3A51%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22Agreed%20updated.%22%2C%20%22created_at%22%3A%20%222015-04-09T21%3A25%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-04-09T22%3A02%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/Microsoft.IdentityModel.Protocol.Extensions/OpenIdConnectMessage.cs%3AL96-103%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-Pull d3562b29ac165ea7790bc90515d0f9ba22b48f03 src/Microsoft.IdentityModel.Protocol.Extensions/OpenIdConnectMessage.cs 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/115#discussion_r28101323'>File: src/Microsoft.IdentityModel.Protocol.Extensions/OpenIdConnectMessage.cs:L96-103</a></b>
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> Do we need this check here? Few lines below this line of code, we check for the null value. Does it have any perf benefit checking it here? If so, we should remove the check from the other line.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> Agreed updated.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/115?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/115?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/115'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>