### PR TITLE
Add assembly version to logs

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -74,6 +74,14 @@ namespace Microsoft.IdentityModel.Protocols
         private T _currentConfiguration;
 
         /// <summary>
+        /// Static initializer for a new object. Static initializers run before the first instance of the type is created.
+        /// </summary>
+        static ConfigurationManager()
+        {
+            IdentityModelEventSource.Logger.WriteVerbose("Assembly version info: " + typeof(ConfigurationManager<T>).AssemblyQualifiedName);
+        }
+
+        /// <summary>
         /// Instantiaties a new <see cref="ConfigurationManager{T}"/> that manages automatic and controls refreshing on configuration data.
         /// </summary>
         /// <param name="metadataAddress">The address to obtain configuration.</param>

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -78,6 +78,14 @@ namespace System.IdentityModel.Tokens.Jwt
         public static ISet<string> DefaultInboundClaimFilter = ClaimTypeMapping.InboundClaimFilter;
 
         /// <summary>
+        /// Static initializer for a new object. Static initializers run before the first instance of the type is created.
+        /// </summary>
+        static JwtSecurityTokenHandler()
+        {
+            IdentityModelEventSource.Logger.WriteVerbose("Assembly version info: " + typeof(JwtSecurityTokenHandler).AssemblyQualifiedName);
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="JwtSecurityTokenHandler"/> class.
         /// </summary>
         public JwtSecurityTokenHandler()


### PR DESCRIPTION
@tushargupta51 @brentschmaltz 
Addressed #270 by adding static ctors to ConfigurationManager and JwtSecurityTokenHandler. Verified that it emits to logs in Verbose mode.