### PR TITLE
Fix $clean handling

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -63,7 +63,7 @@ function SetCoreFxVersion([string]$fileName, [string]$oldVersion, [string]$newVe
     Write-Host "============================"
 }
 
-if ($clean)
+if ($clean -eq "YES")
 {
     Write-Host ""
     Write-Host "============================"


### PR DESCRIPTION
`$clean` like any other input parameter is set to "YES". Presumably the opposite value is expected to be "NO" however the current implementation does not test for "YES" or "NO".