### PR TITLE
Changed the PII logging message to make it clearer.

### DIFF
--- a/src/Microsoft.IdentityModel.Logging/IdentityModelEventSource.cs
+++ b/src/Microsoft.IdentityModel.Logging/IdentityModelEventSource.cs
@@ -61,7 +61,38 @@ namespace Microsoft.IdentityModel.Logging
         /// <summary>
         /// String that is used in place of any arguments to log messages if the 'ShowPII' flag is set to false.
         /// </summary>
-        public static string HiddenPIIString { get; } = "[PII is hidden by default. Set the 'ShowPII' flag in IdentityModelEventSource.cs to true to reveal it.]";
+        public static string HiddenPIIString { get; } = "[PII is hidden]";
+
+        /// <summary>
+        /// Indicates whether or the log message header (contains library version, date/time, and PII debugging information) has been written.
+        /// </summary>
+        public static bool HeaderWritten { get; set; } = false;
+
+        /// <summary>
+        /// The current library version.
+        /// </summary>
+        private static string _version = "5.2.2";
+
+        /// <summary>
+        /// The log message that indicates the current library version.
+        /// </summary>
+        private static string _versionLogMessage = "Library version: {0}.";
+
+        /// <summary>
+        /// The log message that indicates the date.
+        /// </summary>
+        private static string _dateLogMessage = "Date: {0}.";
+
+        /// <summary>
+        /// The log message that is shown when PII is off.
+        /// </summary>
+        private static string _piiOffLogMessage = "PII (personally identifiable information) logging is currently turned off. Set IdentityModelEventSource.ShowPII to 'true' to view the full details of exceptions.";
+
+        /// <summary>
+        /// The log message that is shown when PII is off.
+        /// </summary>
+        private static string _piiOnLogMessage = "PII (personally identifiable information) logging is currently turned on. Set IdentityModelEventSource.ShowPII to 'false' to hide PII from log messages.";
+
 
         /// <summary>
         /// Writes an event log by using the provided string argument and current UTC time.
@@ -277,6 +308,18 @@ namespace Microsoft.IdentityModel.Logging
                     message = string.Format(CultureInfo.InvariantCulture, "Message: {0}, InnerException: {1}", message, innerException.GetType());
                 else // otherwise it's safe to display the entire exception message
                     message = string.Format(CultureInfo.InvariantCulture, "Message: {0}, InnerException: {1}", message, innerException.Message);
+            }
+
+            // Logs basic information: library version, date, and whether PII (personally identifiable information) logging is on or off.
+            if (!HeaderWritten)
+            {
+                WriteAlways(string.Format(CultureInfo.InvariantCulture, _versionLogMessage, _version));
+                WriteAlways(string.Format(CultureInfo.InvariantCulture, _dateLogMessage, DateTime.UtcNow));
+                if (ShowPII) 
+                    WriteAlways(_piiOnLogMessage);
+                else
+                    WriteAlways(_piiOffLogMessage);
+                HeaderWritten = true; // We only want to log this information once before any log messages are written.
             }
 
             switch (level)

--- a/src/Microsoft.IdentityModel.Logging/IdentityModelEventSource.cs
+++ b/src/Microsoft.IdentityModel.Logging/IdentityModelEventSource.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Diagnostics.Tracing;
 using System.Globalization;
+using System.Reflection;
 using static Microsoft.IdentityModel.Logging.LogHelper;
 
 namespace Microsoft.IdentityModel.Logging
@@ -67,11 +68,6 @@ namespace Microsoft.IdentityModel.Logging
         /// Indicates whether or the log message header (contains library version, date/time, and PII debugging information) has been written.
         /// </summary>
         public static bool HeaderWritten { get; set; } = false;
-
-        /// <summary>
-        /// The current library version.
-        /// </summary>
-        private static string _version = "5.2.2";
 
         /// <summary>
         /// The log message that indicates the current library version.
@@ -313,7 +309,8 @@ namespace Microsoft.IdentityModel.Logging
             // Logs basic information: library version, date, and whether PII (personally identifiable information) logging is on or off.
             if (!HeaderWritten)
             {
-                WriteAlways(string.Format(CultureInfo.InvariantCulture, _versionLogMessage, _version));
+                // Obtain the current library version dynamically.
+                WriteAlways(string.Format(CultureInfo.InvariantCulture, _versionLogMessage, typeof(IdentityModelEventSource).GetTypeInfo().Assembly.GetName().Version.ToString()));
                 WriteAlways(string.Format(CultureInfo.InvariantCulture, _dateLogMessage, DateTime.UtcNow));
                 if (ShowPII) 
                     WriteAlways(_piiOnLogMessage);

--- a/src/Microsoft.IdentityModel.Logging/IdentityModelEventSource.cs
+++ b/src/Microsoft.IdentityModel.Logging/IdentityModelEventSource.cs
@@ -316,6 +316,7 @@ namespace Microsoft.IdentityModel.Logging
                     WriteAlways(_piiOnLogMessage);
                 else
                     WriteAlways(_piiOffLogMessage);
+
                 HeaderWritten = true; // We only want to log this information once before any log messages are written.
             }
 


### PR DESCRIPTION
Fixes #884.

Changes made:

- The replacement string for PII in log messages has been shortened.
- The current version, date, and additional information about how to turn PII on/off is now logged before any log messages are written.