### PR TITLE
Add PropertyBag to TokenValidationParameters

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -163,6 +163,7 @@ namespace Microsoft.IdentityModel.Tokens
             TokenReplayValidator = other.TokenReplayValidator;
             NameClaimType = other.NameClaimType;
             NameClaimTypeRetriever = other.NameClaimTypeRetriever;
+            PropertyBag = other.PropertyBag;
             RequireExpirationTime = other.RequireExpirationTime;
             RequireSignedTokens = other.RequireSignedTokens;
             RoleClaimType = other.RoleClaimType;
@@ -498,6 +499,15 @@ namespace Microsoft.IdentityModel.Tokens
         /// after validating a token.
         /// </summary>
         public Func<SecurityToken, string, string> NameClaimTypeRetriever { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IDictionary{String, Object}"/> that contains a collection of custom key/value pairs. This allows addition of parameters that could be used in custom token validation scenarios.
+        /// </summary>
+        public IDictionary<string, Object> PropertyBag
+        {
+            get;
+            set;
+        }
 
         /// <summary>
         /// Gets or sets a value indicating whether tokens must have an 'expiration' value.

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
@@ -42,8 +42,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 35)
-                Assert.True(false, "Number of properties has changed from 35 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 36)
+                Assert.True(false, "Number of properties has changed from 36 to: " + properties.Length + ", adjust tests");
 
             TokenValidationParameters actorValidationParameters = new TokenValidationParameters();
             SecurityKey issuerSigningKey = KeyingMaterial.DefaultX509Key_2048_Public;
@@ -68,6 +68,11 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             string validIssuer = "ValidIssuer";
             List<string> validIssuers = new List<string> { validIssuer };
 
+            var propertyBag =
+                new Dictionary<string, Object>
+                {
+                    { "CustomKey", "CustomValue" }
+                };
 
             TokenValidationParameters validationParametersInline = new TokenValidationParameters()
             {
@@ -78,6 +83,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 IssuerSigningKeys = issuerSigningKeys,
                 IssuerValidator = ValidationDelegates.IssuerValidatorEcho,
                 LifetimeValidator = ValidationDelegates.LifetimeValidatorReturnsTrue,
+                PropertyBag = propertyBag,
                 SignatureValidator = ValidationDelegates.SignatureValidatorReturnsJwtTokenAsIs,
                 SaveSigninToken = true,
                 ValidateAudience = false,
@@ -90,6 +96,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
             Assert.True(object.ReferenceEquals(actorValidationParameters, validationParametersInline.ActorValidationParameters));
             Assert.True(object.ReferenceEquals(validationParametersInline.IssuerSigningKey, issuerSigningKey));
+            Assert.True(object.ReferenceEquals(validationParametersInline.PropertyBag, propertyBag));
             Assert.True(validationParametersInline.SaveSigninToken);
             Assert.False(validationParametersInline.ValidateAudience);
             Assert.False(validationParametersInline.ValidateIssuer);
@@ -105,6 +112,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             validationParametersSets.IssuerSigningKeys = issuerSigningKeysDup;
             validationParametersSets.IssuerValidator = ValidationDelegates.IssuerValidatorEcho;
             validationParametersSets.LifetimeValidator = ValidationDelegates.LifetimeValidatorReturnsTrue;
+            validationParametersSets.PropertyBag = propertyBag;
             validationParametersSets.SignatureValidator = ValidationDelegates.SignatureValidatorReturnsJwtTokenAsIs;
             validationParametersSets.SaveSigninToken = true;
             validationParametersSets.ValidateAudience = false;
@@ -136,8 +144,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 35)
-                Assert.True(false, "Number of public fields has changed from 35 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 36)
+                Assert.True(false, "Number of public fields has changed from 36 to: " + properties.Length + ", adjust tests");
 
             GetSetContext context =
                 new GetSetContext
@@ -151,6 +159,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         new KeyValuePair<string, List<object>>("IssuerSigningKey", new List<object>{(SecurityKey)null, KeyingMaterial.DefaultX509Key_2048, KeyingMaterial.RsaSecurityKey_2048}),
                         new KeyValuePair<string, List<object>>("IssuerSigningKeys", new List<object>{(IEnumerable<SecurityKey>)null, new List<SecurityKey>{KeyingMaterial.DefaultX509Key_2048, KeyingMaterial.RsaSecurityKey_1024}, new List<SecurityKey>()}),
                         new KeyValuePair<string, List<object>>("NameClaimType", new List<object>{ClaimsIdentity.DefaultNameClaimType, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
+                        new KeyValuePair<string, List<object>>("PropertyBag", new List<object>{(IDictionary<string, Object>)null, new Dictionary<string, Object> {{"CustomKey", "CustomValue"}}, new Dictionary<string, Object>()}),
                         new KeyValuePair<string, List<object>>("RoleClaimType", new List<object>{ClaimsIdentity.DefaultRoleClaimType, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                         new KeyValuePair<string, List<object>>("RequireExpirationTime", new List<object>{true, false, true}),
                         new KeyValuePair<string, List<object>>("RequireSignedTokens", new List<object>{true, false, true}),


### PR DESCRIPTION
Ease addition of custom TokenValidationParameters by utilizing
a Property Bag.

Resolves: #985
See also: #874