### PR TITLE
Instance based claim type mapping

### DIFF
--- a/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
@@ -421,8 +421,7 @@ namespace System.IdentityModel.Tokens.Jwt
         /// Adds a number of <see cref="Claim"/> to the <see cref="JwtPayload"/> as JSON { name, value } pairs.
         /// </summary>
         /// <param name="claims">for each <see cref="Claim"/> a JSON pair { 'Claim.Type', 'Claim.Value' } is added. If duplicate claims are found then a { 'Claim.Type', List&lt;object> } will be created to contain the duplicate values.</param>
-        /// <remarks><para>Each <see cref="Claim"/> added will have <see cref="Claim.Type"/> translated according to the mapping found in <see cref="JwtSecurityTokenHandler.OutboundClaimTypeMap"/>. Adding and removing to <see cref="JwtSecurityTokenHandler.OutboundClaimTypeMap"/> 
-        /// will affect the name component of the Json claim</para>
+        /// <remarks>
         /// <para>Any <see cref="Claim"/> in the <see cref="IEnumerable{Claim}"/> that is null, will be ignored.</para></remarks>
         /// <exception cref="ArgumentNullException">'claims' is null.</exception>
         public void AddClaims(IEnumerable<Claim> claims)
@@ -439,12 +438,7 @@ namespace System.IdentityModel.Tokens.Jwt
                     continue;
                 }
 
-                string jsonClaimType = null;
-                if (!JwtSecurityTokenHandler.OutboundClaimTypeMap.TryGetValue(claim.Type, out jsonClaimType))
-                {
-                    jsonClaimType = claim.Type;
-                }
-
+                string jsonClaimType = claim.Type;
                 object jsonClaimValue = claim.ValueType.Equals(ClaimValueTypes.String, StringComparison.Ordinal) ? claim.Value : GetClaimValueUsingValueType(claim);
                 object value;
                 if (TryGetValue(jsonClaimType, out value))

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -54,15 +54,15 @@ namespace System.IdentityModel.Tokens.Jwt
         // Summary:
         //     The claim properties namespace.
         private const string Namespace = "http://schemas.xmlsoap.org/ws/2005/05/identity/claimproperties";
-        private static IDictionary<string, string> inboundClaimTypeMap = ClaimTypeMapping.InboundClaimTypeMap;
-        private static IDictionary<string, string> outboundClaimTypeMap = ClaimTypeMapping.OutboundClaimTypeMap;
         private static string shortClaimTypeProperty = Namespace + "/ShortTypeName";
         private static string jsonClaimTypeProperty = Namespace + "/json_type";
-        private static ISet<string> inboundClaimFilter = ClaimTypeMapping.InboundClaimFilter;
         private static string[] tokenTypeIdentifiers = { JwtConstants.TokenTypeAlt, JwtConstants.TokenType };
         private SignatureProviderFactory signatureProviderFactory = new SignatureProviderFactory();
         private Int32 _maximumTokenSizeInBytes = TokenValidationParameters.DefaultMaximumTokenSizeInBytes;
         private Int32 _defaultTokenLifetimeInMinutes = DefaultTokenLifetimeInMinutes;
+        private IDictionary<string, string> _inboundClaimTypeMap;
+        private IDictionary<string, string> _outboundClaimTypeMap;
+        private ISet<string> _inboundClaimFilter;
 
 
         /// <summary>
@@ -70,15 +70,29 @@ namespace System.IdentityModel.Tokens.Jwt
         /// </summary>
         public static readonly Int32 DefaultTokenLifetimeInMinutes = 60;
 
-        static JwtSecurityTokenHandler()
-        {
-        }
+        /// <summary>
+        /// Default claim type mapping for inbound claims.
+        /// </summary>
+        public static IDictionary<string, string> DefaultInboundClaimTypeMap = ClaimTypeMapping.InboundClaimTypeMap;
+
+        /// <summary>
+        /// Default claim type maping for outbound claims.
+        /// </summary>
+        public static IDictionary<string, string> DefaultOutboundClaimTypeMap = ClaimTypeMapping.OutboundClaimTypeMap;
+
+        /// <summary>
+        /// Default claim type filter list.
+        /// </summary>
+        public static ISet<string> DefaultInboundClaimFilter = ClaimTypeMapping.InboundClaimFilter;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JwtSecurityTokenHandler"/> class.
         /// </summary>
         public JwtSecurityTokenHandler()
         {
+            _inboundClaimTypeMap = new Dictionary<string, string>(DefaultInboundClaimTypeMap);
+            _outboundClaimTypeMap = new Dictionary<string, string>(DefaultOutboundClaimTypeMap);
+            _inboundClaimFilter = new HashSet<string>(DefaultInboundClaimFilter);
         }
 
         /// <summary>Gets or sets the <see cref="IDictionary{TKey, TValue}"/> used to map Inbound Cryptographic Algorithms.</summary>
@@ -137,15 +151,16 @@ namespace System.IdentityModel.Tokens.Jwt
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="InboundClaimTypeMap"/> that is used when setting the <see cref="Claim.Type"/> for claims in the <see cref="ClaimsPrincipal"/> extracted when validating a <see cref="JwtSecurityToken"/>. 
+        /// Gets or sets the <see cref="InboundClaimTypeMap"/> which is used when setting the <see cref="Claim.Type"/> for claims in the <see cref="ClaimsPrincipal"/> extracted when validating a <see cref="JwtSecurityToken"/>. 
         /// <para>The <see cref="Claim.Type"/> is set to the JSON claim 'name' after translating using this mapping.</para>
+        /// <para>The default value is ClaimTypeMapping.InboundClaimTypeMap</para>
         /// </summary>
         /// <exception cref="ArgumentNullException">'value is null.</exception>
-        public static IDictionary<string, string> InboundClaimTypeMap
+        public IDictionary<string, string> InboundClaimTypeMap
         {
             get
             {
-                return inboundClaimTypeMap;
+                return _inboundClaimTypeMap;
             }
 
             set
@@ -155,21 +170,22 @@ namespace System.IdentityModel.Tokens.Jwt
                     LogHelper.Throw(string.Format(CultureInfo.InvariantCulture, ErrorMessages.IDX10001, "InboundClaimTypeMap"), typeof(ArgumentNullException), EventLevel.Verbose);
                 }
 
-                inboundClaimTypeMap = value;
+                _inboundClaimTypeMap = value;
             }
         }
 
         /// <summary>
-        /// <para>Gets or sets the <see cref="OutboundClaimTypeMap"/> that is used when creating a <see cref="JwtSecurityToken"/> from <see cref="Claim"/>(s).</para>
+        /// <para>Gets or sets the <see cref="OutboundClaimTypeMap"/> which is used when creating a <see cref="JwtSecurityToken"/> from <see cref="Claim"/>(s).</para>
         /// <para>The JSON claim 'name' value is set to <see cref="Claim.Type"/> after translating using this mapping.</para>
+        /// <para>The default value is ClaimTypeMapping.OutboundClaimTypeMap</para>
         /// </summary>
         /// <remarks>This mapping is applied only when using <see cref="JwtPayload.AddClaim"/> or <see cref="JwtPayload.AddClaims"/>. Adding values directly will not result in translation.</remarks>
         /// <exception cref="ArgumentNullException">'value is null.</exception>
-        public static IDictionary<string, string> OutboundClaimTypeMap
+        public IDictionary<string, string> OutboundClaimTypeMap
         {
             get
             {
-                return outboundClaimTypeMap;
+                return _outboundClaimTypeMap;
             }
 
             set
@@ -179,18 +195,20 @@ namespace System.IdentityModel.Tokens.Jwt
                     LogHelper.Throw(string.Format(CultureInfo.InvariantCulture, ErrorMessages.IDX10001, "OutboundClaimTypeMap"), typeof(ArgumentNullException), EventLevel.Verbose);
                 }
 
-                outboundClaimTypeMap = value;
+                _outboundClaimTypeMap = value;
             }
         }
 
         /// <summary>Gets or sets the <see cref="ISet{String}"/> used to filter claims when populating a <see cref="ClaimsIdentity"/> claims form a <see cref="JwtSecurityToken"/>.
-        /// When a <see cref="JwtSecurityToken"/> is validated, claims with types found in this <see cref="ISet{String}"/> will not be added to the <see cref="ClaimsIdentity"/>.</summary>
+        /// When a <see cref="JwtSecurityToken"/> is validated, claims with types found in this <see cref="ISet{String}"/> will not be added to the <see cref="ClaimsIdentity"/>.
+        /// <para>The default value is ClaimTypeMapping.InboundClaimFliter</para>
+        /// </summary>
         /// <exception cref="ArgumentNullException">'value' is null.</exception>
-        public static ISet<string> InboundClaimFilter
+        public ISet<string> InboundClaimFilter
         {
             get
             {
-                return inboundClaimFilter;
+                return _inboundClaimFilter;
             }
 
             set
@@ -200,7 +218,7 @@ namespace System.IdentityModel.Tokens.Jwt
                     LogHelper.Throw(string.Format(CultureInfo.InvariantCulture, ErrorMessages.IDX10001, "InboundClaimFilter"), typeof(ArgumentNullException), EventLevel.Verbose);
                 }
 
-                inboundClaimFilter = value;
+                _inboundClaimFilter = value;
             }
         }
 
@@ -387,7 +405,10 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <param name="signatureProvider">optional <see cref="SignatureProvider"/>.</param>
         /// <remarks>If <see cref="ClaimsIdentity.Actor"/> is not null, then a claim { actort, 'value' } will be added to the payload. <see cref="CreateActorValue"/> for details on how the value is created.
         /// <para>See <seealso cref="JwtHeader"/> for details on how the HeaderParameters are added to the header.</para>
-        /// <para>See <seealso cref="JwtPayload"/> for details on how the values are added to the payload.</para></remarks>
+        /// <para>See <seealso cref="JwtPayload"/> for details on how the values are added to the payload.</para>
+        /// <para>Each <see cref="Claim"/> on the <paramref name="subject"/> added will have <see cref="Claim.Type"/> translated according to the mapping found in
+        /// <see cref="OutboundClaimTypeMap"/>. Adding and removing to <see cref="OutboundClaimTypeMap"/> will affect the name component of the Json claim</para>
+        /// </remarks>
         /// <para>If signautureProvider is not null, then it will be used to create the signature and <see cref="System.IdentityModel.Tokens.SignatureProviderFactory.CreateForSigning( SecurityKey, string )"/> will not be called.</para>
         /// <returns>A <see cref="JwtSecurityToken"/>.</returns>
         /// <exception cref="ArgumentException">if 'expires' &lt;= 'notBefore'.</exception>
@@ -410,7 +431,8 @@ namespace System.IdentityModel.Tokens.Jwt
             }
 
             IdentityModelEventSource.Logger.WriteVerbose("Creating payload and header from the passed parameters including issuer, audience, signing credentials and others.");
-            JwtPayload payload = new JwtPayload(issuer, audience, subject == null ? null : subject.Claims, notBefore, expires);
+            IEnumerable<Claim> subjectClaims = subject == null ? null : OutboundClaimTypeTransform(subject.Claims);
+            JwtPayload payload = new JwtPayload(issuer, audience, subjectClaims, notBefore, expires);
             JwtHeader header = new JwtHeader(signingCredentials);
 
             if (subject != null && subject.Actor != null)
@@ -437,6 +459,22 @@ namespace System.IdentityModel.Tokens.Jwt
 
             IdentityModelEventSource.Logger.WriteInformation("Creating security token from the header, payload and raw signature.");
             return new JwtSecurityToken(header, payload, rawHeader, rawPayload, rawSignature);
+        }
+
+        private IEnumerable<Claim> OutboundClaimTypeTransform(IEnumerable<Claim> claims)
+        {
+            foreach (Claim claim in claims)
+            {
+                string type = null;
+                if (_outboundClaimTypeMap.TryGetValue(claim.Type, out type))
+                {
+                    yield return new Claim(type, claim.Value, claim.ValueType, claim.Issuer, claim.OriginalIssuer, claim.Subject);
+                }
+                else
+                {
+                    yield return claim;
+                }
+            }
         }
 
         /// <summary>
@@ -890,14 +928,14 @@ namespace System.IdentityModel.Tokens.Jwt
             ClaimsIdentity identity = validationParameters.CreateClaimsIdentity(jwt, issuer);
             foreach (Claim jwtClaim in jwt.Claims)
             {
-                if (InboundClaimFilter.Contains(jwtClaim.Type))
+                if (_inboundClaimFilter.Contains(jwtClaim.Type))
                 {
                     continue;
                 }
 
                 string claimType;
                 bool wasMapped = true;
-                if (!JwtSecurityTokenHandler.InboundClaimTypeMap.TryGetValue(jwtClaim.Type, out claimType))
+                if (!_inboundClaimTypeMap.TryGetValue(jwtClaim.Type, out claimType))
                 {
                     claimType = jwtClaim.Type;
                     wasMapped = false;

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
@@ -149,8 +149,8 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             createAndValidateParams = new CreateAndValidateParams
             {
                 Case = "ClaimSets.DuplicateTypes",
-                Claims = ClaimSets.DuplicateTypes(),
-                CompareTo = IdentityUtilities.CreateJwtSecurityToken(issuer, originalIssuer, ClaimSets.DuplicateTypes(), null),
+                Claims = ClaimSets.DuplicateTypes(issuer, originalIssuer),
+                CompareTo = IdentityUtilities.CreateJwtSecurityToken(issuer, originalIssuer, ClaimSets.OutboundClaimTypeTransform(ClaimSets.DuplicateTypes(issuer, originalIssuer), JwtSecurityTokenHandler.DefaultOutboundClaimTypeMap), null),
                 ExceptionType = null,
                 TokenValidationParameters = new TokenValidationParameters
                 {
@@ -168,7 +168,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             {
                 Case = "ClaimSets.Simple_simpleSigned_Asymmetric",
                 Claims = ClaimSets.Simple(issuer, originalIssuer),
-                CompareTo = IdentityUtilities.CreateJwtSecurityToken(issuer, originalIssuer, ClaimSets.Simple(issuer, originalIssuer), signingCredentials),
+                CompareTo = IdentityUtilities.CreateJwtSecurityToken(issuer, originalIssuer, ClaimSets.OutboundClaimTypeTransform(ClaimSets.Simple(issuer, originalIssuer), JwtSecurityTokenHandler.DefaultOutboundClaimTypeMap), signingCredentials),
                 ExceptionType = null,
                 SigningCredentials = signingCredentials,
                 TokenValidationParameters = new TokenValidationParameters
@@ -186,7 +186,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             {
                 Case = "ClaimSets.Simple_simpleSigned_Symmetric",
                 Claims = ClaimSets.Simple(issuer, originalIssuer),
-                CompareTo = IdentityUtilities.CreateJwtSecurityToken(issuer, originalIssuer, ClaimSets.Simple(issuer, originalIssuer), KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2),
+                CompareTo = IdentityUtilities.CreateJwtSecurityToken(issuer, originalIssuer, ClaimSets.OutboundTransform(ClaimSets.Simple(issuer, originalIssuer), JwtSecurityTokenHandler.OutboundClaimTypeMap), KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2),
                 ExceptionType = null,
                 SigningCredentials = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2,
                 SigningKey = KeyingMaterial.DefaultSymmetricSecurityKey_256,
@@ -248,11 +248,11 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 });
 
             JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
-            JwtSecurityTokenHandler.InboundClaimFilter.Add("aud");
-            JwtSecurityTokenHandler.InboundClaimFilter.Add("exp");
-            JwtSecurityTokenHandler.InboundClaimFilter.Add("iat");
-            JwtSecurityTokenHandler.InboundClaimFilter.Add("iss");
-            JwtSecurityTokenHandler.InboundClaimFilter.Add("nbf");
+            tokenHandler.InboundClaimFilter.Add("aud");
+            tokenHandler.InboundClaimFilter.Add("exp");
+            tokenHandler.InboundClaimFilter.Add("iat");
+            tokenHandler.InboundClaimFilter.Add("iss");
+            tokenHandler.InboundClaimFilter.Add("nbf");
 
             ClaimsPrincipal claimsPrincipal = tokenHandler.ValidateToken(encodedJwt, IdentityUtilities.DefaultAsymmetricTokenValidationParameters, out validatedToken);
 
@@ -260,7 +260,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             if (!IdentityComparer.AreEqual<IEnumerable<Claim>>(claimsPrincipal.Claims, ClaimSets.DuplicateTypes(IdentityUtilities.DefaultIssuer, IdentityUtilities.DefaultIssuer), context))
                 TestUtilities.AssertFailIfErrors("CreateAndValidateTokens: DuplicateClaims - roundtrips with duplicate claims", context.Diffs);
 
-            JwtSecurityTokenHandler.InboundClaimFilter.Clear();
+            tokenHandler.InboundClaimFilter.Clear();
         }
 
         [Fact(DisplayName = "CreateAndValidateTokens: JsonClaims - claims values are objects serailized as json, can be recognized and reconstituted.")]

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -247,185 +247,187 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         [Fact( DisplayName = "JwtSecurityTokenHandlerTests: Claim Type Mapping - Inbound and Outbound")]
         public void ClaimTypeMapping()
         {
-            Dictionary<string, string> inboundClaimTypeMap = new Dictionary<string, string>(JwtSecurityTokenHandler.InboundClaimTypeMap);
-            Dictionary<string, string> outboundClaimTypeMap = new Dictionary<string, string>(JwtSecurityTokenHandler.OutboundClaimTypeMap);
+            List<KeyValuePair<string, string>> aadStrings = new List<KeyValuePair<string, string>>();
+            aadStrings.Add(new KeyValuePair<string, string>("amr", "http://schemas.microsoft.com/claims/authnmethodsreferences"));
+            aadStrings.Add(new KeyValuePair<string, string>("deviceid", "http://schemas.microsoft.com/2012/01/devicecontext/claims/identifier"));
+            aadStrings.Add(new KeyValuePair<string, string>("family_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"));
+            aadStrings.Add(new KeyValuePair<string, string>("given_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"));
+            aadStrings.Add(new KeyValuePair<string, string>("idp", "http://schemas.microsoft.com/identity/claims/identityprovider"));
+            aadStrings.Add(new KeyValuePair<string, string>("oid", "http://schemas.microsoft.com/identity/claims/objectidentifier"));
+            aadStrings.Add(new KeyValuePair<string, string>("scp", "http://schemas.microsoft.com/identity/claims/scope"));
+            aadStrings.Add(new KeyValuePair<string, string>("tid", "http://schemas.microsoft.com/identity/claims/tenantid"));
+            aadStrings.Add(new KeyValuePair<string, string>("unique_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"));
+            aadStrings.Add(new KeyValuePair<string, string>("upn", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"));
 
-            try
+            foreach (var kv in aadStrings)
             {
-                List<KeyValuePair<string, string>> aadStrings = new List<KeyValuePair<string, string>>();
-                aadStrings.Add(new KeyValuePair<string, string>("amr", "http://schemas.microsoft.com/claims/authnmethodsreferences"));
-                aadStrings.Add(new KeyValuePair<string, string>("deviceid", "http://schemas.microsoft.com/2012/01/devicecontext/claims/identifier"));
-                aadStrings.Add(new KeyValuePair<string, string>("family_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"));
-                aadStrings.Add(new KeyValuePair<string, string>("given_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"));
-                aadStrings.Add(new KeyValuePair<string, string>("idp", "http://schemas.microsoft.com/identity/claims/identityprovider"));
-                aadStrings.Add(new KeyValuePair<string, string>("oid", "http://schemas.microsoft.com/identity/claims/objectidentifier"));
-                aadStrings.Add(new KeyValuePair<string, string>("scp", "http://schemas.microsoft.com/identity/claims/scope"));
-                aadStrings.Add(new KeyValuePair<string, string>("tid", "http://schemas.microsoft.com/identity/claims/tenantid"));
-                aadStrings.Add(new KeyValuePair<string, string>("unique_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"));
-                aadStrings.Add(new KeyValuePair<string, string>("upn", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"));
-
-                foreach (var kv in aadStrings)
-                {
-                    Assert.True(JwtSecurityTokenHandler.InboundClaimTypeMap.ContainsKey(kv.Key), "Inbound short type missing: " + kv.Key);
-                    Assert.True(JwtSecurityTokenHandler.InboundClaimTypeMap[kv.Key] == kv.Value, "Inbound mapping wrong: key " + kv.Key + " expected: " + JwtSecurityTokenHandler.InboundClaimTypeMap[kv.Key] + ", received: " + kv.Value);
-                }
-
-                List<KeyValuePair<string, string>> adfsStrings = new List<KeyValuePair<string, string>>();
-                adfsStrings.Add(new KeyValuePair<string, string>("pwdexptime", "http://schemas.microsoft.com/ws/2012/01/passwordexpirationtime"));
-                adfsStrings.Add(new KeyValuePair<string, string>("pwdexpdays", "http://schemas.microsoft.com/ws/2012/01/passwordexpirationdays"));
-                adfsStrings.Add(new KeyValuePair<string, string>("pwdchgurl", "http://schemas.microsoft.com/ws/2012/01/passwordchangeurl"));
-                adfsStrings.Add(new KeyValuePair<string, string>("clientip", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-ip"));
-                adfsStrings.Add(new KeyValuePair<string, string>("forwardedclientip", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-forwarded-client-ip"));
-                adfsStrings.Add(new KeyValuePair<string, string>("clientapplication", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-application"));
-                adfsStrings.Add(new KeyValuePair<string, string>("clientuseragent", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-user-agent"));
-                adfsStrings.Add(new KeyValuePair<string, string>("endpointpath", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-endpoint-absolute-path"));
-                adfsStrings.Add(new KeyValuePair<string, string>("proxy", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-proxy"));
-                adfsStrings.Add(new KeyValuePair<string, string>("relyingpartytrustid", "http://schemas.microsoft.com/2012/01/requestcontext/claims/relyingpartytrustid"));
-                adfsStrings.Add(new KeyValuePair<string, string>("insidecorporatenetwork", "http://schemas.microsoft.com/ws/2012/01/insidecorporatenetwork"));
-                adfsStrings.Add(new KeyValuePair<string, string>("isregistereduser", "http://schemas.microsoft.com/2012/01/devicecontext/claims/isregistereduser"));
-                adfsStrings.Add(new KeyValuePair<string, string>("deviceowner", "http://schemas.microsoft.com/2012/01/devicecontext/claims/userowner"));
-                adfsStrings.Add(new KeyValuePair<string, string>("deviceid", "http://schemas.microsoft.com/2012/01/devicecontext/claims/identifier"));
-                adfsStrings.Add(new KeyValuePair<string, string>("deviceregid", "http://schemas.microsoft.com/2012/01/devicecontext/claims/registrationid"));
-                adfsStrings.Add(new KeyValuePair<string, string>("devicedispname", "http://schemas.microsoft.com/2012/01/devicecontext/claims/displayname"));
-                adfsStrings.Add(new KeyValuePair<string, string>("deviceosver", "http://schemas.microsoft.com/2012/01/devicecontext/claims/osversion"));
-                adfsStrings.Add(new KeyValuePair<string, string>("deviceismanaged", "http://schemas.microsoft.com/2012/01/devicecontext/claims/ismanaged"));
-                adfsStrings.Add(new KeyValuePair<string, string>("deviceostype", "http://schemas.microsoft.com/2012/01/devicecontext/claims/ostype"));
-                adfsStrings.Add(new KeyValuePair<string, string>("auth_time", "http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationinstant"));
-                adfsStrings.Add(new KeyValuePair<string, string>("authmethod", "http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod"));
-                adfsStrings.Add(new KeyValuePair<string, string>("email", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"));
-                adfsStrings.Add(new KeyValuePair<string, string>("given_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"));
-                adfsStrings.Add(new KeyValuePair<string, string>("unique_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"));
-                adfsStrings.Add(new KeyValuePair<string, string>("upn", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"));
-                adfsStrings.Add(new KeyValuePair<string, string>("commonname", "http://schemas.xmlsoap.org/claims/CommonName"));
-                adfsStrings.Add(new KeyValuePair<string, string>("adfs1email", "http://schemas.xmlsoap.org/claims/EmailAddress"));
-                adfsStrings.Add(new KeyValuePair<string, string>("group", "http://schemas.xmlsoap.org/claims/Group"));
-                adfsStrings.Add(new KeyValuePair<string, string>("adfs1upn", "http://schemas.xmlsoap.org/claims/UPN"));
-                adfsStrings.Add(new KeyValuePair<string, string>("role", "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"));
-                adfsStrings.Add(new KeyValuePair<string, string>("family_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"));
-                adfsStrings.Add(new KeyValuePair<string, string>("ppid", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/privatepersonalidentifier"));
-                adfsStrings.Add(new KeyValuePair<string, string>("nameid", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"));
-                adfsStrings.Add(new KeyValuePair<string, string>("denyonlysid", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/denyonlysid"));
-                adfsStrings.Add(new KeyValuePair<string, string>("denyonlyprimarysid", "http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarysid"));
-                adfsStrings.Add(new KeyValuePair<string, string>("denyonlyprimarygroupsid", "http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarygroupsid"));
-                adfsStrings.Add(new KeyValuePair<string, string>("groupsid", "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid"));
-                adfsStrings.Add(new KeyValuePair<string, string>("primarygroupsid", "http://schemas.microsoft.com/ws/2008/06/identity/claims/primarygroupsid"));
-                adfsStrings.Add(new KeyValuePair<string, string>("primarysid", "http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid"));
-                adfsStrings.Add(new KeyValuePair<string, string>("winaccountname", "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certapppolicy", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/applicationpolicy"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certauthoritykeyidentifier", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/authoritykeyidentifier"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certbasicconstraints", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/basicconstraints"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certeku", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/eku"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certissuer", "http://schemas.microsoft.com/2012/12/certificatecontext/field/issuer"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certissuername", "http://schemas.microsoft.com/2012/12/certificatecontext/field/issuername"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certkeyusage", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/keyusage"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certnotafter", "http://schemas.microsoft.com/2012/12/certificatecontext/field/notafter"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certnotbefore", "http://schemas.microsoft.com/2012/12/certificatecontext/field/notbefore"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certpolicy", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatepolicy"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certpublickey", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/rsa"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certrawdata", "http://schemas.microsoft.com/2012/12/certificatecontext/field/rawdata"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certsubjectaltname", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/san"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certserialnumber", "http://schemas.microsoft.com/ws/2008/06/identity/claims/serialnumber"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certsignaturealgorithm", "http://schemas.microsoft.com/2012/12/certificatecontext/field/signaturealgorithm"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certsubject", "http://schemas.microsoft.com/2012/12/certificatecontext/field/subject"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certsubjectkeyidentifier", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/subjectkeyidentifier"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certsubjectname", "http://schemas.microsoft.com/2012/12/certificatecontext/field/subjectname"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certtemplateinformation", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatetemplateinformation"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certtemplatename", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatetemplatename"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certthumbprint", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/thumbprint"));
-                adfsStrings.Add(new KeyValuePair<string, string>("certx509version", "http://schemas.microsoft.com/2012/12/certificatecontext/field/x509version"));
-                adfsStrings.Add(new KeyValuePair<string, string>("acr", "http://schemas.microsoft.com/claims/authnclassreference"));
-                adfsStrings.Add(new KeyValuePair<string, string>("amr", "http://schemas.microsoft.com/claims/authnmethodsreferences"));
-
-
-                foreach (var kv in adfsStrings)
-                {
-                    Assert.True(JwtSecurityTokenHandler.InboundClaimTypeMap.ContainsKey(kv.Key), "Inbound short type missing: '" + kv.Key + "'");
-                    Assert.True(JwtSecurityTokenHandler.InboundClaimTypeMap[kv.Key] == kv.Value, "Inbound mapping wrong: key '" + kv.Key + "' expected: " + JwtSecurityTokenHandler.InboundClaimTypeMap[kv.Key] + ", received: '" + kv.Value + "'");
-                }
-
-                var handler = new JwtSecurityTokenHandler();
-
-                List<Claim> expectedInboundClaimsMapped = new List<Claim>(
-                    ClaimSets.ExpectedInClaimsIdentityUsingAllInboundShortClaimTypes(
-                            IdentityUtilities.DefaultIssuer,
-                            IdentityUtilities.DefaultIssuer
-                            ));
-
-                var jwt = handler.CreateToken(
-                    issuer: IdentityUtilities.DefaultIssuer,
-                    audience: IdentityUtilities.DefaultAudience,
-                    subject: new ClaimsIdentity(
-                        ClaimSets.AllInboundShortClaimTypes(
-                            IdentityUtilities.DefaultIssuer,
-                            IdentityUtilities.DefaultIssuer)));
-
-                List<Claim> expectedInboundClaimsUnMapped = new List<Claim>(
-                        ClaimSets.AllInboundShortClaimTypes(
-                            IdentityUtilities.DefaultIssuer,
-                            IdentityUtilities.DefaultIssuer
-                          ));
-
-
-                var validationParameters = new TokenValidationParameters
-                {
-                    RequireExpirationTime = false,
-                    RequireSignedTokens = false,
-                    ValidateAudience = false,
-                    ValidateIssuer = false,
-                };
-
-                JwtSecurityTokenHandler.InboundClaimFilter.Add("aud");
-                JwtSecurityTokenHandler.InboundClaimFilter.Add("exp");
-                JwtSecurityTokenHandler.InboundClaimFilter.Add("iat");
-                JwtSecurityTokenHandler.InboundClaimFilter.Add("iss");
-                JwtSecurityTokenHandler.InboundClaimFilter.Add("nbf");
-
-                // ValidateToken will map claims according to the InboundClaimTypeMap
-                RunClaimMappingVariation(jwt: jwt, tokenHandler: handler, validationParameters: validationParameters, expectedClaims: expectedInboundClaimsMapped, identityName: ClaimTypes.Name);
-
-                JwtSecurityTokenHandler.InboundClaimTypeMap.Clear();
-                RunClaimMappingVariation(jwt, handler, validationParameters, expectedClaims: expectedInboundClaimsUnMapped, identityName: null);
-
-                // test that setting the NameClaimType override works.
-                List<Claim> claims = new List<Claim>()
-                {
-                    new Claim( ClaimTypes.GivenName, "Bob", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( ClaimTypes.Spn,       "spn", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( JwtRegisteredClaimNames.Sub,   "Subject1", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( JwtRegisteredClaimNames.Prn,   "Principal1", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( JwtRegisteredClaimNames.Sub,   "Subject2", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( JwtRegisteredClaimNames.Prn,   "Principal2", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( JwtRegisteredClaimNames.Sub,   "Subject3", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                };
-
-                jwt = new JwtSecurityToken(issuer: Issuers.GotJwt, audience: Audiences.AuthFactors, claims: claims);
-                JwtSecurityTokenHandler.InboundClaimTypeMap = new Dictionary<string, string>()
-                {
-                    { JwtRegisteredClaimNames.Email,     "Mapped_" + JwtRegisteredClaimNames.Email },
-                    { JwtRegisteredClaimNames.GivenName, "Mapped_" + JwtRegisteredClaimNames.GivenName },
-                    { JwtRegisteredClaimNames.Prn,       "Mapped_" + JwtRegisteredClaimNames.Prn },
-                    { JwtRegisteredClaimNames.Sub,       "Mapped_" + JwtRegisteredClaimNames.Sub },
-                };
-
-                List<Claim> expectedClaims = new List<Claim>()
-                {
-                    new Claim( JwtRegisteredClaimNames.Iss, Issuers.GotJwt, ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( JwtRegisteredClaimNames.Aud, Audiences.AuthFactors, ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( "Mapped_" + JwtRegisteredClaimNames.Email, "Bob", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( ClaimTypes.Spn,   "spn", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( "Mapped_" + JwtRegisteredClaimNames.Sub, "Subject1", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( "Mapped_" + JwtRegisteredClaimNames.Prn, ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( "Mapped_" + JwtRegisteredClaimNames.Sub, "Subject2", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( "Mapped_" + JwtRegisteredClaimNames.Prn, "Principal2", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                    new Claim( "Mapped_" + JwtRegisteredClaimNames.Sub, "Subject3", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
-                };
+                Assert.True(JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.ContainsKey(kv.Key), "Inbound short type missing: " + kv.Key);
+                Assert.True(JwtSecurityTokenHandler.DefaultInboundClaimTypeMap[kv.Key] == kv.Value, "Inbound mapping wrong: key " + kv.Key + " expected: " + JwtSecurityTokenHandler.DefaultInboundClaimTypeMap[kv.Key] + ", received: " + kv.Value);
             }
-            finally
+
+            List<KeyValuePair<string, string>> adfsStrings = new List<KeyValuePair<string, string>>();
+            adfsStrings.Add(new KeyValuePair<string, string>("pwdexptime", "http://schemas.microsoft.com/ws/2012/01/passwordexpirationtime"));
+            adfsStrings.Add(new KeyValuePair<string, string>("pwdexpdays", "http://schemas.microsoft.com/ws/2012/01/passwordexpirationdays"));
+            adfsStrings.Add(new KeyValuePair<string, string>("pwdchgurl", "http://schemas.microsoft.com/ws/2012/01/passwordchangeurl"));
+            adfsStrings.Add(new KeyValuePair<string, string>("clientip", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-ip"));
+            adfsStrings.Add(new KeyValuePair<string, string>("forwardedclientip", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-forwarded-client-ip"));
+            adfsStrings.Add(new KeyValuePair<string, string>("clientapplication", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-application"));
+            adfsStrings.Add(new KeyValuePair<string, string>("clientuseragent", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-client-user-agent"));
+            adfsStrings.Add(new KeyValuePair<string, string>("endpointpath", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-endpoint-absolute-path"));
+            adfsStrings.Add(new KeyValuePair<string, string>("proxy", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-proxy"));
+            adfsStrings.Add(new KeyValuePair<string, string>("relyingpartytrustid", "http://schemas.microsoft.com/2012/01/requestcontext/claims/relyingpartytrustid"));
+            adfsStrings.Add(new KeyValuePair<string, string>("insidecorporatenetwork", "http://schemas.microsoft.com/ws/2012/01/insidecorporatenetwork"));
+            adfsStrings.Add(new KeyValuePair<string, string>("isregistereduser", "http://schemas.microsoft.com/2012/01/devicecontext/claims/isregistereduser"));
+            adfsStrings.Add(new KeyValuePair<string, string>("deviceowner", "http://schemas.microsoft.com/2012/01/devicecontext/claims/userowner"));
+            adfsStrings.Add(new KeyValuePair<string, string>("deviceid", "http://schemas.microsoft.com/2012/01/devicecontext/claims/identifier"));
+            adfsStrings.Add(new KeyValuePair<string, string>("deviceregid", "http://schemas.microsoft.com/2012/01/devicecontext/claims/registrationid"));
+            adfsStrings.Add(new KeyValuePair<string, string>("devicedispname", "http://schemas.microsoft.com/2012/01/devicecontext/claims/displayname"));
+            adfsStrings.Add(new KeyValuePair<string, string>("deviceosver", "http://schemas.microsoft.com/2012/01/devicecontext/claims/osversion"));
+            adfsStrings.Add(new KeyValuePair<string, string>("deviceismanaged", "http://schemas.microsoft.com/2012/01/devicecontext/claims/ismanaged"));
+            adfsStrings.Add(new KeyValuePair<string, string>("deviceostype", "http://schemas.microsoft.com/2012/01/devicecontext/claims/ostype"));
+            adfsStrings.Add(new KeyValuePair<string, string>("auth_time", "http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationinstant"));
+            adfsStrings.Add(new KeyValuePair<string, string>("authmethod", "http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod"));
+            adfsStrings.Add(new KeyValuePair<string, string>("email", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"));
+            adfsStrings.Add(new KeyValuePair<string, string>("given_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"));
+            adfsStrings.Add(new KeyValuePair<string, string>("unique_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"));
+            adfsStrings.Add(new KeyValuePair<string, string>("upn", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn"));
+            adfsStrings.Add(new KeyValuePair<string, string>("commonname", "http://schemas.xmlsoap.org/claims/CommonName"));
+            adfsStrings.Add(new KeyValuePair<string, string>("adfs1email", "http://schemas.xmlsoap.org/claims/EmailAddress"));
+            adfsStrings.Add(new KeyValuePair<string, string>("group", "http://schemas.xmlsoap.org/claims/Group"));
+            adfsStrings.Add(new KeyValuePair<string, string>("adfs1upn", "http://schemas.xmlsoap.org/claims/UPN"));
+            adfsStrings.Add(new KeyValuePair<string, string>("role", "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"));
+            adfsStrings.Add(new KeyValuePair<string, string>("family_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"));
+            adfsStrings.Add(new KeyValuePair<string, string>("ppid", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/privatepersonalidentifier"));
+            adfsStrings.Add(new KeyValuePair<string, string>("nameid", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"));
+            adfsStrings.Add(new KeyValuePair<string, string>("denyonlysid", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/denyonlysid"));
+            adfsStrings.Add(new KeyValuePair<string, string>("denyonlyprimarysid", "http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarysid"));
+            adfsStrings.Add(new KeyValuePair<string, string>("denyonlyprimarygroupsid", "http://schemas.microsoft.com/ws/2008/06/identity/claims/denyonlyprimarygroupsid"));
+            adfsStrings.Add(new KeyValuePair<string, string>("groupsid", "http://schemas.microsoft.com/ws/2008/06/identity/claims/groupsid"));
+            adfsStrings.Add(new KeyValuePair<string, string>("primarygroupsid", "http://schemas.microsoft.com/ws/2008/06/identity/claims/primarygroupsid"));
+            adfsStrings.Add(new KeyValuePair<string, string>("primarysid", "http://schemas.microsoft.com/ws/2008/06/identity/claims/primarysid"));
+            adfsStrings.Add(new KeyValuePair<string, string>("winaccountname", "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certapppolicy", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/applicationpolicy"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certauthoritykeyidentifier", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/authoritykeyidentifier"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certbasicconstraints", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/basicconstraints"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certeku", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/eku"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certissuer", "http://schemas.microsoft.com/2012/12/certificatecontext/field/issuer"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certissuername", "http://schemas.microsoft.com/2012/12/certificatecontext/field/issuername"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certkeyusage", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/keyusage"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certnotafter", "http://schemas.microsoft.com/2012/12/certificatecontext/field/notafter"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certnotbefore", "http://schemas.microsoft.com/2012/12/certificatecontext/field/notbefore"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certpolicy", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatepolicy"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certpublickey", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/rsa"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certrawdata", "http://schemas.microsoft.com/2012/12/certificatecontext/field/rawdata"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certsubjectaltname", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/san"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certserialnumber", "http://schemas.microsoft.com/ws/2008/06/identity/claims/serialnumber"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certsignaturealgorithm", "http://schemas.microsoft.com/2012/12/certificatecontext/field/signaturealgorithm"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certsubject", "http://schemas.microsoft.com/2012/12/certificatecontext/field/subject"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certsubjectkeyidentifier", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/subjectkeyidentifier"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certsubjectname", "http://schemas.microsoft.com/2012/12/certificatecontext/field/subjectname"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certtemplateinformation", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatetemplateinformation"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certtemplatename", "http://schemas.microsoft.com/2012/12/certificatecontext/extension/certificatetemplatename"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certthumbprint", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/thumbprint"));
+            adfsStrings.Add(new KeyValuePair<string, string>("certx509version", "http://schemas.microsoft.com/2012/12/certificatecontext/field/x509version"));
+            adfsStrings.Add(new KeyValuePair<string, string>("acr", "http://schemas.microsoft.com/claims/authnclassreference"));
+            adfsStrings.Add(new KeyValuePair<string, string>("amr", "http://schemas.microsoft.com/claims/authnmethodsreferences"));
+
+            foreach (var kv in adfsStrings)
             {
-                JwtSecurityTokenHandler.InboundClaimTypeMap = inboundClaimTypeMap;
-                JwtSecurityTokenHandler.OutboundClaimTypeMap = inboundClaimTypeMap;
-                JwtSecurityTokenHandler.InboundClaimFilter.Clear();
+                Assert.True(JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.ContainsKey(kv.Key), "Inbound short type missing: '" + kv.Key + "'");
+                Assert.True(JwtSecurityTokenHandler.DefaultInboundClaimTypeMap[kv.Key] == kv.Value, "Inbound mapping wrong: key '" + kv.Key + "' expected: " + JwtSecurityTokenHandler.DefaultInboundClaimTypeMap[kv.Key] + ", received: '" + kv.Value + "'");
             }
+
+            var handler = new JwtSecurityTokenHandler();
+
+            List<Claim> expectedInboundClaimsMapped = new List<Claim>(
+                ClaimSets.ExpectedInClaimsIdentityUsingAllInboundShortClaimTypes(
+                        IdentityUtilities.DefaultIssuer,
+                        IdentityUtilities.DefaultIssuer
+                        ));
+
+            var jwt = handler.CreateToken(
+                issuer: IdentityUtilities.DefaultIssuer,
+                audience: IdentityUtilities.DefaultAudience,
+                subject: new ClaimsIdentity(
+                    ClaimSets.AllInboundShortClaimTypes(
+                        IdentityUtilities.DefaultIssuer,
+                        IdentityUtilities.DefaultIssuer)));
+
+            List<Claim> expectedInboundClaimsUnMapped = new List<Claim>(
+                    ClaimSets.AllInboundShortClaimTypes(
+                        IdentityUtilities.DefaultIssuer,
+                        IdentityUtilities.DefaultIssuer
+                        ));
+
+            var validationParameters = new TokenValidationParameters
+            {
+                RequireExpirationTime = false,
+                RequireSignedTokens = false,
+                ValidateAudience = false,
+                ValidateIssuer = false,
+            };
+
+            handler.InboundClaimFilter.Add("aud");
+            handler.InboundClaimFilter.Add("exp");
+            handler.InboundClaimFilter.Add("iat");
+            handler.InboundClaimFilter.Add("iss");
+            handler.InboundClaimFilter.Add("nbf");
+
+            // ValidateToken will map claims according to the InboundClaimTypeMap
+            RunClaimMappingVariation(jwt: jwt, tokenHandler: handler, validationParameters: validationParameters, expectedClaims: expectedInboundClaimsMapped, identityName: ClaimTypes.Name);
+
+            handler.InboundClaimTypeMap.Clear();
+            RunClaimMappingVariation(jwt, handler, validationParameters, expectedClaims: expectedInboundClaimsUnMapped, identityName: null);
+
+            // test that setting the NameClaimType override works.
+            List<Claim> claims = new List<Claim>()
+            {
+                new Claim( JwtRegisteredClaimNames.Email, "Bob", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
+                new Claim( ClaimTypes.Spn, "spn", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
+                new Claim( JwtRegisteredClaimNames.Sub, "Subject1", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
+                new Claim( JwtRegisteredClaimNames.Prn, "Principal1", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
+                new Claim( JwtRegisteredClaimNames.Sub, "Subject2", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
+            };
+
+
+            handler = new JwtSecurityTokenHandler();
+            handler.InboundClaimFilter.Add("exp");
+            handler.InboundClaimFilter.Add("nbf");
+            handler.InboundClaimTypeMap = new Dictionary<string, string>()
+            {
+                { JwtRegisteredClaimNames.Email, "Mapped_" + JwtRegisteredClaimNames.Email },
+                { JwtRegisteredClaimNames.GivenName, "Mapped_" + JwtRegisteredClaimNames.GivenName },
+                { JwtRegisteredClaimNames.Prn, "Mapped_" + JwtRegisteredClaimNames.Prn },
+                { JwtRegisteredClaimNames.Sub, "Mapped_" + JwtRegisteredClaimNames.Sub },
+            };
+
+            jwt = handler.CreateToken(issuer: Issuers.GotJwt, audience: Audiences.AuthFactors, subject: new ClaimsIdentity(claims));
+
+            List<Claim> expectedClaims = new List<Claim>()
+            {
+                new Claim( JwtRegisteredClaimNames.Iss, Issuers.GotJwt, ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
+                new Claim( JwtRegisteredClaimNames.Aud, Audiences.AuthFactors, ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
+                new Claim( ClaimTypes.Spn, "spn", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt ),
+
+            };
+            Claim claim = null;
+            claim = new Claim("Mapped_" + JwtRegisteredClaimNames.Email, "Bob", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt);
+            claim.Properties.Add(new KeyValuePair<string, string>(JwtSecurityTokenHandler.ShortClaimTypeProperty, JwtRegisteredClaimNames.Email));
+            expectedClaims.Add(claim);
+
+            claim = new Claim("Mapped_" + JwtRegisteredClaimNames.Sub, "Subject1", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt);
+            claim.Properties.Add(new KeyValuePair<string, string>(JwtSecurityTokenHandler.ShortClaimTypeProperty, JwtRegisteredClaimNames.Sub));
+            expectedClaims.Add(claim);
+
+            claim = new Claim("Mapped_" + JwtRegisteredClaimNames.Prn, "Principal1", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt);
+            claim.Properties.Add(new KeyValuePair<string, string>(JwtSecurityTokenHandler.ShortClaimTypeProperty, JwtRegisteredClaimNames.Prn));
+            expectedClaims.Add(claim);
+
+            claim = new Claim("Mapped_" + JwtRegisteredClaimNames.Sub, "Subject2", ClaimValueTypes.String, Issuers.GotJwt, Issuers.GotJwt);
+            claim.Properties.Add(new KeyValuePair<string, string>(JwtSecurityTokenHandler.ShortClaimTypeProperty, JwtRegisteredClaimNames.Sub));
+            expectedClaims.Add(claim);
+
+            RunClaimMappingVariation(jwt, handler, validationParameters, expectedClaims: expectedClaims, identityName: null);
         }
 
         private void RunClaimMappingVariation(JwtSecurityToken jwt, JwtSecurityTokenHandler tokenHandler, TokenValidationParameters validationParameters, IEnumerable<Claim> expectedClaims, string identityName)
@@ -444,27 +446,72 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 // if it was mapped, make sure the shortname is found in the mapping and equals the claim.Type
                 if (claim.Properties.ContainsKey(JwtSecurityTokenHandler.ShortClaimTypeProperty))
                 {
-                    Assert.True(JwtSecurityTokenHandler.InboundClaimTypeMap.ContainsKey(claim.Properties[JwtSecurityTokenHandler.ShortClaimTypeProperty]), "!JwtSecurityTokenHandler.InboundClaimTypeMap.ContainsKey( claim.Properties[JwtSecurityTokenHandler.ShortClaimTypeProperty] ): " + claim.Type);
+                    Assert.True(tokenHandler.InboundClaimTypeMap.ContainsKey(claim.Properties[JwtSecurityTokenHandler.ShortClaimTypeProperty]), "!JwtSecurityTokenHandler.InboundClaimTypeMap.ContainsKey( claim.Properties[JwtSecurityTokenHandler.ShortClaimTypeProperty] ): " + claim.Type);
                 }
                 // there was no short property.
-                Assert.False(JwtSecurityTokenHandler.InboundClaimTypeMap.ContainsKey(claim.Type), "JwtSecurityTokenHandler.InboundClaimTypeMap.ContainsKey( claim.Type ), wasn't mapped claim.Type: " + claim.Type);
+                Assert.False(tokenHandler.InboundClaimTypeMap.ContainsKey(claim.Type), "JwtSecurityTokenHandler.InboundClaimTypeMap.ContainsKey( claim.Type ), wasn't mapped claim.Type: " + claim.Type);
             }
 
             foreach (Claim claim in jwt.Claims)
             {
                 string claimType = claim.Type;
 
-                if (JwtSecurityTokenHandler.InboundClaimTypeMap.ContainsKey(claimType))
+                if (tokenHandler.InboundClaimTypeMap.ContainsKey(claimType))
                 {
-                    claimType = JwtSecurityTokenHandler.InboundClaimTypeMap[claim.Type];
+                    claimType = tokenHandler.InboundClaimTypeMap[claim.Type];
                 }
 
-                if (!JwtSecurityTokenHandler.InboundClaimFilter.Contains(claim.Type))
+                if (!tokenHandler.InboundClaimFilter.Contains(claim.Type))
                 {
                     Claim firstClaim = identity.FindFirst(claimType);
                     Assert.True(firstClaim != null, "Claim firstClaim = identity.FindFirst( claimType ), firstClaim == null. claim.Type: " + claim.Type + " claimType: " + claimType);
                 }
             }
+        }
+
+        [Fact( DisplayName = "JwtSecurityTokenHandlerTests: Tests local instance claim type mapping and filtering")]
+        public void InstanceClaimMappingAndFiltering()
+        {
+            // testing if one handler overrides instance claim type map of another
+            JwtSecurityTokenHandler handler1 = new JwtSecurityTokenHandler();
+            JwtSecurityTokenHandler handler2 = new JwtSecurityTokenHandler();
+            Assert.True(handler1.InboundClaimTypeMap.Count != 0, "handler1 should not have an empty inbound claim type map");
+            handler1.InboundClaimTypeMap.Clear();
+            Assert.True(handler1.InboundClaimTypeMap.Count == 0, "handler1 should have an empty inbound claim type map");
+            Assert.True(handler2.InboundClaimTypeMap.Count != 0, "handler2 should not have an empty inbound claim type map");
+
+            // Setup
+            var jwtClaim = new Claim("jwtClaim", "claimValue");
+            var internalClaim = new Claim("internalClaim", "claimValue");
+            var unwantedClaim = new Claim("unwantedClaim", "unwantedValue");
+            var handler = new JwtSecurityTokenHandler();
+            handler.InboundClaimFilter = new HashSet<string>();
+            handler.InboundClaimTypeMap = new Dictionary<string, string>();
+            handler.OutboundClaimTypeMap = new Dictionary<string, string>();
+
+            handler.InboundClaimFilter.Add("unwantedClaim");
+            handler.InboundClaimTypeMap.Add("jwtClaim", "internalClaim");
+            handler.OutboundClaimTypeMap.Add("internalClaim", "jwtClaim");
+
+            // Test outgoing
+            var outgoingToken = handler.CreateToken(subject: new ClaimsIdentity(new Claim[] { internalClaim }));
+            var mappedClaim = System.Linq.Enumerable.FirstOrDefault(outgoingToken.Claims);
+            Assert.NotNull(mappedClaim);
+            Assert.Equal("jwtClaim", mappedClaim.Type);
+
+            // Test incoming
+            var incomingToken = handler.CreateToken(issuer: "Test Issuer", subject: new ClaimsIdentity(new Claim[] { jwtClaim, unwantedClaim }));
+            var validationParameters = new TokenValidationParameters
+            {
+                RequireSignedTokens = false,
+                ValidateAudience = false,
+                ValidateIssuer = false
+            };
+            SecurityToken token;
+            var identity = handler.ValidateToken(incomingToken.RawData, validationParameters, out token);
+            Assert.False(identity.HasClaim(c => c.Type == "unwantedClaim"));
+            Assert.False(identity.HasClaim(c => c.Type == "jwtClaim"));
+            Assert.True(identity.HasClaim("internalClaim", "claimValue"));
         }
 
         [Fact( DisplayName = "JwtSecurityTokenHandlerTests: Ensures that JwtSecurityTokenHandler defaults are as expected")]


### PR DESCRIPTION
#95
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23issuecomment-130806582%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23issuecomment-130806796%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23issuecomment-131945618%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23issuecomment-132394344%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23issuecomment-132828524%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23discussion_r37224681%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23discussion_r37224916%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23discussion_r37225310%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23discussion_r37228321%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23discussion_r37228614%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23discussion_r37229782%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23discussion_r37317858%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23discussion_r37325542%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23issuecomment-130806582%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40brentschmaltz%20%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-13T19%3A07%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20will%20squash%20the%20commits%20before%20merging.%22%2C%20%22created_at%22%3A%20%222015-08-13T19%3A08%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40brentschmaltz%20The%20commit%20history%20got%20messed%20up%2C%20I%20will%20clean%20it%20up%20before%20merging%20to%20KDev%22%2C%20%22created_at%22%3A%20%222015-08-17T20%3A07%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40brentschmaltz%20fixed%20the%20redundant%20claim%20type%20map%20properties.%22%2C%20%22created_at%22%3A%20%222015-08-18T23%3A55%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-08-19T23%3A51%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20b29f286399df5cee1b5b4af58adfc156d40f59db%20src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs%20152%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23discussion_r37228614%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22a%20nit%20really%2C%20but%20I%20would%20do%3A%20type%20%3D%20null%20so%20that%20a%20string%20copy%20is%20not%20needed%20for%20non-mapped%20claims.%22%2C%20%22created_at%22%3A%20%222015-08-17T19%3A47%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs%3AL462-484%22%7D%2C%20%22Pull%2039f80c53dd6fb9cbd6369dbfbcb6ef76782086d7%20src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs%20159%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23discussion_r37317858%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Just%20for%20clarity%20could%20you%20rename%20this%3A%20OutboundClaimTypeTransform.%5Cr%5Cnthanks%20%3A-%29%22%2C%20%22created_at%22%3A%20%222015-08-18T16%3A07%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22sure%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-18T17%3A14%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs%3AL460-482%22%7D%2C%20%22Pull%20b29f286399df5cee1b5b4af58adfc156d40f59db%20src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23discussion_r37228321%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Since%20these%20are%20by%20reference%2C%20two%20instances%20of%20JwtSecurityTokenHandler%20will%20point%20to%20the%20same%20instance%20of%20the%20Dictionary.%20The%20constructor%20will%20need%20to%20create%20a%20new%20Dictionary%3Cstring%2C%20string%3E%20for%20each%20instance.%20%5Cr%5CnFor%20example%2C%20create%20two%20JwtSecurityTokenHandlers%20j1%2C%20j2.%20call%20j1.InboundClaimTypeMap.Clear%28%29.%20j2%20will%20also%20have%20been%20cleared.%22%2C%20%22created_at%22%3A%20%222015-08-17T19%3A44%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Good%20catch.%20I%20will%20fix%20this.%22%2C%20%22created_at%22%3A%20%222015-08-17T19%3A59%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs%3AL54-69%22%7D%2C%20%22Pull%20b29f286399df5cee1b5b4af58adfc156d40f59db%20src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23discussion_r37224681%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20did%20we%20pull%20outbound%20claim%20type%20mapping%3F%22%2C%20%22created_at%22%3A%20%222015-08-17T19%3A08%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20think%20this%20is%20the%20change%20you%20suggested%20korroz%20to%20make%2C%20to%20take%20out%20any%20claim%20mapping%20in%20JwtPayload.%20The%20claims%20that%20are%20passed%20to%20JwtPayload%20are%20already%20mapped%20using%20the%20outbound%20claimtype%20map.%20Look%20at%20OutboundTransform.%22%2C%20%22created_at%22%3A%20%222015-08-17T19%3A14%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs%3AL432-439%22%7D%2C%20%22Pull%20b29f286399df5cee1b5b4af58adfc156d40f59db%20src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs%2038%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219%23discussion_r37224916%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20can%20remove%20this%20static%20constructor%22%2C%20%22created_at%22%3A%20%222015-08-17T19%3A10%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs%3AL70-91%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/brentschmaltz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/brentschmaltz'><img src='https://avatars.githubusercontent.com/u/3172421?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull b29f286399df5cee1b5b4af58adfc156d40f59db src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs 14'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219#discussion_r37224681'>File: src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs:L432-439</a></b>
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> Why did we pull outbound claim type mapping?
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> I think this is the change you suggested korroz to make, to take out any claim mapping in JwtPayload. The claims that are passed to JwtPayload are already mapped using the outbound claimtype map. Look at OutboundTransform.
- [ ] <a href='#crh-comment-Pull b29f286399df5cee1b5b4af58adfc156d40f59db src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs 38'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219#discussion_r37224916'>File: src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs:L70-91</a></b>
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> We can remove this static constructor
- [ ] <a href='#crh-comment-Pull b29f286399df5cee1b5b4af58adfc156d40f59db src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219#discussion_r37228321'>File: src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs:L54-69</a></b>
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> Since these are by reference, two instances of JwtSecurityTokenHandler will point to the same instance of the Dictionary. The constructor will need to create a new Dictionary<string, string> for each instance.
For example, create two JwtSecurityTokenHandlers j1, j2. call j1.InboundClaimTypeMap.Clear(). j2 will also have been cleared.
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> Good catch. I will fix this.
- [ ] <a href='#crh-comment-Pull b29f286399df5cee1b5b4af58adfc156d40f59db src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs 152'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219#discussion_r37228614'>File: src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs:L462-484</a></b>
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> a nit really, but I would do: type = null so that a string copy is not needed for non-mapped claims.
- [ ] <a href='#crh-comment-Pull 39f80c53dd6fb9cbd6369dbfbcb6ef76782086d7 src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs 159'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219#discussion_r37317858'>File: src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs:L460-482</a></b>
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> Just for clarity could you rename this: OutboundClaimTypeTransform.
thanks :-)
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> sure
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219#issuecomment-130806582'>General Comment</a></b>
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> @brentschmaltz
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> I will squash the commits before merging.
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> @brentschmaltz The commit history got messed up, I will clean it up before merging to KDev
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> @brentschmaltz fixed the redundant claim type map properties.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/219'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>