### PR TITLE
Fixed a bug in the AsymmetricSignatureProvider_Constructor() test

### DIFF
--- a/test/Microsoft.IdentityModel.Tests/KeyingMaterial.cs
+++ b/test/Microsoft.IdentityModel.Tests/KeyingMaterial.cs
@@ -838,7 +838,7 @@ namespace Microsoft.IdentityModel.Tests
                     ""crv"": ""P-521"",
                     ""x"": ""AHKZLLOsCOzz5cY97ewNUajB957y-C-U88c3v13nmGZx6sYl_oJXu9A5RkTKqjqvjyekWF-7ytDyRXYgCF5cj0Kt"",
                     ""y"": ""AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1"",
-                    ""d"": ""{{0}}""
+                    ""d"": ""{0}""
                     }}", curvePointParameter);
                 
                 return new JsonWebKey(jsonString);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -270,7 +270,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             AsymmetricConstructorVariation("Verifying:    - JsonWebKey for ECDSA with incorrect 'y' value", KeyingMaterial.JsonWebKeyPublicWrongY, SecurityAlgorithms.EcdsaSha512, ExpectedException.ArgumentOutOfRangeException("IDX10675:"));
 
             // Constructing using a key with an incorrect 'D' value
-            AsymmetricConstructorVariation("Verifying:    - JsonWebKey for ECDSA with incorrect 'd' value", KeyingMaterial.JsonWebKeyPrivateWrongD, SecurityAlgorithms.EcdsaSha512, ExpectedException.NoExceptionExpected);
+            AsymmetricConstructorVariation("Signing:    - JsonWebKey for ECDSA with incorrect 'd' value", KeyingMaterial.JsonWebKeyPrivateWrongD, SecurityAlgorithms.EcdsaSha512, ExpectedException.ArgumentOutOfRangeException("IDX10675:"));
         }
 
         private void AsymmetricConstructorVariation(string testcase, SecurityKey key, string algorithm, ExpectedException expectedException)


### PR DESCRIPTION
The AsymmetricSignatureProvider_Constructor() test was failing since one of the test cases was using a JsonWebKey that wasn't formatted properly. 