### PR TITLE
Fixing Rsa Upleveling and cleanup

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -264,7 +264,7 @@ namespace Microsoft.IdentityModel.Tokens
                         _rsa = x509Key.PrivateKey as RSA;
                 }
                 else
-                    _rsa = RSACertificateExtensions.GetRSAPublicKey(x509Key.Certificate);
+                    _rsa = x509Key.PublicKey as RSA;
 
                 return;
             }
@@ -363,7 +363,7 @@ namespace Microsoft.IdentityModel.Tokens
                 if (willCreateSignatures)
                     _rsaCryptoServiceProviderProxy = new RSACryptoServiceProviderProxy(x509Key.PrivateKey as RSACryptoServiceProvider);
                 else
-                    _rsaCryptoServiceProviderProxy = new RSACryptoServiceProviderProxy(x509Key.PublicKey.Key as RSACryptoServiceProvider);
+                    _rsaCryptoServiceProviderProxy = new RSACryptoServiceProviderProxy(x509Key.PublicKey as RSACryptoServiceProvider);
                 return;
             }
 

--- a/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
@@ -40,7 +40,7 @@ namespace Microsoft.IdentityModel.Tokens
         X509Certificate2 _certificate;
         AsymmetricAlgorithm _privateKey;
         bool _privateKeyAvailabilityDetermined;
-        PublicKey _publicKey;
+        AsymmetricAlgorithm _publicKey;
         object _thisLock = new Object();
 
         /// <summary>
@@ -48,22 +48,19 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         /// <param name="certificate"> cert to use.</param>
         public X509SecurityKey(X509Certificate2 certificate)
-        { 
+        {
             if (certificate == null)
                 throw new ArgumentNullException("certificate");
 
             _certificate = certificate;
-			KeyId = certificate.Thumbprint;
+            KeyId = certificate.Thumbprint;
         }
 
         public override int KeySize
         {
-            get {
-#if NETSTANDARD1_4
-                return RSACertificateExtensions.GetRSAPublicKey(_certificate).KeySize;
-#else
-                return PublicKey.Key.KeySize;
-#endif
+            get
+            {
+                return PublicKey.KeySize;
             }
         }
 
@@ -91,7 +88,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
         }
 
-        public PublicKey PublicKey
+        public AsymmetricAlgorithm PublicKey
         {
             get
             {
@@ -101,7 +98,11 @@ namespace Microsoft.IdentityModel.Tokens
                     {
                         if (_publicKey == null)
                         {
-                            _publicKey = _certificate.PublicKey;
+#if NETSTANDARD1_4
+                            _publicKey = RSACertificateExtensions.GetRSAPublicKey(_certificate);
+#else
+                            _publicKey = _certificate.PublicKey.Key;
+#endif
                         }
                     }
                 }

--- a/test/Microsoft.IdentityModel.Logging.Tests/testbuild.cmd
+++ b/test/Microsoft.IdentityModel.Logging.Tests/testbuild.cmd
@@ -5,6 +5,6 @@ for %%* in (.) do set project=%%~nx*
 set root=%~dp0%
 set xunit-root=%root%..\..\.build\xunit.runner.console\2.1.0\tools
 %dotnethome%\dotnet.exe build --configuration Debug
-%dotnethome%\dotnet.exe publish --configuration Debug --framework net451  --output obj\testPublish-net451
-%xunit-root%\xunit.console.exe %root%obj\testPublish-net451\%project%.dll
+%xunit-root%\xunit.console.exe bin\Debug\net451\win7-x64\%project%.dll
+%dotnethome%\dotnet.exe test
 endlocal

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/testbuild.cmd
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/testbuild.cmd
@@ -5,6 +5,6 @@ for %%* in (.) do set project=%%~nx*
 set root=%~dp0%
 set xunit-root=%root%..\..\.build\xunit.runner.console\2.1.0\tools
 %dotnethome%\dotnet.exe build --configuration Debug
-%dotnethome%\dotnet.exe publish --configuration Debug --framework net451  --output obj\testPublish-net451
-%xunit-root%\xunit.console.exe %root%obj\testPublish-net451\%project%.dll
+%xunit-root%\xunit.console.exe bin\Debug\net451\win7-x64\%project%.dll
+%dotnethome%\dotnet.exe test
 endlocal

--- a/test/Microsoft.IdentityModel.Protocols.Tests/testbuild.cmd
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/testbuild.cmd
@@ -5,6 +5,6 @@ for %%* in (.) do set project=%%~nx*
 set root=%~dp0%
 set xunit-root=%root%..\..\.build\xunit.runner.console\2.1.0\tools
 %dotnethome%\dotnet.exe build --configuration Debug
-%dotnethome%\dotnet.exe publish --configuration Debug --framework net451  --output obj\testPublish-net451
-%xunit-root%\xunit.console.exe %root%obj\testPublish-net451\%project%.dll
+%xunit-root%\xunit.console.exe bin\Debug\net451\win7-x64\%project%.dll
+%dotnethome%\dotnet.exe test
 endlocal

--- a/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/testbuild.cmd
+++ b/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/testbuild.cmd
@@ -5,6 +5,6 @@ for %%* in (.) do set project=%%~nx*
 set root=%~dp0%
 set xunit-root=%root%..\..\.build\xunit.runner.console\2.1.0\tools
 %dotnethome%\dotnet.exe build --configuration Debug
-%dotnethome%\dotnet.exe publish --configuration Debug --framework net451  --output obj\testPublish-net451
-%xunit-root%\xunit.console.exe %root%obj\testPublish-net451\%project%.dll
+%xunit-root%\xunit.console.exe bin\Debug\net451\win7-x64\%project%.dll
+%dotnethome%\dotnet.exe test
 endlocal

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaCryptoServiceProviderProxyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaCryptoServiceProviderProxyTests.cs
@@ -1,0 +1,117 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+using System.Security.Cryptography;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Tokens.Tests
+{
+    public class RsaCryptoServiceProviderProxyTests
+    {
+
+        byte[] input = new byte[10];
+
+#if NETSTANDARDAPP1_5
+        HashAlgorithmName _hashAlgorithm = HashAlgorithmName.SHA256;
+#else
+        string _hashAlgorithm = SecurityAlgorithms.Sha256;
+#endif
+
+        [Fact]
+        public void TestCustomRsaCsp()
+        {
+            RSACryptoServiceProvider rsaCsp = KeyingMaterial.DefaultX509Key_2048.PrivateKey as RSACryptoServiceProvider;
+            if (rsaCsp == null)
+                return;
+
+            Assert.True(rsaCsp.CspKeyContainerInfo.ProviderType == 1, "Default RsaCSP provider type is not equal to 1. ProviderType: " + rsaCsp.CspKeyContainerInfo.ProviderType);
+            SignData(rsaCsp, ExpectedException.CryptographicException("Invalid algorithm specified"));
+            SignData(new RSACryptoServiceProviderProxy(rsaCsp), ExpectedException.NoExceptionExpected);
+
+            rsaCsp = CreateProviderWithProviderType(rsaCsp.CspKeyContainerInfo, 1);
+            SignData(rsaCsp, ExpectedException.CryptographicException("Invalid algorithm specified"));
+            SignData(new RSACryptoServiceProviderProxy(rsaCsp), ExpectedException.NoExceptionExpected);
+
+            rsaCsp = CreateProviderWithProviderType(rsaCsp.CspKeyContainerInfo, 12);
+            Assert.True(rsaCsp.CspKeyContainerInfo.ProviderType == 12, "rsa provider type != 12. ProviderType: " + rsaCsp.CspKeyContainerInfo.ProviderType);
+            SignData(rsaCsp, ExpectedException.CryptographicException("Invalid algorithm specified"));
+            SignData(new RSACryptoServiceProviderProxy(rsaCsp), ExpectedException.NoExceptionExpected);
+
+            rsaCsp = CreateProviderWithProviderType(rsaCsp.CspKeyContainerInfo, 24);
+            SignData(rsaCsp, ExpectedException.NoExceptionExpected);
+            SignData(new RSACryptoServiceProviderProxy(rsaCsp), ExpectedException.NoExceptionExpected);
+        }
+
+        private RSACryptoServiceProvider CreateProviderWithProviderType(CspKeyContainerInfo cspKeyContainerInfo, int providerType)
+        {
+            CspParameters csp = new CspParameters();
+            csp.ProviderType = providerType;
+            csp.KeyContainerName = cspKeyContainerInfo.KeyContainerName;
+            csp.KeyNumber = (int)cspKeyContainerInfo.KeyNumber;
+            if (cspKeyContainerInfo.MachineKeyStore)
+                csp.Flags = CspProviderFlags.UseMachineKeyStore;
+            csp.Flags |= CspProviderFlags.UseExistingKey;
+            return new RSACryptoServiceProvider(csp);
+        }
+
+        private void SignData(RSACryptoServiceProvider rsaCsp, ExpectedException ee)
+        {
+            try
+            {
+#if NETSTANDARDAPP1_5
+                rsaCsp.SignData(input, _hashAlgorithm.Name);
+#else
+                rsaCsp.SignData(input, _hashAlgorithm);
+#endif
+                ee.ProcessNoException();
+            }
+            catch (Exception ex)
+            {
+                ee.ProcessException(ex);
+            }
+        }
+        private void SignData(RSACryptoServiceProviderProxy rsaCspProxy, ExpectedException ee)
+        {
+            try
+            {
+#if NETSTANDARDAPP1_5
+                rsaCspProxy.SignData(input, _hashAlgorithm.Name);
+#else
+                rsaCspProxy.SignData(input, _hashAlgorithm);
+#endif
+                ee.ProcessNoException();
+            }
+            catch (Exception ex)
+            {
+                ee.ProcessException(ex);
+            }
+        }
+
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaCryptoServiceProviderProxyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaCryptoServiceProviderProxyTests.cs
@@ -96,6 +96,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 ee.ProcessException(ex);
             }
         }
+
         private void SignData(RSACryptoServiceProviderProxy rsaCspProxy, ExpectedException ee)
         {
             try

--- a/test/Microsoft.IdentityModel.Tokens.Tests/project.json
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/project.json
@@ -11,8 +11,7 @@
     "netstandardapp1.5": {
       "dependencies": {
         "dotnet-test-xunit": "1.0.0-dev-*",
-        "NETStandard.Library": "1.5.0-*",
-        "System.Diagnostics.Process": "4.1.0-*"
+        "NETStandard.Library": "1.5.0-*"
       },
       "imports": [
         "dnxcore50",

--- a/test/Microsoft.IdentityModel.Tokens.Tests/project.json
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/project.json
@@ -11,7 +11,8 @@
     "netstandardapp1.5": {
       "dependencies": {
         "dotnet-test-xunit": "1.0.0-dev-*",
-        "NETStandard.Library": "1.5.0-*"
+        "NETStandard.Library": "1.5.0-*",
+        "System.Reflection.TypeExtensions":  "4.1.0-rc2-*"
       },
       "imports": [
         "dnxcore50",

--- a/test/Microsoft.IdentityModel.Tokens.Tests/testbuild.cmd
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/testbuild.cmd
@@ -5,6 +5,6 @@ for %%* in (.) do set project=%%~nx*
 set root=%~dp0%
 set xunit-root=%root%..\..\.build\xunit.runner.console\2.1.0\tools
 %dotnethome%\dotnet.exe build --configuration Debug
-%dotnethome%\dotnet.exe publish --configuration Debug --framework net451  --output obj\testPublish-net451
-%xunit-root%\xunit.console.exe %root%obj\testPublish-net451\%project%.dll
+%xunit-root%\xunit.console.exe bin\Debug\net451\win7-x64\%project%.dll
+%dotnethome%\dotnet.exe test
 endlocal

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/testbuild.cmd
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/testbuild.cmd
@@ -5,6 +5,6 @@ for %%* in (.) do set project=%%~nx*
 set root=%~dp0%
 set xunit-root=%root%..\..\.build\xunit.runner.console\2.1.0\tools
 %dotnethome%\dotnet.exe build --configuration Debug
-%dotnethome%\dotnet.exe publish --configuration Debug --framework net451  --output obj\testPublish-net451
-%xunit-root%\xunit.console.exe %root%obj\testPublish-net451\%project%.dll
+%xunit-root%\xunit.console.exe bin\Debug\net451\win7-x64\%project%.dll
+%dotnethome%\dotnet.exe test
 endlocal

--- a/test/System.IdentityModel.Tokens.Saml.Tests/testbuild.cmd
+++ b/test/System.IdentityModel.Tokens.Saml.Tests/testbuild.cmd
@@ -5,6 +5,6 @@ for %%* in (.) do set project=%%~nx*
 set root=%~dp0%
 set xunit-root=%root%..\..\.build\xunit.runner.console\2.1.0\tools
 %dotnethome%\dotnet.exe build --configuration Debug
-%dotnethome%\dotnet.exe publish --configuration Debug --framework net451  --output obj\testPublish-net451
-%xunit-root%\xunit.console.exe %root%obj\testPublish-net451\%project%.dll
+%xunit-root%\xunit.console.exe bin\Debug\net451\win7-x64\%project%.dll
+%dotnethome%\dotnet.exe test
 endlocal


### PR DESCRIPTION
1. #353 Removing this workaround since nuget packages are being.
2. #358 : upleveling of rsacsp.
3. Updating testBuild.cmd to run tests for both net451 and netstandardapp1.5