### PR TITLE
Made sure ValidateTokenReplay() uses 'NotOnOrAfter' as the token expiration time.

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -1151,7 +1151,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
             var samlToken = ValidateSignature(token, validationParameters);
             ValidateConditions(samlToken, validationParameters);
             var issuer = ValidateIssuer(samlToken.Issuer, samlToken, validationParameters);
-            ValidateTokenReplay(samlToken.Assertion.Conditions.NotBefore, token, validationParameters);
+            ValidateTokenReplay(samlToken.Assertion.Conditions.NotOnOrAfter, token, validationParameters);
             ValidateIssuerSecurityKey(samlToken.SigningKey, samlToken, validationParameters);
             validatedToken = samlToken;
             var identities = CreateClaimsIdentities(samlToken, issuer, validationParameters);

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -236,7 +236,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
             ValidateConditions(samlToken, validationParameters);
             ValidateSubject(samlToken, validationParameters);
             var issuer = ValidateIssuer(samlToken.Issuer, samlToken, validationParameters);
-            ValidateTokenReplay(samlToken.Assertion.Conditions.NotBefore, token, validationParameters);
+            ValidateTokenReplay(samlToken.Assertion.Conditions.NotOnOrAfter, token, validationParameters);
             ValidateIssuerSecurityKey(samlToken.SigningKey, samlToken, validationParameters);
             validatedToken = samlToken;
             var identity = CreateClaimsIdentity(samlToken, issuer, validationParameters);

--- a/test/Microsoft.IdentityModel.Tests/ReferenceTheoryData.cs
+++ b/test/Microsoft.IdentityModel.Tests/ReferenceTheoryData.cs
@@ -1,4 +1,7 @@
 ﻿using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Saml;
+using Microsoft.IdentityModel.Tokens.Saml2;
+using System.IdentityModel.Tokens.Jwt;
 using Xunit;
 
 namespace Microsoft.IdentityModel.Tests
@@ -58,6 +61,44 @@ namespace Microsoft.IdentityModel.Tests
                 };
             }
         }
+
+        public static TheoryData<TokenReplayTheoryData> CheckParametersForTokenReplayTheoryData
+        {
+            get
+            {
+                return new TheoryData<TokenReplayTheoryData>
+                {
+                    new TokenReplayTheoryData
+                    {
+                        First = true,
+                        TestId = $"ValidateTokenReplay: true, {nameof(ValidationDelegates.TokenReplayValidatorChecksExpirationTimeJwt)}",
+                        SecurityToken = Default.AsymmetricJwt,
+                        SecurityTokenHandler = new JwtSecurityTokenHandler(),
+                        SigningKey = Default.AsymmetricSigningKey,
+                        TokenReplayValidator = ValidationDelegates.TokenReplayValidatorChecksExpirationTimeJwt,
+                        ValidateTokenReplay = true
+                    },
+                    new TokenReplayTheoryData
+                    {
+                        TestId = $"ValidateTokenReplay: true, {nameof(ValidationDelegates.TokenReplayValidatorChecksExpirationTimeSaml)}",
+                        SecurityToken = ReferenceTokens.SamlToken_Valid,
+                        SecurityTokenHandler = new SamlSecurityTokenHandler(),
+                        SigningKey = KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2.Key,
+                        TokenReplayValidator = ValidationDelegates.TokenReplayValidatorChecksExpirationTimeSaml,
+                        ValidateTokenReplay = true,
+                    },
+                    new TokenReplayTheoryData
+                    {
+                        TestId = $"ValidateTokenReplay: true, {nameof(ValidationDelegates.TokenReplayValidatorChecksExpirationTimeSaml2)}",
+                        SecurityToken = ReferenceTokens.Saml2Token_Valid,
+                        SecurityTokenHandler = new Saml2SecurityTokenHandler(),
+                        SigningKey = KeyingMaterial.DefaultAADSigningKey,
+                        TokenReplayValidator = ValidationDelegates.TokenReplayValidatorChecksExpirationTimeSaml2,
+                        ValidateTokenReplay = true,
+                    }
+                };
+            }
+        }
     }
 
     public class TokenReplayTheoryData : TheoryDataBase
@@ -72,5 +113,23 @@ namespace Microsoft.IdentityModel.Tests
             get;
             set;
         } = false;
+
+        public string SecurityToken
+        {
+            get;
+            set;
+        }
+
+        public SecurityTokenHandler SecurityTokenHandler
+        {
+            get;
+            set;
+        }
+
+        public SecurityKey SigningKey
+        {
+            get;
+            set;
+        }
     }
 }

--- a/test/Microsoft.IdentityModel.Tests/ValidationDelegates.cs
+++ b/test/Microsoft.IdentityModel.Tests/ValidationDelegates.cs
@@ -29,6 +29,8 @@ using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Saml;
+using Microsoft.IdentityModel.Tokens.Saml2;
 
 namespace Microsoft.IdentityModel.Tests
 {
@@ -132,17 +134,44 @@ namespace Microsoft.IdentityModel.Tests
             throw new SecurityTokenInvalidSignatureException("TokenReaderThrows");
         }
 
-        public static bool TokenReplayValidatorReturnsTrue(DateTime? exipres, string token, TokenValidationParameters validationParameters)
+        public static bool TokenReplayValidatorReturnsTrue(DateTime? expires, string token, TokenValidationParameters validationParameters)
         {
             return true;
         }
 
-        public static bool TokenReplayValidatorReturnsFalse(DateTime? exipres, string token, TokenValidationParameters validationParameters)
+        public static bool TokenReplayValidatorReturnsFalse(DateTime? expires, string token, TokenValidationParameters validationParameters)
         {
             return false;
         }
 
-        public static bool TokenReplayValidatorThrows(DateTime? exipres, string token, TokenValidationParameters validationParameters)
+        public static bool TokenReplayValidatorChecksExpirationTimeJwt(DateTime? expires, string token, TokenValidationParameters validationParameters)
+        {
+            if (expires == null)
+                return false;
+
+            var jwtToken = new JwtSecurityTokenHandler().ReadToken(token);
+            return jwtToken.ValidTo == expires;
+        }
+
+        public static bool TokenReplayValidatorChecksExpirationTimeSaml(DateTime? expires, string token, TokenValidationParameters validationParameters)
+        {
+            if (expires == null)
+                return false;
+
+            var samlToken = (SamlSecurityToken) new SamlSecurityTokenHandler().ReadToken(token);
+            return samlToken.Assertion.Conditions.NotOnOrAfter == expires;
+        }
+
+        public static bool TokenReplayValidatorChecksExpirationTimeSaml2(DateTime? expires, string token, TokenValidationParameters validationParameters)
+        {
+            if (expires == null)
+                return false;
+
+            var saml2Token = (Saml2SecurityToken) new Saml2SecurityTokenHandler().ReadToken(token);
+            return saml2Token.Assertion.Conditions.NotOnOrAfter == expires;
+        }
+
+        public static bool TokenReplayValidatorThrows(DateTime? expires, string token, TokenValidationParameters validationParameters)
         {
             throw new SecurityTokenReplayDetectedException("TokenReplayValidatorThrows");
         }


### PR DESCRIPTION
Addresses #898.
Previously 'NotBefore' time was used.