### PR TITLE
fixing dispose method

### DIFF
--- a/src/Microsoft.IdentityModel.Logging/TextWriterEventListener.cs
+++ b/src/Microsoft.IdentityModel.Logging/TextWriterEventListener.cs
@@ -105,7 +105,7 @@ namespace Microsoft.IdentityModel.Logging
 
         public override void Dispose()
         {
-            if (_disposeStreamWriter)
+            if (_disposeStreamWriter && _streamWriter != null)
             {
                 _streamWriter.Flush();
                 _streamWriter.Dispose();

--- a/src/Microsoft.IdentityModel.Logging/project.json
+++ b/src/Microsoft.IdentityModel.Logging/project.json
@@ -3,8 +3,7 @@
     "description": "Includes Event Source based logging support.",
     "dependencies": { },
     "frameworks": {
-        "dnx451": { },
-        "dnxcore50": {
+        "dotnet5.4": {
             "dependencies": {
                 "System.Diagnostics.Tracing": "4.0.21-beta-*",
                 "System.Globalization": "4.0.11-beta-*",

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/project.json
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/project.json
@@ -5,8 +5,7 @@
         "Microsoft.IdentityModel.Protocols": "2.0.0-*"
     },
     "frameworks": {
-        "dnx451": { },
-        "dnxcore50": {
+        "dotnet5.4": {
             "dependencies": {
                 "System.Diagnostics.Tracing": "4.0.21-beta-*",
                 "System.Globalization": "4.0.11-beta-*",

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/project.json
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/project.json
@@ -10,14 +10,7 @@
         "Configuration\\WsFederationConfigurationRetriever.cs"
     ],
     "frameworks": {
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.IO": "",
-                "System.Net.Http": "",
-                "System.Xml": ""
-            }
-        },
-        "dnxcore50": {
+        "dotnet5.4": {
             "dependencies": {
                 "System.Collections.Specialized": "4.0.1-beta-*",
                 "System.Diagnostics.Contracts": "4.0.1-beta-*",

--- a/src/Microsoft.IdentityModel.Protocols/project.json
+++ b/src/Microsoft.IdentityModel.Protocols/project.json
@@ -5,14 +5,7 @@
         "System.IdentityModel.Tokens.Jwt": "5.0.0-*"
     },
     "frameworks": {
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.IO": "",
-                "System.Net.Http": "",
-                "System.Xml": ""
-            }
-        },
-        "dnxcore50": {
+        "dotnet5.4": {
             "dependencies": {
                 "System.Collections.Specialized": "4.0.1-beta-*",
                 "System.Diagnostics.Contracts": "4.0.1-beta-*",

--- a/src/System.IdentityModel.Tokens.Jwt/project.json
+++ b/src/System.IdentityModel.Tokens.Jwt/project.json
@@ -5,8 +5,7 @@
         "System.IdentityModel.Tokens": "5.0.0-*"
     },
     "frameworks": {
-        "dnx451": { },
-        "dnxcore50": {
+        "dotnet5.4": {
             "dependencies": {
                 "System.Collections": "4.0.11-beta-*",
                 "System.Diagnostics.Tools": "4.0.1-beta-*",

--- a/src/System.IdentityModel.Tokens.Saml/project.json
+++ b/src/System.IdentityModel.Tokens.Saml/project.json
@@ -5,15 +5,7 @@
         "System.IdentityModel.Tokens": "5.0.0-*"
     },
     "frameworks": {
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Runtime.Serialization": "",
-                "System.Security": "",
-                "System.Xml": "",
-                "System.Xml.Linq": ""
-            }
-        },
-        "dnxcore50": {
+        "dotnet5.4": {
             "dependencies": {
                 "System.Collections": "4.0.11-beta-*",
                 "System.Diagnostics.Tools": "4.0.1-beta-*",

--- a/src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -39,6 +39,7 @@ namespace System.IdentityModel.Tokens
     public class AsymmetricSignatureProvider : SignatureProvider
     {
 #if DNXCORE50
+        private bool _disposeRsa;
         private ECDsa _ecdsaCng;
         private HashAlgorithmName _hashAlgorithm;
         private RSA _rsa;
@@ -188,6 +189,7 @@ namespace System.IdentityModel.Tokens
             {
                 _rsa = new RSACng();
                 (_rsa as RSA).ImportParameters(rsaKey.Parameters);
+                _disposeRsa = true;
                 return;
             }
 
@@ -429,9 +431,22 @@ namespace System.IdentityModel.Tokens
         {
             if (!_disposed)
             {
+                _disposed = true;
+
                 if (disposing)
                 {
-                    _disposed = true;
+#if DNXCORE50
+                    if (_rsa != null && _disposeRsa)
+                        _rsa.Dispose();
+#else
+                    if (_rsaCryptoServiceProvider != null)
+                        _rsaCryptoServiceProvider.Dispose();
+#endif
+                    if (_ecdsaCng != null)
+                        _ecdsaCng.Dispose();
+
+                    if (_rsaCryptoServiceProviderProxy != null)
+                        _rsaCryptoServiceProviderProxy.Dispose();
                 }
             }
         }

--- a/src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -38,7 +38,7 @@ namespace System.IdentityModel.Tokens
     /// </summary>
     public class AsymmetricSignatureProvider : SignatureProvider
     {
-#if DNXCORE50
+#if DOTNET5_4
         private bool _disposeRsa;
         private ECDsa _ecdsaCng;
         private HashAlgorithmName _hashAlgorithm;
@@ -120,7 +120,7 @@ namespace System.IdentityModel.Tokens
             if (willCreateSignatures && !key.HasPrivateKey)
                 throw LogHelper.LogException<InvalidOperationException>(LogMessages.IDX10638, key);
 
-#if DNXCORE50
+#if DOTNET5_4
             ResolveDotNetCoreAsymmetricAlgorithm(key, algorithm, willCreateSignatures);
 #else
             ResolveDotNetDesktopAsymmetricAlgorithm(key, algorithm, willCreateSignatures);
@@ -149,7 +149,7 @@ namespace System.IdentityModel.Tokens
             }
         }
 
-#if DNXCORE50
+#if DOTNET5_4
         protected virtual HashAlgorithmName GetHashAlgorithmName(string algorithm)
         {
             if (string.IsNullOrWhiteSpace(algorithm))
@@ -336,7 +336,7 @@ namespace System.IdentityModel.Tokens
             if (_disposed)
                 throw LogHelper.LogException<ObjectDisposedException>(GetType().ToString());
 
-#if DNXCORE50
+#if DOTNET5_4
             if (_rsa != null)
                 return _rsa.SignData(input, _hashAlgorithm, RSASignaturePadding.Pkcs1);
             else if (_rsaCryptoServiceProviderProxy != null)
@@ -387,7 +387,7 @@ namespace System.IdentityModel.Tokens
             if (_hashAlgorithm == null)
                 throw LogHelper.LogException<InvalidOperationException>(LogMessages.IDX10621, "signature");
 
-#if DNXCORE50
+#if DOTNET5_4
             if (_rsa != null)
                 return _rsa.VerifyData(input, signature, _hashAlgorithm, RSASignaturePadding.Pkcs1);
             else if (_rsaCryptoServiceProviderProxy != null)
@@ -435,7 +435,7 @@ namespace System.IdentityModel.Tokens
 
                 if (disposing)
                 {
-#if DNXCORE50
+#if DOTNET5_4
                     if (_rsa != null && _disposeRsa)
                         _rsa.Dispose();
 #else

--- a/src/System.IdentityModel.Tokens/Utility.cs
+++ b/src/System.IdentityModel.Tokens/Utility.cs
@@ -100,7 +100,7 @@ namespace System.IdentityModel.Tokens
             {
                 return false;
             }
-#if DNXCORE50
+#if DOTNET5_4
             return uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase); //Uri.UriSchemeHttps is internal in dnxcore
 #else
             return uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);

--- a/src/System.IdentityModel.Tokens/X509SecurityKey.cs
+++ b/src/System.IdentityModel.Tokens/X509SecurityKey.cs
@@ -58,7 +58,7 @@ namespace System.IdentityModel.Tokens
         public override int KeySize
         {
             get {
-#if DNXCORE50
+#if DOTNET5_4
                 return RSACertificateExtensions.GetRSAPublicKey(_certificate).KeySize;
 #else
                 return PublicKey.Key.KeySize;
@@ -76,7 +76,7 @@ namespace System.IdentityModel.Tokens
                     {
                         if (!_privateKeyAvailabilityDetermined)
                         {
-#if DNXCORE50
+#if DOTNET5_4
                             _privateKey = RSACertificateExtensions.GetRSAPrivateKey(_certificate);
 #else
                             _privateKey = _certificate.PrivateKey;

--- a/src/System.IdentityModel.Tokens/project.json
+++ b/src/System.IdentityModel.Tokens/project.json
@@ -6,13 +6,7 @@
         "Newtonsoft.Json": "6.0.6"
     },
     "frameworks": {
-        "dnx451": {
-            "frameworkAssemblies": {
-                "System.Runtime.Serialization": "",
-                "System.Xml": ""
-            }
-        },
-        "dnxcore50": {
+        "dotnet5.4": {
             "dependencies": {
                 "System.Collections": "4.0.11-beta-*",
                 "System.Diagnostics.Tools": "4.0.1-beta-*",

--- a/test/Microsoft.IdentityModel.Logging.Tests/1d8014ea-c5df-4f95-8b15-233da0682cc3.txt
+++ b/test/Microsoft.IdentityModel.Logging.Tests/1d8014ea-c5df-4f95-8b15-233da0682cc3.txt
@@ -1,1 +1,0 @@
-ERROR: Exception in Command Processing for EventSource Microsoft.IdentityModel.EventSource: Unsupported type Object[] in event source.

--- a/test/Microsoft.IdentityModel.Logging.Tests/1d8014ea-c5df-4f95-8b15-233da0682cc3.txt
+++ b/test/Microsoft.IdentityModel.Logging.Tests/1d8014ea-c5df-4f95-8b15-233da0682cc3.txt
@@ -1,0 +1,1 @@
+ERROR: Exception in Command Processing for EventSource Microsoft.IdentityModel.EventSource: Unsupported type Object[] in event source.

--- a/test/System.IdentityModel.Tokens.Tests/project.json
+++ b/test/System.IdentityModel.Tokens.Tests/project.json
@@ -13,7 +13,8 @@
         "dnx451": { },
         "dnxcore50": {
             "dependencies": {
-                "System.IO": "4.0.11-beta-*"
+                "System.IO": "4.0.11-beta-*",
+                "System.Reflection.TypeExtensions": "4.1.0-beta-*"
             }
         }
     },


### PR DESCRIPTION
#288
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/295%23issuecomment-150059020%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/295%23issuecomment-151246152%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/295%23issuecomment-152245750%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/295%23discussion_r42832703%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/295%23discussion_r42911320%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/295%23issuecomment-150059020%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40brentschmaltz%20%22%2C%20%22created_at%22%3A%20%222015-10-22T00%3A11%3A57Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40brentschmaltz%20about%20%5C%22call%20the%20base.Dispose%28disposing%29%3B..%5C%22%2C%20what%20I%20am%20referring%20here%20is%20that%20the%20method%20is%20abstract%20and%20it%20cannot%20be%20called%20from%20the%20derived%20class.%22%2C%20%22created_at%22%3A%20%222015-10-26T18%3A50%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20however%2C%20we%20still%20have%20some%20additional%20work%20todo%2C%20since%20SecurityKey%20does%20not%20implement%20IDisposable%2C%20yet%20some%20of%20our%20keys%20are%20disposable.%22%2C%20%22created_at%22%3A%20%222015-10-29T16%3A49%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20479246107f1083dc63cd0e8222d0533f22a40184%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%2017%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/295%23discussion_r42832703%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20need%20to%20do%20two%20things%3A%5Cr%5Cn1.%20We%20need%20a%20finalizer%5Cr%5Cn2.%20call%20the%20base.Dispose%28disposing%29%3B%20%3C---%20There%20is%20disagreement%20on%20what%20to%20pass%20%28true%20or%20disposing%29%20according%20to%3A%20https%3A//msdn.microsoft.com/en-us/library/fs2xkftw%28v%3Dvs.110%29.aspx%22%2C%20%22created_at%22%3A%20%222015-10-23T04%3A40%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brentschmaltz%22%7D%7D%2C%20%7B%22body%22%3A%20%221.%20Why%20we%20need%20a%20finalizer%3F%20I%20don%27t%20think%20there%20are%20any%20unmanaged%20resources%20that%20we%20need%20to%20get%20%20rid%20of%3F%5Cr%5Cn2.%20base%20class%20-%20SignatureProvider%20is%20an%20abstract%20class.%20We%20don%27t%20need%20to%20call%20its%20dispose.%22%2C%20%22created_at%22%3A%20%222015-10-23T20%3A35%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs%3AL466-488%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/brentschmaltz%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3172421%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/brentschmaltz'><img src='https://avatars.githubusercontent.com/u/3172421?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull 479246107f1083dc63cd0e8222d0533f22a40184 src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs 17'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/295#discussion_r42832703'>File: src/System.IdentityModel.Tokens/AsymmetricSignatureProvider.cs:L466-488</a></b>
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> We need to do two things:
1. We need a finalizer
2. call the base.Dispose(disposing); <--- There is disagreement on what to pass (true or disposing) according to: https://msdn.microsoft.com/en-us/library/fs2xkftw(v=vs.110).aspx
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> 1. Why we need a finalizer? I don't think there are any unmanaged resources that we need to get  rid of?
2. base class - SignatureProvider is an abstract class. We don't need to call its dispose.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/295#issuecomment-150059020'>General Comment</a></b>
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> @brentschmaltz
- <a href='https://github.com/tushargupta51'><img border=0 src='https://avatars.githubusercontent.com/u/803796?v=3' height=16 width=16'></a> @brentschmaltz about "call the base.Dispose(disposing);..", what I am referring here is that the method is abstract and it cannot be called from the derived class.
- <a href='https://github.com/brentschmaltz'><img border=0 src='https://avatars.githubusercontent.com/u/3172421?v=3' height=16 width=16'></a> :shipit: however, we still have some additional work todo, since SecurityKey does not implement IDisposable, yet some of our keys are disposable.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/295?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/295?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/295?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/295'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>