### PR TITLE
Add 'sid' to OpenIdConnectMessage/OpenIdConnectParameterNames/JwtRegisteredClaimNames

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs
@@ -497,6 +497,15 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         }
 
         /// <summary>
+        /// Gets or sets 'sid'.
+        /// </summary>
+        public string Sid
+        {
+            get { return GetParameter(OpenIdConnectParameterNames.Sid); }
+            set { SetParameter(OpenIdConnectParameterNames.Sid, value); }
+        }
+
+        /// <summary>
         /// Gets or sets 'state'.
         /// </summary>
         public string State

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectParameterNames.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectParameterNames.cs
@@ -66,6 +66,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         public const string ResponseType = "response_type";
         public const string Scope = "scope";
         public const string SessionState = "session_state";
+        public const string Sid = "sid";
         public const string State = "state";
         public const string TargetLinkUri = "target_link_uri";
         public const string TokenType = "token_type";

--- a/src/System.IdentityModel.Tokens.Jwt/JwtRegisteredClaimNames.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtRegisteredClaimNames.cs
@@ -140,6 +140,11 @@ namespace System.IdentityModel.Tokens.Jwt
         public const string Prn = "prn";
 
         /// <summary>
+        /// http://openid.net/specs/openid-connect-frontchannel-1_0.html#OPLogout
+        /// </summary>
+        public const string Sid = "sid";
+
+        /// <summary>
         /// http://tools.ietf.org/html/rfc7519#section-4
         /// </summary>
         public const string Sub = "sub";

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
@@ -165,8 +165,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             OpenIdConnectMessage message = new OpenIdConnectMessage();
             Type type = typeof(OpenIdConnectMessage);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 46)
-                Assert.True(true, "Number of public fields has changed from 46 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 47)
+                Assert.True(true, "Number of public fields has changed from 47 to: " + properties.Length + ", adjust tests");
 
             GetSetContext context =
                 new GetSetContext
@@ -204,6 +204,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new KeyValuePair<string, List<object>>("Resource", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                         new KeyValuePair<string, List<object>>("Scope", new List<object>{null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                         new KeyValuePair<string, List<object>>("SessionState", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
+                        new KeyValuePair<string, List<object>>("Sid", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                         new KeyValuePair<string, List<object>>("State", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                         new KeyValuePair<string, List<object>>("TargetLinkUri", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                         new KeyValuePair<string, List<object>>("TokenEndpoint", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),


### PR DESCRIPTION
The OIDC middleware is going to use `sid` soon: https://github.com/aspnet/Security/pull/852. That would be great if we could have a constant for that.

@tushargupta51 @brentschmaltz @polita any chance it could be merged soon? :smile: 