### PR TITLE
Modified regex to support the equals character which is valid for base64...

### DIFF
--- a/src/System.IdentityModel.Tokens.Jwt/JwtConstants.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtConstants.cs
@@ -49,7 +49,7 @@ namespace System.IdentityModel.Tokens
         /// <summary>
         /// Token format: 'header.payload.signature'. Signature is optional, but '.' is required.
         /// </summary>
-        public const string JsonCompactSerializationRegex = @"^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$";
+        public const string JsonCompactSerializationRegex = @"^[A-Za-z0-9-_\\=]+\.[A-Za-z0-9-_\\=]+\.[A-Za-z0-9-_\\=]*$";
 
         /// <summary>
         /// When mapping json to .Net Claim(s), if the value was not a string (or an enumeration of strings), the ClaimValue will serialized using the current JSON serializer, a property will be added with the .Net type and the ClaimTypeValue will be set to 'JsonClaimValueType'.


### PR DESCRIPTION
I have modified the regex that validates raw token strings to allow the use of the equals character

The following test shows a valid jwt header (generated in this case from wso2) which results in a base64 encoded string with an equals. The same is true for a single comma and lots of other combinations. It is also true in the payload and therefore I would expect in the signature.

        [Test]
        [Ignore("This test was created to play with base 64 encoding showing an equals sign")]
        public void ShowEquals()
        {
            // Assign

            const string header = "{\"typ\":\"JWT\",\"alg\":\"none\"}";

            // Act
            byte[] headerBytes = Encoding.UTF8.GetBytes(header);
            string result = Convert.ToBase64String(headerBytes);

            // Assert
            Assert.IsTrue(result.Contains("="));
        }
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/117%23issuecomment-91595713%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/117%23issuecomment-91692276%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/117%23issuecomment-91595713%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40cardinal252__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Open%20Technologies%2C%20Inc.%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSOTBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20This%20seems%20like%20a%20small%20%28but%20important%29%20contribution%2C%20so%20no%20Contribution%20License%20Agreement%20is%20required%20at%20this%20point.%20Real%20humans%20will%20now%20evaluate%20your%20PR.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSOTBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-04-10T15%3A39%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22JsonWebToken%20use%20base64url%20encoding%20which%20does%20not%20have%20any%20%27%3D%27.%5Cr%5Cnsee%3A%20%5Cr%5Cnhttp%3A//tools.ietf.org/html/draft-ietf-oauth-json-web-token-32%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-04-10T21%3A10%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/117#issuecomment-91595713'>General Comment</a></b>
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> Hi __@cardinal252__, I'm your friendly neighborhood Microsoft Open Technologies, Inc. Pull Request Bot (You can call me MSOTBOT). Thanks for your contribution!
<span>
This seems like a small (but important) contribution, so no Contribution License Agreement is required at this point. Real humans will now evaluate your PR.
</span>
TTYL, MSOTBOT;
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> JsonWebToken use base64url encoding which does not have any '='.
see:
http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/117?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/117?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/117'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>