### PR TITLE
Fix newline formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ IdentityModel Extensions library Microsoft.IdentityModel.Tokens has a known secu
 IdentityModel Extensions for .NET 5 has now been released. If you are using IdentityModel Extensions with ASP.NET, the following combinations are supported:
 * **IdentityModel Extensions for .NET 4.x** and **ASP.NET 4**
 * **IdentityModel Extensions for .NET 5.x** and **ASP.NET Core 1.x**
+
 All other combinations aren't supported.
 
 ## Samples and Documentation


### PR DESCRIPTION
For text to show up on its own line after a list, there has to be a blank line. (Previously the text showed up *within* the list.)