### PR TITLE
The NotBefore and NotAfter properties of X509Certificates are now checked against local time instead of UTC

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -79,9 +79,11 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10245 = "IDX10245: Creating claims identity from the validated token: '{0}'.";
         public const string IDX10246 = "IDX10246: ValidateTokenReplay property on ValidationParameters is set to false. Exiting without validating the token replay.";
         public const string IDX10247 = "IDX10247: The current issuer value in ValidateIssuers property on ValidationParameters is null or emptry, skipping it for issuer validation.";
-        public const string IDX10248 = "IDX10248: X509SecurityKey validation failed. The associated certificate is not yet valid. ValidFrom: '{0}', Current time: '{1}'.";
-        public const string IDX10249 = "IDX10249: X509SecurityKey validation failed. The associated certificate has expired. ValidTo: '{0}', Current time: '{1}'.";
-
+        public const string IDX10248 = "IDX10248: X509SecurityKey validation failed. The associated certificate is not yet valid. ValidFrom (UTC): '{0}', Current time (UTC): '{1}'.";
+        public const string IDX10249 = "IDX10249: X509SecurityKey validation failed. The associated certificate has expired. ValidTo (UTC): '{0}', Current time (UTC): '{1}'.";
+        public const string IDX10250 = "IDX10250: The associated certificate is valid. ValidFrom (UTC): '{0}', Current time (UTC): '{1}'.";
+        public const string IDX10251 = "IDX10251: The associated certificate is valid. ValidTo (UTC): '{0}', Current time (UTC): '{1}'.";
+        
         // 10500 - SignatureValidation
         public const string IDX10500 = "IDX10500: Signature validation failed. No security keys were provided to validate the signature.";
         public const string IDX10501 = "IDX10501: Signature validation failed. Unable to match keys: \nkid: '{0}', \ntoken: '{1}'.";

--- a/test/Microsoft.IdentityModel.Net45.Tests/Microsoft.IdentityModel.Net45.cs
+++ b/test/Microsoft.IdentityModel.Net45.Tests/Microsoft.IdentityModel.Net45.cs
@@ -28,7 +28,7 @@
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
-
+using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tests;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -44,6 +44,7 @@ namespace Microsoft.IdentityModel.Net45.Tests
         [TestMethod]
         public void TestJwtTokenCreationAndValidation()
         {
+            IdentityModelEventSource.ShowPII = true;
             var handler = new JwtSecurityTokenHandler();
             handler.InboundClaimTypeMap.Clear();
             var jwt = handler.CreateEncodedJwt(Default.AsymmetricSignSecurityTokenDescriptor(null));


### PR DESCRIPTION
Fixes #967.