### PR TITLE
Adding ArgumentOutOfRangeException messages that include the argument…

### DIFF
--- a/src/Microsoft.IdentityModel.Logging/LogHelper.cs
+++ b/src/Microsoft.IdentityModel.Logging/LogHelper.cs
@@ -37,7 +37,7 @@ namespace Microsoft.IdentityModel.Logging
     public class LogHelper
     {
         /// <summary>
-        /// Logs an event using the event source logger and returns new <see cref="ArgumentNullException"/> exception.
+        /// Logs an exception using the event source logger and returns new <see cref="ArgumentNullException"/> exception.
         /// </summary>
         /// <param name="argument">argument that is null or empty.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
@@ -47,7 +47,7 @@ namespace Microsoft.IdentityModel.Logging
         }
 
         /// <summary>
-        /// Logs an event using the event source logger and returns new typed exception.
+        /// Logs an exception using the event source logger and returns new typed exception.
         /// </summary>
         /// <param name="message">message to log.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
@@ -57,7 +57,19 @@ namespace Microsoft.IdentityModel.Logging
         }
 
         /// <summary>
-        /// Logs an event using the event source logger and returns new typed exception.
+        /// Logs an argument exception using the event source logger and returns new typed exception.
+        /// </summary>
+        /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
+        /// <param name="message">message to log.</param>
+        /// <remarks>EventLevel is set to Error.</remarks>
+        public static T LogArgumentException<T>(string argumentName, string message) where T : ArgumentException
+        {
+            return LogArgumentException<T>(EventLevel.Error, argumentName, null, message, null);
+        }
+
+
+        /// <summary>
+        /// Logs an exception using the event source logger and returns new typed exception.
         /// </summary>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
@@ -68,7 +80,19 @@ namespace Microsoft.IdentityModel.Logging
         }
 
         /// <summary>
-        /// Logs an event using the event source logger and returns new typed exception.
+        /// Logs an argument exception using the event source logger and returns new typed exception.
+        /// </summary>
+        /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
+        /// <param name="format">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        /// <remarks>EventLevel is set to Error.</remarks>
+        public static T LogArgumentException<T>(string argumentName, string format, params object[] args) where T : ArgumentException
+        {
+            return LogArgumentException<T>(EventLevel.Error, argumentName, null, format, args);
+        }
+
+        /// <summary>
+        /// Logs an exception using the event source logger and returns new typed exception.
         /// </summary>
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="message">message to log.</param>
@@ -79,7 +103,19 @@ namespace Microsoft.IdentityModel.Logging
         }
 
         /// <summary>
-        /// Logs an event using the event source logger and returns new typed exception.
+        /// Logs an argument exception using the event source logger and returns new typed exception.
+        /// </summary>
+        /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
+        /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
+        /// <param name="message">message to log.</param>
+        /// <remarks>EventLevel is set to Error.</remarks>
+        public static T LogArgumentException<T>(string argumentName, Exception innerException, string message) where T : ArgumentException
+        {
+            return LogArgumentException<T>(EventLevel.Error, argumentName, innerException, message, null);
+        }
+
+        /// <summary>
+        /// Logs an exception using the event source logger and returns new typed exception.
         /// </summary>
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="format">Format string of the log message.</param>
@@ -91,7 +127,20 @@ namespace Microsoft.IdentityModel.Logging
         }
 
         /// <summary>
-        /// Logs an event using the event source logger and returns new typed exception.
+        /// Logs an argument exception using the event source logger and returns new typed exception.
+        /// </summary>
+        /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
+        /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
+        /// <param name="format">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        /// <remarks>EventLevel is set to Error.</remarks>
+        public static T LogArgumentException<T>(string argumentName, Exception innerException, string format, params object[] args) where T : ArgumentException
+        {
+            return LogArgumentException<T>(EventLevel.Error, argumentName, innerException, format, args);
+        }
+
+        /// <summary>
+        /// Logs an exception using the event source logger and returns new typed exception.
         /// </summary>
         /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
         /// <param name="message">message to log.</param>
@@ -101,7 +150,18 @@ namespace Microsoft.IdentityModel.Logging
         }
 
         /// <summary>
-        /// Logs an event using the event source logger and returns new typed exception.
+        /// Logs an argument exception using the event source logger and returns new typed exception.
+        /// </summary>
+        /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
+        /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
+        /// <param name="message">message to log.</param>
+        public static T LogArgumentException<T>(EventLevel eventLevel, string argumentName, string message) where T : ArgumentException
+        {
+            return LogArgumentException<T>(eventLevel, argumentName, null, message, null);
+        }
+
+        /// <summary>
+        /// Logs an exception using the event source logger and returns new typed exception.
         /// </summary>
         /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
         /// <param name="format">Format string of the log message.</param>
@@ -112,7 +172,19 @@ namespace Microsoft.IdentityModel.Logging
         }
 
         /// <summary>
-        /// Logs an event using the event source logger and returns new typed exception.
+        /// Logs an argument exception using the event source logger and returns new typed exception.
+        /// </summary>
+        /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
+        /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
+        /// <param name="format">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static T LogArgumentException<T>(EventLevel eventLevel, string argumentName, string format, params object[] args) where T : ArgumentException
+        {
+            return LogArgumentException<T>(eventLevel, argumentName, null, format, args);
+        }
+
+        /// <summary>
+        /// Logs an exception using the event source logger and returns new typed exception.
         /// </summary>
         /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
@@ -123,13 +195,51 @@ namespace Microsoft.IdentityModel.Logging
         }
 
         /// <summary>
-        /// Logs an event using the event source logger and returns new typed exception.
+        /// Logs an argument exception using the event source logger and returns new typed exception.
+        /// </summary>
+        /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
+        /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
+        /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
+        /// <param name="message">message to log.</param>
+        public static T LogArgumentException<T>(EventLevel eventLevel, string argumentName, Exception innerException, string message) where T : ArgumentException
+        {
+            return LogArgumentException<T>(eventLevel, argumentName, innerException, message, null);
+        }
+
+        /// <summary>
+        /// Logs an exception using the event source logger and returns new typed exception.
         /// </summary>
         /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static T LogException<T>(EventLevel eventLevel, Exception innerException, string format, params object[] args) where T : Exception
+        {
+            return LogExceptionImpl<T>(eventLevel, null, innerException, format, args);
+        }
+
+        /// <summary>
+        /// Logs an argument exception using the event source logger and returns new typed exception.
+        /// </summary>
+        /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
+        /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
+        /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
+        /// <param name="format">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static T LogArgumentException<T>(EventLevel eventLevel, string argumentName, Exception innerException, string format, params object[] args) where T : ArgumentException
+        {
+            return LogExceptionImpl<T>(eventLevel, argumentName, innerException, format, args);
+        }
+
+        /// <summary>
+        /// Logs an exception using the event source logger and returns new typed exception.
+        /// </summary>
+        /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
+        /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
+        /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
+        /// <param name="format">Format string of the log message.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        private static T LogExceptionImpl<T>(EventLevel eventLevel, string argumentName, Exception innerException, string format, params object[] args) where T : Exception 
         {
             string message = null;
 
@@ -141,10 +251,17 @@ namespace Microsoft.IdentityModel.Logging
             if (IdentityModelEventSource.Logger.IsEnabled() && IdentityModelEventSource.Logger.LogLevel >= eventLevel)
                 IdentityModelEventSource.Logger.Write(eventLevel, innerException, message);
 
-            if (innerException != null)
-                return (T)Activator.CreateInstance(typeof(T), message, innerException);
+            if (innerException != null) 
+                if (String.IsNullOrEmpty(argumentName))
+                    return (T)Activator.CreateInstance(typeof(T), message, innerException);
+                else
+                    return (T)Activator.CreateInstance(typeof(T), argumentName, message, innerException);
             else
-                return (T)Activator.CreateInstance(typeof(T), message);
+                if (String.IsNullOrEmpty(argumentName))
+                    return (T)Activator.CreateInstance(typeof(T), message);
+                else
+                    return (T)Activator.CreateInstance(typeof(T), argumentName, message);
         }
+
     }
 }

--- a/src/Microsoft.IdentityModel.Logging/LogHelper.cs
+++ b/src/Microsoft.IdentityModel.Logging/LogHelper.cs
@@ -43,7 +43,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <remarks>EventLevel is set to Error.</remarks>
         public static ArgumentNullException LogArgumentNullException(string argument)
         {
-            return LogException<ArgumentNullException>(EventLevel.Error, null, "IDX10000: The parameter '{0}' cannot be a 'null' or an empty object.", argument);
+            return LogArgumentException<ArgumentNullException>(EventLevel.Error, argument, "IDX10000: The parameter '{0}' cannot be a 'null' or an empty object.", argument);
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfigurationRetriever.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfigurationRetriever.cs
@@ -81,11 +81,11 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         public static async Task<OpenIdConnectConfiguration> GetAsync(string address, IDocumentRetriever retriever, CancellationToken cancel)
         {
             if (string.IsNullOrWhiteSpace(address))
-                throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10000, "address");
+                throw LogHelper.LogArgumentNullException(nameof(address));
 
             if (retriever == null)
             {
-                throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10000, "retriever");
+                throw LogHelper.LogArgumentNullException(nameof(retriever));
             }
 
             string doc = await retriever.GetDocumentAsync(address, cancel).ConfigureAwait(false);

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
@@ -35,8 +35,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 #pragma warning disable 1591
         // general
         internal const string IDX10000 = "IDX10000: The parameter '{0}' cannot be a 'null' or an empty object.";
-        internal const string IDX10001 = "IDX10001: The property value '{0}' cannot be a 'null' or an empty object.";
-        internal const string IDX10002 = "IDX10002: The parameter '{0}' cannot be 'null' or a string containing only whitespace.";
 
         // properties, configuration 
         internal const string IDX10105 = "IDX10105: NonceLifetime must be greater than zero. value: '{0}'";

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -134,7 +134,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             {
                 if (value <= TimeSpan.Zero)
                 {
-                    throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10105, value);
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("value", LogMessages.IDX10105, value);
                 }
 
                 _nonceLifetime = value;

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/LogMessages.cs
@@ -35,8 +35,6 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         #pragma warning disable 1591
         // general
         internal const string IDX10000 = "IDX10000: The parameter '{0}' cannot be a 'null' or an empty object.";
-        internal const string IDX10001 = "IDX10001: The property value '{0}' cannot be a 'null' or an empty object.";
-        internal const string IDX10002 = "IDX10002: The parameter '{0}' cannot be 'null' or a string containing only whitespace.";
 
         // wsfederation messages
         internal const string IDX10900 = "IDX10900: Building wsfederation message from query string: '{0}'.";

--- a/src/Microsoft.IdentityModel.Protocols/AuthenticationProtocolMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols/AuthenticationProtocolMessage.cs
@@ -145,7 +145,7 @@ namespace Microsoft.IdentityModel.Protocols
             set
             {
                 if (value == null)
-                    throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10001, "IssuerAddress");
+                    throw LogHelper.LogArgumentNullException("value");
 
                 _issuerAddress = value;
             }
@@ -176,7 +176,7 @@ namespace Microsoft.IdentityModel.Protocols
             set
             {
                 if (value == null)
-                    throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10001, "PostTitle");
+                    throw LogHelper.LogArgumentNullException("value");
 
                 _postTitle = value;
             }
@@ -190,7 +190,7 @@ namespace Microsoft.IdentityModel.Protocols
         public virtual void RemoveParameter(string parameter)
         {
             if (string.IsNullOrEmpty(parameter))
-                throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10001, "parameter");
+                throw LogHelper.LogArgumentNullException(nameof(parameter));
 
             if (_parameters.ContainsKey(parameter))
                 _parameters.Remove(parameter);
@@ -247,7 +247,7 @@ namespace Microsoft.IdentityModel.Protocols
             set
             {
                 if (value == null)
-                    throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10001, "ScriptButtonText");
+                    throw LogHelper.LogArgumentNullException("value");
 
                 _scriptButtonText = value;
             }
@@ -267,7 +267,7 @@ namespace Microsoft.IdentityModel.Protocols
             set
             {
                 if (value == null)
-                    throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10001, "ScriptDisabledText");
+                    throw LogHelper.LogArgumentNullException("value");
 
                 _scriptDisabledText = value;
             }

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -124,7 +124,7 @@ namespace Microsoft.IdentityModel.Protocols
             set
             {
                 if (value < MinimumAutomaticRefreshInterval)
-                    throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10107, MinimumAutomaticRefreshInterval, value);
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("value", LogMessages.IDX10107, MinimumAutomaticRefreshInterval, value);
 
                 _automaticRefreshInterval = value;
             }
@@ -139,7 +139,7 @@ namespace Microsoft.IdentityModel.Protocols
             set
             {
                 if (value < MinimumRefreshInterval)
-                    throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10106, MinimumRefreshInterval, value);
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("value", LogMessages.IDX10106, MinimumRefreshInterval, value);
 
                 _refreshInterval = value;
             }

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/StaticConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/StaticConfigurationManager.cs
@@ -48,7 +48,7 @@ namespace Microsoft.IdentityModel.Protocols
         public StaticConfigurationManager(T configuration)
         {
             if (configuration == null)
-                throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10108, "configuration");
+                throw LogHelper.LogArgumentException<ArgumentNullException>(LogMessages.IDX10108, nameof(configuration));
 
             _configuration = configuration;
         }

--- a/src/Microsoft.IdentityModel.Protocols/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols/LogMessages.cs
@@ -35,13 +35,11 @@ namespace Microsoft.IdentityModel.Protocols
 #pragma warning disable 1591
         // general
         internal const string IDX10000 = "IDX10000: The parameter '{0}' cannot be a 'null' or an empty object.";
-        internal const string IDX10001 = "IDX10001: The property value '{0}' cannot be a 'null' or an empty object.";
-        internal const string IDX10002 = "IDX10002: The parameter '{0}' cannot be 'null' or a string containing only whitespace.";
 
         // properties, configuration 
         internal const string IDX10106 = "IDX10106: When setting RefreshInterval, the value must be greater than MinimumRefreshInterval: '{0}'. value: '{1}'.";
         internal const string IDX10107 = "IDX10107: When setting AutomaticRefreshInterval, the value must be greater than MinimumAutomaticRefreshInterval: '{0}'. value: '{1}'.";
-        internal const string IDX10108 = "IDX10108: The address specified is not valid as per HTTPS scheme. Please specify an https address for security reasons. If you want to test with http address, set the RequireHttps property  on IDocumentRetriever to false. address: '{0}'.";
+        internal const string IDX10108 = "IDX10108: The address specified is not valid as per HTTPS scheme. Please specify an https address for security reasons. If you want to test with http address, set the RequireHttps property  on IDocumentRetriever to false.";
 
         // configuration retrieval errors
         internal const string IDX10803 = "IDX10803: Unable to obtain configuration from: '{0}'.";

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -141,7 +141,7 @@ namespace Microsoft.IdentityModel.Tokens
                 {
                     _ecdsa = asymmetricAlgorithm as ECDsa;
                     if (_ecdsa == null)
-                        throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key", LogMessages.IDX10641, key);
+                        throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>(nameof(key), LogMessages.IDX10641, key);
                 }
 #else
                 _rsaCryptoServiceProvider = asymmetricAlgorithm as RSACryptoServiceProvider;
@@ -149,7 +149,7 @@ namespace Microsoft.IdentityModel.Tokens
                 {
                     _ecdsa = asymmetricAlgorithm as ECDsaCng;
                     if (_ecdsa == null)
-                        throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key", LogMessages.IDX10641, key);
+                        throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>(nameof(key), LogMessages.IDX10641, key);
                 }
 #endif
             }
@@ -221,7 +221,7 @@ namespace Microsoft.IdentityModel.Tokens
                     return HashAlgorithmName.SHA512;
             }
 
-            throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("algorithm", LogMessages.IDX10640, algorithm);
+            throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>(nameof(algorithm), LogMessages.IDX10640, algorithm);
         }
 
         private void ResolveAsymmetricAlgorithm(SecurityKey key, string algorithm, bool willCreateSignatures)
@@ -301,7 +301,7 @@ namespace Microsoft.IdentityModel.Tokens
                 return;
             }
 
-            throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key", LogMessages.IDX10641, key);
+            throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>(nameof(key), LogMessages.IDX10641, key);
         }
 #else
         protected virtual string GetHashAlgorithmString(string algorithm)
@@ -330,7 +330,7 @@ namespace Microsoft.IdentityModel.Tokens
                     return SecurityAlgorithms.Sha512;
             }
 
-            throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("algorithm", LogMessages.IDX10640, algorithm);
+            throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>(nameof(algorithm), LogMessages.IDX10640, algorithm);
         }
 
         private void ResolveAsymmetricAlgorithm(SecurityKey key, string algorithm, bool willCreateSignatures)
@@ -392,7 +392,7 @@ namespace Microsoft.IdentityModel.Tokens
                 return;
             }
 
-            throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key", LogMessages.IDX10641, key);
+            throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>(nameof(key), LogMessages.IDX10641, key);
         }
 #endif
 

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -141,7 +141,7 @@ namespace Microsoft.IdentityModel.Tokens
                 {
                     _ecdsa = asymmetricAlgorithm as ECDsa;
                     if (_ecdsa == null)
-                        throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10641, key);
+                        throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key", LogMessages.IDX10641, key);
                 }
 #else
                 _rsaCryptoServiceProvider = asymmetricAlgorithm as RSACryptoServiceProvider;
@@ -149,7 +149,7 @@ namespace Microsoft.IdentityModel.Tokens
                 {
                     _ecdsa = asymmetricAlgorithm as ECDsaCng;
                     if (_ecdsa == null)
-                        throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10641, key);
+                        throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key", LogMessages.IDX10641, key);
                 }
 #endif
             }
@@ -221,7 +221,7 @@ namespace Microsoft.IdentityModel.Tokens
                     return HashAlgorithmName.SHA512;
             }
 
-            throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10640, algorithm);
+            throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("algorithm", LogMessages.IDX10640, algorithm);
         }
 
         private void ResolveAsymmetricAlgorithm(SecurityKey key, string algorithm, bool willCreateSignatures)
@@ -301,7 +301,7 @@ namespace Microsoft.IdentityModel.Tokens
                 return;
             }
 
-            throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10641, key);
+            throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key", LogMessages.IDX10641, key);
         }
 #else
         protected virtual string GetHashAlgorithmString(string algorithm)
@@ -330,7 +330,7 @@ namespace Microsoft.IdentityModel.Tokens
                     return SecurityAlgorithms.Sha512;
             }
 
-            throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10640, algorithm);
+            throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("algorithm", LogMessages.IDX10640, algorithm);
         }
 
         private void ResolveAsymmetricAlgorithm(SecurityKey key, string algorithm, bool willCreateSignatures)
@@ -392,7 +392,7 @@ namespace Microsoft.IdentityModel.Tokens
                 return;
             }
 
-            throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10641, key);
+            throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key", LogMessages.IDX10641, key);
         }
 #endif
 
@@ -684,11 +684,11 @@ namespace Microsoft.IdentityModel.Tokens
             if (willCreateSignatures)
             {
                 if (MinimumAsymmetricKeySizeInBitsForSigningMap.ContainsKey(algorithm) && key.KeySize < MinimumAsymmetricKeySizeInBitsForSigningMap[algorithm])
-                    throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10630, key, MinimumAsymmetricKeySizeInBitsForSigningMap[algorithm], key.KeySize);
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key.KeySize", LogMessages.IDX10630, key, MinimumAsymmetricKeySizeInBitsForSigningMap[algorithm], key.KeySize);
             }
 
             if (MinimumAsymmetricKeySizeInBitsForVerifyingMap.ContainsKey(algorithm) && key.KeySize < MinimumAsymmetricKeySizeInBitsForVerifyingMap[algorithm])
-                throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10631, key, MinimumAsymmetricKeySizeInBitsForVerifyingMap[algorithm], key.KeySize);
+                throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key.KeySize", LogMessages.IDX10631, key, MinimumAsymmetricKeySizeInBitsForVerifyingMap[algorithm], key.KeySize);
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -408,7 +408,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (willCreateSignatures)
             {
                 if (webKey.D == null || webKey.DP == null || webKey.DQ == null || webKey.QI == null || webKey.P == null || webKey.Q == null)
-                    throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10702, webKey);
+                    throw LogHelper.LogArgumentException<ArgumentNullException>(nameof(webKey), LogMessages.IDX10702, webKey);
 
                 parameters = new RSAParameters()
                 {

--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -111,7 +111,7 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogArgumentNullException("algorithm");
 
             if (string.IsNullOrWhiteSpace(algorithm))
-                throw LogHelper.LogException<ArgumentException>(LogMessages.IDX10002, "algorithm");
+                throw LogHelper.LogArgumentNullException(nameof(algorithm));
 
             AsymmetricSecurityKey asymmetricKey = key as AsymmetricSecurityKey;
             if (asymmetricKey != null)

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -71,7 +71,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         // Crypto Errors
         internal const string IDX10600 = "IDX10600: '{0}' supports: '{1}' of types: '{2}' or '{3}'. SecurityKey received was of type: '{4}'.";
-        internal const string IDX10603 = "IDX10603: The algorithm: '{0}' cannot have less than: '{1}' bits. KeySize: '{2}'.";
+        internal const string IDX10603 = "IDX10603: The algorithm: '{0}' cannot have less than: '{1}' bits. KeySize is: '{2}'.";
         internal const string IDX10613 = "IDX10613: Cannot set the MinimumAsymmetricKeySizeInBitsForSigning to less than: '{0}'.";
         internal const string IDX10621 = "IDX10621: This AsymmetricSignatureProvider has a minimum key size requirement of: '{0}', the AsymmetricSecurityKey in has a KeySize of: '{1}'.";
         internal const string IDX10623 = "IDX10623: The KeyedHashAlgorithm is null, cannot sign data.";

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -35,8 +35,6 @@ namespace Microsoft.IdentityModel.Tokens
         #pragma warning disable 1591
         // general
         internal const string IDX10000 = "IDX10000: The parameter '{0}' cannot be a 'null' or an empty object.";
-        internal const string IDX10001 = "IDX10001: The property value '{0}' cannot be a 'null' or an empty object.";
-        internal const string IDX10002 = "IDX10002: The parameter '{0}' cannot be 'null' or a string containing only whitespace.";
 
         // properties, configuration 
         internal const string IDX10100 = "IDX10100: ClockSkew must be greater than TimeSpan.Zero. value: '{0}'";

--- a/src/Microsoft.IdentityModel.Tokens/SignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SignatureProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.IdentityModel.Tokens
         protected SignatureProvider(SecurityKey key, string algorithm)
         {
             if (key == null)
-                throw LogHelper.LogException<ArgumentNullException>("key");
+                throw LogHelper.LogArgumentNullException(nameof(key));
 
             Key = key;
             Algorithm = algorithm;

--- a/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogArgumentNullException("key");
 
             if (!key.IsSupportedAlgorithm(algorithm))
-                throw LogHelper.LogArgumentException<ArgumentException>("algorithm", LogMessages.IDX10640, (algorithm ?? "null"));
+                throw LogHelper.LogArgumentException<ArgumentException>(nameof(algorithm), LogMessages.IDX10640, (algorithm ?? "null"));
 
             if (key.KeySize < MinimumSymmetricKeySizeInBits)
                 throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key.KeySize", LogMessages.IDX10603, (algorithm ?? "null"), MinimumSymmetricKeySizeInBits, key.KeySize);
@@ -95,7 +95,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
 
             if (_keyedHash == null)
-                throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key", LogMessages.IDX10641, key);
+                throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>(nameof(key), LogMessages.IDX10641, key);
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace Microsoft.IdentityModel.Tokens
                 case SecurityAlgorithms.HmacSha512:
                     return new HMACSHA512(key);
                 default:
-                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("algorithm", LogMessages.IDX10640, algorithm);
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>(nameof(algorithm), LogMessages.IDX10640, algorithm);
             }
         }
 

--- a/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
@@ -68,10 +68,10 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogArgumentNullException("key");
 
             if (!key.IsSupportedAlgorithm(algorithm))
-                throw LogHelper.LogException<ArgumentException>(LogMessages.IDX10640, (algorithm ?? "null"));
+                throw LogHelper.LogArgumentException<ArgumentException>("algorithm", LogMessages.IDX10640, (algorithm ?? "null"));
 
             if (key.KeySize < MinimumSymmetricKeySizeInBits)
-                throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10603, (algorithm ?? "null"), MinimumSymmetricKeySizeInBits, key.KeySize);
+                throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key.KeySize", LogMessages.IDX10603, (algorithm ?? "null"), MinimumSymmetricKeySizeInBits, key.KeySize);
 
             try
             {
@@ -95,7 +95,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
 
             if (_keyedHash == null)
-                throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10641, key);
+                throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("key", LogMessages.IDX10641, key);
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Microsoft.IdentityModel.Tokens
             set
             {
                 if (value < DefaultMinimumSymmetricKeySizeInBits)
-                    throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10628, DefaultMinimumSymmetricKeySizeInBits);
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("value", LogMessages.IDX10628, DefaultMinimumSymmetricKeySizeInBits);
 
                 _minimumSymmetricKeySizeInBits = value;
             }
@@ -138,7 +138,7 @@ namespace Microsoft.IdentityModel.Tokens
                 case SecurityAlgorithms.HmacSha512:
                     return new HMACSHA512(key);
                 default:
-                    throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10640, algorithm);
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("algorithm", LogMessages.IDX10640, algorithm);
             }
         }
 

--- a/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
@@ -200,7 +200,7 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogException<ObjectDisposedException>(typeof(SymmetricSignatureProvider).ToString());
 
             if (_keyedHash == null)
-                throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10623);
+                throw LogHelper.LogException<ArgumentException>(LogMessages.IDX10623);
 
             IdentityModelEventSource.Logger.WriteInformation(LogMessages.IDX10643, input);
             return AreEqual(signature, _keyedHash.ComputeHash(input));

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -301,7 +301,7 @@ namespace Microsoft.IdentityModel.Tokens
             set
             {
                 if (value == null)
-                    throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10001, nameof(CryptoProviderFactory));
+                    throw LogHelper.LogArgumentNullException("value");
 
                 _cryptoProviderFactory = value;
             }

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -240,7 +240,7 @@ namespace Microsoft.IdentityModel.Tokens
             set
             {
                 if (value < TimeSpan.Zero)
-                    throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10100, value);
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("value", LogMessages.IDX10100, value);
 
                 _clockSkew = value;
             }
@@ -391,7 +391,7 @@ namespace Microsoft.IdentityModel.Tokens
             set
             {
                 if (string.IsNullOrWhiteSpace(value))
-                    throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10102);
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("value", LogMessages.IDX10102);
 
                 _nameClaimType = value;
             }
@@ -414,7 +414,7 @@ namespace Microsoft.IdentityModel.Tokens
             set
             {
                 if (string.IsNullOrWhiteSpace(value))
-                    throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10103);
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("value", LogMessages.IDX10103);
 
                 _roleClaimType = value;
             }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
@@ -51,11 +51,8 @@ namespace System.IdentityModel.Tokens.Jwt
         /// </remarks>
         public JwtSecurityToken(string jwtEncodedString)
         {
-            if (null == jwtEncodedString)
-                throw LogHelper.LogArgumentNullException("jwtEncodedString");
-
             if (string.IsNullOrWhiteSpace(jwtEncodedString))
-                throw LogHelper.LogException<ArgumentException>(LogMessages.IDX10002, "jwtEncodedString");
+                throw LogHelper.LogArgumentNullException(nameof(jwtEncodedString));
 
             // Quick fix prior to beta8, will add configuration in RC
             var regex = new Regex(JwtConstants.JsonCompactSerializationRegex);
@@ -85,19 +82,19 @@ namespace System.IdentityModel.Tokens.Jwt
         public JwtSecurityToken(JwtHeader header, JwtPayload payload, string rawHeader, string rawPayload, string rawSignature)
         {
             if (header == null)
-                throw LogHelper.LogArgumentNullException("header");
+                throw LogHelper.LogArgumentNullException(nameof(header));
 
             if (payload == null)
-                throw LogHelper.LogArgumentNullException("payload");
+                throw LogHelper.LogArgumentNullException(nameof(payload));
 
             if (string.IsNullOrWhiteSpace(rawHeader))
-                throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10002, "rawHeader");
+                throw LogHelper.LogArgumentNullException(nameof(rawHeader));
 
             if (string.IsNullOrWhiteSpace(rawPayload))
-                throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10002, "rawPayload");
+                throw LogHelper.LogArgumentNullException(nameof(rawPayload));
 
             if (rawSignature == null)
-                throw LogHelper.LogArgumentNullException("rawSignature");
+                throw LogHelper.LogArgumentNullException(nameof(rawSignature));
 
             Header = header;
             Payload = payload;

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -229,7 +229,7 @@ namespace System.IdentityModel.Tokens.Jwt
             set
             {
                 if (value < 1)
-                    throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10104, value);
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("value", LogMessages.IDX10104, value);
 
                 _defaultTokenLifetimeInMinutes = value;
             }
@@ -254,7 +254,7 @@ namespace System.IdentityModel.Tokens.Jwt
             set
             {
                 if (value < 1)
-                    throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10101, value);
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("value", LogMessages.IDX10101, value);
 
                 _maximumTokenSizeInBytes = value;
             }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -104,7 +104,7 @@ namespace System.IdentityModel.Tokens.Jwt
             set
             {
                 if (value == null)
-                    throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10001, "InboundClaimTypeMap");
+                    throw LogHelper.LogArgumentNullException("value");
 
                 _inboundClaimTypeMap = value;
             }
@@ -127,7 +127,7 @@ namespace System.IdentityModel.Tokens.Jwt
             set
             {
                 if (value == null)
-                    throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10001, "OutboundClaimTypeMap");
+                    throw LogHelper.LogArgumentNullException("value");
 
                 _outboundClaimTypeMap = value;
             }
@@ -148,7 +148,7 @@ namespace System.IdentityModel.Tokens.Jwt
             set
             {
                 if (value == null)
-                    throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10001, "InboundClaimFilter");
+                    throw LogHelper.LogArgumentNullException("value");
 
                 _inboundClaimFilter = value;
             }
@@ -169,7 +169,7 @@ namespace System.IdentityModel.Tokens.Jwt
             set
             {
                 if (string.IsNullOrWhiteSpace(value))
-                    throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10001, "ShortClaimTypeProperty");
+                    throw LogHelper.LogArgumentNullException("value");
 
                 shortClaimTypeProperty = value;
             }
@@ -190,7 +190,7 @@ namespace System.IdentityModel.Tokens.Jwt
             set
             {
                 if (string.IsNullOrWhiteSpace(value))
-                    throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10001, "JsonClaimTypeProperty");
+                    throw LogHelper.LogArgumentNullException("value");
 
                 jsonClaimTypeProperty = value;
             }
@@ -633,7 +633,7 @@ namespace System.IdentityModel.Tokens.Jwt
 
             JwtSecurityToken jwt = token as JwtSecurityToken;
             if (jwt == null)
-                throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10706, new object[] { GetType(), typeof(JwtSecurityToken), token.GetType() });
+                throw LogHelper.LogArgumentException<ArgumentException>(nameof(token), LogMessages.IDX10706, new object[] { GetType(), typeof(JwtSecurityToken), token.GetType() });
 
             string signingInput = string.Concat(jwt.EncodedHeader, ".", jwt.EncodedPayload);
             if (jwt.SigningCredentials == null)
@@ -855,7 +855,7 @@ namespace System.IdentityModel.Tokens.Jwt
         protected virtual string CreateActorValue(ClaimsIdentity actor)
         {
             if (actor == null)
-                throw LogHelper.LogException<ArgumentNullException>(LogMessages.IDX10003, "actor");
+                throw LogHelper.LogArgumentNullException(nameof(actor));
 
             if (actor.BootstrapContext != null)
             {

--- a/src/System.IdentityModel.Tokens.Jwt/LogMessages.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/LogMessages.cs
@@ -35,9 +35,6 @@ namespace System.IdentityModel.Tokens.Jwt
         #pragma warning disable 1591
         // general
         internal const string IDX10000 = "IDX10000: The parameter '{0}' cannot be a 'null' or an empty object.";
-        internal const string IDX10001 = "IDX10001: The property value '{0}' cannot be a 'null' or an empty object.";
-        internal const string IDX10002 = "IDX10002: The parameter '{0}' cannot be 'null' or a string containing only whitespace.";
-        internal const string IDX10003 = "IDX10003: The parameter '{0}' cannot be 'null'.";
 
         // properties, configuration 
         internal const string IDX10101 = "IDX10101: MaximumTokenSizeInBytes must be greater than zero. value: '{0}'";

--- a/src/System.IdentityModel.Tokens.Saml/LogMessages.cs
+++ b/src/System.IdentityModel.Tokens.Saml/LogMessages.cs
@@ -35,8 +35,6 @@ namespace System.IdentityModel.Tokens.Saml
 #pragma warning disable 1591
         // general
         internal const string IDX10000 = "IDX10000: The parameter '{0}' cannot be a 'null' or an empty object.";
-        internal const string IDX10001 = "IDX10001: The property value '{0}' cannot be a 'null' or an empty object.";
-        internal const string IDX10002 = "IDX10002: The parameter '{0}' cannot be 'null' or a string containing only whitespace.";
 
         // properties, configuration 
         internal const string IDX10101 = "IDX10101: MaximumTokenSizeInBytes must be greater than zero. value: '{0}'";

--- a/src/System.IdentityModel.Tokens.Saml/Saml2SecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Saml/Saml2SecurityTokenHandler.cs
@@ -193,7 +193,7 @@ namespace System.IdentityModel.Tokens.Saml2
             {
                 if (value < 1)
                 {
-                    throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10101, value.ToString(CultureInfo.InvariantCulture));
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("value", LogMessages.IDX10101, value.ToString(CultureInfo.InvariantCulture));
                 }
 
                 _maximumTokenSizeInBytes = value;

--- a/src/System.IdentityModel.Tokens.Saml/SamlSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Saml/SamlSecurityTokenHandler.cs
@@ -180,7 +180,7 @@ namespace System.IdentityModel.Tokens.Saml
             {
                 if (value < 1)
                 {
-                    throw LogHelper.LogException<ArgumentOutOfRangeException>(LogMessages.IDX10101, value);
+                    throw LogHelper.LogArgumentException<ArgumentOutOfRangeException>("value", LogMessages.IDX10101, value);
                 }
 
                 _maximumTokenSizeInBytes = value;

--- a/test/Microsoft.IdentityModel.Protocols.Tests/AuthenticationProtocolMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/AuthenticationProtocolMessageTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.IdentityModel.Protocols.Tests
 
             foreach(string property in properties)
             {
-                TestUtilities.SetGet(authenticationProtocolMessage, property, null, ExpectedException.ArgumentNullException(substringExpected: property));
+                TestUtilities.SetGet(authenticationProtocolMessage, property, null, ExpectedException.ArgumentNullException(substringExpected: "value"));
                 TestUtilities.SetGet(authenticationProtocolMessage, property, property, ExpectedException.NoExceptionExpected);
                 TestUtilities.SetGet(authenticationProtocolMessage, property, "    ", ExpectedException.NoExceptionExpected);
                 TestUtilities.SetGet(authenticationProtocolMessage, property, "\t\n\r", ExpectedException.NoExceptionExpected);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -47,8 +47,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             CryptoProviderFactory factory = new CryptoProviderFactory();
 
             // Asymmetric / Symmetric both need signature alg specified
-            FactoryCreateFor("Signing:    - algorithm string.Empty", KeyingMaterial.X509SecurityKey_1024, string.Empty, factory, ExpectedException.ArgumentException());
-            FactoryCreateFor("Verifying: - algorithm string.Empty", KeyingMaterial.X509SecurityKey_1024, string.Empty, factory, ExpectedException.ArgumentException());
+            FactoryCreateFor("Signing:    - algorithm string.Empty", KeyingMaterial.X509SecurityKey_1024, string.Empty, factory, ExpectedException.ArgumentNullException());
+            FactoryCreateFor("Verifying: - algorithm string.Empty", KeyingMaterial.X509SecurityKey_1024, string.Empty, factory, ExpectedException.ArgumentNullException());
 
             // Json Web Keys
             FactoryCreateFor("Signing: - No exception", KeyingMaterial.JsonWebKeyRsa256, SecurityAlgorithms.RsaSha256, factory, ExpectedException.NoExceptionExpected);

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
@@ -103,7 +103,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             {
                 Name = "EncodedString: string.Empty",
                 EncodedString = string.Empty,
-                ExpectedException = ExpectedException.ArgumentException(substringExpected: "IDX10002:"),
+                ExpectedException = ExpectedException.ArgumentNullException(),
             });
 
             RunEncodedTest(new JwtSecurityTokenTestVariation


### PR DESCRIPTION
… name

@tushargupta51 @brentschmaltz @ChenYan98 
This addresses #374 to clean up ArgumentOutOfRangeException messages for users. I didn't pull out the error numbers because I assume those are used to diagnose and debug when users report issues. ArgumentNullException messages didn't change because they already had clear messages.