### PR TITLE
Beta8 fixes2

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -187,7 +187,13 @@ namespace Microsoft.IdentityModel.Protocols
                 }
 
                 // Stale metadata is better than no metadata
-                return _currentConfiguration;
+                if (_currentConfiguration != null)
+                    return _currentConfiguration;
+                else
+                {
+                    LogHelper.Throw(string.Format(CultureInfo.InvariantCulture, LogMessages.IDX10803, _metadataAddress ?? "null", ""), typeof(InvalidOperationException), EventLevel.Error);
+                    return null;
+                }
             }
             finally
             {

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1062,7 +1062,7 @@ namespace System.IdentityModel.Tokens.Jwt
                     {
                         if (signingKey != null && string.Equals(signingKey.KeyId, kid, StringComparison.Ordinal))
                         {
-                            return validationParameters.IssuerSigningKey;
+                            return signingKey;
                         }
                     }
                 }
@@ -1081,7 +1081,7 @@ namespace System.IdentityModel.Tokens.Jwt
                     {
                         if (signingKey != null && string.Equals(signingKey.KeyId, x5t, StringComparison.Ordinal))
                         {
-                            return validationParameters.IssuerSigningKey;
+                            return signingKey;
                         }
                     }
                 }

--- a/src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -345,6 +345,13 @@ namespace System.IdentityModel.Tokens
                 {
                     this.disposed = true;
                 }
+#if !DNXCORE50
+                if (hash != null)
+                {
+                    hash.Dispose();
+                    hash = null;
+                }
+#endif
             }
         }
     }

--- a/src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -29,7 +29,7 @@ namespace System.IdentityModel.Tokens
     {
         private bool disposed;
 #if DNXCORE50
-        private RSACng rsaCng;
+        private RSA rsaCng;
         private HashAlgorithmName hash;
 #else
         private RSACryptoServiceProvider rsaCryptoServiceProvider;
@@ -109,11 +109,11 @@ namespace System.IdentityModel.Tokens
 #if DNXCORE50
                 if (willCreateSignatures)
                 {
-                    rsaCng = RSACertificateExtensions.GetRSAPrivateKey(x509Key.Certificate) as RSACng;
+                    rsaCng = RSACertificateExtensions.GetRSAPrivateKey(x509Key.Certificate);
                 }
                 else
                 {
-                    rsaCng = RSACertificateExtensions.GetRSAPublicKey(x509Key.Certificate) as RSACng;
+                    rsaCng = RSACertificateExtensions.GetRSAPublicKey(x509Key.Certificate);
                 }
                 return;
 #else

--- a/src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -106,28 +106,23 @@ namespace System.IdentityModel.Tokens
             if (x509Key != null)
             {
                 RSACryptoServiceProvider rsa = null;
-#if DNXCORE50
-                if (willCreateSignatures)
-                {
-                    rsa = RSACertificateExtensions.GetRSAPrivateKey(x509Key.Certificate) as RSACryptoServiceProvider;
-                }
-                else
-                {
-                    rsaCng = RSACertificateExtensions.GetRSAPublicKey(x509Key.Certificate);
-                    return;
-                }
-#else
                 if (willCreateSignatures)
                 {
                     rsa = x509Key.PrivateKey as RSACryptoServiceProvider;
+                    rsaCryptoServiceProviderProxy = new RSACryptoServiceProviderProxy(rsa);
                 }
+#if DNXCORE50
+                else
+                {
+                    rsaCng = RSACertificateExtensions.GetRSAPublicKey(x509Key.Certificate);
+                }
+#else
                 else
                 {
                     rsa = x509Key.PublicKey.Key as RSACryptoServiceProvider;
+                    rsaCryptoServiceProviderProxy = new RSACryptoServiceProviderProxy(rsa);
                 }
-
 #endif
-                rsaCryptoServiceProviderProxy = new RSACryptoServiceProviderProxy(rsa);
                 return;
             }
 

--- a/src/System.IdentityModel.Tokens/LogMessages.cs
+++ b/src/System.IdentityModel.Tokens/LogMessages.cs
@@ -142,6 +142,7 @@ namespace System.IdentityModel.Tokens
         public const string IDX10504 = "IDX10504: Unable to validate signature, token does not have a signature: '{0}'";
         public const string IDX10505 = "IDX10505: Unable to validate signature. The 'Delegate' specified on TokenValidationParameters, returned a null SecurityKey.\nSecurityKeyIdentifier: '{0}'\nToken: '{1}'.";
         public const string IDX10506 = "IDX10506: Signature validation failed. The 'Delegate' specified on TokenValidationParameters returned null SecurityToken, token: '{0}'.";
+        public const string IDX10507 = "IDX10507: Cannot create RSACryptoServiceProviderProxy since the input RSACryptoServiceProvider object is null.";
 
         // Crypto Errors
         public const string IDX10600 = "IDX10600: '{0}' supports: '{1}' of types: '{2}' or '{3}'. SecurityKey received was of type: '{4}'.";

--- a/src/System.IdentityModel.Tokens/LogMessages.cs
+++ b/src/System.IdentityModel.Tokens/LogMessages.cs
@@ -138,8 +138,6 @@ namespace System.IdentityModel.Tokens
 
         // SignatureValidation
         public const string IDX10500 = "IDX10500: Signature validation failed. Unable to resolve SecurityKeyIdentifier: '{0}', \ntoken: '{1}'.";
-        public const string IDX10501 = "IDX10501: Signature validation failed. Key tried: '{0}'.\ntoken: '{1}'";
-        public const string IDX10502 = "IDX10502: Signature validation failed. Key tried: '{0}'.\nException caught:\n '{1}'.\ntoken: '{2}'";
         public const string IDX10503 = "IDX10503: Signature validation failed. Keys tried: '{0}'.\nExceptions caught:\n '{1}'.\ntoken: '{2}'";
         public const string IDX10504 = "IDX10504: Unable to validate signature, token does not have a signature: '{0}'";
         public const string IDX10505 = "IDX10505: Unable to validate signature. The 'Delegate' specified on TokenValidationParameters, returned a null SecurityKey.\nSecurityKeyIdentifier: '{0}'\nToken: '{1}'.";

--- a/src/System.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
+++ b/src/System.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Security.Cryptography;
+using Microsoft.IdentityModel.Logging;
 
 namespace System.IdentityModel.Tokens
 {
@@ -41,6 +42,7 @@ namespace System.IdentityModel.Tokens
         {
             if (rsa == null)
             {
+                LogHelper.Throw(LogMessages.IDX10507, typeof(ArgumentException));
                 return;
             }
 

--- a/src/System.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
+++ b/src/System.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
@@ -39,6 +39,11 @@ namespace System.IdentityModel.Tokens
 
         public RSACryptoServiceProviderProxy(RSACryptoServiceProvider rsa)
         {
+            if (rsa == null)
+            {
+                return;
+            }
+
             //
             // If the provider does not understand SHA256, 
             // replace it with one that does.

--- a/src/System.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/System.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -41,7 +41,7 @@ namespace System.IdentityModel.Tokens
     /// <param name="kid">a key identifier. It may be null.</param>
     /// <param name="validationParameters"><see cref="TokenValidationParameters"/> required for validation.</param>
     /// <returns>A <see cref="SecurityKey"/> to use when validating a signature.</returns>
-    public delegate SecurityKey IssuerSigningKeyResolver(string token, SecurityToken securityToken, string kid, TokenValidationParameters validationParameters);
+    public delegate IEnumerable<SecurityKey> IssuerSigningKeyResolver(string token, SecurityToken securityToken, string kid, TokenValidationParameters validationParameters);
 
     /// <summary>
     /// Definition for IssuerSigningKeyValidator.

--- a/src/System.IdentityModel.Tokens/project.json
+++ b/src/System.IdentityModel.Tokens/project.json
@@ -21,6 +21,7 @@
                 "System.Runtime.InteropServices": "4.0.21-beta-*",
                 "System.Security.Claims": "4.0.1-beta-*",
                 "System.Security.Cryptography.Algorithms": "4.0.0-beta-*",
+                "System.Security.Cryptography.Csp": "4.0.0-beta-*",
                 "System.Security.Cryptography.X509Certificates": "4.0.0-beta-*",
                 "System.Security.Principal": "4.0.1-beta-*",
                 "System.Text.RegularExpressions": "4.0.11-beta-*",

--- a/src/System.IdentityModel.Tokens/project.json
+++ b/src/System.IdentityModel.Tokens/project.json
@@ -25,7 +25,8 @@
                 "System.Security.Principal": "4.0.1-beta-*",
                 "System.Text.RegularExpressions": "4.0.11-beta-*",
                 "System.Threading": "4.0.11-beta-*",
-                "System.Xml.ReaderWriter": "4.0.11-beta-*"
+                "System.Xml.ReaderWriter": "4.0.11-beta-*",
+                "System.Security.Cryptography.Cng": "4.0.0-beta-*"
             }
         },
         "net451": {

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -147,6 +147,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
             catch (AggregateException ex)
             {
+                // this should throw, because last configuration retrived was null
+                Assert.Throws<AggregateException>(() => configuration = configManager.GetConfigurationAsync().Result);
+
                 ex.Handle((x) =>
                 {
                     ee.ProcessException(x);

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/ExtensibilityTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/ExtensibilityTests.cs
@@ -133,9 +133,8 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             string originalAlgorithmValue = ReplaceAlgorithm(SecurityAlgorithms.RsaSha256Signature, newAlgorithmValue, JwtSecurityTokenHandler.OutboundAlgorithmMap);
             JwtSecurityToken jwt = handler.CreateToken(issuer: IdentityUtilities.DefaultIssuer, audience: IdentityUtilities.DefaultAudience, signingCredentials: KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2) as JwtSecurityToken;
             ReplaceAlgorithm(SecurityAlgorithms.RsaSha256Signature, originalAlgorithmValue, JwtSecurityTokenHandler.OutboundAlgorithmMap);
-            //System.Diagnostics.Debugger.Launch();
             // outbound mapped algorithm is "bobsYourUncle", inbound map will not find this
-            ExpectedException expectedException = ExpectedException.SecurityTokenInvalidSignatureException(substringExpected: "IDX10502:");
+            ExpectedException expectedException = ExpectedException.SecurityTokenInvalidSignatureException(substringExpected: "IDX10503:");
             RunAlgorithmMappingTest(jwt.RawData, IdentityUtilities.DefaultAsymmetricTokenValidationParameters, handler, expectedException);
 
             // "bobsYourUncle" is mapped to RsaSha256

--- a/test/System.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
+++ b/test/System.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
@@ -60,7 +60,7 @@ namespace System.IdentityModel.Tokens.Tests
             {
                 AudienceValidator = IdentityUtilities.AudienceValidatorReturnsTrue,
                 IssuerSigningKey = issuerSigningKey,
-                IssuerSigningKeyResolver = (token, securityToken, keyIdentifier, tvp) => { return issuerSigningKey; },
+                IssuerSigningKeyResolver = (token, securityToken, keyIdentifier, tvp) => { return new List<SecurityKey> { issuerSigningKey }; },
                 IssuerSigningKeys = issuerSigningKeys,
                 IssuerValidator = IdentityUtilities.IssuerValidatorEcho,
                 LifetimeValidator = IdentityUtilities.LifetimeValidatorReturnsTrue,
@@ -87,7 +87,7 @@ namespace System.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParametersSets = new TokenValidationParameters();
             validationParametersSets.AudienceValidator = IdentityUtilities.AudienceValidatorReturnsTrue;
             validationParametersSets.IssuerSigningKey = KeyingMaterial.DefaultX509Key_Public_2048;
-            validationParametersSets.IssuerSigningKeyResolver = (token, securityToken, keyIdentifier, tvp) => { return issuerSigningKey2; };
+            validationParametersSets.IssuerSigningKeyResolver = (token, securityToken, keyIdentifier, tvp) => { return new List<SecurityKey> { issuerSigningKey2 }; };
             validationParametersSets.IssuerSigningKeys = issuerSigningKeysDup;
             validationParametersSets.IssuerValidator = IdentityUtilities.IssuerValidatorEcho;
             validationParametersSets.LifetimeValidator = IdentityUtilities.LifetimeValidatorReturnsTrue;


### PR DESCRIPTION
#215, #254
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23issuecomment-143049196%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23issuecomment-143267290%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23issuecomment-143270120%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23issuecomment-143271039%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23issuecomment-143356385%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23issuecomment-143878913%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23issuecomment-144121862%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40446187%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40446333%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40447144%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40447243%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40447403%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40447479%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40448127%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40486328%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40486476%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40490590%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40490602%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40609480%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40609559%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40614822%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40615255%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40619941%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40622924%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40623343%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23issuecomment-143049196%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40brentschmaltz%20%22%2C%20%22created_at%22%3A%20%222015-09-24T20%3A58%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20don%27t%20see%20anywhere%20in%20this%20change%20that%20warrants%20using%20the%20%60RSACng%60%20type%20over%20the%20%60RSA%60%20type.%20%20And%20if%20your%20desktop%20equivalency%20is%204.6%20you%20could%20even%20get%20rid%20of%20all%20of%20the%20%5C%5C%23if%20blocks%20and%20have%20unified%20code.%5Cr%5Cn%5Cr%5CnOn%20Windows%20RSACng%20is%20preferred%20over%20RSACryptoServiceProvider%2C%20but%20not%20guaranteed.%20%20But%20in%20cross-platform%20scenarios%20it%27s%20neither%20of%20those.%22%2C%20%22created_at%22%3A%20%222015-09-25T16%3A21%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10642668%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bartonjs%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40bartonjs%20thank%20you%20very%20much%20for%20your%20precious%20remarks%21%20%3A%2B1%3A%20%5Cr%5Cn%5Cr%5CnAnother%20question%3A%20IdentityModel%20has%20a%20%60RSACryptoServiceProviderProxy%60%20to%20allow%20creating%20SHA-256%20hashes%20when%20the%20original%20%60RSACryptoServiceProvider%60%20only%20supports%20SHA1%20%28primarily%20when%20the%20RSA%20key%20is%20extracted%20from%20a%20certificate%20I%20guess%29.%5Cr%5Cn%5Cr%5CnSadly%2C%20it%20crashes%20on%20Mono%20as%20it%20doesn%27t%20like%20%60CspProviderFlags.UseExistingKey%60%3A%20https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/179%5Cr%5Cn%5Cr%5CnIs%20it%20still%20the%20only%20approach%20supported%20to%20get%20a%20SHA2-compatible%20provider%3F%22%2C%20%22created_at%22%3A%20%222015-09-25T16%3A31%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6998306%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/PinpointTownes%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40PinpointTownes%20Really%20it%20depends%20on%20CAPI.%20%20If%20the%20PFX%20that%20conveyed%20the%20private%20key%20to%20the%20machine%20explicitly%20specified%20a%20CSP%2C%20and%20that%20CSP%20doesn%27t%20understand%20SHA2%2C%20it%27ll%20fail.%20%20Recent%20versions%20%28I%20couldn%27t%20find%20the%20actual%20change%2C%20so%20I%20can%27t%20say%20how%20recent%20%5C%22recent%5C%22%20is%29%20of%20the%20framework%20should%20be%20happier%20to%20use%20SHA2%20on%20RSACryptoServiceProvider%20keys%20that%20came%20from%20an%20X509Store.%5Cr%5Cn%5Cr%5CnSo%20I%27d%20suggest%20a%20flow%20of%20try%20/%20catch%20%3D%3E%20promote/wrap%3B%20and%20hopefully%20mono%27s%20RSACryptoServiceProvider%20just%20always%20accepts%20SHA-2%20family%20algorithms%20for%20input.%22%2C%20%22created_at%22%3A%20%222015-09-25T16%3A36%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10642668%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bartonjs%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40PinpointTownes%20%40bartonjs%20Thanks%20for%20your%20inputs.%20I%20did%20not%20realize%20that%20these%20changes%20got%20part%20of%20the%20PR%2C%20they%20were%20not%20ready%20for%20the%20review%20yet.%20My%20mistake.%20I%20am%20still%20in%20process%20of%20testing%20the%20code.%20I%20will%20update%20the%20code%20based%20on%20the%20feedback%2C%20not%20casting%20to%20RSACng%20and%20others.%20Will%20send%20an%20update.%22%2C%20%22created_at%22%3A%20%222015-09-25T21%3A15%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22Using%20RSACSP%20proxy%20in%20dnxcore50%20will%20be%20removed%20in%20next%20milestone%20since%20fix%20for%20https%3A//github.com/dotnet/corefx/issues/3502%20is%20in%20RC.%22%2C%20%22created_at%22%3A%20%222015-09-28T21%3A25%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-29T17%3A03%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%201d2b8a5ae29b48121233c9c16936c502585d0d23%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%2049%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40619941%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20can%20code%20this%20a%20bit%20differently%20so%20that%20when%20DNXCORE50%20is%20updated%20and%20returns%20rsaCNG%20we%20will%20not%20break.%20Basically%20expand%20the%20%23if%20DNXCORE50%22%2C%20%22created_at%22%3A%20%222015-09-28T23%3A43%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%3AL108-136%22%7D%2C%20%22Pull%20efcbd9a155cca0dadd0a9e5d8a49706e3d7000fa%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%20181%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40447243%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22SignData%20is%20available%20on%20the%20RSA%20base%20class%3B%20you%20really%20should%20avoid%20casting%20to%20the%20implementation%20type%20unless%20you%27re%20doing%20native%20interop.%22%2C%20%22created_at%22%3A%20%222015-09-25T16%3A16%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10642668%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bartonjs%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40bartonjs%20In%20FxCore%20RSA.SignData%20%28public%20byte%5B%5D%20SignData%28byte%5B%5D%20data%2C%20HashAlgorithmName%20hashAlgorithm%2C%20RSASignaturePadding%20padding%29%29%20has%20a%20different%20signature%20than%20RSA%20in%20.net%20451%20public%20byte%5B%5D%20SignData%28byte%5B%5D%20buffer%2C%20Object%20halg%29.%20How%20are%20we%20to%20think%20about%20the%20%27padding%27%3F%22%2C%20%22created_at%22%3A%20%222015-09-26T00%3A03%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40brentschmaltz%20CoreFX%27s%20RSA%20is%20aligned%20with%20.net%204.6.%5Cr%5Cn%5Cr%5Cn%60RSASignaturePadding.Pkcs1%60%20is%20the%20only%20mode%20that%20RSACryptoServiceProvider%20understands%2C%20which%20is%20why%20it%20previously%20wasn%27t%20an%20option.%20%20RSACng%20supports%20mode%20kinds%20of%20padding%2C%20so%20it%27s%20now%20a%20parameter%20on%20Sign%20and%20Verify.%22%2C%20%22created_at%22%3A%20%222015-09-26T05%3A59%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10642668%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bartonjs%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40bartonjs%20Thanks.%20It%20looks%20like%20we%20need%20to%20expand%20our%20OM%20then.%22%2C%20%22created_at%22%3A%20%222015-09-28T21%3A43%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%3AL255-270%22%7D%2C%20%22Pull%2032a2bf0da765286d68edba026e8ba3f801f19aa6%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%20225%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40623343%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20are%20we%20not%20disposing%20the%20HashAlgorithm%20for%20%21DNXCORE50%3F%22%2C%20%22created_at%22%3A%20%222015-09-29T00%3A38%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%3AL344-350%22%7D%2C%20%22Pull%201d2b8a5ae29b48121233c9c16936c502585d0d23%20src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40615255%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ResolveIssuerSigningKey%20needs%20to%20return%20%27signingKey%27%20from%20the%20enumeration.%20It%20currently%20always%20returns%20validationParameters.IssuerSigningKey.%22%2C%20%22created_at%22%3A%20%222015-09-28T22%3A43%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs%3AL787-840%22%7D%2C%20%22Pull%20efcbd9a155cca0dadd0a9e5d8a49706e3d7000fa%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%20118%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40486476%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40bartonjs%20are%20there%20any%20plans%20to%20allow%20for%20an%20algorithm%20object%20rather%20than%20%27name%27%20to%20be%20passed%20as%20an%20argument%3F%20%20I%20am%20wondering%20how%20crypto%20agility%20is%20implemented%3F%22%2C%20%22created_at%22%3A%20%222015-09-26T00%3A07%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40brentschmaltz%20I%27m%20not%20sure%20I%20follow%20the%20question.%22%2C%20%22created_at%22%3A%20%222015-09-26T06%3A00%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10642668%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bartonjs%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40bartonjs%20how%20will%20users%20plug%20in%20their%20own%20HASH%20algorithms%20when%20validating%20signatures%3F%20The%20current%20OM%20allows%20for%20passing%20a%20Hashing%20algorithm.%20AFAIK%20FxCore%20doesn%27t%20support%20CryptoConfig.%20So%20I%20am%20wondering%20that%20since%20the%20Crypto%20provider%20is%20responsible%20for%20creating%20the%20HASH%20algorithm%20from%20a%20string%2C%20how%20can%20users%20can%20plug%20a%20custom%20algorithm.%22%2C%20%22created_at%22%3A%20%222015-09-28T21%3A42%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40brentschmaltz%20I%20don%27t%20think%20that%20actually%20would%20have%20worked%20in%20the%20past%3B%20because%20at%20the%20end%20we%20wouldn%27t%20have%20known%20what%20OID%20to%20include%20in%20the%20signed%20data.%5Cr%5Cn%5Cr%5CnThat%20said%2C%20HashAlgorithmName%20isn%27t%20a%20closed%20type%2C%20so%20as%20long%20as%20they%20can%20teach%20the%20Windows%20OID%20repository%20about%20their%20algorithm%20it%20would%20work%20to%20hash%20it%20themselves%20and%20just%20call%20SignHash.%22%2C%20%22created_at%22%3A%20%222015-09-28T22%3A36%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10642668%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bartonjs%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40bartonjs%20Thanks.%5Cr%5Cn%5Cr%5CnI%20was%20referring%20specifically%20to%3A%20AsymmetricSignatureDeformatter.VerifySignature%28byte%5B%5D%20rgbHash%2C%20byte%5B%5D%20rgbSignature%29%2C%20where%20the%20%27hash%27%20was%20calculated%20independently%20and%20the%20signature%20was%20then%20verified.%20%5Cr%5Cn%5Cr%5CnWe%20will%20need%20make%20sure%20we%20can%20provide%20this%20extensibility%2C%20we%20can%20tackle%20this%20post%20beta8..%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-29T00%3A31%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%3AL142-175%22%7D%2C%20%22Pull%20efcbd9a155cca0dadd0a9e5d8a49706e3d7000fa%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%2034%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40446187%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20code%20path%20seems%20to%20assume%20that%20CNG%20is%20always%20available%20on%20CoreCLR%2C%20is%20it%20still%20true%3F%5Cr%5Cn%5Cr%5Cn/cc%20%40bartonjs%22%2C%20%22created_at%22%3A%20%222015-09-25T16%3A05%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6998306%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/PinpointTownes%22%7D%7D%2C%20%7B%22body%22%3A%20%22%5C%22Always%5C%22%20is%20a%20tough%20thing%20to%20say%3B%20because%20who%20knows%20when%20CNGNG%20will%20come%20out%20%3A%29%5Cr%5Cn%5Cr%5CnBut%2C%20yes%2C%20RSACng%20is%20always%20available%20for%20CoreFX%20%3Cstrong%3Eon%20Windows%3C/strong%3E.%22%2C%20%22created_at%22%3A%20%222015-09-25T16%3A15%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10642668%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bartonjs%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%27s%20what%20I%20though%2C%20this%20code%20is%20too%20fragile%20for%20cross-platform%20stuff%20%3Asmile%3A%20%5Cr%5Cn%5Cr%5CnCurious%3A%20is%20%60RSA.Create%28%29%60%20a%20thing%20yet%3F%22%2C%20%22created_at%22%3A%20%222015-09-25T16%3A17%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6998306%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/PinpointTownes%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nope%20%3Afrowning%3A.%20%20https%3A//github.com/dotnet/corefx/issues/2953%2C%20if%20you%20want%20to%20watch%20for%20progress.%22%2C%20%22created_at%22%3A%20%222015-09-25T16%3A25%3A58Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10642668%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bartonjs%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%3AL83-141%22%7D%2C%20%22Pull%20efcbd9a155cca0dadd0a9e5d8a49706e3d7000fa%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255%23discussion_r40446333%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Same%20remark.%20Will%20%60GetRSAPrivateKey%60%20ALWAYS%20return%20a%20CNG-based%20instance%3F%20I%27m%20pretty%20sure%20I%20read%20somewhere%20there%20was%20a%20degraded%20mode%20falling%20back%20to%20CAPI%20when%20CNG%20is%20unavailable.%5Cr%5Cn%5Cr%5Cn/cc%20%40bartonjs%22%2C%20%22created_at%22%3A%20%222015-09-25T16%3A06%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/6998306%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/PinpointTownes%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40PinpointTownes%20you%27re%20correct%3B%20there%20are%20cases%20where%20CNG%20can%20report%20back%20that%20it%20doesn%27t%20know%20how%20to%20handle%20the%20key%20%28hardware%20keys%20with%20CAPI-only%20providers%2C%20for%20example%29%2C%20in%20which%20case%20it%20falls%20back%20to%20CAPI%20%28RSACryptoServiceProvider%29.%5Cr%5Cn%5Cr%5CnOr%2C%20you%20know%2C%20you%27re%20running%20on%20non-Windows%20%3A%29.%22%2C%20%22created_at%22%3A%20%222015-09-25T16%3A18%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/10642668%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/bartonjs%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%3AL83-141%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/brentschmaltz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/brentschmaltz'><img src='https://avatars.githubusercontent.com/u/3172421?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull efcbd9a155cca0dadd0a9e5d8a49706e3d7000fa src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs 34'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255#discussion_r40446187'>File: src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs:L83-141</a></b>
- <a href='https://github.com/PinpointTownes'><img border=0 src='https://avatars.githubusercontent.com/u/6998306?v=3' height=16 width=16'></a> This code path seems to assume that CNG is always available on CoreCLR, is it still true?
/cc @bartonjs
- <a href='https://github.com/bartonjs'><img border=0 src='https://avatars.githubusercontent.com/u/10642668?v=3' height=16 width=16'></a> "Always" is a tough thing to say; because who knows when CNGNG will come out :)
But, yes, RSACng is always available for CoreFX <strong>on Windows</strong>.
- <a href='https://github.com/PinpointTownes'><img border=0 src='https://avatars.githubusercontent.com/u/6998306?v=3' height=16 width=16'></a> That's what I though, this code is too fragile for cross-platform stuff :smile:
Curious: is `RSA.Create()` a thing yet?
- <a href='https://github.com/bartonjs'><img border=0 src='https://avatars.githubusercontent.com/u/10642668?v=3' height=16 width=16'></a> Nope :frowning:.  https://github.com/dotnet/corefx/issues/2953, if you want to watch for progress.
- [ ] <a href='#crh-comment-Pull efcbd9a155cca0dadd0a9e5d8a49706e3d7000fa src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs 52'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255#discussion_r40446333'>File: src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs:L83-141</a></b>
- <a href='https://github.com/PinpointTownes'><img border=0 src='https://avatars.githubusercontent.com/u/6998306?v=3' height=16 width=16'></a> Same remark. Will `GetRSAPrivateKey` ALWAYS return a CNG-based instance? I'm pretty sure I read somewhere there was a degraded mode falling back to CAPI when CNG is unavailable.
/cc @bartonjs
- <a href='https://github.com/bartonjs'><img border=0 src='https://avatars.githubusercontent.com/u/10642668?v=3' height=16 width=16'></a> @PinpointTownes you're correct; there are cases where CNG can report back that it doesn't know how to handle the key (hardware keys with CAPI-only providers, for example), in which case it falls back to CAPI (RSACryptoServiceProvider).
Or, you know, you're running on non-Windows :).
- [ ] <a href='#crh-comment-Pull efcbd9a155cca0dadd0a9e5d8a49706e3d7000fa src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs 181'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255#discussion_r40447243'>File: src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs:L255-270</a></b>
- <a href='https://github.com/bartonjs'><img border=0 src='https://avatars.githubusercontent.com/u/10642668?v=3' height=16 width=16'></a> SignData is available on the RSA base class; you really should avoid casting to the implementation type unless you're doing native interop.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> @bartonjs In FxCore RSA.SignData (public byte[] SignData(byte[] data, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)) has a different signature than RSA in .net 451 public byte[] SignData(byte[] buffer, Object halg). How are we to think about the 'padding'?
- <a href='https://github.com/bartonjs'><img border=0 src='https://avatars.githubusercontent.com/u/10642668?v=3' height=16 width=16'></a> @brentschmaltz CoreFX's RSA is aligned with .net 4.6.
`RSASignaturePadding.Pkcs1` is the only mode that RSACryptoServiceProvider understands, which is why it previously wasn't an option.  RSACng supports mode kinds of padding, so it's now a parameter on Sign and Verify.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> @bartonjs Thanks. It looks like we need to expand our OM then.
- [ ] <a href='#crh-comment-Pull efcbd9a155cca0dadd0a9e5d8a49706e3d7000fa src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs 118'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255#discussion_r40486476'>File: src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs:L142-175</a></b>
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> @bartonjs are there any plans to allow for an algorithm object rather than 'name' to be passed as an argument?  I am wondering how crypto agility is implemented?
- <a href='https://github.com/bartonjs'><img border=0 src='https://avatars.githubusercontent.com/u/10642668?v=3' height=16 width=16'></a> @brentschmaltz I'm not sure I follow the question.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> @bartonjs how will users plug in their own HASH algorithms when validating signatures? The current OM allows for passing a Hashing algorithm. AFAIK FxCore doesn't support CryptoConfig. So I am wondering that since the Crypto provider is responsible for creating the HASH algorithm from a string, how can users can plug a custom algorithm.
- <a href='https://github.com/bartonjs'><img border=0 src='https://avatars.githubusercontent.com/u/10642668?v=3' height=16 width=16'></a> @brentschmaltz I don't think that actually would have worked in the past; because at the end we wouldn't have known what OID to include in the signed data.
That said, HashAlgorithmName isn't a closed type, so as long as they can teach the Windows OID repository about their algorithm it would work to hash it themselves and just call SignHash.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> @bartonjs Thanks.
I was referring specifically to: AsymmetricSignatureDeformatter.VerifySignature(byte[] rgbHash, byte[] rgbSignature), where the 'hash' was calculated independently and the signature was then verified.
We will need make sure we can provide this extensibility, we can tackle this post beta8..
- [ ] <a href='#crh-comment-Pull 1d2b8a5ae29b48121233c9c16936c502585d0d23 src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs 30'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255#discussion_r40615255'>File: src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs:L787-840</a></b>
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> ResolveIssuerSigningKey needs to return 'signingKey' from the enumeration. It currently always returns validationParameters.IssuerSigningKey.
- [ ] <a href='#crh-comment-Pull 1d2b8a5ae29b48121233c9c16936c502585d0d23 src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs 49'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255#discussion_r40619941'>File: src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs:L108-136</a></b>
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> We can code this a bit differently so that when DNXCORE50 is updated and returns rsaCNG we will not break. Basically expand the #if DNXCORE50
- [ ] <a href='#crh-comment-Pull 32a2bf0da765286d68edba026e8ba3f801f19aa6 src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs 225'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255#discussion_r40623343'>File: src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs:L344-350</a></b>
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> Why are we not disposing the HashAlgorithm for !DNXCORE50?
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255#issuecomment-143049196'>General Comment</a></b>
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> @brentschmaltz
- <a href='https://github.com/bartonjs'><img border=0 src='https://avatars.githubusercontent.com/u/10642668?v=3' height=16 width=16'></a> I don't see anywhere in this change that warrants using the `RSACng` type over the `RSA` type.  And if your desktop equivalency is 4.6 you could even get rid of all of the \#if blocks and have unified code.
On Windows RSACng is preferred over RSACryptoServiceProvider, but not guaranteed.  But in cross-platform scenarios it's neither of those.
- <a href='https://github.com/PinpointTownes'><img border=0 src='https://avatars.githubusercontent.com/u/6998306?v=3' height=16 width=16'></a> @bartonjs thank you very much for your precious remarks! :+1:
Another question: IdentityModel has a `RSACryptoServiceProviderProxy` to allow creating SHA-256 hashes when the original `RSACryptoServiceProvider` only supports SHA1 (primarily when the RSA key is extracted from a certificate I guess).
Sadly, it crashes on Mono as it doesn't like `CspProviderFlags.UseExistingKey`: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/179
Is it still the only approach supported to get a SHA2-compatible provider?
- <a href='https://github.com/bartonjs'><img border=0 src='https://avatars.githubusercontent.com/u/10642668?v=3' height=16 width=16'></a> @PinpointTownes Really it depends on CAPI.  If the PFX that conveyed the private key to the machine explicitly specified a CSP, and that CSP doesn't understand SHA2, it'll fail.  Recent versions (I couldn't find the actual change, so I can't say how recent "recent" is) of the framework should be happier to use SHA2 on RSACryptoServiceProvider keys that came from an X509Store.
So I'd suggest a flow of try / catch => promote/wrap; and hopefully mono's RSACryptoServiceProvider just always accepts SHA-2 family algorithms for input.
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> @PinpointTownes @bartonjs Thanks for your inputs. I did not realize that these changes got part of the PR, they were not ready for the review yet. My mistake. I am still in process of testing the code. I will update the code based on the feedback, not casting to RSACng and others. Will send an update.
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> Using RSACSP proxy in dnxcore50 will be removed in next milestone since fix for https://github.com/dotnet/corefx/issues/3502 is in RC.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/255'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>