### PR TITLE
SecurityTokenDescriptor uses ClaimsIdentity instead of IEnumerable<Claim>

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/SecurityTokenDescriptor.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityTokenDescriptor.cs
@@ -26,7 +26,6 @@
 //------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Security.Claims;
 
 namespace Microsoft.IdentityModel.Tokens
@@ -34,8 +33,6 @@ namespace Microsoft.IdentityModel.Tokens
     public class SecurityTokenDescriptor
     {
         public string Audience { get; set; }
-
-        public IEnumerable<Claim> Claims { get; set; }
 
         public DateTime? Expires { get; set; }
 
@@ -46,5 +43,7 @@ namespace Microsoft.IdentityModel.Tokens
         public DateTime? NotBefore { get; set; }
 
         public SigningCredentials SigningCredentials { get; set; }
+
+        public ClaimsIdentity Subject { get; set; }
     }
 }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -386,6 +386,26 @@ namespace System.IdentityModel.Tokens.Jwt
             return CreateJwtSecurityTokenPrivate(issuer, audience, subject, notBefore, expires, issuedAt, signingCredentials);
         }
 
+        /// <summary>
+        /// Creates a Json Web Token (JWT).
+        /// </summary>
+        /// <param name="tokenDescriptor"> a <see cref="SecurityTokenDescriptor"/> that contains details of contents of the token.</param>
+        /// <remarks><see cref="SecurityTokenDescriptor.SigningCredentials"/> is used to sign <see cref="JwtSecurityToken.RawData"/>.</remarks>
+        public override SecurityToken CreateToken(SecurityTokenDescriptor tokenDescriptor)
+        {
+            if (tokenDescriptor == null)
+                throw LogHelper.LogArgumentNullException("tokenDescriptor");
+
+            return CreateJwtSecurityTokenPrivate(
+                tokenDescriptor.Issuer,
+                tokenDescriptor.Audience,
+                tokenDescriptor.Subject,
+                tokenDescriptor.NotBefore,
+                tokenDescriptor.Expires,
+                tokenDescriptor.IssuedAt,
+                tokenDescriptor.SigningCredentials);
+        }
+
         private JwtSecurityToken CreateJwtSecurityTokenPrivate(string issuer, string audience, ClaimsIdentity subject, DateTime? notBefore, DateTime? expires, DateTime? issuedAt, SigningCredentials signingCredentials)
         {
             if (SetDefaultTimesOnTokenCreation)
@@ -405,7 +425,7 @@ namespace System.IdentityModel.Tokens.Jwt
             JwtPayload payload = new JwtPayload(issuer, audience, (subject == null ? null : OutboundClaimTypeTransform(subject.Claims)), notBefore, expires, issuedAt);
             JwtHeader header = new JwtHeader(signingCredentials);
 
-            if (subject != null && subject.Actor != null)
+            if (subject?.Actor != null)
             {
                 payload.AddClaim(new Claim(JwtRegisteredClaimNames.Actort, this.CreateActorValue(subject.Actor)));
             }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -301,49 +301,30 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <summary>
         /// Returns a Json Web Token (JWT).
         /// </summary>
-        /// <param name="tokenDescriptor"> a <see cref="SecurityTokenDescriptor"/> that contains details of token contents and <see cref="SignatureProvider"/>.
-        public string CreateEncodedJwt(SecurityTokenDescriptor tokenDescriptor)
+        /// <param name="tokenDescriptor"> a <see cref="SecurityTokenDescriptor"/> that contains details of contents of the token.</param>
+        /// <remarks><see cref="SecurityTokenDescriptor.SigningCredentials"/> is used to sign the JSON.</remarks>
+        public virtual string CreateEncodedJwt(SecurityTokenDescriptor tokenDescriptor)
         {
             if (tokenDescriptor == null)
                 throw LogHelper.LogArgumentNullException("tokenDescriptor");
 
-            return (CreateEncodedJwt(
+            return CreateJwtSecurityTokenPrivate(
                 tokenDescriptor.Issuer,
                 tokenDescriptor.Audience,
-                tokenDescriptor.Claims,
+                tokenDescriptor.Subject,
                 tokenDescriptor.NotBefore,
                 tokenDescriptor.Expires,
                 tokenDescriptor.IssuedAt,
-                tokenDescriptor.SigningCredentials));
+                tokenDescriptor.SigningCredentials).RawData;
         }
 
         /// <summary>
-        /// Creates a Json Web Token (JWT).
-        /// </summary>
-        /// <param name="tokenDescriptor"> a <see cref="SecurityTokenDescriptor"/> that contains details of token contents and <see cref="SignatureProvider"/>.
-        public JwtSecurityToken CreateJwtSecurityToken(SecurityTokenDescriptor tokenDescriptor)
-        {
-            if (tokenDescriptor == null)
-                throw LogHelper.LogArgumentNullException("tokenDescriptor");
-
-            return CreateJwt(
-                tokenDescriptor.Issuer,
-                tokenDescriptor.Audience,
-                tokenDescriptor.Claims,
-                tokenDescriptor.NotBefore,
-                tokenDescriptor.Expires,
-                tokenDescriptor.IssuedAt,
-                tokenDescriptor.SigningCredentials);
-        }
-
-        /// <summary>
-        /// Uses the <see cref="JwtSecurityToken(JwtHeader, JwtPayload, string, string, string)"/> constructor, first creating the <see cref="JwtHeader"/> and <see cref="JwtPayload"/>.
-        /// <para>If <see cref="SigningCredentials"/> is not null, <see cref="JwtSecurityToken.RawData"/> will be signed.</para>
+        /// Creates a <see cref="JwtSecurityToken"/>
         /// </summary>
         /// <param name="issuer">the issuer of the token.</param>
         /// <param name="audience">the audience for this token.</param>
         /// <param name="subject">the source of the <see cref="Claim"/>(s) for this token.</param>
-        /// <param name="notBefore">the notbefore time for this token.</param> 
+        /// <param name="notBefore">the notbefore time for this token.</param>
         /// <param name="expires">the expiration time for this token.</param>
         /// <param name="issuedAt">the issue time for this token.</param>
         /// <param name="signingCredentials">contains cryptographic material for generating a signature.</param>
@@ -351,27 +332,61 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <para>See <seealso cref="JwtHeader"/> for details on how the HeaderParameters are added to the header.</para>
         /// <para>See <seealso cref="JwtPayload"/> for details on how the values are added to the payload.</para>
         /// <para>Each <see cref="Claim"/> on the <paramref name="subject"/> added will have <see cref="Claim.Type"/> translated according to the mapping found in
-        /// <see cref="OutboundClaimTypeMap"/>. Adding and removing to <see cref="OutboundClaimTypeMap"/> will affect the name component of the Json claim</para>
+        /// <see cref="OutboundClaimTypeMap"/>. Adding and removing to <see cref="OutboundClaimTypeMap"/> will affect the name component of the Json claim.</para>
+        /// <para><see cref="SigningCredentials.SigningCredentials(SecurityKey, string)"/> is used to sign the JSON.</para>
         /// </remarks>
         /// <returns>A <see cref="JwtSecurityToken"/>.</returns>
         /// <exception cref="ArgumentException">if 'expires' &lt;= 'notBefore'.</exception>
-        public virtual JwtSecurityToken CreateToken(string issuer = null, string audience = null, ClaimsIdentity subject = null, DateTime? notBefore = null, DateTime? expires = null, DateTime? issuedAt = null, SigningCredentials signingCredentials = null)
+        public virtual string CreateEncodedJwt(string issuer, string audience, ClaimsIdentity subject, DateTime? notBefore, DateTime? expires, DateTime? issuedAt, SigningCredentials signingCredentials)
         {
-            var jwt = CreateJwt(issuer, audience, (subject != null ? subject.Claims : null), notBefore, expires, issuedAt, signingCredentials);
-            if (subject != null && subject.Actor != null)
-            {
-                jwt.Payload.AddClaim(new Claim(JwtRegisteredClaimNames.Actort, this.CreateActorValue(subject.Actor)));
-            }
-
-            return jwt;
+            return CreateJwtSecurityTokenPrivate(issuer, audience, subject, notBefore, expires, issuedAt, signingCredentials).RawData;
         }
 
-        private JwtSecurityToken CreateJwt(string issuer, string audience, IEnumerable<Claim> claims, DateTime? notBefore, DateTime? expires, DateTime? issuedAt, SigningCredentials signingCredentials)
+        /// <summary>
+        /// Creates a Json Web Token (JWT).
+        /// </summary>
+        /// <param name="tokenDescriptor"> a <see cref="SecurityTokenDescriptor"/> that contains details of contents of the token.</param>
+        /// <remarks><see cref="SecurityTokenDescriptor.SigningCredentials"/> is used to sign <see cref="JwtSecurityToken.RawData"/>.</remarks>
+        public virtual JwtSecurityToken CreateJwtSecurityToken(SecurityTokenDescriptor tokenDescriptor)
         {
-            return new JwtSecurityToken(CreateEncodedJwt(issuer, audience, claims, notBefore, expires, issuedAt, signingCredentials));
+            if (tokenDescriptor == null)
+                throw LogHelper.LogArgumentNullException("tokenDescriptor");
+
+            return CreateJwtSecurityTokenPrivate(
+                tokenDescriptor.Issuer,
+                tokenDescriptor.Audience,
+                tokenDescriptor.Subject,
+                tokenDescriptor.NotBefore,
+                tokenDescriptor.Expires,
+                tokenDescriptor.IssuedAt,
+                tokenDescriptor.SigningCredentials);
         }
 
-        public string CreateEncodedJwt(string issuer, string audience, IEnumerable<Claim> claims, DateTime? notBefore, DateTime? expires, DateTime? issuedAt, SigningCredentials signingCredentials)
+        /// <summary>
+        /// Creates a <see cref="JwtSecurityToken"/>
+        /// </summary>
+        /// <param name="issuer">the issuer of the token.</param>
+        /// <param name="audience">the audience for this token.</param>
+        /// <param name="subject">the source of the <see cref="Claim"/>(s) for this token.</param>
+        /// <param name="notBefore">the notbefore time for this token.</param>
+        /// <param name="expires">the expiration time for this token.</param>
+        /// <param name="issuedAt">the issue time for this token.</param>
+        /// <param name="signingCredentials">contains cryptographic material for generating a signature.</param>
+        /// <remarks>If <see cref="ClaimsIdentity.Actor"/> is not null, then a claim { actort, 'value' } will be added to the payload. <see cref="CreateActorValue"/> for details on how the value is created.
+        /// <para>See <seealso cref="JwtHeader"/> for details on how the HeaderParameters are added to the header.</para>
+        /// <para>See <seealso cref="JwtPayload"/> for details on how the values are added to the payload.</para>
+        /// <para>Each <see cref="Claim"/> on the <paramref name="subject"/> added will have <see cref="Claim.Type"/> translated according to the mapping found in
+        /// <see cref="OutboundClaimTypeMap"/>. Adding and removing to <see cref="OutboundClaimTypeMap"/> will affect the name component of the Json claim.</para>
+        /// <para><see cref="SigningCredentials.SigningCredentials(SecurityKey, string)"/> is used to sign <see cref="JwtSecurityToken.RawData"/>.</para>
+        /// </remarks>
+        /// <returns>A <see cref="JwtSecurityToken"/>.</returns>
+        /// <exception cref="ArgumentException">if 'expires' &lt;= 'notBefore'.</exception>
+        public virtual JwtSecurityToken CreateJwtSecurityToken(string issuer = null, string audience = null, ClaimsIdentity subject = null, DateTime? notBefore = null, DateTime? expires = null, DateTime? issuedAt = null, SigningCredentials signingCredentials = null)
+        {
+            return CreateJwtSecurityTokenPrivate(issuer, audience, subject, notBefore, expires, issuedAt, signingCredentials);
+        }
+
+        private JwtSecurityToken CreateJwtSecurityTokenPrivate(string issuer, string audience, ClaimsIdentity subject, DateTime? notBefore, DateTime? expires, DateTime? issuedAt, SigningCredentials signingCredentials)
         {
             if (SetDefaultTimesOnTokenCreation)
             {
@@ -387,8 +402,13 @@ namespace System.IdentityModel.Tokens.Jwt
             }
 
             IdentityModelEventSource.Logger.WriteVerbose(LogMessages.IDX10721, (audience ?? "null"), (issuer ?? "null"));
-            JwtPayload payload = new JwtPayload(issuer, audience, (claims == null ? null : OutboundClaimTypeTransform(claims)), notBefore, expires, issuedAt);
+            JwtPayload payload = new JwtPayload(issuer, audience, (subject == null ? null : OutboundClaimTypeTransform(subject.Claims)), notBefore, expires, issuedAt);
             JwtHeader header = new JwtHeader(signingCredentials);
+
+            if (subject != null && subject.Actor != null)
+            {
+                payload.AddClaim(new Claim(JwtRegisteredClaimNames.Actort, this.CreateActorValue(subject.Actor)));
+            }
 
             string rawHeader = header.Base64UrlEncode();
             string rawPayload = payload.Base64UrlEncode();
@@ -402,8 +422,7 @@ namespace System.IdentityModel.Tokens.Jwt
             }
 
             IdentityModelEventSource.Logger.WriteInformation(LogMessages.IDX10722, rawHeader, rawPayload, rawSignature);
-
-            return signingInput + "." + rawSignature;
+            return new JwtSecurityToken(header, payload, rawHeader, rawPayload, rawSignature);
         }
 
         private IEnumerable<Claim> OutboundClaimTypeTransform(IEnumerable<Claim> claims)

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -306,7 +306,7 @@ namespace System.IdentityModel.Tokens.Jwt
         public virtual string CreateEncodedJwt(SecurityTokenDescriptor tokenDescriptor)
         {
             if (tokenDescriptor == null)
-                throw LogHelper.LogArgumentNullException("tokenDescriptor");
+                throw LogHelper.LogArgumentNullException(nameof(tokenDescriptor));
 
             return CreateJwtSecurityTokenPrivate(
                 tokenDescriptor.Issuer,
@@ -350,7 +350,7 @@ namespace System.IdentityModel.Tokens.Jwt
         public virtual JwtSecurityToken CreateJwtSecurityToken(SecurityTokenDescriptor tokenDescriptor)
         {
             if (tokenDescriptor == null)
-                throw LogHelper.LogArgumentNullException("tokenDescriptor");
+                throw LogHelper.LogArgumentNullException(nameof(tokenDescriptor));
 
             return CreateJwtSecurityTokenPrivate(
                 tokenDescriptor.Issuer,
@@ -394,7 +394,7 @@ namespace System.IdentityModel.Tokens.Jwt
         public override SecurityToken CreateToken(SecurityTokenDescriptor tokenDescriptor)
         {
             if (tokenDescriptor == null)
-                throw LogHelper.LogArgumentNullException("tokenDescriptor");
+                throw LogHelper.LogArgumentNullException(nameof(tokenDescriptor));
 
             return CreateJwtSecurityTokenPrivate(
                 tokenDescriptor.Issuer,

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/End2EndTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/End2EndTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             OpenIdConnectConfiguration configuration = OpenIdConnectConfigurationRetriever.GetAsync(OpenIdConfigData.OpenIdConnectMetadataFileEnd2End, new FileDocumentRetriever(), CancellationToken.None).Result;
             JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
             JwtSecurityToken jwtToken = 
-                tokenHandler.CreateToken(
+                tokenHandler.CreateJwtSecurityToken(
                     configuration.Issuer,
                     IdentityUtilities.DefaultAudience,
                     ClaimSets.DefaultClaimsIdentity,

--- a/test/Microsoft.IdentityModel.Tokens.Tests/IdentityUtilities.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/IdentityUtilities.cs
@@ -215,7 +215,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             var retval = DefaultSecurityTokenDescriptor(DefaultAsymmetricSigningCredentials);
             if (claims != null)
-                retval.Claims = claims;
+                retval.Subject = new ClaimsIdentity(claims);
 
             return retval;
         }
@@ -223,7 +223,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             var retval = DefaultSecurityTokenDescriptor(DefaultSymmetricSigningCredentials);
             if (claims != null)
-                retval.Claims = claims;
+                retval.Subject = new ClaimsIdentity(claims);
 
             return retval;
         }
@@ -233,7 +233,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             return new SecurityTokenDescriptor
             {
                 Audience = DefaultAudience,
-                Claims = ClaimSets.DefaultClaims,
+                Subject = ClaimSets.DefaultClaimsIdentity,
                 Issuer = DefaultIssuer,
                 IssuedAt = DateTime.UtcNow,
                 Expires = DateTime.UtcNow + TimeSpan.FromDays(1),

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
@@ -177,8 +177,10 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 createParams.SecurityTokenDescriptor.Expires,
                 createParams.SecurityTokenDescriptor.IssuedAt,
                 createParams.SecurityTokenDescriptor.SigningCredentials);
+            var jwtToken5 = handler.CreateToken(createParams.SecurityTokenDescriptor) as JwtSecurityToken;
             var encodedJwt3 = handler.WriteToken(jwtToken3);
             var encodedJwt4 = handler.WriteToken(jwtToken4);
+            var encodedJwt5 = handler.WriteToken(jwtToken5);
 
             SecurityToken validatedJwtToken1 = null;
             var claimsPrincipal1 = handler.ValidateToken(encodedJwt1, createParams.TokenValidationParameters, out validatedJwtToken1);
@@ -191,6 +193,9 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
             SecurityToken validatedJwtToken4 = null;
             var claimsPrincipal4 = handler.ValidateToken(encodedJwt4, createParams.TokenValidationParameters, out validatedJwtToken4);
+
+            SecurityToken validatedJwtToken5 = null;
+            var claimsPrincipal5 = handler.ValidateToken(encodedJwt5, createParams.TokenValidationParameters, out validatedJwtToken5);
 
             var context = new CompareContext();
             var localContext = new CompareContext();
@@ -208,23 +213,37 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
 
             localContext.Diffs.Clear();
-            if (!IdentityComparer.AreJwtSecurityTokensEqual(validatedJwtToken1 as JwtSecurityToken, validatedJwtToken2 as JwtSecurityToken, localContext))
+            if (!IdentityComparer.AreJwtSecurityTokensEqual(jwtToken3, jwtToken5, localContext))
+            {
+                context.Diffs.Add("jwtToken3 != jwtToken5");
+                context.Diffs.AddRange(localContext.Diffs);
+            }
+
+            localContext.Diffs.Clear();
+            if (!IdentityComparer.AreEqual(validatedJwtToken1, validatedJwtToken2, localContext))
             {
                 context.Diffs.Add("validatedJwtToken1 != validatedJwtToken2");
                 context.Diffs.AddRange(localContext.Diffs);
             }
 
             localContext.Diffs.Clear();
-            if (!IdentityComparer.AreJwtSecurityTokensEqual(validatedJwtToken1 as JwtSecurityToken, validatedJwtToken3 as JwtSecurityToken, localContext))
+            if (!IdentityComparer.AreEqual(validatedJwtToken1, validatedJwtToken3, localContext))
             {
                 context.Diffs.Add("validatedJwtToken1 != validatedJwtToken3");
                 context.Diffs.AddRange(localContext.Diffs);
             }
 
             localContext.Diffs.Clear();
-            if (!IdentityComparer.AreJwtSecurityTokensEqual(validatedJwtToken1 as JwtSecurityToken, validatedJwtToken4 as JwtSecurityToken, localContext))
+            if (!IdentityComparer.AreEqual(validatedJwtToken1, validatedJwtToken4, localContext))
             {
                 context.Diffs.Add("validatedJwtToken1 != validatedJwtToken4");
+                context.Diffs.AddRange(localContext.Diffs);
+            }
+
+            localContext.Diffs.Clear();
+            if (!IdentityComparer.AreEqual(validatedJwtToken1, validatedJwtToken5, localContext))
+            {
+                context.Diffs.Add("validatedJwtToken1 != validatedJwtToken5");
                 context.Diffs.AddRange(localContext.Diffs);
             }
 
@@ -246,6 +265,13 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             if (!IdentityComparer.AreClaimsPrincipalsEqual(claimsPrincipal1, claimsPrincipal4, localContext))
             {
                 context.Diffs.Add("claimsPrincipal1 != claimsPrincipal4");
+                context.Diffs.AddRange(localContext.Diffs);
+            }
+
+            localContext.Diffs.Clear();
+            if (!IdentityComparer.AreClaimsPrincipalsEqual(claimsPrincipal1, claimsPrincipal5, localContext))
+            {
+                context.Diffs.Add("claimsPrincipal1 != claimsPrincipal5");
                 context.Diffs.AddRange(localContext.Diffs);
             }
 

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
@@ -343,6 +343,46 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         [Fact]
+        public void CreateTokenNegativeCases()
+        {
+            var errors = new List<string>();
+            var handler = new JwtSecurityTokenHandler();
+            var ee = ExpectedException.ArgumentNullException("tokenDescriptor");
+
+            try
+            {
+                handler.CreateEncodedJwt((SecurityTokenDescriptor)null);
+                ee.ProcessNoException(errors);
+            }
+            catch(Exception ex)
+            {
+                ee.ProcessException(ex, errors);
+            }
+
+            try
+            {
+                handler.CreateJwtSecurityToken((SecurityTokenDescriptor)null);
+                ee.ProcessNoException(errors);
+            }
+            catch (Exception ex)
+            {
+                ee.ProcessException(ex, errors);
+            }
+
+            try
+            {
+                handler.CreateToken((SecurityTokenDescriptor)null);
+                ee.ProcessNoException(errors);
+            }
+            catch (Exception ex)
+            {
+                ee.ProcessException(ex, errors);
+            }
+
+            TestUtilities.AssertFailIfErrors(errors);
+        }
+
+        [Fact]
         public void InboundFilterTest()
         {
             var handler = new JwtSecurityTokenHandler();

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
@@ -157,64 +157,104 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         {
             var handler = new JwtSecurityTokenHandler();
             handler.InboundClaimTypeMap.Clear();
-            var jwt1 = handler.CreateEncodedJwt(createParams.SecurityTokenDescriptor);
-            var jwtToken1 = new JwtSecurityToken(jwt1);
-            SecurityToken validatedJwtToken1 = null;
-            var claimsPrincipal1 = handler.ValidateToken(jwt1, createParams.TokenValidationParameters, out validatedJwtToken1);
-
-            var jwt2 = handler.CreateEncodedJwt(
+            var encodedJwt1 = handler.CreateEncodedJwt(createParams.SecurityTokenDescriptor);
+            var encodedJwt2 = handler.CreateEncodedJwt(
                 createParams.SecurityTokenDescriptor.Issuer,
                 createParams.SecurityTokenDescriptor.Audience,
-                createParams.SecurityTokenDescriptor.Claims,
+                createParams.SecurityTokenDescriptor.Subject,
                 createParams.SecurityTokenDescriptor.NotBefore,
                 createParams.SecurityTokenDescriptor.Expires,
                 createParams.SecurityTokenDescriptor.IssuedAt,
                 createParams.SecurityTokenDescriptor.SigningCredentials);
-            var jwtToken2 = new JwtSecurityToken(jwt2);
-            SecurityToken validatedJwtToken2 = null;
-            var claimsPrincipal2 = handler.ValidateToken(jwt1, createParams.TokenValidationParameters, out validatedJwtToken2);
-
+            var jwtToken1 = new JwtSecurityToken(encodedJwt1);
+            var jwtToken2 = new JwtSecurityToken(encodedJwt2);
             var jwtToken3 = handler.CreateJwtSecurityToken(createParams.SecurityTokenDescriptor);
-            var jwt3 = handler.WriteToken(jwtToken3);
+            var jwtToken4 = handler.CreateJwtSecurityToken(
+                createParams.SecurityTokenDescriptor.Issuer,
+                createParams.SecurityTokenDescriptor.Audience,
+                createParams.SecurityTokenDescriptor.Subject,
+                createParams.SecurityTokenDescriptor.NotBefore,
+                createParams.SecurityTokenDescriptor.Expires,
+                createParams.SecurityTokenDescriptor.IssuedAt,
+                createParams.SecurityTokenDescriptor.SigningCredentials);
+            var encodedJwt3 = handler.WriteToken(jwtToken3);
+            var encodedJwt4 = handler.WriteToken(jwtToken4);
+
+            SecurityToken validatedJwtToken1 = null;
+            var claimsPrincipal1 = handler.ValidateToken(encodedJwt1, createParams.TokenValidationParameters, out validatedJwtToken1);
+
+            SecurityToken validatedJwtToken2 = null;
+            var claimsPrincipal2 = handler.ValidateToken(encodedJwt2, createParams.TokenValidationParameters, out validatedJwtToken2);
+
             SecurityToken validatedJwtToken3 = null;
-            var claimsPrincipal3 = handler.ValidateToken(jwt1, createParams.TokenValidationParameters, out validatedJwtToken3);
+            var claimsPrincipal3 = handler.ValidateToken(encodedJwt3, createParams.TokenValidationParameters, out validatedJwtToken3);
+
+            SecurityToken validatedJwtToken4 = null;
+            var claimsPrincipal4 = handler.ValidateToken(encodedJwt4, createParams.TokenValidationParameters, out validatedJwtToken4);
 
             var context = new CompareContext();
             var localContext = new CompareContext();
             if (!IdentityComparer.AreJwtSecurityTokensEqual(jwtToken1, jwtToken2, localContext))
             {
-                context.Diffs.Add(string.Format(Environment.NewLine + "RoundTripTokens: Case '{0}', jwtToken != jwtToken2", createParams.Case));
+                context.Diffs.Add("jwtToken1 != jwtToken2");
                 context.Diffs.AddRange(localContext.Diffs);
             }
 
             localContext.Diffs.Clear();
-            if (!IdentityComparer.AreJwtSecurityTokensEqual(jwtToken1, jwtToken3, localContext))
+            if (!IdentityComparer.AreJwtSecurityTokensEqual(jwtToken3, jwtToken4, localContext))
             {
-                context.Diffs.Add(string.Format(Environment.NewLine + "RoundTripTokens: Case '{0}': jwtToken != jwtToken3", createParams.Case));
+                context.Diffs.Add("jwtToken3 != jwtToken4");
                 context.Diffs.AddRange(localContext.Diffs);
             }
 
             localContext.Diffs.Clear();
             if (!IdentityComparer.AreJwtSecurityTokensEqual(validatedJwtToken1 as JwtSecurityToken, validatedJwtToken2 as JwtSecurityToken, localContext))
             {
-                context.Diffs.Add(string.Format(Environment.NewLine + "RoundTripTokens: Case '{0}': validatedJwtToken1 != validatedJwtToken2", createParams.Case));
+                context.Diffs.Add("validatedJwtToken1 != validatedJwtToken2");
                 context.Diffs.AddRange(localContext.Diffs);
             }
 
             localContext.Diffs.Clear();
             if (!IdentityComparer.AreJwtSecurityTokensEqual(validatedJwtToken1 as JwtSecurityToken, validatedJwtToken3 as JwtSecurityToken, localContext))
             {
-                context.Diffs.Add(string.Format(Environment.NewLine + "RoundTripTokens: Case '{0}': validatedJwtToken1 != validatedJwtToken3", createParams.Case));
+                context.Diffs.Add("validatedJwtToken1 != validatedJwtToken3");
                 context.Diffs.AddRange(localContext.Diffs);
             }
 
-            TestUtilities.AssertFailIfErrors("RoundTripTokens", context.Diffs);
+            localContext.Diffs.Clear();
+            if (!IdentityComparer.AreJwtSecurityTokensEqual(validatedJwtToken1 as JwtSecurityToken, validatedJwtToken4 as JwtSecurityToken, localContext))
+            {
+                context.Diffs.Add("validatedJwtToken1 != validatedJwtToken4");
+                context.Diffs.AddRange(localContext.Diffs);
+            }
+
+            localContext.Diffs.Clear();
+            if (!IdentityComparer.AreClaimsPrincipalsEqual(claimsPrincipal1, claimsPrincipal2, localContext))
+            {
+                context.Diffs.Add("claimsPrincipal1 != claimsPrincipal2");
+                context.Diffs.AddRange(localContext.Diffs);
+            }
+
+            localContext.Diffs.Clear();
+            if (!IdentityComparer.AreClaimsPrincipalsEqual(claimsPrincipal1, claimsPrincipal3, localContext))
+            {
+                context.Diffs.Add("claimsPrincipal1 != claimsPrincipal3");
+                context.Diffs.AddRange(localContext.Diffs);
+            }
+
+            localContext.Diffs.Clear();
+            if (!IdentityComparer.AreClaimsPrincipalsEqual(claimsPrincipal1, claimsPrincipal4, localContext))
+            {
+                context.Diffs.Add("claimsPrincipal1 != claimsPrincipal4");
+                context.Diffs.AddRange(localContext.Diffs);
+            }
+
+            TestUtilities.AssertFailIfErrors(string.Format(CultureInfo.InvariantCulture, "RoundTripTokens: Case '{0}'", createParams.Case), context.Diffs);
         }
 
         public static TheoryData<CreateAndValidateParams> CreationParams()
         {
             var createParams = new TheoryData<CreateAndValidateParams>();
-
             var expires = DateTime.UtcNow + TimeSpan.FromDays(1);
             var handler = new JwtSecurityTokenHandler();
             var nbf = DateTime.UtcNow;
@@ -223,12 +263,11 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
             createParams.Add(new CreateAndValidateParams
             {
-                Case = "ClaimSets.DefaultClaims",
+                Case = "ClaimSets.NoClaims",
                 SecurityTokenDescriptor = IdentityUtilities.DefaultAsymmetricSecurityTokenDescriptor(null),
                 TokenValidationParameters = IdentityUtilities.DefaultAsymmetricTokenValidationParameters,
             });
 
-            // empty token
             createParams.Add(new CreateAndValidateParams
             {
                 Case = "EmptyToken",
@@ -352,7 +391,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             DateTime utcNow = DateTime.UtcNow;
             DateTime expire = utcNow + TimeSpan.FromHours(1);
             ClaimsIdentity subject = new ClaimsIdentity(claims: ClaimSets.GetDefaultRoleClaims(null));
-            JwtSecurityToken jwtToken = handler.CreateToken(IdentityUtilities.DefaultIssuer, IdentityUtilities.DefaultAudience, subject, utcNow, expire, utcNow);
+            JwtSecurityToken jwtToken = handler.CreateJwtSecurityToken(IdentityUtilities.DefaultIssuer, IdentityUtilities.DefaultAudience, subject, utcNow, expire, utcNow);
 
             SecurityToken securityToken;
             ClaimsPrincipal principal = handler.ValidateToken(jwtToken.RawData, validationParameters, out securityToken);
@@ -417,7 +456,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                         new Claim(ClaimsIdentity.DefaultRoleClaimType, defaultRole), 
                     });
 
-            JwtSecurityToken jwt = handler.CreateToken(issuer: "https://gotjwt.com", signingCredentials: KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2, subject: subject) as JwtSecurityToken;
+            JwtSecurityToken jwt = handler.CreateJwtSecurityToken(issuer: "https://gotjwt.com", signingCredentials: KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2, subject: subject) as JwtSecurityToken;
 
             // Delegates should override any other settings
             validationParameters.NameClaimTypeRetriever = NameClaimTypeDelegate;


### PR DESCRIPTION
Includes Issues:
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/363
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/361
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/360
