### PR TITLE
Downgrade to support .Net 4.5 (instead of 4.5.1)

### DIFF
--- a/src/Microsoft.IdentityModel.Logging/project.json
+++ b/src/Microsoft.IdentityModel.Logging/project.json
@@ -11,7 +11,7 @@
         "System.IO.FileSystem": "4.3.0-*"
       }
     },
-    "net451": { }
+    "net45": { }
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/project.json
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/project.json
@@ -10,7 +10,7 @@
         "System.Dynamic.Runtime": "4.3.0-*"
       }
     },
-    "net451": { }
+    "net45": { }
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/project.json
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/project.json
@@ -6,7 +6,7 @@
   },
   "frameworks": {
     "netstandard1.4": {},
-    "net451": { }
+    "net45": { }
   },
   "buildOptions": {
     "compile": { "exclude": [ "WsFederationMessage.cs", "Configuration\\WsFederationConfiguration.cs", "Configuration\\WsFederationConfigurationRetriever.cs"] },

--- a/src/Microsoft.IdentityModel.Protocols/project.json
+++ b/src/Microsoft.IdentityModel.Protocols/project.json
@@ -12,7 +12,7 @@
         "System.Net.Http": "4.3.0-*"
       }
     },
-    "net451": {
+    "net45": {
       "frameworkAssemblies": {
         "System.Net.Http": ""
       }

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
@@ -299,9 +299,17 @@ namespace Microsoft.IdentityModel.Tokens
                 uint cbKey = GetKeyByteCount(Crv);
                 byte[] keyBlob;
                 if (usePrivateKey)
+#if NET45
+                    keyBlob = new byte[3 * cbKey + 2 * Marshal.SizeOf(typeof(uint))];
+#else
                     keyBlob = new byte[3 * cbKey + 2 * Marshal.SizeOf<uint>()];
+#endif
                 else
+#if NET45
+                    keyBlob = new byte[2 * cbKey + 2 * Marshal.SizeOf(typeof(uint))];
+#else
                     keyBlob = new byte[2 * cbKey + 2 * Marshal.SizeOf<uint>()];
+#endif
 
                 keyBlobHandle = GCHandle.Alloc(keyBlob, GCHandleType.Pinned);
                 IntPtr keyBlobPtr = keyBlobHandle.AddrOfPinnedObject();

--- a/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
@@ -25,7 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
-#if NET451
+#if !NETSTANDARD1_4
 
 using System;
 using System.Security.Cryptography;

--- a/src/Microsoft.IdentityModel.Tokens/project.json
+++ b/src/Microsoft.IdentityModel.Tokens/project.json
@@ -26,7 +26,7 @@
         "System.Xml.ReaderWriter": "4.3.0-*"
       }
     },
-    "net451": {
+    "net45": {
       "frameworkAssemblies": {
         "System.Xml": ""
       }

--- a/src/System.IdentityModel.Tokens.Jwt/project.json
+++ b/src/System.IdentityModel.Tokens.Jwt/project.json
@@ -6,7 +6,7 @@
   },
   "frameworks": {
     "netstandard1.4": { },
-    "net451": { }
+    "net45": { }
   },
   "buildOptions": {
     "warningsAsErrors": true,

--- a/src/System.IdentityModel.Tokens.Saml/project.json
+++ b/src/System.IdentityModel.Tokens.Saml/project.json
@@ -11,7 +11,7 @@
         "System.Runtime.Serialization.Xml": "4.3.0-*"
       }
     },
-    "net451": {
+    "net45": {
       "frameworkAssemblies": {
         "System.Runtime.Serialization": ""
       }


### PR DESCRIPTION
This change simply re-targets the projects to depend on .Net 4.5 instead of 4.5.1.