### PR TITLE
Fixes issues with oidc protocol validation

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs
@@ -480,15 +480,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         }
 
         /// <summary>
-        /// Gets or sets 'token'.
-        /// </summary>
-        public string Token
-        {
-            get { return GetParameter(OpenIdConnectParameterNames.Token); }
-            set { SetParameter(OpenIdConnectParameterNames.Token, value); }
-        }
-
-        /// <summary>
         /// Gets or sets the value for the token endpoint.
         /// </summary>
         public string TokenEndpoint { get; set; }

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectParameterNames.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectParameterNames.cs
@@ -59,7 +59,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         public const string SessionState = "session_state";
         public const string State = "state";
         public const string TargetLinkUri = "target_link_uri";
-        public const string Token = "token";
         public const string TokenType = "token_type";
         public const string UiLocales = "ui_locales";
         public const string UserId = "user_id";

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -261,8 +261,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 LogHelper.Throw(LogMessages.IDX10333, typeof(OpenIdConnectProtocolException), EventLevel.Error);
             }
 
-            // both 'id_token' and 'token' are required
-            if (string.IsNullOrEmpty(validationContext.ProtocolMessage.IdToken) || string.IsNullOrEmpty(validationContext.ProtocolMessage.Token))
+            // both 'id_token' and 'access_token' are required
+            if (string.IsNullOrEmpty(validationContext.ProtocolMessage.IdToken) || string.IsNullOrEmpty(validationContext.ProtocolMessage.AccessToken))
             {
                 LogHelper.Throw(LogMessages.IDX10336, typeof(OpenIdConnectProtocolException), EventLevel.Error);
             }
@@ -547,7 +547,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 LogHelper.Throw(LogMessages.IDX10333, typeof(OpenIdConnectProtocolException), EventLevel.Error);
             }
 
-            if (validationContext.ProtocolMessage.Token == null)
+            if (validationContext.ProtocolMessage.AccessToken == null)
             {
                 IdentityModelEventSource.Logger.WriteInformation(LogMessages.IDX10310);
                 return;
@@ -567,7 +567,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 
             try
             {
-                ValidateHash(atHash, validationContext.ProtocolMessage.Token, validationContext.ValidatedIdToken.Header.Alg);
+                ValidateHash(atHash, validationContext.ProtocolMessage.AccessToken, validationContext.ValidatedIdToken.Header.Alg);
             }
             catch (OpenIdConnectProtocolException ex)
             {

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -77,6 +77,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             RequireState = true;
             RequireSub = false;
             RequireTimeStampInNonce = true;
+            RequireStateValidation = true;
         }
 
         /// <summary>
@@ -167,6 +168,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         /// </summary>
         [DefaultValue(true)]
         public bool RequireState { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating if validation of 'state' is turned on or off.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool RequireStateValidation { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating if a 'sub' claim is required.
@@ -672,6 +679,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         /// <exception cref="OpenIdConnectProtocolInvalidStateException">if 'state' in the context does not match the state in the message.</exception>
         protected virtual void ValidateState(OpenIdConnectProtocolValidationContext validationContext)
         {
+            if (!RequireStateValidation)
+            {
+                IdentityModelEventSource.Logger.WriteVerbose(LogMessages.IDX10342);
+                return;
+            }
+
             if (validationContext == null)
             {
                 LogHelper.Throw(string.Format(CultureInfo.InvariantCulture, LogMessages.IDX10000, GetType() + ": validationContext"), typeof(ArgumentNullException), EventLevel.Verbose);

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -225,7 +225,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 
             if (validationContext.ValidatedIdToken == null)
             {
-                LogHelper.Throw(LogMessages.IDX10331, typeof(OpenIdConnectProtocolException), EventLevel.Error);
+                LogHelper.Throw(LogMessages.IDX10332, typeof(OpenIdConnectProtocolException), EventLevel.Error);
             }
 
             // 'refresh_token' should not be returned from 'authorization_endpoint'. http://tools.ietf.org/html/rfc6749#section-4.2.2.
@@ -269,7 +269,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 
             if (validationContext.ValidatedIdToken == null)
             {
-                LogHelper.Throw(LogMessages.IDX10331, typeof(OpenIdConnectProtocolException), EventLevel.Error);
+                LogHelper.Throw(LogMessages.IDX10332, typeof(OpenIdConnectProtocolException), EventLevel.Error);
             }
 
             ValidateIdToken(validationContext);

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -74,7 +74,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             RequireAuthTime = false;
             RequireAzp = false;
             RequireNonce = true;
-            RequireStateValidation = true;
+            RequireState = true;
             RequireSub = false;
             RequireTimeStampInNonce = true;
         }
@@ -163,10 +163,10 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         public bool RequireNonce { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating if a 'state' validation is required.
+        /// Gets or sets a value indicating if a 'state' is required.
         /// </summary>
         [DefaultValue(true)]
-        public bool RequireStateValidation { get; set; }
+        public bool RequireState { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating if a 'sub' claim is required.
@@ -683,19 +683,19 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             }
 
             // if state is missing, but not required just return. Otherwise process it.
-            if (!RequireStateValidation && string.IsNullOrEmpty(validationContext.State) && string.IsNullOrEmpty(validationContext.ProtocolMessage.State))
+            if (!RequireState && string.IsNullOrEmpty(validationContext.State) && string.IsNullOrEmpty(validationContext.ProtocolMessage.State))
             {
                 IdentityModelEventSource.Logger.WriteInformation(LogMessages.IDX10341);
                 return;
             }
             else if (string.IsNullOrEmpty(validationContext.State))
             {
-                LogHelper.Throw(string.Format(CultureInfo.InvariantCulture, LogMessages.IDX10329, RequireStateValidation.ToString()), typeof(OpenIdConnectProtocolInvalidStateException), EventLevel.Error);
+                LogHelper.Throw(string.Format(CultureInfo.InvariantCulture, LogMessages.IDX10329, RequireState.ToString()), typeof(OpenIdConnectProtocolInvalidStateException), EventLevel.Error);
             }
             else if (string.IsNullOrEmpty(validationContext.ProtocolMessage.State))
             {
                 // 'state' was sent, but message does not contain 'state'
-                LogHelper.Throw(string.Format(CultureInfo.InvariantCulture, LogMessages.IDX10330, RequireStateValidation.ToString()), typeof(OpenIdConnectProtocolInvalidStateException), EventLevel.Error);
+                LogHelper.Throw(string.Format(CultureInfo.InvariantCulture, LogMessages.IDX10330, RequireState.ToString()), typeof(OpenIdConnectProtocolInvalidStateException), EventLevel.Error);
             }
 
             if (!string.Equals(validationContext.State, validationContext.ProtocolMessage.State, StringComparison.Ordinal))

--- a/src/System.IdentityModel.Tokens/LogMessages.cs
+++ b/src/System.IdentityModel.Tokens/LogMessages.cs
@@ -97,10 +97,10 @@ namespace System.IdentityModel.Tokens
         public const string IDX10306 = "IDX10306: The 'c_hash' claim was not a string in the 'id_token', but a 'code' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
         public const string IDX10307 = "IDX10307: The 'c_hash' claim was not found in the id_token, but a 'code' was in the OpenIdConnectMessage, id_token: '{0}'";
         public const string IDX10308 = "IDX10308: 'Azp' claim exist in the 'id_token' but 'ciient_id' is null. Cannot validate the 'azp' claim.";
-        public const string IDX10309 = "IDX10309: Validating 'at_hash' using id_token and token.";
-        public const string IDX10310 = "IDX10310: OpenIdConnectProtocolValidationContext.ProtocolMessage.token is null, there is no 'token' in the OpenIdConnect Response to validate.";
-        public const string IDX10311 = "IDX10311: The 'at_hash' claim was not a string in the 'id_token', but a 'token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
-        public const string IDX10312 = "IDX10312: The 'at_hash' claim was not found in the 'id_token', but a 'token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
+        public const string IDX10309 = "IDX10309: Validating 'at_hash' using id_token and access_token.";
+        public const string IDX10310 = "IDX10310: OpenIdConnectProtocolValidationContext.ProtocolMessage.AccessToken is null, there is no 'token' in the OpenIdConnect Response to validate.";
+        public const string IDX10311 = "IDX10311: The 'at_hash' claim was not a string in the 'id_token', but an 'access_token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
+        public const string IDX10312 = "IDX10312: The 'at_hash' claim was not found in the 'id_token', but a 'access_token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
         public const string IDX10313 = "IDX10313: The id_token: '{0}' is not valid. Please see exception for more details. exception: '{1}'.";
         public const string IDX10314 = "IDX10314: OpenIdConnectProtocol requires the jwt token to have an '{0}' claim. The jwt did not contain an '{0}' claim, jwt: '{1}'.";
         public const string IDX10315 = "IDX10315: RequireAcr is 'true' (default is 'false') but jwt.PayLoad.Acr is 'null or whitespace', jwt: '{0}'.";
@@ -124,7 +124,7 @@ namespace System.IdentityModel.Tokens
         public const string IDX10333 = "IDX10333: OpenIdConnectProtocolValidationContext.ProtocolMessage is null, there is no OpenIdConnect Response to validate.";
         public const string IDX10334 = "IDX10334: Both 'id_token' and 'code' are null in OpenIdConnectProtocolValidationContext.ProtocolMessage received from Authorization Endpoint. Cannot process the message.";
         public const string IDX10335 = "IDX10335: 'refresh_token' cannot be present in a response message received from Authorization Endpoint.";
-        public const string IDX10336 = "IDX10336: Both 'id_token' and 'token' should be present in OpenIdConnectProtocolValidationContext.ProtocolMessage received from Token Endpoint. Cannot process the message.";
+        public const string IDX10336 = "IDX10336: Both 'id_token' and 'access_token' should be present in OpenIdConnectProtocolValidationContext.ProtocolMessage received from Token Endpoint. Cannot process the message.";
         public const string IDX10337 = "IDX10337: OpenIdConnectProtocolValidationContext.UserInfoEndpointResponse is null, there is no OpenIdConnect Response to validate.";
         public const string IDX10338 = "IDX10338: Subject claim present in 'id_token': '{0}' does not match the claim received from UserInfo Endpoint: '{1}'.";
         public const string IDX10339 = "IDX10339: The 'id_token' contains multiple audiences but 'azp' claim is missing.";

--- a/src/System.IdentityModel.Tokens/LogMessages.cs
+++ b/src/System.IdentityModel.Tokens/LogMessages.cs
@@ -130,6 +130,7 @@ namespace System.IdentityModel.Tokens
         public const string IDX10339 = "IDX10339: The 'id_token' contains multiple audiences but 'azp' claim is missing.";
         public const string IDX10340 = "IDX10340: The 'id_token' contains 'azp' claim but its value is not equal to Client Id. 'azp': '{0}'. clientId: '{1}'.";
         public const string IDX10341 = "IDX10341: 'RequireState' = false, OpenIdConnectProtocolValidationContext.State is null and there is no 'state' in the OpenIdConnect response to validate.";
+        public const string IDX10342 = "IDX10342: 'RequireStateValidation' = false, not validating the state.";
 
 
         // SecurityTokenHandler messages

--- a/src/System.IdentityModel.Tokens/LogMessages.cs
+++ b/src/System.IdentityModel.Tokens/LogMessages.cs
@@ -117,8 +117,8 @@ namespace System.IdentityModel.Tokens
         public const string IDX10326 = "IDX10326: The 'nonce' timestamp could not be converted to a positive integer (greater than 0).\ntimestamp: '{0}'\nnonce: '{1}'.";
         public const string IDX10327 = "IDX10327: The 'nonce' timestamp: '{0}', could not be converted to a DateTime using DateTime.FromBinary({0}).\nThe value must be between: '{1}' and '{2}'.";
         public const string IDX10328 = "IDX10328: Generating nonce for openIdConnect message.";
-        public const string IDX10329 = "IDX10329: RequireStateValidation is '{0}' but the OpenIdConnectProtocolValidationContext.State is null. State cannot be validated.";
-        public const string IDX10330 = "IDX10330: RequireStateValidation is '{0}', the OpenIdConnect Request contained 'state', but the Response does not contain 'state'.";
+        public const string IDX10329 = "IDX10329: RequireState is '{0}' but the OpenIdConnectProtocolValidationContext.State is null. State cannot be validated.";
+        public const string IDX10330 = "IDX10330: RequireState is '{0}', the OpenIdConnect Request contained 'state', but the Response does not contain 'state'.";
         public const string IDX10331 = "IDX10331: The 'state' parameter in the message: '{0}', does not equal the 'state' in the context: '{1}'.";
         public const string IDX10332 = "IDX10332: OpenIdConnectProtocolValidationContext.ValidatedIdToken is null. There is no 'id_token' to validate against.";
         public const string IDX10333 = "IDX10333: OpenIdConnectProtocolValidationContext.ProtocolMessage is null, there is no OpenIdConnect Response to validate.";
@@ -129,7 +129,7 @@ namespace System.IdentityModel.Tokens
         public const string IDX10338 = "IDX10338: Subject claim present in 'id_token': '{0}' does not match the claim received from UserInfo Endpoint: '{1}'.";
         public const string IDX10339 = "IDX10339: The 'id_token' contains multiple audiences but 'azp' claim is missing.";
         public const string IDX10340 = "IDX10340: The 'id_token' contains 'azp' claim but its value is not equal to Client Id. 'azp': '{0}'. clientId: '{1}'.";
-        public const string IDX10341 = "IDX10341: 'RequireStateValidation' = false, OpenIdConnectProtocolValidationContext.State is null and there is no 'state' in the OpenIdConnect response to validate.";
+        public const string IDX10341 = "IDX10341: 'RequireState' = false, OpenIdConnectProtocolValidationContext.State is null and there is no 'state' in the OpenIdConnect response to validate.";
 
 
         // SecurityTokenHandler messages

--- a/src/System.IdentityModel.Tokens/project.json
+++ b/src/System.IdentityModel.Tokens/project.json
@@ -21,6 +21,7 @@
                 "System.Runtime.InteropServices": "4.0.21-beta-*",
                 "System.Security.Claims": "4.0.1-beta-*",
                 "System.Security.Cryptography.Algorithms": "4.0.0-beta-*",
+                "System.Security.Cryptography.Csp": "4.0.0-beta-*",
                 "System.Security.Cryptography.X509Certificates": "4.0.0-beta-*",
                 "System.Security.Principal": "4.0.1-beta-*",
                 "System.Text.RegularExpressions": "4.0.11-beta-*",

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
@@ -109,8 +109,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             OpenIdConnectMessage message = new OpenIdConnectMessage();
             Type type = typeof(OpenIdConnectMessage);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 47)
-                Assert.True(true, "Number of public fields has changed from 47 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 46)
+                Assert.True(true, "Number of public fields has changed from 46 to: " + properties.Length + ", adjust tests");
 
             GetSetContext context =
                 new GetSetContext
@@ -150,7 +150,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new KeyValuePair<string, List<object>>("SessionState", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                         new KeyValuePair<string, List<object>>("State", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                         new KeyValuePair<string, List<object>>("TargetLinkUri", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
-                        new KeyValuePair<string, List<object>>("Token", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                         new KeyValuePair<string, List<object>>("TokenEndpoint", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                         new KeyValuePair<string, List<object>>("TokenType", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                         new KeyValuePair<string, List<object>>("UiLocales", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             ValidateAuthenticationResponse(protocolValidationContext, protocolValidator, ExpectedException.NoExceptionExpected);
 
-            // no 'token' in the message
+            // no 'access_token' in the message
             ValidateTokenResponse(
                 protocolValidationContext,
                 protocolValidator,
@@ -187,7 +187,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 protocolValidator,
                 new ExpectedException(typeof(OpenIdConnectProtocolInvalidCHashException), "IDX10307:")
                 );
-            // no 'token' in the message
+            // no 'access_token' in the message
             ValidateTokenResponse(
                 protocolValidationContext,
                 protocolValidator,
@@ -197,7 +197,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             // adding chash claim
             protocolValidationContext.ValidatedIdToken.Payload.AddClaim(new Claim(JwtRegisteredClaimNames.CHash, cHashClaim));
             ValidateAuthenticationResponse(protocolValidationContext, protocolValidator, ExpectedException.NoExceptionExpected);
-            // no 'token' in the message
+            // no 'access_token' in the message
             ValidateTokenResponse(
                 protocolValidationContext,
                 protocolValidator,
@@ -228,13 +228,13 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     IdToken = Guid.NewGuid().ToString(),
                     State = validState,
                     Code = validCode,
-                    Token = validAccessToken
+                    AccessToken = validAccessToken
                 },
                 Nonce = validNonce,
                 State = validState
             };
 
-            // token present, but no atHash claim
+            // access_token present, but no atHash claim
             ValidateAuthenticationResponse(
                 protocolValidationContext,
                 protocolValidator,
@@ -268,13 +268,13 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 {
                     IdToken = Guid.NewGuid().ToString(),
                     State = validState,
-                    Token = validAccessToken
+                    AccessToken = validAccessToken
                 },
                 Nonce = validNonce,
                 State = validState
             };
 
-            // token present, but no atHash claim
+            // access_token present, but no atHash claim
             ValidateAuthenticationResponse(
                 protocolValidationContext,
                 protocolValidator,
@@ -324,7 +324,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             protocolValidationContext.State = validState;
             ValidateAuthenticationResponse(protocolValidationContext, protocolValidator, ExpectedException.NoExceptionExpected);
 
-            // absence of 'id_token' and 'token'
+            // absence of 'id_token' and 'access_token'
             ValidateTokenResponse(
                 protocolValidationContext,
                 protocolValidator,
@@ -344,12 +344,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 ProtocolMessage = new OpenIdConnectMessage
                 {
                     State = validState,
-                    Token = validAccessToken
+                    AccessToken = validAccessToken
                 },
                 State = validState
             };
 
-            // token present, but no 'id_token'
+            // access_token present, but no 'id_token'
             ValidateAuthenticationResponse(
                 protocolValidationContext,
                 protocolValidator,
@@ -378,7 +378,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 {
                     State = validState,
                     Code = validCode,
-                    Token = validAccessToken
+                    AccessToken = validAccessToken
                 },
                 State = validState
             };
@@ -386,7 +386,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             // code present, but no 'id_token'
             ValidateAuthenticationResponse(protocolValidationContext, protocolValidator, ExpectedException.NoExceptionExpected);
 
-            // 'code' and 'token' present but no 'id_token'
+            // 'code' and 'access_token' present but no 'id_token'
             ValidateTokenResponse(
                 protocolValidationContext,
                 protocolValidator,
@@ -973,7 +973,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         ProtocolMessage = new OpenIdConnectMessage
                         {
                             IdToken = Guid.NewGuid().ToString(),
-                            Token = token
+                            AccessToken = token
                         }
                     },
                     validator,
@@ -988,7 +988,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     {
                         ProtocolMessage = new OpenIdConnectMessage
                         {
-                            Token = token,
+                            AccessToken = token,
                         }
                     },
                     validator,
@@ -1004,7 +1004,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     {
                         ProtocolMessage = new OpenIdConnectMessage
                         {
-                            Token = token,
+                            AccessToken = token,
                         }
                     },
                     validator,
@@ -1020,7 +1020,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     {
                         ProtocolMessage = new OpenIdConnectMessage
                         {
-                            Token = Guid.NewGuid().ToString(),
+                            AccessToken = Guid.NewGuid().ToString(),
                         }
                     },
                     validator,
@@ -1036,7 +1036,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     {
                         ProtocolMessage = new OpenIdConnectMessage
                         {
-                            Token = Guid.NewGuid().ToString(),
+                            AccessToken = Guid.NewGuid().ToString(),
                         }
                     },
                     validator,

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new KeyValuePair<string, List<object>>("RequireNonce", new List<object>{true, false, true}),
                         new KeyValuePair<string, List<object>>("RequireSub", new List<object>{false, true, false}),
                         new KeyValuePair<string, List<object>>("RequireTimeStampInNonce", new List<object>{true, false, true}),
-                        new KeyValuePair<string, List<object>>("RequireStateValidation", new List<object>{true, false, true}),
+                        new KeyValuePair<string, List<object>>("RequireState", new List<object>{true, false, true}),
                     },
                     Object = validationParameters,
                 };
@@ -304,7 +304,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 }
             };
 
-            // 'RequireStateValidation' is true but no state passed in validationContext
+            // 'RequireState' is true but no state passed in validationContext
             ValidateAuthenticationResponse(
                 protocolValidationContext,
                 protocolValidator,
@@ -312,7 +312,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 );
 
             // turn off state validation but message.State is not null
-            protocolValidator.RequireStateValidation = false;
+            protocolValidator.RequireState = false;
             ValidateAuthenticationResponse(
                 protocolValidationContext,
                 protocolValidator,
@@ -320,7 +320,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 );
 
             // turn on state validation and add valid state
-            protocolValidator.RequireStateValidation = true;
+            protocolValidator.RequireState = true;
             protocolValidationContext.State = validState;
             ValidateAuthenticationResponse(protocolValidationContext, protocolValidator, ExpectedException.NoExceptionExpected);
 
@@ -407,7 +407,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         [Fact(DisplayName = "OpenIdConnectProtocolValidatorTests: ValidateAuthenticationResponse")]
         public void ValidateAuthenticationResponse()
         {
-            var validator = new PublicOpenIdConnectProtocolValidator { RequireStateValidation = false };
+            var validator = new PublicOpenIdConnectProtocolValidator { RequireState = false };
             var protocolValidationContext = new OpenIdConnectProtocolValidationContext
             {
                 ProtocolMessage = new OpenIdConnectMessage()
@@ -466,7 +466,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         [Fact(DisplayName = "OpenIdConnectProtocolValidatorTests: Validation of IdToken")]
         public void ValidateIdToken()
         {
-            var validator = new PublicOpenIdConnectProtocolValidator { RequireStateValidation = false };
+            var validator = new PublicOpenIdConnectProtocolValidator { RequireState = false };
             var protocolValidationContext = new OpenIdConnectProtocolValidationContext
             {
                 ProtocolMessage = new OpenIdConnectMessage()
@@ -1069,13 +1069,13 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             {
                 var dataset = new TheoryData<OpenIdConnectProtocolValidationContext, PublicOpenIdConnectProtocolValidator, ExpectedException>();
                 var validator = new PublicOpenIdConnectProtocolValidator();
-                var validatorRequireStateFalse = new PublicOpenIdConnectProtocolValidator { RequireStateValidation = false };
+                var validatorRequireStateFalse = new PublicOpenIdConnectProtocolValidator { RequireState = false };
                 var state1 = Guid.NewGuid().ToString();
                 var state2 = Guid.NewGuid().ToString();
 
                 // validationContext is null
                 dataset.Add(null, validator, ExpectedException.ArgumentNullException());
-                // validationContext does not contain state and RequireStateValidation is true
+                // validationContext does not contain state and RequireState is true
                 dataset.Add(
                     new OpenIdConnectProtocolValidationContext
                     {
@@ -1084,7 +1084,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     validator,
                     new ExpectedException(typeof(OpenIdConnectProtocolInvalidStateException), "IDX10329:")
                 );
-                // validationContext does not contain state and RequireStateValidation is false
+                // validationContext does not contain state and RequireState is false
                 dataset.Add(
                     new OpenIdConnectProtocolValidationContext
                     {

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
@@ -435,7 +435,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             ValidateAuthenticationResponse(
                 protocolValidationContext,
                 validator,
-                new ExpectedException(typeof(OpenIdConnectProtocolException), "IDX10331:")
+                new ExpectedException(typeof(OpenIdConnectProtocolException), "IDX10332:")
                 );
 
             // 'refresh_token' should not be present in the response received from Authorization Endpoint

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
@@ -25,8 +25,6 @@ using System.IdentityModel.Tokens.Tests;
 using System.Reflection;
 using System.Security.Claims;
 using System.Threading;
-using Microsoft.IdentityModel.Logging;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Xunit;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
@@ -59,8 +57,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             OpenIdConnectProtocolValidator validationParameters = new OpenIdConnectProtocolValidator();
             Type type = typeof(OpenIdConnectProtocolValidator);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 9)
-                Assert.True(true, "Number of properties has changed from 9 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 10)
+                Assert.True(true, "Number of properties has changed from 10 to: " + properties.Length + ", adjust tests");
 
             GetSetContext context =
                 new GetSetContext
@@ -76,6 +74,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new KeyValuePair<string, List<object>>("RequireSub", new List<object>{false, true, false}),
                         new KeyValuePair<string, List<object>>("RequireTimeStampInNonce", new List<object>{true, false, true}),
                         new KeyValuePair<string, List<object>>("RequireState", new List<object>{true, false, true}),
+                        new KeyValuePair<string, List<object>>("RequireStateValidation", new List<object>{true, false, true}),
                     },
                     Object = validationParameters,
                 };
@@ -1070,6 +1069,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 var dataset = new TheoryData<OpenIdConnectProtocolValidationContext, PublicOpenIdConnectProtocolValidator, ExpectedException>();
                 var validator = new PublicOpenIdConnectProtocolValidator();
                 var validatorRequireStateFalse = new PublicOpenIdConnectProtocolValidator { RequireState = false };
+                var validatorRequireStateValidationFalse = new PublicOpenIdConnectProtocolValidator { RequireStateValidation = false };
                 var state1 = Guid.NewGuid().ToString();
                 var state2 = Guid.NewGuid().ToString();
 
@@ -1128,6 +1128,20 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     },
                     validator,
                     new ExpectedException(typeof(OpenIdConnectProtocolInvalidStateException), "IDX10331:")
+                );
+
+                // state mismatch but RequireStateValidation is false
+                dataset.Add(
+                    new OpenIdConnectProtocolValidationContext()
+                    {
+                        State = state1,
+                        ProtocolMessage = new OpenIdConnectMessage
+                        {
+                            State = state2
+                        }
+                    },
+                    validatorRequireStateValidationFalse,
+                    ExpectedException.NoExceptionExpected
                 );
                 return dataset;
             }


### PR DESCRIPTION
#256 #258
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/259%23issuecomment-143480280%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/259%23issuecomment-143519877%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/259%23issuecomment-143837662%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/259%23issuecomment-143881812%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/259%23discussion_r40501580%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/259%23issuecomment-143480280%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40brentschmaltz%20%40Tratcher%20%22%2C%20%22created_at%22%3A%20%222015-09-26T19%3A14%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-27T05%3A18%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1821173%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tratcher%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40brentschmaltz%20updated%20the%20PR%22%2C%20%22created_at%22%3A%20%222015-09-28T18%3A38%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-09-28T21%3A39%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2034926216f75256053e724d79e6b9dfb83d20659e%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs%2091%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/259%23discussion_r40501580%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%27Not%20Required%27%20implies%20the%20value%20is%20optional%20rather%20than%20that%20it%20is%20required%20not%20to%20be%20present.%20What%20about%20%60ExpectState%60%20vs%20%60%21ExpectState%60%3F%20Or%20%60RequireEmptyState%60%20vs%20%60%21RequireEmptyState%60%3F%20Hmm%2C%20I%20don%27t%20know%20if%20there%27s%20a%20clear%20way%20to%20say%20this%20with%20a%20Boolean.%20You%20could%20always%20make%20it%20an%20enum%3A%20RequireState%20vs%20RequireNoState.%5Cr%5Cn%5Cr%5CnRegardless%2C%20don%27t%20block%20on%20my%20feedback%20for%20this%20property%2C%20I%20won%27t%20be%20using%20it.%22%2C%20%22created_at%22%3A%20%222015-09-27T05%3A17%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1821173%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Tratcher%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs%3AL696-715%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/brentschmaltz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%7D%2C%20%22https%3A//github.com/Tratcher%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1821173%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/brentschmaltz'><img src='https://avatars.githubusercontent.com/u/3172421?v=3' width=34 height=34></a><a href='https://github.com/Tratcher'><img src='https://avatars.githubusercontent.com/u/1821173?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull 34926216f75256053e724d79e6b9dfb83d20659e src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs 91'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/259#discussion_r40501580'>File: src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs:L696-715</a></b>
- <a href='https://github.com/Tratcher'><img border=0 src='https://avatars.githubusercontent.com/u/1821173?v=3' height=16 width=16'></a> 'Not Required' implies the value is optional rather than that it is required not to be present. What about `ExpectState` vs `!ExpectState`? Or `RequireEmptyState` vs `!RequireEmptyState`? Hmm, I don't know if there's a clear way to say this with a Boolean. You could always make it an enum: RequireState vs RequireNoState.
Regardless, don't block on my feedback for this property, I won't be using it.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/259#issuecomment-143480280'>General Comment</a></b>
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> @brentschmaltz @Tratcher
- <a href='https://github.com/Tratcher'><img border=0 src='https://avatars.githubusercontent.com/u/1821173?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> @brentschmaltz updated the PR


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/259?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/259?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/259?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/259'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>