### PR TITLE
Pass valid JWT, issue #262

### DIFF
--- a/src/System.IdentityModel.Tokens.Jwt/JwtConstants.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtConstants.cs
@@ -47,9 +47,9 @@ namespace System.IdentityModel.Tokens
         public const string TokenTypeAlt = "urn:ietf:params:oauth:token-type:jwt";
 
         /// <summary>
-        /// Token format: 'header.payload.signature'. Signature is optional, but '.' is required.
+        /// Token format: 'header.payload.signature'. Signature is optional, and if missing, trailing '.' is also optional.
         /// </summary>
-        public const string JsonCompactSerializationRegex = @"^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$";
+        public const string JsonCompactSerializationRegex = @"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$";
 
         /// <summary>
         /// When mapping json to .Net Claim(s), if the value was not a string (or an enumeration of strings), the ClaimValue will serialized using the current JSON serializer, a property will be added with the .Net type and the ClaimTypeValue will be set to 'JsonClaimValueType'.

--- a/src/System.IdentityModel.Tokens.Jwt/JwtConstants.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtConstants.cs
@@ -49,7 +49,7 @@ namespace System.IdentityModel.Tokens
         /// <summary>
         /// Token format: 'header.payload.signature'. Signature is optional, and if missing, trailing '.' is also optional.
         /// </summary>
-        public const string JsonCompactSerializationRegex = @"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$";
+        public const string JsonCompactSerializationRegex = @"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)\.(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)\.?(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$";
 
         /// <summary>
         /// When mapping json to .Net Claim(s), if the value was not a string (or an enumeration of strings), the ClaimValue will serialized using the current JSON serializer, a property will be added with the .Net type and the ClaimTypeValue will be set to 'JsonClaimValueType'.

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
@@ -373,6 +373,10 @@ namespace System.IdentityModel.Tokens
         /// <param name="jwtEncodedString">Base64Url encoded string.</param>
         internal void Decode(string jwtEncodedString)
         {
+            if (jwtEncodedString.Split(new char[] { '.' }).Length == 2)
+            {
+                jwtEncodedString += ".";
+            }
             string[] tokenParts = jwtEncodedString.Split(new char[] { '.' }, 4);
             if (tokenParts.Length != 3)
             {


### PR DESCRIPTION
Update regex, and update Decode to pass valid JWT

The current code comment in JwtConstants.cs says that the second period in the JWT is required, but my reading of the spec says otherwise, so the updated regex allows for optional second period.

7.2. Validating a JWT

When validating a JWT, the following steps are performed. The order of the steps is not significant in cases where there are no dependencies between the inputs and outputs of the steps. If any of the listed steps fail, then the JWT MUST be rejected -- that is, treated by the application as an invalid input.

    1. Verify that the JWT contains at least one period ('.') character. 


To handle this condition, JwtSecurityToken.cs Decode method could be modified to append trailing period, if there is only one present:
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-146862037%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-146864079%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-146945977%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-146954682%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-147369710%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-147781589%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-148482528%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-148865889%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-150009797%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-150662915%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-151223301%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-151225650%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-151229199%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23discussion_r43035333%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23discussion_r43038221%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23discussion_r43047212%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23discussion_r43048067%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-146862037%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40tgitchel__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20In%20order%20for%20us%20to%20evaluate%20and%20accept%20your%20PR%2C%20we%20ask%20that%20you%20sign%20a%20contribution%20license%20agreement.%20It%27s%20all%20electronic%20and%20will%20take%20just%20minutes.%20I%20promise%20there%27s%20no%20faxing.%20https%3A//cla.microsoft.com.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-10-09T12%3A55%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9287708%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msftclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22__%40tgitchel__%2C%20Thanks%20for%20signing%20the%20contribution%20license%20agreement%20so%20quickly%21%20Actual%20humans%20will%20now%20validate%20the%20agreement%20and%20then%20evaluate%20the%20PR.%5Cr%5Cn%3Cbr%20/%3EThanks%2C%20MSBOT%3B%22%2C%20%22created_at%22%3A%20%222015-10-09T13%3A00%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9287708%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msftclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40tgitchel%20thanks.%5Cr%5CnWhat%20spec%20are%20you%20referring%20to%3F%22%2C%20%22created_at%22%3A%20%222015-10-09T17%3A49%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40brentschmaltz%2C%20I%20was%20referring%20to%20the%20IETF%20draft%3A%5Cr%5Cnhttps%3A//tools.ietf.org/html/draft-ietf-oauth-json-web-token-25%5Cr%5Cnpages%2013-14%20has%20the%20validation%20rules%20I%20referenced.%22%2C%20%22created_at%22%3A%20%222015-10-09T18%3A26%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/13698635%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgitchel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Updated%20the%20regex%20to%20validate%20base64%20encoding%20of%20header%2C%20payload%2C%20and%20signature%2C%20instead%20of%20just%20simply%20checking%20for%20list%20of%20characters.%22%2C%20%22created_at%22%3A%20%222015-10-12T11%3A28%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/13698635%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgitchel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40tgitchel%20thanks%2C%20I%20hope%20to%20complete%20on%20this%20by%20EOD%2010/14.%22%2C%20%22created_at%22%3A%20%222015-10-13T17%3A14%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40tgitchel%20I%20think%20I%20see%20what%20is%20going%20on%20he.%20https%3A//tools.ietf.org/html/rfc7519%23section-7.2%20contains%20instructions%20for%20ensuring%20the%20JOSE%20header%20exists.%20It%20doesn%27t%20define%20a%20well%20formed%20JWS%20or%20JWE%20for%20that%20we%20have%20to%20consult%20http%3A//tools.ietf.org/html/rfc7515%23section-7.1%20%28JWS%29%20and%20https%3A//tools.ietf.org/html/rfc7516%23section-7.1%20%28JWE%29.%202%20and%204%20%27.%27%20dots%20are%20required%20respectively.%22%2C%20%22created_at%22%3A%20%222015-10-15T18%3A34%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Brent%2C%5Cn%5CnI%20think%20the%20use%20case%20is%20when%20we%20have%20a%20simple%20JWT%20that%20is%20neither%20signed%20nor%20encrypted.%20In%20that%20case%2C%20I%20don%27t%20think%20the%20second%20period%20is%20required.%20If%20you%20feel%20the%20second%20period%20should%20be%20required%20in%20all%20cases%2C%20remove%20the%20relevant%20question%20mark%20in%20the%20updated%20regex.%5Cn%5CnThanks%2C%5CnTim%5Cn%5Cn%5Cn%5CnSent%20with%20Good%20%28www.good.com%29%5Cn%5Cn________________________________%5CnFrom%3A%20BrentSchmaltz%5CnSent%3A%20Thursday%2C%20October%2015%2C%202015%201%3A34%3A07%20PM%5CnTo%3A%20AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet%5CnCc%3A%20Gitchel%2C%20Timothy%20A%5CnSubject%3A%20Re%3A%20%5Bazure-activedirectory-identitymodel-extensions-for-dotnet%5D%20Pass%20valid%20JWT%2C%20issue%20%23262%20%28%23277%29%5Cn%5Cn%5Cn%40tgitchel%3Chttps%3A//github.com/tgitchel%3E%20I%20think%20I%20see%20what%20is%20going%20on%20he.%20https%3A//tools.ietf.org/html/rfc7519%23section-7.2%20contains%20instructions%20for%20ensuring%20the%20JOSE%20header%20exists.%20It%20doesn%27t%20define%20a%20well%20formed%20JWS%20or%20JWE%20for%20that%20we%20have%20to%20consult%20http%3A//tools.ietf.org/html/rfc7515%23section-7.1%20%28JWS%29%20and%20https%3A//tools.ietf.org/html/rfc7516%23section-7.1%20%28JWE%29.%202%20and%204%20%27.%27%20dots%20are%20required%20respectively.%5Cn%5Cn%5Cu2014%5CnReply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%3Chttps%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23issuecomment-148482528%3E.%5Cn%5CnThe%20information%20contained%20in%20this%20e-mail%2C%20and%20any%20attachment%2C%20is%20confidential%20and%20is%20intended%20solely%20for%20the%20use%20of%20the%20intended%20recipient.%20Access%2C%20copying%20or%20re-use%20of%20the%20e-mail%20or%20any%20attachment%2C%20or%20any%20information%20contained%20therein%2C%20by%20any%20other%20person%20is%20not%20authorized.%20If%20you%20are%20not%20the%20intended%20recipient%20please%20return%20the%20e-mail%20to%20the%20sender%20and%20delete%20it%20from%20your%20computer.%20Although%20we%20attempt%20to%20sweep%20e-mail%20and%20attachments%20for%20viruses%2C%20we%20do%20not%20guarantee%20that%20either%20are%20virus-free%20and%20accept%20no%20liability%20for%20any%20damage%20sustained%20as%20a%20result%20of%20viruses.%20%5Cn%5CnPlease%20refer%20to%20http%3A//disclaimer.bnymellon.com/eu.htm%20for%20certain%20disclosures%20relating%20to%20European%20legal%20entities.%22%2C%20%22created_at%22%3A%20%222015-10-16T23%3A38%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/13698635%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgitchel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40brentschmaltz%20We%20have%20a%20property%20%5C%22RequireSignedTokens%5C%22%20in%20TVP%20to%20allow%20unsigned%20jwt%20tokens.%20That%2C%20I%20think%2C%20means%20that%20the%20token%20is%20just%20a%20JWT%20and%20not%20a%20JWS.%20In%20that%20scenario%2C%20does%20the%202%20%5C%22.%5C%22%20requirement%20make%20sense%3F%22%2C%20%22created_at%22%3A%20%222015-10-21T20%3A04%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40tushargupta51%2C%5Cr%5CnYes%2C%20that%20is%20exactly%20the%20use%20case%20that%20I%20was%20referring%20to.%20%20I%20tested%20the%20updated%20code%20using%3A%5Cr%5Cn%60%60%60%5Cr%5Cnvar%20validationParameters%20%3D%20new%20TokenValidationParameters%28%29%5Cr%5Cn%7B%5Cr%5Cn%20%20%20%20NameClaimType%20%3D%20%5C%22http%3A//wso2.org/claims/enduser%5C%22%2C%5Cr%5Cn%20%20%20%20AuthenticationType%20%3D%20%5C%22WSO2%5C%22%2C%5Cr%5Cn%20%20%20%20ValidateAudience%20%3D%20false%2C%5Cr%5Cn%20%20%20%20ValidateIssuerSigningKey%20%3D%20false%2C%5Cr%5Cn%20%20%20%20RequireSignedTokens%20%3D%20false%5Cr%5Cn%7D%3B%5Cr%5Cn%60%60%60%5Cr%5Cnwhich%20worked%20as%20expected%20for%20JWT%20in%20the%20form%20of%20%5C%22%7Bheader%7D.%7Bpayload%7D%5C%22%2C%20as%20well%20as%20%5C%22%7Bheader%7D.%7Bpayload%7D.%5C%22%2C%20and%20%5C%22%7Bheader%7D.%7Bpayload%7D.%7Bsignature%7D%5C%22%20%28signature%20ignored%29.%22%2C%20%22created_at%22%3A%20%222015-10-23T18%3A55%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/13698635%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgitchel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40tgitchel%20%40tushargupta51%20I%20agree%20that%20it%20may%20seem%20that%20logically%20the%20second%20%27.%27%20is%20not%20required%2C%20https%3A//tools.ietf.org/html/rfc7519%23section-7.2%20point%206%20indicates%20it%20is.%20It%20is%20not%20about%20the%20JSON%2C%20it%27s%20about%20JSON%20in%20compact%20serialization%20format.%20I%20checked%20with%20the%20authors%20of%20the%20specification%20as%20what%20was%20said%20made%20me%20question%20our%20implementation.%5Cr%5Cn%5Cr%5CnThe%20regex%20is%20a%20different%20issue%20and%20needs%20addressing.%20%22%2C%20%22created_at%22%3A%20%222015-10-26T17%3A45%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40brentschmaltz%20%5Cr%5CnI%20think%20that%20hard%20failing%20the%20JWT%20based%20on%20the%20%5C%22missing%5C%22%20second%20period%20would%20be%20a%20bad%20idea%20as%20the%20specification%20could%20be%20easily%20interpreted%20as%20not%20requiring%20it%2C%20but%20yes%2C%20the%20main%20point%20for%20my%20project%20is%20that%20fully%20valid%20JWS%20is%20not%20parsing%20due%20to%20errors%20in%20the%20regex.%22%2C%20%22created_at%22%3A%20%222015-10-26T17%3A52%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/13698635%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgitchel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40tgitchel%20I%20have%20to%20follow%20the%20spec%20on%20the%20%27.%27%2C%20which%20we%20can%20re-address%20by%20directly%20contacting%20the%20authors.%20For%20now%20let%27s%20focus%20on%20the%20Regex.%20Technically%2C%20I%20am%20OOF%20till%20tomorrow.%20So%2C%20let%27s%20pick%20it%20up%20then.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-10-26T18%3A04%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%206e469d58e94553fa5a68eb828f6568959a9a26b8%20src/System.IdentityModel.Tokens.Jwt/JwtConstants.cs%208%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277%23discussion_r43035333%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%27%2B%27%20and%20%27/%27%20are%20not%20valid%20base64url%20encoded%20character.%22%2C%20%22created_at%22%3A%20%222015-10-26T18%3A45%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40brentschmaltz%20Here%20are%20a%20couple%20examples%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cntoken%20%3D%20%5C%22eyJ0eXAiOiJKV1QiLCJhbGciOiJTSEEyNTZ3aXRoUlNBIiwieDV0IjoiWldVNVlqazRNVEV3WmpsaVptRm1ZMk0yT0RsbVpUWmlPVEptWWpaa01ESTJOell6WWpBeU1BPT0ifQ%3D%3D.eyJpc3MiOiJ3c28yLm9yZy9wcm9kdWN0cy9hbSIsImV4cCI6MTQzNDQ4NjQyNjM5NywiaHR0cDovL3dzbzIub3JnL2NsYWltcy9zdWJzY3JpYmVyIjoieGJibHRuYyIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvYXBwbGljYXRpb25pZCI6Ijg0MSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvYXBwbGljYXRpb25uYW1lIjoiRGVmYXVsdEFwcGxpY2F0aW9uIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9hcHBsaWNhdGlvbnRpZXIiOiJVbmxpbWl0ZWQiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2FwaWNvbnRleHQiOiIvaW1hZ2VuZXciLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL3ZlcnNpb24iOiJ2MSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvdGllciI6IkJyb256ZSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMva2V5dHlwZSI6IlNBTkRCT1giLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL3VzZXJ0eXBlIjoiQVBQTElDQVRJT04iLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2VuZHVzZXIiOiJ4YmJsdG5jIiwiaWF0IjoxNDM0NDg1NTI2Mzk3fQ%3D%3D.AgWYgHeMqcSQQQIhflvZlsa2LLKIKjhAD/2lDH82SB/27FoodZk4CSfzXnQh9DDZGXWHfxuCDH18TlRY6WpH7HCOKZRre3dbnxx0%2BhbjX8iUUk1XggQIGJTRXBHpm35ZqQcDJHxJ/3Kw%2BxvGJT0sopukbjbMhdZVQzSkfLNpDxA%3D%5C%22%3B%5Cr%5Cntoken%20%3D%20%5C%22eyJ0eXAiOiJKV1QiLCJhbGciOiJTSEEyNTZ3aXRoUlNBIiwieDV0IjoiWldVNVlqazRNVEV3WmpsaVptRm1ZMk0yT0RsbVpUWmlPVEptWWpaa01ESTJOell6WWpBeU1BPT0ifQ%3D%3D.eyJpc3MiOiJ3c28yLm9yZy9wcm9kdWN0cy9hbSIsImV4cCI6MTQ0NDgwNjg3Mjk3NCwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9zdWJzY3JpYmVyIjoieGJiajlmeSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvYXBwbGljYXRpb25pZCI6IjE1NzgiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2FwcGxpY2F0aW9ubmFtZSI6IlNlY3VyaXRpZXNEYXRhU2VydmljZUFwcGxpY2F0aW9uIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9hcHBsaWNhdGlvbnRpZXIiOiJVbmxpbWl0ZWQiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2FwaWNvbnRleHQiOiIvc2RzIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy92ZXJzaW9uIjoidjEiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL3RpZXIiOiJVbmxpbWl0ZWQiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2tleXR5cGUiOiJQUk9EVUNUSU9OIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VydHlwZSI6IkFQUExJQ0FUSU9OIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9lbmR1c2VyIjoieGJiajlmeSIsImlhdCI6MTQ0NDgwNTk3Mjk3NH0%3D.MMfZeYcfOLYwaMBP1M7oY4WpplROt7L5t%2BgtzAtQzB4ktYBCMest7TsGYvgOzN8agjGOijYlIG33N8HgEkP4KPi3Ajpcgxp6rD4jeKIIeU3NeeGGYVHPOCCww3R8uHD4mJI8QgZRO0cDoeq4ZWpzS///e4v/GUSY%2BCN8J6om6VY%3D%5C%22%3B%5Cr%5Cn%60%60%60%5Cr%5CnThe%20above%20regex%20was%20created%20from%20base64%20regex%20referenced%20here%3A%5Cr%5Cnhttp%3A//stackoverflow.com/questions/475074/regex-to-parse-or-validate-base64-data%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-10-26T19%3A06%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/13698635%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgitchel%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20see%20what%20you%20are%20talking%20about...%20%20The%20WSO2%20API%20Gateway%20is%20sending%20the%20JWS%20in%20Base64%20instead%20of%20Base64Url.%20%20I%20will%20need%20to%20do%20a%20conversion%2C%20but%20then%20the%20existing%20regex%20at%20least%20passes%20the%20token.%20%20Sorry%20for%20my%20confusion%20on%20that%20point.%22%2C%20%22created_at%22%3A%20%222015-10-26T20%3A22%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/13698635%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tgitchel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40tgitchel%20It%20might%20be%20a%20good%20idea%20to%20let%20the%20owners%20of%20WSO2%20API%20Gateway%20know%20they%20are%20not%20generating%20spec%20compliant%20Compact%20JWT%27s.%20There%20could%20be%20an%20issue%20with%20the%20signature%20if%20the%20signature%20is%20based%20off%20of%20the%20base64%20encodings.%22%2C%20%22created_at%22%3A%20%222015-10-26T20%3A28%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens.Jwt/JwtConstants.cs%3AL47-56%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277#issuecomment-146862037'>General Comment</a></b>
- <a href='https://github.com/msftclas'><img border=0 src='https://avatars.githubusercontent.com/u/9287708?v=3' height=16 width=16'></a> Hi __@tgitchel__, I'm your friendly neighborhood Microsoft Pull Request Bot (You can call me MSBOT). Thanks for your contribution!
<span>
In order for us to evaluate and accept your PR, we ask that you sign a contribution license agreement. It's all electronic and will take just minutes. I promise there's no faxing. https://cla.microsoft.com.
</span>
TTYL, MSBOT;
- <a href='https://github.com/msftclas'><img border=0 src='https://avatars.githubusercontent.com/u/9287708?v=3' height=16 width=16'></a> __@tgitchel__, Thanks for signing the contribution license agreement so quickly! Actual humans will now validate the agreement and then evaluate the PR.
<br />Thanks, MSBOT;
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> @tgitchel thanks.
What spec are you referring to?
- <a href='https://github.com/tgitchel'><img border=0 src='https://avatars.githubusercontent.com/u/13698635?v=3' height=16 width=16'></a> @brentschmaltz, I was referring to the IETF draft:
https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25
pages 13-14 has the validation rules I referenced.
- <a href='https://github.com/tgitchel'><img border=0 src='https://avatars.githubusercontent.com/u/13698635?v=3' height=16 width=16'></a> Updated the regex to validate base64 encoding of header, payload, and signature, instead of just simply checking for list of characters.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> @tgitchel thanks, I hope to complete on this by EOD 10/14.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> @tgitchel I think I see what is going on he. https://tools.ietf.org/html/rfc7519#section-7.2 contains instructions for ensuring the JOSE header exists. It doesn't define a well formed JWS or JWE for that we have to consult http://tools.ietf.org/html/rfc7515#section-7.1 (JWS) and https://tools.ietf.org/html/rfc7516#section-7.1 (JWE). 2 and 4 '.' dots are required respectively.
- <a href='https://github.com/tgitchel'><img border=0 src='https://avatars.githubusercontent.com/u/13698635?v=3' height=16 width=16'></a> Brent,
I think the use case is when we have a simple JWT that is neither signed nor encrypted. In that case, I don't think the second period is required. If you feel the second period should be required in all cases, remove the relevant question mark in the updated regex.
Thanks,
Tim
Sent with Good (www.good.com)
________________________________
From: BrentSchmaltz
Sent: Thursday, October 15, 2015 1:34:07 PM
To: AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet
Cc: Gitchel, Timothy A
Subject: Re: [azure-activedirectory-identitymodel-extensions-for-dotnet] Pass valid JWT, issue #262 (#277)
@tgitchel<https://github.com/tgitchel> I think I see what is going on he. https://tools.ietf.org/html/rfc7519#section-7.2 contains instructions for ensuring the JOSE header exists. It doesn't define a well formed JWS or JWE for that we have to consult http://tools.ietf.org/html/rfc7515#section-7.1 (JWS) and https://tools.ietf.org/html/rfc7516#section-7.1 (JWE). 2 and 4 '.' dots are required respectively.
—
Reply to this email directly or view it on GitHub<https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277#issuecomment-148482528>.
The information contained in this e-mail, and any attachment, is confidential and is intended solely for the use of the intended recipient. Access, copying or re-use of the e-mail or any attachment, or any information contained therein, by any other person is not authorized. If you are not the intended recipient please return the e-mail to the sender and delete it from your computer. Although we attempt to sweep e-mail and attachments for viruses, we do not guarantee that either are virus-free and accept no liability for any damage sustained as a result of viruses.
Please refer to http://disclaimer.bnymellon.com/eu.htm for certain disclosures relating to European legal entities.
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> @brentschmaltz We have a property "RequireSignedTokens" in TVP to allow unsigned jwt tokens. That, I think, means that the token is just a JWT and not a JWS. In that scenario, does the 2 "." requirement make sense?
- <a href='https://github.com/tgitchel'><img border=0 src='https://avatars.githubusercontent.com/u/13698635?v=3' height=16 width=16'></a> @tushargupta51,
Yes, that is exactly the use case that I was referring to.  I tested the updated code using:
```
var validationParameters = new TokenValidationParameters()
{
NameClaimType = "http://wso2.org/claims/enduser",
AuthenticationType = "WSO2",
ValidateAudience = false,
ValidateIssuerSigningKey = false,
RequireSignedTokens = false
};
```
which worked as expected for JWT in the form of "{header}.{payload}", as well as "{header}.{payload}.", and "{header}.{payload}.{signature}" (signature ignored).
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> @tgitchel @tushargupta51 I agree that it may seem that logically the second '.' is not required, https://tools.ietf.org/html/rfc7519#section-7.2 point 6 indicates it is. It is not about the JSON, it's about JSON in compact serialization format. I checked with the authors of the specification as what was said made me question our implementation.
The regex is a different issue and needs addressing.
- <a href='https://github.com/tgitchel'><img border=0 src='https://avatars.githubusercontent.com/u/13698635?v=3' height=16 width=16'></a> @brentschmaltz
I think that hard failing the JWT based on the "missing" second period would be a bad idea as the specification could be easily interpreted as not requiring it, but yes, the main point for my project is that fully valid JWS is not parsing due to errors in the regex.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> @tgitchel I have to follow the spec on the '.', which we can re-address by directly contacting the authors. For now let's focus on the Regex. Technically, I am OOF till tomorrow. So, let's pick it up then.
- [ ] <a href='#crh-comment-Pull 6e469d58e94553fa5a68eb828f6568959a9a26b8 src/System.IdentityModel.Tokens.Jwt/JwtConstants.cs 8'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277#discussion_r43035333'>File: src/System.IdentityModel.Tokens.Jwt/JwtConstants.cs:L47-56</a></b>
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> '+' and '/' are not valid base64url encoded character.
- <a href='https://github.com/tgitchel'><img border=0 src='https://avatars.githubusercontent.com/u/13698635?v=3' height=16 width=16'></a> @brentschmaltz Here are a couple examples:
```
token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJTSEEyNTZ3aXRoUlNBIiwieDV0IjoiWldVNVlqazRNVEV3WmpsaVptRm1ZMk0yT0RsbVpUWmlPVEptWWpaa01ESTJOell6WWpBeU1BPT0ifQ==.eyJpc3MiOiJ3c28yLm9yZy9wcm9kdWN0cy9hbSIsImV4cCI6MTQzNDQ4NjQyNjM5NywiaHR0cDovL3dzbzIub3JnL2NsYWltcy9zdWJzY3JpYmVyIjoieGJibHRuYyIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvYXBwbGljYXRpb25pZCI6Ijg0MSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvYXBwbGljYXRpb25uYW1lIjoiRGVmYXVsdEFwcGxpY2F0aW9uIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9hcHBsaWNhdGlvbnRpZXIiOiJVbmxpbWl0ZWQiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2FwaWNvbnRleHQiOiIvaW1hZ2VuZXciLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL3ZlcnNpb24iOiJ2MSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvdGllciI6IkJyb256ZSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMva2V5dHlwZSI6IlNBTkRCT1giLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL3VzZXJ0eXBlIjoiQVBQTElDQVRJT04iLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2VuZHVzZXIiOiJ4YmJsdG5jIiwiaWF0IjoxNDM0NDg1NTI2Mzk3fQ==.AgWYgHeMqcSQQQIhflvZlsa2LLKIKjhAD/2lDH82SB/27FoodZk4CSfzXnQh9DDZGXWHfxuCDH18TlRY6WpH7HCOKZRre3dbnxx0+hbjX8iUUk1XggQIGJTRXBHpm35ZqQcDJHxJ/3Kw+xvGJT0sopukbjbMhdZVQzSkfLNpDxA=";
token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJTSEEyNTZ3aXRoUlNBIiwieDV0IjoiWldVNVlqazRNVEV3WmpsaVptRm1ZMk0yT0RsbVpUWmlPVEptWWpaa01ESTJOell6WWpBeU1BPT0ifQ==.eyJpc3MiOiJ3c28yLm9yZy9wcm9kdWN0cy9hbSIsImV4cCI6MTQ0NDgwNjg3Mjk3NCwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9zdWJzY3JpYmVyIjoieGJiajlmeSIsImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvYXBwbGljYXRpb25pZCI6IjE1NzgiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2FwcGxpY2F0aW9ubmFtZSI6IlNlY3VyaXRpZXNEYXRhU2VydmljZUFwcGxpY2F0aW9uIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9hcHBsaWNhdGlvbnRpZXIiOiJVbmxpbWl0ZWQiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2FwaWNvbnRleHQiOiIvc2RzIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy92ZXJzaW9uIjoidjEiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL3RpZXIiOiJVbmxpbWl0ZWQiLCJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2tleXR5cGUiOiJQUk9EVUNUSU9OIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy91c2VydHlwZSI6IkFQUExJQ0FUSU9OIiwiaHR0cDovL3dzbzIub3JnL2NsYWltcy9lbmR1c2VyIjoieGJiajlmeSIsImlhdCI6MTQ0NDgwNTk3Mjk3NH0=.MMfZeYcfOLYwaMBP1M7oY4WpplROt7L5t+gtzAtQzB4ktYBCMest7TsGYvgOzN8agjGOijYlIG33N8HgEkP4KPi3Ajpcgxp6rD4jeKIIeU3NeeGGYVHPOCCww3R8uHD4mJI8QgZRO0cDoeq4ZWpzS///e4v/GUSY+CN8J6om6VY=";
```
The above regex was created from base64 regex referenced here:
http://stackoverflow.com/questions/475074/regex-to-parse-or-validate-base64-data
- <a href='https://github.com/tgitchel'><img border=0 src='https://avatars.githubusercontent.com/u/13698635?v=3' height=16 width=16'></a> I see what you are talking about...  The WSO2 API Gateway is sending the JWS in Base64 instead of Base64Url.  I will need to do a conversion, but then the existing regex at least passes the token.  Sorry for my confusion on that point.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> @tgitchel It might be a good idea to let the owners of WSO2 API Gateway know they are not generating spec compliant Compact JWT's. There could be an issue with the signature if the signature is based off of the base64 encodings.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/277'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>