### PR TITLE
JwtPayload.Claims broken in Mono

### DIFF
--- a/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
@@ -371,9 +371,30 @@ namespace System.IdentityModel.Tokens
                             }
                             else
                             {
-                                c = new Claim(claimType, JsonExtensions.SerializeToJson(keyValuePair.Value), JwtConstants.JsonClaimValueType, issuer, issuer);
-                                c.Properties[JwtSecurityTokenHandler.JsonClaimTypeProperty] = keyValuePair.Value.GetType().ToString();
-                                claims.Add(c);
+                                ArrayList arrayList = keyValuePair.Value as ArrayList;
+                                if (arrayList != null)
+                                {
+                                    foreach (var item in arrayList)
+                                    {
+                                        string str = item as string;
+                                        if (str != null)
+                                        {
+                                            claims.Add(new Claim(keyValuePair.Key, str, ClaimValueTypes.String, issuer, issuer));
+                                        }
+                                        else
+                                        {
+                                            c = new Claim(keyValuePair.Key, JsonExtensions.SerializeToJson(item), JwtConstants.JsonClaimValueType, issuer, issuer);
+                                            c.Properties[JwtSecurityTokenHandler.JsonClaimTypeProperty] = item.GetType().ToString();
+                                            claims.Add(c);
+                                        }
+                                    }
+                                }
+                                else
+                                {
+                                    c = new Claim(claimType, JsonExtensions.SerializeToJson(keyValuePair.Value), JwtConstants.JsonClaimValueType, issuer, issuer);
+                                    c.Properties[JwtSecurityTokenHandler.JsonClaimTypeProperty] = keyValuePair.Value.GetType().ToString();
+                                    claims.Add(c);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
In Windows, JwtPayload.Claims works fine. If a JWT claim has an array of strings, for example, "scope": ["openid", "email", "profiles"], it decomposes them fine. One claim is turned into three.

With Mono however (4.0.1), the claim value is treated as an ArrayList, so it doesn't match IEnumerable<Object> and thus falls through to being serialized as JSON.

This PR works on Mono and is pretty simple. I just added a check for the ArrayList type and then mimicked the IEnumerable decomposition.

If it's too big of a change, I'm at least hoping it starts a discussion on how to fix claims for use with Mono.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/153%23issuecomment-105257432%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/153%23issuecomment-105257964%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/153%23issuecomment-105257432%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40ryan1234__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Open%20Technologies%2C%20Inc.%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSOTBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20In%20order%20for%20us%20to%20evaluate%20and%20accept%20your%20PR%2C%20we%20ask%20that%20you%20sign%20a%20contribution%20license%20agreement.%20It%27s%20all%20electronic%20and%20will%20take%20just%20minutes.%20I%20promise%20there%27s%20no%20faxing.%20https%3A//cla2.msopentech.com.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSOTBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-05-25T16%3A06%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22__%40ryan1234__%2C%20Thanks%20for%20signing%20the%20contribution%20license%20agreement%20so%20quickly%21%20Actual%20humans%20will%20now%20validate%20the%20agreement%20and%20then%20evaluate%20the%20PR.%5Cr%5Cn%3Cbr%20/%3EThanks%2C%20MSOTBOT%3B%22%2C%20%22created_at%22%3A%20%222015-05-25T16%3A10%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/153#issuecomment-105257432'>General Comment</a></b>
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> Hi __@ryan1234__, I'm your friendly neighborhood Microsoft Open Technologies, Inc. Pull Request Bot (You can call me MSOTBOT). Thanks for your contribution!
<span>
In order for us to evaluate and accept your PR, we ask that you sign a contribution license agreement. It's all electronic and will take just minutes. I promise there's no faxing. https://cla2.msopentech.com.
</span>
TTYL, MSOTBOT;
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> __@ryan1234__, Thanks for signing the contribution license agreement so quickly! Actual humans will now validate the agreement and then evaluate the PR.
<br />Thanks, MSOTBOT;


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/153?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/153?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/153'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>