### PR TITLE
JwtPayload.Claims broken in Mono

### DIFF
--- a/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
@@ -371,9 +371,30 @@ namespace System.IdentityModel.Tokens
                             }
                             else
                             {
-                                c = new Claim(claimType, JsonExtensions.SerializeToJson(keyValuePair.Value), JwtConstants.JsonClaimValueType, issuer, issuer);
-                                c.Properties[JwtSecurityTokenHandler.JsonClaimTypeProperty] = keyValuePair.Value.GetType().ToString();
-                                claims.Add(c);
+                                ArrayList arrayList = keyValuePair.Value as ArrayList;
+                                if (arrayList != null)
+                                {
+                                    foreach (var item in arrayList)
+                                    {
+                                        string str = item as string;
+                                        if (str != null)
+                                        {
+                                            claims.Add(new Claim(keyValuePair.Key, str, ClaimValueTypes.String, issuer, issuer));
+                                        }
+                                        else
+                                        {
+                                            c = new Claim(keyValuePair.Key, JsonExtensions.SerializeToJson(item), JwtConstants.JsonClaimValueType, issuer, issuer);
+                                            c.Properties[JwtSecurityTokenHandler.JsonClaimTypeProperty] = item.GetType().ToString();
+                                            claims.Add(c);
+                                        }
+                                    }
+                                }
+                                else
+                                {
+                                    c = new Claim(claimType, JsonExtensions.SerializeToJson(keyValuePair.Value), JwtConstants.JsonClaimValueType, issuer, issuer);
+                                    c.Properties[JwtSecurityTokenHandler.JsonClaimTypeProperty] = keyValuePair.Value.GetType().ToString();
+                                    claims.Add(c);
+                                }
                             }
                         }
                     }

--- a/tests/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
+++ b/tests/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
@@ -157,18 +157,18 @@ namespace System.IdentityModel.Test
 
         [TestMethod]
         [TestProperty("TestCaseID", "41b560fa-dddf-47cf-a8f0-b6f85e01b61e")]
-        [Description("Test claim array decomposition")]
-        public void JwtPayload_ClaimArrayDecomposition()
+        [Description("Test claim array decomposition in Mono")]
+        public void JwtPayload_Mono_ClaimArrayDecomposition()
         {
             List<string> errors = new List<string>();
+
             var jwtPayload = new JwtPayload();
+            jwtPayload["scope"] = new ArrayList() { "openid", "email", "profile" };
 
-            jwtPayload.AddClaim(new Claim("scope", "[\"openid\", \"email\", \"profile\"]"));
             int claimCount = ((IList<Claim>)jwtPayload.Claims).Count;
-
-            if (claimCount == 3)
+            if (claimCount != 3)
             {
-                errors.Add("!claimCount === 3");
+                errors.Add("!claimCount == 3");
             }
 
             TestUtilities.AssertFailIfErrors(MethodInfo.GetCurrentMethod().Name, errors);

--- a/tests/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
+++ b/tests/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
@@ -128,7 +128,7 @@ namespace System.IdentityModel.Test
         [TestMethod]
         [TestProperty( "TestCaseID", "4D8369F1-8846-41C2-89C9-3827955032A6" )]
         [Description( "Test claims as objects" )]
-        public void JwtPalyoad_Claims()
+        public void JwtPayload_Claims()
         {
             List<string> errors = new List<string>();
             var jwtPayload = new JwtPayload();
@@ -156,9 +156,28 @@ namespace System.IdentityModel.Test
         }
 
         [TestMethod]
+        [TestProperty("TestCaseID", "41b560fa-dddf-47cf-a8f0-b6f85e01b61e")]
+        [Description("Test claim array decomposition")]
+        public void JwtPayload_ClaimArrayDecomposition()
+        {
+            List<string> errors = new List<string>();
+            var jwtPayload = new JwtPayload();
+
+            jwtPayload.AddClaim(new Claim("scope", "[\"openid\", \"email\", \"profile\"]"));
+            int claimCount = ((IList<Claim>)jwtPayload.Claims).Count;
+
+            if (claimCount == 3)
+            {
+                errors.Add("!claimCount === 3");
+            }
+
+            TestUtilities.AssertFailIfErrors(MethodInfo.GetCurrentMethod().Name, errors);
+        }
+
+        [TestMethod]
         [TestProperty( "TestCaseID", "F443747C-5AA1-406D-B0FE-53152CA92DA3" )]
         [Description( "Tests adding non-strings as 'exp'" )]
-        public void JwtPalyoad_ObjectClaims()
+        public void JwtPayload_ObjectClaims()
         {
             JwtPayload jwtPayload = new JwtPayload();
             int? time = 10000;


### PR DESCRIPTION
In Windows, JwtPayload.Claims works fine. If a JWT claim has an array of strings, for example, "scope": ["openid", "email", "profiles"], it decomposes them fine. One claim is turned into three.

With Mono however (4.0.1), the claim value is treated as an ArrayList, so it doesn't match IEnumerable and thus falls through to being serialized as JSON.

This PR works on Mono and is pretty simple. I just added a check for the ArrayList type and then mimicked the IEnumerable decomposition.

If it's too big of a change, I'm at least hoping it starts a discussion on how to fix claims for use with Mono.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161%23issuecomment-105979845%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161%23issuecomment-106082058%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161%23issuecomment-106083150%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161%23issuecomment-106103290%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161%23issuecomment-106116626%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161%23issuecomment-106116811%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161%23issuecomment-106117462%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161%23issuecomment-106528269%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161%23issuecomment-106534925%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161%23issuecomment-106537370%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161%23issuecomment-106560521%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161%23issuecomment-105979845%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40ryan1234__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Open%20Technologies%2C%20Inc.%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSOTBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3EYou%27ve%20already%20signed%20the%20contribution%20license%20agreement.%20Thanks%21%3C/span%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%3Cp%3EThe%20agreement%20was%20validated%20by%20Microsoft%20Open%20Technologies%2C%20Inc.%20and%20real%20humans%20are%20currently%20evaluating%20your%20PR.%3C/p%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSOTBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-05-27T16%3A08%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%20%40ryan1234%20Can%20you%20add%20some%20tests%3F%22%2C%20%22created_at%22%3A%20%222015-05-27T21%3A18%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sure%20thing.%20I%27ll%20update%20the%20PR.%22%2C%20%22created_at%22%3A%20%222015-05-27T21%3A22%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1672337%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ryan1234%22%7D%7D%2C%20%7B%22body%22%3A%20%22A%20few%20notes%20with%20the%20update%3A%5Cr%5Cn%5Cr%5Cn1.%20Fixed%20two%20spelling%20mistakes.%5Cr%5Cn2.%20The%20new%20test%20tests%20the%20use%20case%20that%20was%20breaking%20on%20Mono.%20In%20the%20example%20in%20the%20test%2C%20if%20the%20scope%20claim%20was%20the%20only%20claim%2C%20Windows%20would%20return%203%20claims%20and%20Mono%20would%20return%201.%20Mono%20for%20whatever%20reason%20treats%20the%20string%20as%20an%20ArrayList.%5Cr%5Cn3.%20The%20test%20is%20ok%20in%20Windows%2C%20but%20that%20doesn%27t%20test%20the%20original%20commit.%20%3D%28%20It%20would%20work%20fine%20without%20my%20first%20commit.%5Cr%5Cn4.%20The%20only%20way%20I%20can%20think%20of%20testing%20the%20change%20I%20submitted%20is%20to%3A%5Cr%5Cn%5Cr%5Cn%20%20a.%20Somehow%20mock%20the%20%60as%60%20operator%20to%20match%20something%20like%20this%3A%20%5B%5C%22openid%5C%22%2C%20%5C%22email%5C%22%5D%2C%20to%20an%20ArrayList%20and%20_nothing_%20else.%5Cr%5Cn%20%20b.%20Setup%20a%20build%20with%20Travis%20CI%20that%20might%20be%20able%20to%20run%20in%20a%20Mono%20environment%3F%5Cr%5Cn%5Cr%5Cn5.%20I%20suppose%20I%20can%20just%20write%20tests%20that%20prove%20that%20existing%20functionality%20doesn%27t%20break%20with%20the%20extra%20check%20as%20well.%5Cr%5Cn%5Cr%5CnCurious%20what%20your%20thoughts%20are.%22%2C%20%22created_at%22%3A%20%222015-05-27T22%3A57%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1672337%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ryan1234%22%7D%7D%2C%20%7B%22body%22%3A%20%22could%20you%20plug%20your%20own%20serializer%20and%20return%20and%20arraylist%3F%22%2C%20%22created_at%22%3A%20%222015-05-28T00%3A07%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27ll%20sure%20try.%20%3D%29%22%2C%20%22created_at%22%3A%20%222015-05-28T00%3A08%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1672337%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ryan1234%22%7D%7D%2C%20%7B%22body%22%3A%20%22Have%20a%20look%20at%3A%20C%3A%5C%5Cgithub%5C%5Cwilson4k%5C%5Csrc%5C%5CSystem.IdentityModel.Tokens%5C%5CJwt%5C%5CJsonExtensions.cs%5Cr%5Cn%5Cr%5CnIt%20not%20fully%20tested%2C%20if%20it%20blows%20up%20we%20will%20need%20to%20do%20some%20work.%22%2C%20%22created_at%22%3A%20%222015-05-28T00%3A10%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looked%20at%20the%20test%20more%20and%20more%20thoughts%20...%5Cr%5Cn%5Cr%5Cn1.%20I%20was%20able%20to%20replace%20the%20default%20deserializer%20fine%2C%20but%20I%20wasn%27t%20sure%20how%20to%20mimic%20taking%20a%20raw%20base64encoded%20JWT%20such%20that%20it%20ultimately%20ends%20up%20with%20a%20JwtPayload%20object.%5Cr%5Cn%5Cr%5Cn2.%20Considering%20%281%29%2C%20it%20seemed%20easier%20to%20just%20explicitly%20set%20a%20claim%20that%20was%20already%20typed%20as%20an%20ArrayList.%20This%20explicitly%20exercises%20the%20branch%20of%20code%20that%20manages%20ArrayLists%2C%20so%20in%20that%20sense%20we%20have%20coverage.%5Cr%5Cn%5Cr%5CnThoughts%3F%5Cr%5Cn%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-05-28T17%3A54%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1672337%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ryan1234%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20fine%20with%20setting%20the%20Payload%20explicitly%20to%20an%20ArrayList.%20%282.%29.%20%20It%20seems%20fine.%5Cr%5Cn%5Cr%5CnI%20spoke%20with%20some%20folks%20on%20the%20Mono%20team%20and%20the%20feeling%20is%20that%20perhaps%20Mono%20should%20take%20a%20fix.%5Cr%5CnWe%20could%20still%20take%20this%20fix%20for%20beta5%2C%20open%20an%20issue%20to%20revisit%20in%20beta6.%5Cr%5Cn%5Cr%5Cnthoughts%3F%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-05-28T18%3A02%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%20that%27s%20fine%20with%20me.%20Right%20now%20I%27m%20using%20a%20forked%20version%20of%20System.IdentityModel.Tokens.Jwt%20so%20I%20can%20keep%20pushing%20a%20product%20towards%20production.%20I%27m%20several%20months%20away%20from%20going%20live.%5Cr%5Cn%5Cr%5CnIn%20a%20few%20months%20though%20I%27d%20like%20to%20just%20pull%20the%20library%20and%20have%20it%20work%20on%20Mono.%20%3D%29%20It%20does%20seem%20like%20it%27s%20more%20of%20their%20responsibility%2C%20but%20this%20code%20base%20is%20much%20easier%20for%20me%20to%20debug.%20Haha.%22%2C%20%22created_at%22%3A%20%222015-05-28T18%3A05%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1672337%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ryan1234%22%7D%7D%2C%20%7B%22body%22%3A%20%22Thanks%2C%20I%20try%20to%20keep%20it%20simple%20%3A-%29%5Cr%5CnI%20think%20it%20is%20important%20enough%20for%20the%20Mono%20group%20of%20folks%20to%20take%20this%20fix.%20It%20will%20have%20a%20small%20perf%20hit.%20Just%20so%20you%20know%20I%20am%20a%20believer%20in%20%27death%20by%20a%20thousand%20paper%20cuts%27.%5Cr%5Cn%5Cr%5CnLet%20me%20merge%20the%20your%20fix%20and%20open%20an%20issue.%5Cr%5Cn%5Cr%5Cnthanks%20for%20the%20help.%22%2C%20%22created_at%22%3A%20%222015-05-28T18%3A38%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161#issuecomment-105979845'>General Comment</a></b>
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> Hi __@ryan1234__, I'm your friendly neighborhood Microsoft Open Technologies, Inc. Pull Request Bot (You can call me MSOTBOT). Thanks for your contribution!
<span>You've already signed the contribution license agreement. Thanks!</span>
<p>The agreement was validated by Microsoft Open Technologies, Inc. and real humans are currently evaluating your PR.</p>
TTYL, MSOTBOT;
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> Thanks @ryan1234 Can you add some tests?
- <a href='https://github.com/ryan1234'><img border=0 src='https://avatars.githubusercontent.com/u/1672337?v=3' height=16 width=16'></a> Sure thing. I'll update the PR.
- <a href='https://github.com/ryan1234'><img border=0 src='https://avatars.githubusercontent.com/u/1672337?v=3' height=16 width=16'></a> A few notes with the update:
1. Fixed two spelling mistakes.
2. The new test tests the use case that was breaking on Mono. In the example in the test, if the scope claim was the only claim, Windows would return 3 claims and Mono would return 1. Mono for whatever reason treats the string as an ArrayList.
3. The test is ok in Windows, but that doesn't test the original commit. =( It would work fine without my first commit.
4. The only way I can think of testing the change I submitted is to:
a. Somehow mock the `as` operator to match something like this: ["openid", "email"], to an ArrayList and _nothing_ else.
b. Setup a build with Travis CI that might be able to run in a Mono environment?
5. I suppose I can just write tests that prove that existing functionality doesn't break with the extra check as well.
Curious what your thoughts are.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> could you plug your own serializer and return and arraylist?
- <a href='https://github.com/ryan1234'><img border=0 src='https://avatars.githubusercontent.com/u/1672337?v=3' height=16 width=16'></a> I'll sure try. =)
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> Have a look at: C:\github\wilson4k\src\System.IdentityModel.Tokens\Jwt\JsonExtensions.cs
It not fully tested, if it blows up we will need to do some work.
- <a href='https://github.com/ryan1234'><img border=0 src='https://avatars.githubusercontent.com/u/1672337?v=3' height=16 width=16'></a> Looked at the test more and more thoughts ...
1. I was able to replace the default deserializer fine, but I wasn't sure how to mimic taking a raw base64encoded JWT such that it ultimately ends up with a JwtPayload object.
2. Considering (1), it seemed easier to just explicitly set a claim that was already typed as an ArrayList. This explicitly exercises the branch of code that manages ArrayLists, so in that sense we have coverage.
Thoughts?
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> I am fine with setting the Payload explicitly to an ArrayList. (2.).  It seems fine.
I spoke with some folks on the Mono team and the feeling is that perhaps Mono should take a fix.
We could still take this fix for beta5, open an issue to revisit in beta6.
thoughts?
- <a href='https://github.com/ryan1234'><img border=0 src='https://avatars.githubusercontent.com/u/1672337?v=3' height=16 width=16'></a> Yeah that's fine with me. Right now I'm using a forked version of System.IdentityModel.Tokens.Jwt so I can keep pushing a product towards production. I'm several months away from going live.
In a few months though I'd like to just pull the library and have it work on Mono. =) It does seem like it's more of their responsibility, but this code base is much easier for me to debug. Haha.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> Thanks, I try to keep it simple :-)
I think it is important enough for the Mono group of folks to take this fix. It will have a small perf hit. Just so you know I am a believer in 'death by a thousand paper cuts'.
Let me merge the your fix and open an issue.
thanks for the help.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/161'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>