### PR TITLE
JsonWebKey 'kid' and 'KeyId' values are now kept in sync.

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
@@ -40,6 +40,9 @@ namespace Microsoft.IdentityModel.Tokens
     [JsonObject]
     public class JsonWebKey : SecurityKey
     {
+
+        private string _kid;
+
         /// <summary>
         /// Magic numbers identifying ECDSA blob types
         /// </summary>
@@ -150,6 +153,16 @@ namespace Microsoft.IdentityModel.Tokens
         public string K { get; set; }
 
         /// <summary>
+        /// Gets the key id of this <see cref="JsonWebKey"/>.
+        /// </summary>
+        [JsonIgnore]
+        public override string KeyId
+        {
+            get { return _kid; }
+            set { _kid = value; }
+        }
+
+        /// <summary>
         /// Gets the 'key_ops' (Key Operations)..
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore, PropertyName = JsonWebKeyParameterNames.KeyOps, Required = Required.Default)]
@@ -159,7 +172,11 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets or sets the 'kid' (Key ID)..
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore, PropertyName = JsonWebKeyParameterNames.Kid, Required = Required.Default)]
-        public string Kid { get; set; }
+        public string Kid
+        {
+            get { return _kid; }
+            set { _kid = value; }
+        }
 
         /// <summary>
         /// Gets or sets the 'kty' (Key Type)..

--- a/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
@@ -46,7 +46,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets the key id of this <see cref="SecurityKey"/>.
         /// </summary>
         [JsonIgnore]
-        public string KeyId { get; set; }
+        public virtual string KeyId { get; set; }
 
         /// <summary>
         /// Gets or sets <see cref="Microsoft.IdentityModel.Tokens.CryptoProviderFactory"/>.

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtHeaderTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtHeaderTests.cs
@@ -76,5 +76,14 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         public void Publics()
         {
         }
+
+        [Fact]
+        public void Kid()
+        {
+            var jsonWebKey = new JsonWebKey(DataSets.JsonWebKeyString1);
+            var credentials = new SigningCredentials(jsonWebKey, SecurityAlgorithms.RsaSha256Signature);
+            var token = new JwtSecurityToken(claims: Default.Claims, signingCredentials: credentials);
+            Assert.Equal(jsonWebKey.Kid, token.Header.Kid);
+        }
     }
 }


### PR DESCRIPTION
Addresses #885.

The SecurityKey.KeyId property has been changed to virtual so that JsonWebKey can override it. JsonWebKey now uses the same backing field for its 'KeyId' and 'kid' properties, ensuring that when one changes the other changes as well (ensuring the two properties stay in sync).