### PR TITLE
Skip C_Hash validation if c_hash is not present.

### DIFF
--- a/src/Microsoft.IdentityModel.Protocol.Extensions/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocol.Extensions/OpenIdConnectProtocolValidator.cs
@@ -247,7 +247,7 @@ namespace Microsoft.IdentityModel.Protocols
 
             if (!jwt.Payload.ContainsKey(JwtRegisteredClaimNames.CHash))
             {
-                throw new OpenIdConnectProtocolInvalidCHashException(string.Format(CultureInfo.InvariantCulture, ErrorMessages.IDX10308, jwt));
+                return;
             }
 
             HashAlgorithm hashAlgorithm = null;


### PR DESCRIPTION
The actual [specification] (http://openid.net/specs/openid-connect-core-1_0.html#CodeValidation) states: The value of c_hash in the ID Token MUST match the value produced in the previous step **if** c_hash is present in the ID Token.

This validation was not taking into account the condition **IF c_hash is present** and is throwing an exception regardless.