### PR TITLE
Made sure that the GetStandardClaim() method returns null if the value associated with the claimType passed into it is null

### DIFF
--- a/src/System.IdentityModel.Tokens.Jwt/JwtHeader.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtHeader.cs
@@ -289,20 +289,19 @@ namespace System.IdentityModel.Tokens.Jwt
         }
         /// <summary>
         /// Gets a standard claim from the header.
-        /// A standard cliam is either a string or a value of another type serialized in JSON format.
+        /// A standard claim is either a string or a value of another type serialized in JSON format.
         /// </summary>
         /// <param name="claimType">The key of the claim.</param>
         /// <returns>The standard claim string; or null if not found.</returns>
         internal string GetStandardClaim(string claimType)
         {
-            object value = null;
-            if (TryGetValue(claimType, out value))
+            if (TryGetValue(claimType, out object value))
             {
-                string str = value as string;
-                if (str != null)
-                {
+                if (value == null)
+                    return null;
+
+                if (value is string str)
                     return str;
-                }
 
                 return JsonExtensions.SerializeToJson(value);
             }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
@@ -583,14 +583,13 @@ namespace System.IdentityModel.Tokens.Jwt
 
         internal string GetStandardClaim(string claimType)
         {
-            object value = null;
-            if (TryGetValue(claimType, out value))
+            if (TryGetValue(claimType, out object value))
             {
-                string str = value as string;
-                if (str != null)
-                {
+                if (value == null)
+                    return null;
+
+                if (value is string str)
                     return str;
-                }
 
                 return JsonExtensions.SerializeToJson(value);
             }

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtHeaderTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtHeaderTests.cs
@@ -152,6 +152,16 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             var token = new JwtSecurityToken(claims: Default.Claims, signingCredentials: credentials);
             Assert.Equal(jsonWebKey.Kid, token.Header.Kid);
         }
+
+        // Test checks to make sure that GetStandardClaim() returns null (not "null") if the value associated with the claimType parameter is null.
+        [Fact]
+        public void GetStandardClaimNull()
+        {
+            var jwtHeader = new JwtHeader();
+            jwtHeader[JwtHeaderParameterNames.Kid] = null;
+            var kid = jwtHeader.Kid;
+            Assert.True(kid == null);
+        }
     }
 
     public class JwtHeaderTheoryData : TheoryDataBase

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
@@ -479,6 +479,16 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             jwtPayload2 = JwtPayload.Base64UrlDeserialize(jwtPayload2.Base64UrlEncode());
             IdentityComparer.AreEqual(jwtPayload1, jwtPayload2, context);
         }
+
+        // Test checks to make sure that GetStandardClaim() returns null (not "null") if the value associated with the claimType parameter is null.
+        [Fact]
+        public void GetStandardClaimNull()
+        {
+            var jwtPayload = new JwtPayload();
+            jwtPayload[JwtRegisteredClaimNames.Iss] = null;
+            var issuer = jwtPayload.Iss;
+            Assert.True(issuer == null);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #863.
Changes were made to both the JwtPayload and the JwtHeader classes.