### PR TITLE
Saml2Serializer no longer requires NameID to be an absolute URI

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Serializer.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Serializer.cs
@@ -1020,9 +1020,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                 if (nameIdentifier.Format != null &&
                     StringComparer.Ordinal.Equals(nameIdentifier.Format.OriginalString, Saml2Constants.NameIdentifierFormats.Entity.OriginalString))
                 {
-                    if (!CanCreateValidUri(nameIdentifier.Value, UriKind.Absolute))
-                        throw LogReadException(LogMessages.IDX13107, Saml2Constants.Elements.NameID, Saml2Constants.Types.NameIDType, nameIdentifier.Value);
-
                     if (!string.IsNullOrEmpty(nameIdentifier.NameQualifier)
                         || !string.IsNullOrEmpty(nameIdentifier.SPNameQualifier)
                         || !string.IsNullOrEmpty(nameIdentifier.SPProvidedId))

--- a/test/Microsoft.IdentityModel.Tests/ReferenceSaml.cs
+++ b/test/Microsoft.IdentityModel.Tests/ReferenceSaml.cs
@@ -1157,6 +1157,19 @@ namespace Microsoft.IdentityModel.Tests
             }
         }
 
+        public static SamlSubjectTestSet SamlSubjectNameIDNotAbsoluteURI
+        {
+            get
+            {
+                return new SamlSubjectTestSet
+                {
+                    Subject = new SamlSubject("urn:oasis:names:tc:SAML:1.1:nameid-format:entity", null, "test", new List<string> { Default.SamlConfirmationMethod }, Default.SamlConfirmationData),
+                    Xml = XmlGenerator.SamlSubjectXml(XmlGenerator.SamlNameIdentifierXml(null, "urn:oasis:names:tc:SAML:1.1:nameid-format:entity", "test"),
+                                XmlGenerator.SamlSubjectConfirmationXml(new List<string> { XmlGenerator.SamlConfirmationMethodXml(Default.SamlConfirmationMethod) }, Default.SamlConfirmationData))
+                };
+            }
+        }
+
         public static SamlSubjectTestSet SamlSubjectNameEmptyString
         {
             get

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SerializerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SerializerTests.cs
@@ -155,12 +155,13 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                 {
                     new Saml2TheoryData
                     {
+                        First = true,
                         Assertion = new Saml2Assertion(new Saml2NameIdentifier(Default.Issuer)),
                         Xml = "<Assertion Version=\"2.0\" ID=\"_b95759d0-73ae-4072-a140-567ade10a7ad\" Issuer=\"http://Default.Issuer.com\" IssueInstant=\"2017-03-17T18:33:37.095Z\" xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\"/>",
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenReadException), "IDX13102", typeof(XmlReadException)),
                         Saml2Serializer = new Saml2SerializerPublic(),
                         TestId = "Saml2AssertionEmpty"
-                    }
+                    },
                 };
             }
         }
@@ -500,12 +501,19 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                 {
                     new Saml2TheoryData
                     {
+                        First = true,
                         Subject = new Saml2Subject(),
                         Xml = "<Subject NameId=\"test\" xmlns =\"urn:oasis:names:tc:SAML:2.0:assertion\"/>",
-                        First = true,
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenReadException), "IDX13125:"),
                         Saml2Serializer = new Saml2SerializerPublic(),
                         TestId = "Saml2SubjectEmpty"
+                    },
+                    new Saml2TheoryData
+                    {
+                        Subject = new Saml2Subject(),
+                        Xml = "<Subject NameId=\"test\" xmlns =\"urn:oasis:names:tc:SAML:2.0:assertion\"><NameID Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\">test</NameID></Subject>",
+                        Saml2Serializer = new Saml2SerializerPublic(),
+                        TestId = "Saml2SubjectNameIDIsNotAbsoluteURI"
                     }
                 };
             }

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSerializerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSerializerTests.cs
@@ -1079,6 +1079,12 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                         SamlSerializer = new SamlSerializerPublic(),
                         SubjectTestSet = ReferenceSaml.SamlSubjectEmpty,
                         TestId = nameof(ReferenceSaml.SamlSubjectEmpty)
+                    },
+                    new SamlTheoryData
+                    {
+                        SamlSerializer = new SamlSerializerPublic(),
+                        SubjectTestSet = ReferenceSaml.SamlSubjectNameIDNotAbsoluteURI,
+                        TestId = nameof(ReferenceSaml.SamlSubjectNameIDNotAbsoluteURI)
                     }
                 };
             }


### PR DESCRIPTION
Fixes #815.

Also added in similar tests for SamlSerializer (even though the absolute URI check was not being performed).