### PR TITLE
Allow base64 padding characters in tokens

### DIFF
--- a/src/System.IdentityModel.Tokens.Jwt/JwtConstants.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtConstants.cs
@@ -55,7 +55,7 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <summary>
         /// JWS - Token format: 'header.payload.signature'. Signature is optional, but '.' is required.
         /// </summary>
-        public const string JsonCompactSerializationRegex = @"^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]*$";
+        public const string JsonCompactSerializationRegex = @"^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]*$";
 
         /// <summary>
         /// JWE - Token format: 'protectedheader.encryptedkey.iv.cyphertext.authenticationtag'.

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/CanReadTokenTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/CanReadTokenTests.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace System.IdentityModel.Tokens.Jwt.Tests
+{
+    public class CanReadTokenTests
+    {
+        [Fact]
+        public void CanReadUnsignedTokenWithBase64PaddingCharacters()
+        {
+            var encodedHeaderWithPaddingCharacters = $"{Base64UrlEncoder.Encode(@"{""typ"":""JWT""}")}==";
+            var encodedHeader = Base64UrlEncoder.Encode(@"{""typ"": ""JWT""}");
+
+            var encodedPayload = Base64UrlEncoder.Encode(@"{""iss"":""some-issuer""}");
+
+            var handler = new JwtSecurityTokenHandler();
+
+            Assert.True(handler.CanReadToken($"{encodedHeaderWithPaddingCharacters}.{encodedPayload}."));
+            Assert.True(handler.CanReadToken($"{encodedHeader}.{encodedPayload}."));
+        }
+    }
+}


### PR DESCRIPTION
Hello!

I've been testing out the JwtBearer middleware and was having some problems with tokens that contain [base64 padding characters](https://en.wikipedia.org/wiki/Base64#Output_Padding). 

This PR has an example test, which demonstrates the issue in the JWS header, but it also applies to the payload and signature, which have been updated in the `JsonCompactSerializationRegex`. I have not update d the `JweCompactSerializationRegex`, but would guess that this also applies here.

Hope this is useful.