### PR TITLE
Protocol validation

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Exceptions/OpenIdConnectProtocolInvalidAtHashException.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Exceptions/OpenIdConnectProtocolInvalidAtHashException.cs
@@ -1,0 +1,69 @@
+//-----------------------------------------------------------------------
+// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved
+// Apache License 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
+{
+    /// <summary>
+    /// This exception is thrown when an OpenIdConnect protocol handler encounters an invalid at_hash.
+    /// </summary>
+#if DESKTOPNET45
+    [Serializable]
+#endif
+    public class OpenIdConnectProtocolInvalidAtHashException : OpenIdConnectProtocolException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenIdConnectProtocolInvalidAtHashException"/> class.
+        /// </summary>
+        public OpenIdConnectProtocolInvalidAtHashException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenIdConnectProtocolInvalidAtHashException"/> class.
+        /// </summary>
+        /// <param name="message">Addtional information to be included in the exception and displayed to user.</param>
+        public OpenIdConnectProtocolInvalidAtHashException(String message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenIdConnectProtocolInvalidAtHashException"/> class.
+        /// </summary>
+        /// <param name="message">Addtional information to be included in the exception and displayed to user.</param>
+        /// <param name="innerException">A <see cref="Exception"/> that represents the root cause of the exception.</param>
+        public OpenIdConnectProtocolInvalidAtHashException(String message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+#if DESKTOPNET45
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenIdConnectProtocolInvalidAtHashException"/> class.
+        /// </summary>
+        /// <param name="info">the <see cref="SerializationInfo"/> that holds the serialized object data.</param>
+        /// <param name="context">The contextual information about the source or destination.</param>
+        protected OpenIdConnectProtocolInvalidAtHashException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+    }
+}

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Exceptions/OpenIdConnectProtocolInvalidStateException.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Exceptions/OpenIdConnectProtocolInvalidStateException.cs
@@ -1,0 +1,69 @@
+//-----------------------------------------------------------------------
+// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved
+// Apache License 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
+{
+    /// <summary>
+    /// This exception is thrown when an OpenIdConnect protocol handler encounters an invalid state.
+    /// </summary>
+#if DESKTOPNET45
+    [Serializable]
+#endif
+    public class OpenIdConnectProtocolInvalidStateException : OpenIdConnectProtocolException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenIdConnectProtocolInvalidStateException"/> class.
+        /// </summary>
+        public OpenIdConnectProtocolInvalidStateException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenIdConnectProtocolInvalidStateException"/> class.
+        /// </summary>
+        /// <param name="message">Addtional information to be included in the exception and displayed to user.</param>
+        public OpenIdConnectProtocolInvalidStateException(String message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenIdConnectProtocolInvalidStateException"/> class.
+        /// </summary>
+        /// <param name="message">Addtional information to be included in the exception and displayed to user.</param>
+        /// <param name="innerException">A <see cref="Exception"/> that represents the root cause of the exception.</param>
+        public OpenIdConnectProtocolInvalidStateException(String message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+#if DESKTOPNET45
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenIdConnectProtocolInvalidStateException"/> class.
+        /// </summary>
+        /// <param name="info">the <see cref="SerializationInfo"/> that holds the serialized object data.</param>
+        /// <param name="context">The contextual information about the source or destination.</param>
+        protected OpenIdConnectProtocolInvalidStateException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+    }
+}

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidationContext.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidationContext.cs
@@ -16,29 +16,51 @@
 // limitations under the License.
 //-----------------------------------------------------------------------
 
+using System;
+using System.IdentityModel.Tokens.Jwt;
+
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 {
     /// <summary>
-    /// A context that is used by a <see cref="OpenIdConnectProtocolValidator"/> when validating a JwtSecurityToken.
-    /// to ensure it compliant with  http://openid.net/specs/openid-connect-core-1_0.html#IDToken .
+    /// A context that is used by a <see cref="OpenIdConnectProtocolValidator"/> when validating an OpenIdConnect Response
+    /// to ensure it compliant with http://openid.net/specs/openid-connect-core-1_0.html.
     /// </summary>
     public class OpenIdConnectProtocolValidationContext
     {
         /// <summary>
         /// Creates an instance of <see cref="OpenIdConnectProtocolValidationContext"/>
         /// </summary>
-        public OpenIdConnectProtocolValidationContext()
-        {
-        }
+        public OpenIdConnectProtocolValidationContext() {}
 
         /// <summary>
-        /// Gets or sets the 'authorizationcode'.
+        /// Gets or sets the 'code' to validate.
         /// </summary>
+        /// Obsolete - Will be removed in beta8, the Property: ProtocolMessage will have the 'code'
         public string AuthorizationCode { get; set; }
 
         /// <summary>
-        /// Gets or sets the 'nonce'
+        /// Gets or sets the 'client_id'.
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the 'nonce' that was sent with the 'Request'.
         /// </summary>
         public string Nonce { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="OpenIdConnectMessage"/> that represents the 'Response'.
+        /// </summary>
+        public OpenIdConnectMessage ProtocolMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the state that was sent with the 'Request'.
+        /// </summary>
+        public string State { get; set; }
+
+        /// <summary>
+        /// Gets or sets a validated id_token.
+        /// </summary>
+        public JwtSecurityToken IdToken { get; set; }
     }
 }

--- a/src/System.IdentityModel.Tokens/ErrorMessages.cs
+++ b/src/System.IdentityModel.Tokens/ErrorMessages.cs
@@ -77,10 +77,10 @@ namespace System.IdentityModel.Tokens
         public const string IDX10300 = "IDX10300: A claim of type: '{0}', was not found in the jwt: '{1}'.";
         public const string IDX10301 = "IDX10301: The 'nonce' found in the jwt token did not match the expected nonce.\nexpected: '{0}'\nfound in jwt: '{1}'.\njwt: '{2}'.";
         public const string IDX10303 = "IDX10303: The 'c_hash' claim was null or an empty string, jwt: '{0}'.";
-        public const string IDX10304 = "IDX10304: The c_hash: '{0}' in the jwt did not validate with the authorizationCode: '{1}', algorithm: '{2}', jwt: '{3}'.";
-        public const string IDX10306 = "IDX10306: The algorithm: '{0}' specified in the jwt header was unable to create a .Net hashAlgorithm, jwt: '{1}'. See inner exception for details.\nPossible solution is to ensure that the algorithm specified in the 'JwtHeader' is understood by .Net. You can make additions to the OpenIdConnectProtocolValidationParameters.AlgorithmMap to map algorithms from the 'Jwt' space to .Net. In .Net you can also make use of 'CryptoConfig' to map algorithms.";
-        public const string IDX10307 = "IDX10307: The algorithm: '{0}' specified in the jwt header resulted in a hashAlgorithm that was null,  jwt: '{1}'.";
-        public const string IDX10308 = "IDX10308: The 'c_hash' claim was not found in the jwt and validationContext.AuthorizationCode was not null therefore expected. jwt: '{0}'.";
+        public const string IDX10304 = "IDX10304: The hash claim: '{0}' in the id_token did not validate with against: '{1}', algorithm: '{2}'.";
+        public const string IDX10306 = "IDX10306: The algorithm: '{0}' specified in the jwt header was unable to create a .Net hashAlgorithm. See inner exception for details.\nPossible solution is to ensure that the algorithm specified in the 'JwtHeader' is understood by .Net. You can make additions to the OpenIdConnectProtocolValidationParameters.AlgorithmMap to map algorithms from the 'Jwt' space to .Net. In .Net you can also make use of 'CryptoConfig' to map algorithms.";
+        public const string IDX10307 = "IDX10307: The algorithm: '{0}' specified in the jwt header is not suported.";
+        public const string IDX10308 = "IDX10308: The 'c_hash' claim was not found in the id_token, but a 'code' was in the OpenIdConnectMessage, id_token: '{0}'";
         public const string IDX10309 = "IDX10309: OpenIdConnectProtocol requires the jwt token to have an '{0}' claim. The jwt did not contain an '{0}' claim, jwt: '{1}'.";
         public const string IDX10310 = "IDX10310: OpenIdConnectProtocol requires the jwt token to have a  valid 'aud' claim, jwt: '{0}'.";
         public const string IDX10311 = "IDX10311: RequireNonce is 'true' (default) but validationContext.Nonce is null. A nonce cannot be validated. If you don't need to check the nonce, set OpenIdConnectProtocolValidator.RequireNonce to 'false'.";
@@ -93,9 +93,18 @@ namespace System.IdentityModel.Tokens
         public const string IDX10318 = "IDX10318: The 'nonce' timestamp could not be converted to a positive integer (greater than 0).\ntimestamp: '{0}'\nnonce: '{1}'.";
         public const string IDX10319 = "IDX10319: The 'nonce' claim contains only whitespace, jwt: '{0}'.";
         public const string IDX10320 = "IDX10320: The 'nonce' timestamp: '{0}', could not be converted to a DateTime using DateTime.FromBinary({0}).\nThe value must be between: '{1}' and '{2}'.";
-        public const string IDX10321 = "IDX10321: Ahe 'nonce' timestamp: '{0}', could not be converted to a DateTime using DateTime.FromBinary({0}).\nThe value must be between: '{1}' and '{2}'.";
+        public const string IDX10321 = "IDX10321: The 'nonce' timestamp: '{0}', could not be converted to a DateTime using DateTime.FromBinary({0}).\nThe value must be between: '{1}' and '{2}'.";
         public const string IDX10322 = "IDX10322: RequireNonce is 'true' (default) but the jwt did not contain a 'nonce' claim. The nonce cannot be validated. If you don't need to check the nonce, set OpenIdConnectProtocolValidator.RequireNonce to 'false'.\n jwt: '{0}'.";
         public const string IDX10323 = "IDX10323: RequireNonce is 'false' (default is 'true') OpenIdConnectProtocolValidationContext.Nonce was NOT null, but the jwt did not contain a 'nonce' claim.\nOpenIdConnectProtocolValidationContext.Nonce: '{0}'\njwt: '{1}'.";
+        public const string IDX10324 = "IDX10324: The 'at_hash' claim was not found in the 'id_token', but a 'token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
+        public const string IDX10325 = "IDX10325: The 'at_hash' claim was not a string in the 'id_token', but a 'token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
+        public const string IDX10326 = "IDX10326: The 'c_hash' claim was not a string in the 'id_token', but a 'code' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
+        public const string IDX10327 = "IDX10327: The OpenIdConnect Request contained 'state', but the Response does not contain 'state'.";
+        public const string IDX10328 = "IDX10328: The 'state' parameter in the message: '{0}', does not equal the 'state' in the context: '{1}'.";
+        public const string IDX10329 = "IDX10329: The 'c_hash claim did not validate.";
+        public const string IDX10330 = "IDX10330: The 'at_hash' claim did not validate.";
+        public const string IDX10331 = "IDX10331: The OpenIdConnectProtocolValidationContext.IdToken == null, but OpenIdConnectProtocolValidationContext.ProtocolMessage.IdToken != null, which indicates that the 'id_token' in the OpenIdConnect Response was not validated. Validate the 'id_token' and set 'OpenIdConnectProtocolValidationContext.IdToken' property with the validated JwtSecurityToken.";
+        public const string IDX10332 = "IDX10332: The OpenIdConnectProtocolValidationContext.State is null and RequireState is true.";
 
         // SecurityTokenHandler messages
         public const string IDX10400 = "IDX10400: The '{0}', can only process SecurityTokens of type: '{1}'. The SecurityToken received is of type: '{2}'.";

--- a/test/System.IdentityModel.Tokens.Tests/ExpectedException.cs
+++ b/test/System.IdentityModel.Tokens.Tests/ExpectedException.cs
@@ -121,7 +121,7 @@ namespace System.IdentityModel.Tokens.Tests
 
             if (exception.InnerException != null && InnerTypeExpected == null)
             {
-                HandleError("exception.InnerException != null && expectedException.InnterTypeExpected == null.\nexception.InnerException: " + exception.InnerException, errors);
+                HandleError("exception.InnerException != null && expectedException.InnerTypeExpected == null.\nexception.InnerException: " + exception.InnerException, errors);
                 return;
             }
 

--- a/test/System.IdentityModel.Tokens.Tests/IdentityUtilities.cs
+++ b/test/System.IdentityModel.Tokens.Tests/IdentityUtilities.cs
@@ -38,12 +38,12 @@ namespace System.IdentityModel.Tokens.Tests
     public static class IdentityUtilities
     {
         /// <summary>
-        /// Computes the CHash per 
+        /// Computes the OIDC hash for a claim. Used for creating c_hash and at_hash claims
         /// </summary>
-        /// <param name="authorizationCode"></param>
+        /// <param name="item"></param>
         /// <param name="algorithm"></param>
         /// <returns></returns>
-        public static string CreateCHash(string authorizationCode, string algorithm)
+        public static string CreateHashClaim(string item, string algorithm)
         {
             HashAlgorithm hashAlgorithm = null;
             switch (algorithm)
@@ -64,7 +64,7 @@ namespace System.IdentityModel.Tokens.Tests
                     throw new ArgumentOutOfRangeException("Hash algorithm not known: " + algorithm);
             }
 
-            byte[] hashBytes = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(authorizationCode));
+            byte[] hashBytes = hashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(item));
             return Base64UrlEncoder.Encode(hashBytes, 0, hashBytes.Length / 2);
         }
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/tushargupta51%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23issuecomment-133114964%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-08-20T18%3A46%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20e74b59122d7a92c85cf31ffc2e703574998aacb3%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs%20401%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37554302%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%2Adoes%20not%20match%22%2C%20%22created_at%22%3A%20%222015-08-20T17%3A05%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22thanks%22%2C%20%22created_at%22%3A%20%222015-08-20T17%3A12%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs%3AL178-488%22%7D%2C%20%22Pull%202bc558de4990206ea634e5be49223b245dd53f23%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs%20471%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37563023%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20should%20validate%20the%20state%20when%20RequireState%20is%20false%20but%20ValidationContext.State%20and%20ValidationContext.Message.State%20exists.%20Similar%20to%20ValidateNonce.%20If%20state%20is%20sent%20is%20the%20request%2C%20it%20must%20be%20present%20in%20the%20response.%22%2C%20%22created_at%22%3A%20%222015-08-20T18%3A19%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22agreed%22%2C%20%22created_at%22%3A%20%222015-08-20T18%3A36%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs%3AL551-591%22%7D%2C%20%22Pull%20e74b59122d7a92c85cf31ffc2e703574998aacb3%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs%20487%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37554644%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22no%20need%20of%20conditional%20checks%20%28validationContext.State%20%3F%3F%20%5C%22null%5C%22%29%20here%20because%20of%20the%20if%20right%20above%20this.%22%2C%20%22created_at%22%3A%20%222015-08-20T17%3A08%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20need%20to%20check%20if%20%27validationContext.ProtocolMessage%27%20is%20null.%22%2C%20%22created_at%22%3A%20%222015-08-20T17%3A11%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20referring%20to%20the%20checks%20in%20the%20log%20message%3A%20validationContext.State%20%3F%3F%20%5C%22null%5C%22%2C%20validationContext.ProtocolMessage.State%20%3F%3F%20%5C%22null%5C%22%29%20as%20they%20wont%20be%20null%20at%20this%20point%20because%20of%20the%20if%20statement%20right%20above%3A%20if%28string.IsNullOrEmpty%28validationContext.State%29%20%7C%7C%20string.IsNullOrEmpty%28validationContext.ProtocolMessage.State%29%29.%20You%20can%20just%20use%5Cr%5Cn%5Cr%5CnLogHelper.Throw%28string.Format%28CultureInfo.InvariantCulture%2C%20ErrorMessages.IDX10328%2C%20validationContext.State%2C%20validationContext.ProtocolMessage.State%29%2C%20typeof%28OpenIdConnectProtocolInvalidStateException%29%2C%20EventLevel.Error%29%3B%22%2C%20%22created_at%22%3A%20%222015-08-20T17%3A17%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20I%20agree%20with%20removing%20the%20%3F%3F%2C%20I%20was%20just%20onto%20something%20else%20that%20caught%20my%20attention.%5Cr%5CnThanks%20for%20noticing%20the%20issue.%22%2C%20%22created_at%22%3A%20%222015-08-20T17%3A25%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Got%20you.%20You%20were%20talking%20about%20not%20checking%20validationContext.ProtocolMessage%20%3D%3D%20null%20at%20the%20top.%22%2C%20%22created_at%22%3A%20%222015-08-20T17%3A27%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs%3AL550-584%22%7D%2C%20%22Pull%202bc558de4990206ea634e5be49223b245dd53f23%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs%20481%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37563071%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22isNullorEmpty%28validationContext.State%29%20%3F%22%2C%20%22created_at%22%3A%20%222015-08-20T18%3A19%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs%3AL551-591%22%7D%2C%20%22Pull%202bc558de4990206ea634e5be49223b245dd53f23%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs%20487%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37563116%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22can%20remove%20the%20check%20for%20validationContext.State.%22%2C%20%22created_at%22%3A%20%222015-08-20T18%3A19%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs%3AL551-591%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23issuecomment-133114964%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37554302%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37554644%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37555017%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37555054%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37555676%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37556474%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37556607%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37563023%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37563071%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37563116%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228%23discussion_r37565221%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/tushargupta51'><img src='https://avatars.githubusercontent.com/u/803796?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull e74b59122d7a92c85cf31ffc2e703574998aacb3 src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs 401'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228#discussion_r37554302'>File: src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs:L178-488</a></b>
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> *does not match
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> thanks
- [ ] <a href='#crh-comment-Pull e74b59122d7a92c85cf31ffc2e703574998aacb3 src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs 487'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228#discussion_r37554644'>File: src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs:L550-584</a></b>
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> no need of conditional checks (validationContext.State ?? "null") here because of the if right above this.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> I need to check if 'validationContext.ProtocolMessage' is null.
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> I am referring to the checks in the log message: validationContext.State ?? "null", validationContext.ProtocolMessage.State ?? "null") as they wont be null at this point because of the if statement right above: if(string.IsNullOrEmpty(validationContext.State) || string.IsNullOrEmpty(validationContext.ProtocolMessage.State)). You can just use
LogHelper.Throw(string.Format(CultureInfo.InvariantCulture, ErrorMessages.IDX10328, validationContext.State, validationContext.ProtocolMessage.State), typeof(OpenIdConnectProtocolInvalidStateException), EventLevel.Error);
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> Yes, I agree with removing the ??, I was just onto something else that caught my attention.
Thanks for noticing the issue.
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> Got you. You were talking about not checking validationContext.ProtocolMessage == null at the top.
- [ ] <a href='#crh-comment-Pull 2bc558de4990206ea634e5be49223b245dd53f23 src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs 471'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228#discussion_r37563023'>File: src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs:L551-591</a></b>
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> We should validate the state when RequireState is false but ValidationContext.State and ValidationContext.Message.State exists. Similar to ValidateNonce. If state is sent is the request, it must be present in the response.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> agreed
- [ ] <a href='#crh-comment-Pull 2bc558de4990206ea634e5be49223b245dd53f23 src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs 481'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228#discussion_r37563071'>File: src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs:L551-591</a></b>
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> isNullorEmpty(validationContext.State) ?
- [ ] <a href='#crh-comment-Pull 2bc558de4990206ea634e5be49223b245dd53f23 src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs 487'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228#discussion_r37563116'>File: src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs:L551-591</a></b>
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> can remove the check for validationContext.State.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/228'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>