### PR TITLE
Fix for deadlock. Issue #183

### DIFF
--- a/src/Microsoft.IdentityModel.Protocol.Extensions/Configuration/HttpDocumentRetriever.cs
+++ b/src/Microsoft.IdentityModel.Protocol.Extensions/Configuration/HttpDocumentRetriever.cs
@@ -50,7 +50,7 @@ namespace Microsoft.IdentityModel.Protocols
             }
             try
             {
-                HttpResponseMessage response = await _httpClient.GetAsync(address, cancel).ConfigureAwait(false);
+                HttpResponseMessage response = _httpClient.GetAsync(address, cancel).Result;
                 response.EnsureSuccessStatusCode();
                 return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
             }

--- a/src/Microsoft.IdentityModel.Protocol.Extensions/Configuration/OpenIdConnectConfigurationRetriever.cs
+++ b/src/Microsoft.IdentityModel.Protocol.Extensions/Configuration/OpenIdConnectConfigurationRetriever.cs
@@ -82,8 +82,8 @@ namespace Microsoft.IdentityModel.Protocols
             OpenIdConnectConfiguration openIdConnectConfiguration = new OpenIdConnectConfiguration(doc);
             if (!string.IsNullOrEmpty(openIdConnectConfiguration.JwksUri))
             {
-                doc = await retriever.GetDocumentAsync(openIdConnectConfiguration.JwksUri, cancel);
-                openIdConnectConfiguration.JsonWebKeySet = new JsonWebKeySet(doc);
+                string keys = await retriever.GetDocumentAsync(openIdConnectConfiguration.JwksUri, cancel);
+                openIdConnectConfiguration.JsonWebKeySet = new JsonWebKeySet(keys);
                 foreach (SecurityToken token in openIdConnectConfiguration.JsonWebKeySet.GetSigningTokens())
                 {
                     openIdConnectConfiguration.SigningTokens.Add(token);


### PR DESCRIPTION
The double 'await' in HttpDocumentRetriever.cs caused a deadlock.
Introduced new variable 'keys' in OpenIdConnectConfigurationRetriever.cs for clarification.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/184?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/184'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>