### PR TITLE
Added in logic to ensure the x,y, and d JsonWebKey parameters are the correct size.

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -165,6 +165,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10672 = "IDX10672: GetKeyedHashAlgorithm returned null, key: {0}, algorithm {1}.";
         public const string IDX10673 = "IDX10673: CryptoProviderFactory.GetHashAlgorithm returned null, factory: {0}, algorithm: {1}.";
         public const string IDX10674 = "IDX10674: JsonWebKeyConverter does not support SecurityKey of type: {0}";
+        public const string IDX10675 = "IDX10675: The value of '{0}' must be '{1}' bits, but was {2}.";
 
         // security keys
         public const string IDX10700 = "IDX10700: Invalid RsaParameters: '{0}'. Both modulus and exponent should be present";

--- a/test/Microsoft.IdentityModel.Tests/KeyingMaterial.cs
+++ b/test/Microsoft.IdentityModel.Tests/KeyingMaterial.cs
@@ -783,6 +783,68 @@ namespace Microsoft.IdentityModel.Tests
             get => new SigningCredentials(JsonWebKeyRsa256Public, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256);
         }
 
+        public static JsonWebKey JsonWebKeyPublicWrongX
+        {
+            get
+            {
+                var curvePointParameterLength = 2 << 20;
+                var curvePointParameter = Base64UrlEncoder.Encode(new byte[curvePointParameterLength]);
+
+                var jsonString = string.Format(
+                    @"{{
+                    ""kty"": ""EC"",
+                    ""kid"": ""bilbo.baggins@hobbiton.example"",
+                    ""use"": ""sig"",
+                    ""crv"": ""P-521"",
+                    ""x"": ""{0}"",
+                    ""y"": ""AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1""
+                    }}", curvePointParameter);
+
+                return new JsonWebKey(jsonString);
+            }
+        }
+
+        public static JsonWebKey JsonWebKeyPublicWrongY
+        {
+            get
+            {
+                var curvePointParameterLength = 2 << 20;
+                var curvePointParameter = Base64UrlEncoder.Encode(new byte[curvePointParameterLength]);
+
+                var jsonString = string.Format(@"{{
+                    ""kty"": ""EC"",
+                    ""kid"": ""bilbo.baggins@hobbiton.example"",
+                    ""use"": ""sig"",
+                    ""crv"": ""P-521"",
+                    ""x"": ""AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1"",
+                    ""y"": ""{0}""
+                    }}", curvePointParameter);
+
+                return new JsonWebKey(jsonString);
+            }
+        }
+
+        public static JsonWebKey JsonWebKeyPrivateWrongD
+        {
+            get
+            {
+                var curvePointParameterLength = 2 << 20;
+                var curvePointParameter = Base64UrlEncoder.Encode(new byte[curvePointParameterLength]);
+
+                var jsonString = string.Format(@"{{
+                    ""kty"": ""EC"",
+                    ""kid"": ""bilbo.baggins@hobbiton.example"",
+                    ""use"": ""sig"",
+                    ""crv"": ""P-521"",
+                    ""x"": ""AHKZLLOsCOzz5cY97ewNUajB957y-C-U88c3v13nmGZx6sYl_oJXu9A5RkTKqjqvjyekWF-7ytDyRXYgCF5cj0Kt"",
+                    ""y"": ""AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1"",
+                    ""d"": ""{{0}}""
+                    }}", curvePointParameter);
+                
+                return new JsonWebKey(jsonString);
+            }
+        }
+
         public static JsonWebKey JsonWebKeyEcdsa256
         {
             get

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -261,7 +261,16 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
             // constructing using a key with wrong key size:
             AsymmetricConstructorVariation("Verifying:    - ECDSA with unmatched keysize", KeyingMaterial.ECDsa256Key, SecurityAlgorithms.EcdsaSha512, ExpectedException.NotSupportedException("IDX10641:"));
-            AsymmetricConstructorVariation("Verifying:    - JsonWebKey for ECDSA with unmatched keysize", KeyingMaterial.JsonWebKeyEcdsa256, SecurityAlgorithms.EcdsaSha512, ExpectedException.ArgumentOutOfRangeException("IDX10671:"));
+            AsymmetricConstructorVariation("Verifying:    - JsonWebKey for ECDSA with unmatched keysize", KeyingMaterial.JsonWebKeyEcdsa256, SecurityAlgorithms.EcdsaSha512, ExpectedException.ArgumentOutOfRangeException("IDX10675:"));
+
+            // Constructing using a key with an incorrect 'X' value
+            AsymmetricConstructorVariation("Verifying:    - JsonWebKey for ECDSA with incorrect 'x' value", KeyingMaterial.JsonWebKeyPublicWrongX, SecurityAlgorithms.EcdsaSha512, ExpectedException.ArgumentOutOfRangeException("IDX10675:"));
+
+            // Constructing using a key with an incorrect 'Y' value
+            AsymmetricConstructorVariation("Verifying:    - JsonWebKey for ECDSA with incorrect 'y' value", KeyingMaterial.JsonWebKeyPublicWrongY, SecurityAlgorithms.EcdsaSha512, ExpectedException.ArgumentOutOfRangeException("IDX10675:"));
+
+            // Constructing using a key with an incorrect 'D' value
+            AsymmetricConstructorVariation("Verifying:    - JsonWebKey for ECDSA with incorrect 'd' value", KeyingMaterial.JsonWebKeyPrivateWrongD, SecurityAlgorithms.EcdsaSha512, ExpectedException.ArgumentOutOfRangeException("IDX10675:"));
         }
 
         private void AsymmetricConstructorVariation(string testcase, SecurityKey key, string algorithm, ExpectedException expectedException)


### PR DESCRIPTION
Addresses #488. 

The check for valid ECDSA key size has also been moved so that it is done before any bytes are written.