### PR TITLE
Fixed the RsaSecurityKey validation test

### DIFF
--- a/test/Microsoft.IdentityModel.Tests/IdentityComparer.cs
+++ b/test/Microsoft.IdentityModel.Tests/IdentityComparer.cs
@@ -89,6 +89,7 @@ namespace Microsoft.IdentityModel.Tests
                 { typeof(OpenIdConnectMessage).ToString(), CompareAllPublicProperties },
                 { typeof(Reference).ToString(), CompareAllPublicProperties },
                 { typeof(RsaSecurityKey).ToString(), CompareAllPublicProperties },
+                { typeof(RSAParameters).ToString(), AreRsaParametersEqual },
                 { typeof(SamlAction).ToString(), CompareAllPublicProperties },
                 { typeof(SamlAudienceRestrictionCondition).ToString(), CompareAllPublicProperties },
                 { typeof(SamlAssertion).ToString(), CompareAllPublicProperties},
@@ -657,41 +658,67 @@ namespace Microsoft.IdentityModel.Tests
             if (rsaKey1 != null && rsaKey2 != null)
             {
                 CompareAllPublicProperties(rsaKey1, rsaKey2, localContext);
-                AreRsaParametersEqual(rsaKey1.Parameters, rsaKey2.Parameters, localContext);
             }
 
             return context.Merge(localContext);
         }
 
-        public static bool AreRsaParametersEqual(RSAParameters rsaParameters1, RSAParameters rsaParameters2, CompareContext context)
+        public static bool AreRsaParametersEqual(object object1, object object2, CompareContext context)
         {
+            RSAParameters rsaParameters1 = (RSAParameters) object1;
+            RSAParameters rsaParameters2 = (RSAParameters) object2;
+
             var localContext = new CompareContext(context);
             if (!ContinueCheckingEquality(rsaParameters1, rsaParameters2, localContext))
                 return context.Merge(localContext);
 
             if (!AreBytesEqual(rsaParameters1.D, rsaParameters2.D, context))
+            {
+                localContext.Diffs.Add("D:");
                 localContext.Diffs.Add("!AreBytesEqual(rsaParameters1.D, rsaParameters2.D)");
+            }
 
             if (!AreBytesEqual(rsaParameters1.DP, rsaParameters2.DP, context))
+            {
+                localContext.Diffs.Add("DP:");
                 localContext.Diffs.Add("!AreBytesEqual(rsaParameters1.DP, rsaParameters2.DP)");
+            }
 
             if (!AreBytesEqual(rsaParameters1.DQ, rsaParameters2.DQ, context))
+            {
+                localContext.Diffs.Add("DQ:");
                 localContext.Diffs.Add("!AreBytesEqual(rsaParameters1.DQ, rsaParameters2.DQ)");
+            }
 
             if (!AreBytesEqual(rsaParameters1.Exponent, rsaParameters2.Exponent, context))
+            {
+                localContext.Diffs.Add("Exponent:");
                 localContext.Diffs.Add("!AreBytesEqual(rsaParameters1.Exponent, rsaParameters2.Exponent)");
+            }
 
             if (!AreBytesEqual(rsaParameters1.InverseQ, rsaParameters2.InverseQ, context))
+            {
+                localContext.Diffs.Add("InverseQ:");
                 localContext.Diffs.Add("!AreBytesEqual(rsaParameters1.InverseQ, rsaParameters2.InverseQ)");
+            }
 
             if (!AreBytesEqual(rsaParameters1.Modulus, rsaParameters2.Modulus, context))
+            {
+                localContext.Diffs.Add("Modulus:");
                 localContext.Diffs.Add("!AreBytesEqual(rsaParameters1.Modulus, rsaParameters2.Modulus)");
+            }
 
             if (!AreBytesEqual(rsaParameters1.P, rsaParameters2.P, context))
+            {
+                localContext.Diffs.Add("P:");
                 localContext.Diffs.Add("!AreBytesEqual(rsaParameters1.P, rsaParameters2.P)");
+            }
 
             if (!AreBytesEqual(rsaParameters1.Q, rsaParameters2.Q, context))
+            {
+                localContext.Diffs.Add("Q:");
                 localContext.Diffs.Add("!AreBytesEqual(rsaParameters1.Q, rsaParameters2.Q)");
+            }
 
             return context.Merge(localContext);
         }
@@ -842,7 +869,7 @@ namespace Microsoft.IdentityModel.Tests
                             localContext.Diffs.Add($"{propertyInfo.Name}:");
                             localContext.Diffs.Add(BuildStringDiff(propertyInfo.Name, val1, val2));
                         }
-                        else if (val1.GetType().BaseType == typeof(System.ValueType))
+                        else if (val1.GetType().BaseType == typeof(System.ValueType) && !_equalityDict.Keys.Contains(val1.GetType().ToString()))
                         {
                             if (!val1.Equals(val2))
                             {

--- a/test/Microsoft.IdentityModel.Tokens.Tests/IdentityComparerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/IdentityComparerTests.cs
@@ -379,7 +379,18 @@ namespace Microsoft.IdentityModel.Tests
             IdentityComparer.AreEqual(rsaSecurityKey1, rsaSecurityKey2, context);
 
             Assert.True(context.Diffs.Count(s => s == "HasPrivateKey:") == 1);
-            Assert.True(context.Diffs.Count(s => s == "Parameters:") == 1);
+        }
+
+        [Fact]
+        public void CompareRsaParameters()
+        {
+            TestUtilities.WriteHeader($"{this}.CompareRSAParameters", true);
+            var context = new CompareContext($"{this}.CompareRSAParameters");
+            var rsaParameters1 = KeyingMaterial.RsaParametersFromPing1;
+            var rsaParameters2 = KeyingMaterial.RsaParametersFromPing2;
+            IdentityComparer.AreEqual(rsaParameters1, rsaParameters2, context);
+
+            Assert.True(context.Diffs.Count(s => s == "Modulus:") == 1);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #686.

Instead of adding in a function that compares RsaSecurityKeys, I added the AreRSAParametersEqual() function to the _equalityDict. 

I also modified the BaseType == typeof(System.ValueType) condition so that it also checks whether or not the specific type is located in the dictionary. If it is (such as in the case of RsaParameters), we know that we need to call AreEqual() and not treat the property in the same way that we would treat other properties whose BaseType is a ValueType.

I feel like this makes more sense since the function for RsaSecurityKeys would essentially be CompareAllPublicProperties but with a special case for RSAParameters.