### PR TITLE
Rc1 fixes p1

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfiguration.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfiguration.cs
@@ -128,12 +128,14 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             _displayValuesSupported = config._displayValuesSupported;
             EndSessionEndpoint = config.EndSessionEndpoint;
             _grantTypesSupported = config._grantTypesSupported;
+            HttpLogoutSupported = config.HttpLogoutSupported;
             _idTokenEncryptionAlgValuesSupported = config._idTokenEncryptionAlgValuesSupported;
             _idTokenEncryptionEncValuesSupported = config._idTokenEncryptionEncValuesSupported;
             _idTokenSigningAlgValuesSupported = config._idTokenSigningAlgValuesSupported;
             Issuer = config.Issuer;
             JwksUri = config.JwksUri;
             JsonWebKeySet = config.JsonWebKeySet;
+            LogoutSessionSupported = config.LogoutSessionSupported;
             OpPolicyUri = config.OpPolicyUri;
             OpTosUri = config.OpTosUri;
             RegistrationEndpoint = config.RegistrationEndpoint;
@@ -256,6 +258,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         }
 
         /// <summary>
+        /// Boolean value specifying whether the OP supports HTTP-based logout. Default is false.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore, PropertyName = OpenIdProviderMetadataNames.HttpLogoutSupported, Required = Required.Default)]
+        public bool HttpLogoutSupported { get; set; }
+
+        /// <summary>
         /// Gets the collection of 'id_token_encryption_alg_values_supported'.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore, PropertyName = OpenIdProviderMetadataNames.IdTokenEncryptionAlgValuesSupported, Required = Required.Default)]
@@ -307,6 +315,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         /// Gets or sets the <see cref="JsonWebKeySet"/>
         /// </summary>
         public JsonWebKeySet JsonWebKeySet {get; set;}
+
+        /// <summary>
+        /// Boolean value specifying whether the OP can pass a sid (session ID) query parameter to identify the RP session at the OP when the logout_uri is used. Dafault Value is false.
+        /// </summary>
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore, PropertyName = OpenIdProviderMetadataNames.LogoutSessionSupported, Required = Required.Default)]
+        public bool LogoutSessionSupported { get; set; }
 
         /// <summary>
         /// Gets or sets the 'op_policy_uri'

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs
@@ -21,8 +21,8 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics.Tracing;
 using System.Globalization;
-using System.IdentityModel.Tokens;
 using Microsoft.IdentityModel.Logging;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 {
@@ -74,8 +74,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         {
             if (nameValueCollection == null)
             {
-                IdentityModelEventSource.Logger.WriteWarning(string.Format(CultureInfo.InvariantCulture, LogMessages.IDX10000, GetType() + ": nameValueCollection"));
-                return;
+                LogHelper.Throw(string.Format(CultureInfo.InvariantCulture, LogMessages.IDX10000, GetType() + ": nameValueCollection"), typeof(ArgumentNullException), EventLevel.Verbose);
             }
 
             foreach (var key in nameValueCollection.AllKeys)
@@ -95,8 +94,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         {
             if (parameters == null)
             {
-                IdentityModelEventSource.Logger.WriteWarning(string.Format(CultureInfo.InvariantCulture, LogMessages.IDX10000, GetType() + ": parameters key-value pairs"));
-                return;
+                LogHelper.Throw(string.Format(CultureInfo.InvariantCulture, LogMessages.IDX10000, GetType() + ": parameters"), typeof(ArgumentNullException), EventLevel.Verbose);
             }
 
             foreach (KeyValuePair<string, string[]> keyValue in parameters)
@@ -111,6 +109,27 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                             break;
                         }
                     }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenIdConnectMessage"/> class.
+        /// </summary>
+        /// <param name="json">the json object from which the instance is created.</param>
+        public OpenIdConnectMessage(JObject json)
+        {
+            if (json == null)
+            {
+                LogHelper.Throw(string.Format(CultureInfo.InvariantCulture, LogMessages.IDX10000, "OpenIdConnectMessage.json"), typeof(ArgumentNullException), EventLevel.Verbose);
+            }
+
+            foreach (var pair in json)
+            {
+                JToken value;
+                if (json.TryGetValue(pair.Key, out value))
+                {
+                    SetParameter(pair.Key, value.ToString());
                 }
             }
         }

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdProviderMetadataNames.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdProviderMetadataNames.cs
@@ -35,12 +35,14 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         public const string Discovery = ".well-known/openid-configuration";
         public const string DisplayValuesSupported = "display_values_supported";
         public const string EndSessionEndpoint = "end_session_endpoint";
+        public const string HttpLogoutSupported = "http_logout_supported";
         public const string GrantTypesSupported = "grant_types_supported";
         public const string IdTokenEncryptionAlgValuesSupported = "id_token_encryption_alg_values_supported";
         public const string IdTokenEncryptionEncValuesSupported = "id_token_encryption_enc_values_supported";
         public const string IdTokenSigningAlgValuesSupported = "id_token_signing_alg_values_supported";
         public const string JwksUri = "jwks_uri";
         public const string Issuer = "issuer";
+        public const string LogoutSessionSupported = "logout_session_supported";
         public const string MicrosoftMultiRefreshToken = "microsoft_multi_refresh_token";
         public const string OpPolicyUri = "op_policy_uri";
         public const string OpTosUri = "op_tos_uri";

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -173,7 +173,6 @@ namespace Microsoft.IdentityModel.Protocols
                     {
                         // Don't use the individual CT here, this is a shared operation that shouldn't be affected by an individual's cancellation.
                         // The transport should have it's own timeouts, etc..
-
                         _currentConfiguration = await _configRetriever.GetConfigurationAsync(_metadataAddress, _docRetriever, CancellationToken.None);
                         Contract.Assert(_currentConfiguration != null);
                         _lastRefresh = now;

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationTests.cs
@@ -97,8 +97,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             OpenIdConnectConfiguration configuration = new OpenIdConnectConfiguration();
             Type type = typeof(OpenIdConnectConfiguration);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 39)
-                Assert.True(false, "Number of properties has changed from 39 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 41)
+                Assert.True(false, "Number of properties has changed from 41 to: " + properties.Length + ", adjust tests");
 
             TestUtilities.CallAllPublicInstanceAndStaticPropertyGets(configuration, "OpenIdConnectConfiguration_GetSets");
 
@@ -111,9 +111,11 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                             new KeyValuePair<string, List<object>>("CheckSessionIframe", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                             new KeyValuePair<string, List<object>>("ClaimsParameterSupported", new List<object>{false, true, false}),
                             new KeyValuePair<string, List<object>>("EndSessionEndpoint", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
+                            new KeyValuePair<string, List<object>>("HttpLogoutSupported", new List<object>{false, true, true}),
                             new KeyValuePair<string, List<object>>("Issuer",  new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                             new KeyValuePair<string, List<object>>("JwksUri",  new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                             new KeyValuePair<string, List<object>>("JsonWebKeySet",  new List<object>{null, new JsonWebKeySet()}),
+                            new KeyValuePair<string, List<object>>("LogoutSessionSupported", new List<object>{false, true, true}),
                             new KeyValuePair<string, List<object>>("OpPolicyUri", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                             new KeyValuePair<string, List<object>>("OpTosUri", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                             new KeyValuePair<string, List<object>>("RegistrationEndpoint", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IdentityModel.Tokens.Tests;
 using System.Reflection;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
@@ -47,6 +48,25 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             {
                 expectedException.ProcessException(exception);
             }
+
+            expectedException = ExpectedException.NoExceptionExpected;
+            try
+            {
+                string json = @"{""response_mode"":""responseMode"", ""response_type"":""responseType"", ""refresh_token"":""refreshToken""}";
+                openIdConnectMessage = new OpenIdConnectMessage(JObject.Parse(json));
+                expectedException.ProcessNoException();
+            }
+            catch (Exception exception)
+            {
+                expectedException.ProcessException(exception);
+            }
+            Assert.True(openIdConnectMessage.RefreshToken.Equals("refreshToken"), "openIdConnectMessage.RefreshToken does not match expected value: refreshToken");
+            Assert.True(openIdConnectMessage.ResponseMode.Equals("responseMode"), "openIdConnectMessage.ResponseMode does not match expected value: refreshToken");
+            Assert.True(openIdConnectMessage.ResponseType.Equals("responseType"), "openIdConnectMessage.ResponseType does not match expected value: refreshToken");
+            Assert.True(openIdConnectMessage.ClientId == null, "openIdConnectMessage.ClientId is not null");
+
+            // test with an empty JObject
+            openIdConnectMessage = new OpenIdConnectMessage(new JObject());
         }
 
         [Fact(DisplayName = "OpenIdConnectMessageTests: Defaults")]


### PR DESCRIPTION
#266, #276
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/285%23issuecomment-148280458%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/285%23issuecomment-148789911%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/285%23discussion_r42083265%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/commit/9656e93833ae56367b1f2a30caa7d4068dc07f00%23commitcomment-13802676%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/commit/9656e93833ae56367b1f2a30caa7d4068dc07f00%23commitcomment-13803102%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/285%23issuecomment-148280458%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40brentschmaltz%20%22%2C%20%22created_at%22%3A%20%222015-10-15T04%3A45%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-10-16T18%3A16%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Commit%209656e93833ae56367b1f2a30caa7d4068dc07f00%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs%2049%20132%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/commit/9656e93833ae56367b1f2a30caa7d4068dc07f00%23commitcomment-13802676%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22What%20is%20going%20to%20happen%20if%20the%20value%20is%20an%20object%20other%20than%20string%3F%20Will%20we%20get%20the%20type%20name%3F%22%2C%20%22created_at%22%3A%20%222015-10-15T20%3A33%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%22ToString%28%29%20always%20returns%20JSON%20representation%20of%20the%20JToken%20which%20will%20be%20a%20string.%22%2C%20%22created_at%22%3A%20%222015-10-15T20%3A53%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs%3AL132%20%289656e93%29%22%7D%2C%20%22Pull%20caa2be3b7522b44f0c740fd605f7425b50c44c60%20src/System.IdentityModel.Tokens.Jwt/JwtHeader.cs%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/285%23discussion_r42083265%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20added%20this%20optional%20parameter%20for%20instance%20based%20maps%20to%20actually%20work.%20We%20can%20revisit%20this%20when%20we%20tackle%20the%20signing%20credentials%20problems.%22%2C%20%22created_at%22%3A%20%222015-10-15T04%3A46%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens.Jwt/JwtHeader.cs%3AL60-67%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/brentschmaltz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/brentschmaltz'><img src='https://avatars.githubusercontent.com/u/3172421?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull caa2be3b7522b44f0c740fd605f7425b50c44c60 src/System.IdentityModel.Tokens.Jwt/JwtHeader.cs 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/285#discussion_r42083265'>File: src/System.IdentityModel.Tokens.Jwt/JwtHeader.cs:L60-67</a></b>
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> I added this optional parameter for instance based maps to actually work. We can revisit this when we tackle the signing credentials problems.
- [ ] <a href='#crh-comment-Commit 9656e93833ae56367b1f2a30caa7d4068dc07f00 src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs 49 132'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/commit/9656e93833ae56367b1f2a30caa7d4068dc07f00#commitcomment-13802676'>File: src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs:L132 (9656e93)</a></b>
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> What is going to happen if the value is an object other than string? Will we get the type name?
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> ToString() always returns JSON representation of the JToken which will be a string.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/285#issuecomment-148280458'>General Comment</a></b>
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> @brentschmaltz


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/285?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/285?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/285?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/285'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>