### PR TITLE
Exception is no longer thrown when a large 'exp' value is encountered

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/EpochTime.cs
+++ b/src/Microsoft.IdentityModel.Tokens/EpochTime.cs
@@ -74,6 +74,9 @@ namespace Microsoft.IdentityModel.Tokens
                 return UnixEpoch;
             }
 
+            if (secondsSinceUnixEpoch > TimeSpan.MaxValue.TotalSeconds)
+                return DateTimeUtil.Add(UnixEpoch, TimeSpan.MaxValue).ToUniversalTime();
+
             return DateTimeUtil.Add(UnixEpoch, TimeSpan.FromSeconds(secondsSinceUnixEpoch)).ToUniversalTime();
         }
     }

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
@@ -175,6 +175,15 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             Assert.Equal(payload.SerializeToJson(), compareTo);
         }
 
+        [Fact]
+        public void TestClaimWithLargeExpValue()
+        {
+            JwtPayload jwtPayload = new JwtPayload();
+            jwtPayload.Add("exp", 1507680819080);
+            DateTime expirationTime = jwtPayload.ValidTo;
+            Assert.True(DateTime.MaxValue == expirationTime, "EpochTime.DateTime( time ) != jwtPayload.ValidTo");
+        }
+
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
         [Theory, MemberData("PayloadDataSet")]
 #pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant


### PR DESCRIPTION
Fixes #795.