### PR TITLE
Added in a new abstract TokenHandler class that contains properties shared across all token handlers

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -219,7 +219,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// Gets the 'value' of the 'iat' claim { iat, 'value' } converted to a <see cref="DateTime"/> assuming 'value' is seconds since UnixEpoch (UTC 1970-01-01T0:0:0Z).
         /// </summary>
         /// <remarks>If the 'iat' claim is not found, then <see cref="DateTime.MinValue"/> is returned.</remarks>
-        public DateTime IssuedAt => GetDateTime(JwtRegisteredClaimNames.Iat);
+        public DateTime IssuedAt => JwtTokenUtilities.GetDateTime(JwtRegisteredClaimNames.Iat, Payload);
 
         /// <summary>
         /// Gets the 'value' of the 'iss' claim { iss, 'value' }.
@@ -291,13 +291,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// Gets the 'value' of the 'nbf' claim { nbf, 'value' } converted to a <see cref="DateTime"/> assuming 'value' is seconds since UnixEpoch (UTC 1970-01-01T0:0:0Z).
         /// </summary>
         /// <remarks>If the 'nbf' claim is not found, then <see cref="DateTime.MinValue"/> is returned.</remarks>
-        public override DateTime ValidFrom => GetDateTime(JwtRegisteredClaimNames.Nbf);
+        public override DateTime ValidFrom => JwtTokenUtilities.GetDateTime(JwtRegisteredClaimNames.Nbf, Payload);
 
         /// <summary>
         /// Gets the 'value' of the 'exp' claim { exp, 'value' } converted to a <see cref="DateTime"/> assuming 'value' is seconds since UnixEpoch (UTC 1970-01-01T0:0:0Z).
         /// </summary>
         /// <remarks>If the 'exp' claim is not found, then <see cref="DateTime.MinValue"/> is returned.</remarks>
-        public override DateTime ValidTo => GetDateTime(JwtRegisteredClaimNames.Exp);
+        public override DateTime ValidTo => JwtTokenUtilities.GetDateTime(JwtRegisteredClaimNames.Exp, Payload);
 
         /// <summary>
         /// Gets the 'value' of the 'x5t' claim { x5t, 'value' }.
@@ -459,46 +459,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 return JsonClaimValueTypes.JsonArray;
 
             return objType.ToString();
-        }
-
-        /// <summary>
-        /// Gets the DateTime using the number of seconds from 1970-01-01T0:0:0Z (UTC)
-        /// </summary>
-        /// <param name="key">Claim in the payload that should map to an integer, float, or string.</param>
-        /// <remarks>If the claim is not found, the function returns: DateTime.MinValue
-        /// </remarks>
-        /// <exception cref="FormatException">If the value of the claim cannot be parsed into a long.</exception>
-        /// <returns>The DateTime representation of a claim.</returns>
-        private DateTime GetDateTime(string key)
-        {
-            if (!Payload.TryGetValue(key, out var jToken))
-                return DateTime.MinValue;
-
-            var dateValue = ParseTimeValue(jToken, key);
-
-            var secondsAfterBaseTime = Convert.ToInt64(Math.Truncate(Convert.ToDouble(dateValue, CultureInfo.InvariantCulture)));
-            return EpochTime.DateTime(secondsAfterBaseTime);
-        }
-
-        private long ParseTimeValue(JToken jToken, string claimName)
-        {
-            if (jToken.Type == JTokenType.Integer || jToken.Type == JTokenType.Float)
-            {
-                return (long)jToken;
-            }
-            else if (jToken.Type == JTokenType.String)
-            {
-                if (long.TryParse((string)jToken, out long resultLong))
-                    return resultLong;
-
-                if (float.TryParse((string)jToken, out float resultFloat))
-                    return (long)resultFloat;
-
-                if (double.TryParse((string)jToken, out double resultDouble))
-                    return (long)resultDouble;
-            }
-
-            throw LogHelper.LogExceptionMessage(new FormatException(LogHelper.FormatInvariant(LogMessages.IDX14300, claimName, jToken.ToString(), typeof(long))));
         }
     }
 }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -27,9 +27,11 @@
 
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -119,6 +121,44 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     decryptionKeys.Add(key);
 
             return decryptionKeys;
+
+        }
+        /// <summary>
+        /// Gets the DateTime using the number of seconds from 1970-01-01T0:0:0Z (UTC)
+        /// </summary>
+        /// <param name="key">Claim in the payload that should map to an integer, float, or string.</param>
+        /// <param name="payload">The payload that contains the desired claim value.</param>
+        /// <remarks>If the claim is not found, the function returns: DateTime.MinValue
+        /// </remarks>
+        /// <exception cref="FormatException">If the value of the claim cannot be parsed into a long.</exception>
+        /// <returns>The DateTime representation of a claim.</returns>
+        internal static DateTime GetDateTime(string key, JObject payload)
+        {
+            if (!payload.TryGetValue(key, out var jToken))
+                return DateTime.MinValue;
+
+            return EpochTime.DateTime(Convert.ToInt64(Math.Truncate(Convert.ToDouble(ParseTimeValue(jToken, key), CultureInfo.InvariantCulture))));
+        }
+
+        private static long ParseTimeValue(JToken jToken, string claimName)
+        {
+            if (jToken.Type == JTokenType.Integer || jToken.Type == JTokenType.Float)
+            {
+                return (long)jToken;
+            }
+            else if (jToken.Type == JTokenType.String)
+            {
+                if (long.TryParse((string)jToken, out long resultLong))
+                    return resultLong;
+
+                if (float.TryParse((string)jToken, out float resultFloat))
+                    return (long)resultFloat;
+
+                if (double.TryParse((string)jToken, out double resultDouble))
+                    return (long)resultDouble;
+            }
+
+            throw LogHelper.LogExceptionMessage(new FormatException(LogHelper.FormatInvariant(LogMessages.IDX14300, claimName, jToken.ToString(), typeof(long))));
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -49,22 +49,9 @@ namespace Microsoft.IdentityModel.Tokens.Saml
     {
         internal const string Actor = "Actor";
 
-        private int _defaultTokenLifetimeInMinutes = DefaultTokenLifetimeInMinutes;
         private IEqualityComparer<SamlSubject> _samlSubjectEqualityComparer = new SamlSubjectEqualityComparer();
         private SamlSerializer _serializer = new SamlSerializer();
         private static string[] _tokenTypeIdentifiers = new string[] { SamlConstants.Namespace, SamlConstants.OasisWssSamlTokenProfile11 };
-
-        /// <summary>
-        /// Default lifetime of tokens created. When creating tokens, if 'expires' and 'notbefore' are both null, then a default will be set to: expires = DateTime.UtcNow, notbefore = DateTime.UtcNow + TimeSpan.FromMinutes(TokenLifetimeInMinutes).
-        /// </summary>
-        public static readonly int DefaultTokenLifetimeInMinutes = 60;
-
-        /// <summary>
-        /// Initializes an instance of <see cref="SamlSecurityTokenHandler"/>.
-        /// </summary>
-        public SamlSecurityTokenHandler()
-        {
-        }
 
 #region fields
         /// <summary>
@@ -112,30 +99,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml
             get { return _serializer; }
             set { _serializer = value ?? throw LogHelper.LogArgumentNullException(nameof(value)); }
         } 
-
-        /// <summary>
-        /// Gets or sets a bool that controls if token creation will set default 'NotBefore', 'NotOnOrAfter' and 'IssueInstant' if not specified.
-        /// </summary>
-        /// <remarks>See: <see cref="DefaultTokenLifetimeInMinutes"/>, <see cref="TokenLifetimeInMinutes"/> for defaults and configuration.</remarks>
-        [DefaultValue(true)]
-        public bool SetDefaultTimesOnTokenCreation { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets the token lifetime in minutes.
-        /// </summary>
-        /// <remarks>Used by <see cref="CreateToken(SecurityTokenDescriptor)"/> to set the default expiration ('exp'). <see cref="DefaultTokenLifetimeInMinutes"/> for the default.</remarks>
-        /// <exception cref="ArgumentOutOfRangeException">'value' less than 1.</exception>
-        public int TokenLifetimeInMinutes
-        {
-            get { return _defaultTokenLifetimeInMinutes; }
-            set
-            {
-                if (value < 1)
-                    throw LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), FormatInvariant(TokenLogMessages.IDX10104, value)));
-
-                _defaultTokenLifetimeInMinutes = value;
-            }
-        }
 
         /// <summary>
         /// Gets the securityToken type supported by this handler.
@@ -757,7 +720,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         /// <param name="token">a Saml token as a string.</param>
         /// <returns>A <see cref="SamlSecurityToken"/></returns>
         /// <exception cref="ArgumentNullException">if <paramref name="token"/> is null or empty.</exception>
-        /// <exception cref="ArgumentException">If 'token.Length' $gt; <see cref="SecurityTokenHandler.MaximumTokenSizeInBytes"/>.</exception>
+        /// <exception cref="ArgumentException">If 'token.Length' $gt; <see cref="TokenHandler.MaximumTokenSizeInBytes"/>.</exception>
         public virtual SamlSecurityToken ReadSamlToken(string token)
         {
             if (string.IsNullOrEmpty(token))
@@ -782,7 +745,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         /// <param name="token">a Saml token as a string.</param>
         /// <returns>A <see cref="SamlSecurityToken"/></returns>
         /// <exception cref="ArgumentNullException"> If <paramref name="token"/> is null or empty.</exception>
-        /// <exception cref="ArgumentException"> If 'token.Length' $gt; <see cref="SecurityTokenHandler.MaximumTokenSizeInBytes"/>.</exception>
+        /// <exception cref="ArgumentException"> If 'token.Length' $gt; <see cref="TokenHandler.MaximumTokenSizeInBytes"/>.</exception>
         public override SecurityToken ReadToken(string token)
         {
             return ReadSamlToken(token);
@@ -1144,7 +1107,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         /// <returns>A <see cref="ClaimsPrincipal"/> generated from the claims in the Saml securityToken.</returns>
         /// <exception cref="ArgumentNullException">if <paramref name="token"/> is null or whitespace.</exception>
         /// <exception cref="ArgumentNullException">if <paramref name="validationParameters"/> is null.</exception>
-        /// <exception cref="ArgumentException">if 'securityToken.Length' $gt; <see cref="SecurityTokenHandler.MaximumTokenSizeInBytes"/>.</exception>
+        /// <exception cref="ArgumentException">if 'securityToken.Length' $gt; <see cref="TokenHandler.MaximumTokenSizeInBytes"/>.</exception>
         public override ClaimsPrincipal ValidateToken(string token, TokenValidationParameters validationParameters, out SecurityToken validatedToken)
         {
             if (string.IsNullOrWhiteSpace(token))

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -46,19 +46,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
     public class Saml2SecurityTokenHandler : SecurityTokenHandler
     {
         private const string _actor = "Actor";
-        private int _defaultTokenLifetimeInMinutes = DefaultTokenLifetimeInMinutes;
         private Saml2Serializer _serializer = new Saml2Serializer();
-
-        /// <summary>
-        /// Default lifetime of tokens created. When creating tokens, if 'expires' and 'notbefore' are both null, then a default will be set to: expires = DateTime.UtcNow, notbefore = DateTime.UtcNow + TimeSpan.FromMinutes(TokenLifetimeInMinutes).
-        /// </summary>
-        public static readonly int DefaultTokenLifetimeInMinutes = 60;
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="Saml2SecurityTokenHandler"/>.
-        /// </summary>
-        public Saml2SecurityTokenHandler()
-        { }
 
         /// <summary>
         /// Gets or set the <see cref="Saml2Serializer"/> that will be used to read and write a <see cref="Saml2SecurityToken"/>.
@@ -68,30 +56,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         {
             get { return _serializer; }
             set { _serializer = value ?? throw LogHelper.LogArgumentNullException(nameof(value)); }
-        }
-
-        /// <summary>
-        /// Gets or sets a bool that controls if token creation will set default 'NotBefore', 'NotOnOrAfter' and 'IssueInstant' if not specified.
-        /// </summary>
-        /// <remarks>See: <see cref="DefaultTokenLifetimeInMinutes"/>, <see cref="TokenLifetimeInMinutes"/> for defaults and configuration.</remarks>
-        [DefaultValue(true)]
-        public bool SetDefaultTimesOnTokenCreation { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets the token lifetime in minutes.
-        /// </summary>
-        /// <remarks>Used by <see cref="CreateToken(SecurityTokenDescriptor)"/> to set the default expiration ('exp'). <see cref="DefaultTokenLifetimeInMinutes"/> for the default.</remarks>
-        /// <exception cref="ArgumentOutOfRangeException">'value' less than 1.</exception>
-        public int TokenLifetimeInMinutes
-        {
-            get { return _defaultTokenLifetimeInMinutes; }
-            set
-            {
-                if (value < 1)
-                    throw LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), FormatInvariant(TokenLogMessages.IDX10104, value)));
-
-                _defaultTokenLifetimeInMinutes = value;
-            }
         }
 
         /// <summary>
@@ -222,7 +186,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         /// <param name="validatedToken">The <see cref="Saml2SecurityToken"/> that was validated.</param>
         /// <exception cref="ArgumentNullException"><paramref name="token"/> is null or empty.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="validationParameters"/> is null.</exception>
-        /// <exception cref="ArgumentException"><paramref name="token"/>.Length is greater than <see cref="SecurityTokenHandler.MaximumTokenSizeInBytes"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="token"/>.Length is greater than <see cref="TokenHandler.MaximumTokenSizeInBytes"/>.</exception>
         /// <exception cref="Saml2SecurityTokenReadException">if the <paramref name="token"/> is not well-formed.</exception>
         /// <returns>A <see cref="ClaimsPrincipal"/> representing the identity contained in the token.</returns>
         public override ClaimsPrincipal ValidateToken(string token, TokenValidationParameters validationParameters, out SecurityToken validatedToken)
@@ -482,7 +446,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         /// </summary>
         /// <param name="token">a Saml2 token as a string.</param>
         /// <exception cref="ArgumentNullException"> If <paramref name="token"/> is null or empty.</exception>
-        /// <exception cref="ArgumentException"> If <paramref name="token"/>.Length $gt; <see cref="SecurityTokenHandler.MaximumTokenSizeInBytes"/>.</exception>
+        /// <exception cref="ArgumentException"> If <paramref name="token"/>.Length $gt; <see cref="TokenHandler.MaximumTokenSizeInBytes"/>.</exception>
         /// <returns>A <see cref="Saml2SecurityToken"/></returns>
         public virtual Saml2SecurityToken ReadSaml2Token(string token)
         {
@@ -507,7 +471,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         /// </summary>
         /// <param name="token">a Saml2 token as a string.</param>
         /// <exception cref="ArgumentNullException"> If <paramref name="token"/> is null or empty.</exception>
-        /// <exception cref="ArgumentException"> If <paramref name="token"/>.Length $gt; <see cref="SecurityTokenHandler.MaximumTokenSizeInBytes"/>.</exception>
+        /// <exception cref="ArgumentException"> If <paramref name="token"/>.Length $gt; <see cref="TokenHandler.MaximumTokenSizeInBytes"/>.</exception>
         /// <returns>A <see cref="Saml2SecurityToken"/></returns>
         public override SecurityToken ReadToken(string token)
         {
@@ -654,6 +618,9 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         {
             if (tokenDescriptor == null)
                 throw LogArgumentNullException(nameof(tokenDescriptor));
+
+            if (tokenDescriptor.Subject == null)
+                throw LogArgumentNullException(nameof(tokenDescriptor.Subject));
 
             var attributes = new List<Saml2Attribute>();
             foreach (Claim claim in tokenDescriptor.Subject.Claims)

--- a/src/Microsoft.IdentityModel.Tokens/SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityTokenHandler.cs
@@ -28,18 +28,14 @@
 using System;
 using System.Security.Claims;
 using System.Xml;
-using static Microsoft.IdentityModel.Logging.LogHelper;
-
-using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
 
 namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
     /// Defines the interface for a Security Token Handler.
     /// </summary>
-    public abstract class SecurityTokenHandler : ISecurityTokenValidator
+    public abstract class SecurityTokenHandler : TokenHandler, ISecurityTokenValidator
     {
-        private int _maximumTokenSizeInBytes = TokenValidationParameters.DefaultMaximumTokenSizeInBytes;
 
         /// <summary>
         /// Creates an instance of <see cref="SecurityTokenHandler"/>
@@ -105,22 +101,6 @@ namespace Microsoft.IdentityModel.Tokens
         public virtual bool CanReadToken(string tokenString)
         {
             return false;
-        }
-
-        /// <summary>
-        /// Gets and sets the maximum token size in bytes that will be processed.
-        /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">'value' less than 1.</exception>
-        public virtual int MaximumTokenSizeInBytes
-        {
-            get { return _maximumTokenSizeInBytes; }
-            set
-            {
-                if (value < 1)
-                    throw LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), FormatInvariant(TokenLogMessages.IDX10101, value)));
-
-                _maximumTokenSizeInBytes = value;
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/TokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenHandler.cs
@@ -1,0 +1,77 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using Microsoft.IdentityModel.Logging;
+using System;
+using System.ComponentModel;
+using static Microsoft.IdentityModel.Logging.LogHelper;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Defines properties shared across all security token handlers.
+    /// </summary>
+    public abstract class TokenHandler
+    {
+        private int _defaultTokenLifetimeInMinutes = DefaultTokenLifetimeInMinutes;
+        private int _maximumTokenSizeInBytes = TokenValidationParameters.DefaultMaximumTokenSizeInBytes;
+
+        /// <summary>
+        /// Default lifetime of tokens created. When creating tokens, if 'expires' and 'notbefore' are both null, 
+        /// then a default will be set to: expires = DateTime.UtcNow, notbefore = DateTime.UtcNow + TimeSpan.FromMinutes(TokenLifetimeInMinutes).
+        /// </summary>
+        public static readonly int DefaultTokenLifetimeInMinutes = 60;
+
+        /// <summary>
+        /// Gets and sets the maximum token size in bytes that will be processed.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">'value' less than 1.</exception>
+        public virtual int MaximumTokenSizeInBytes
+        {
+            get => _maximumTokenSizeInBytes; 
+            set => _maximumTokenSizeInBytes =  (value < 1) ? throw LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), FormatInvariant(LogMessages.IDX10101, value))) : value;
+        }
+
+        /// <summary>
+        /// Gets or sets a bool that controls if token creation will set default 'exp', 'nbf' and 'iat' if not specified.
+        /// </summary>
+        /// <remarks>See: <see cref="TokenLifetimeInMinutes"/> for configuration.</remarks>
+        [DefaultValue(true)]
+        public bool SetDefaultTimesOnTokenCreation { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the token lifetime in minutes.
+        /// </summary>
+        /// <remarks>Used during token creation to set the default expiration ('exp'). </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">'value' less than 1.</exception>
+        public int TokenLifetimeInMinutes
+        {
+            get => _defaultTokenLifetimeInMinutes;
+            set => _defaultTokenLifetimeInMinutes = (value < 1) ? throw LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), FormatInvariant(LogMessages.IDX10104, value))) : value;
+        }
+    }
+}

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
@@ -412,7 +412,7 @@ namespace System.IdentityModel.Tokens.Jwt
         }
 
         /// <summary>
-        /// Gets teh <see cref="EncryptingCredentials"/> to use when writing this token.
+        /// Gets the <see cref="EncryptingCredentials"/> to use when writing this token.
         /// </summary>
         public EncryptingCredentials EncryptingCredentials
         {

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -26,7 +26,6 @@
 //------------------------------------------------------------------------------
 
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -46,7 +45,6 @@ namespace System.IdentityModel.Tokens.Jwt
     {
 
         private delegate bool CertMatcher(X509Certificate2 cert);
-        private int _defaultTokenLifetimeInMinutes = DefaultTokenLifetimeInMinutes;
         private ISet<string> _inboundClaimFilter;
         private IDictionary<string, string> _inboundClaimTypeMap;
         private static string _jsonClaimType = _namespace + "/json_type";
@@ -55,11 +53,6 @@ namespace System.IdentityModel.Tokens.Jwt
         private IDictionary<string, string> _outboundAlgorithmMap = null;
         private static string _shortClaimType = _namespace + "/ShortTypeName";
         private bool _mapInboundClaims = DefaultMapInboundClaims;
-
-        /// <summary>
-        /// Default lifetime of tokens created. When creating tokens, if 'expires' and 'notbefore' are both null, then a default will be set to: expires = DateTime.UtcNow, notbefore = DateTime.UtcNow + TimeSpan.FromMinutes(TokenLifetimeInMinutes).
-        /// </summary>
-        public static readonly int DefaultTokenLifetimeInMinutes = 60;
 
         /// <summary>
         /// Default claim type mapping for inbound claims.
@@ -279,27 +272,6 @@ namespace System.IdentityModel.Tokens.Jwt
         }
 
         /// <summary>
-        /// Gets or sets the token lifetime in minutes.
-        /// </summary>
-        /// <remarks>Used by <see cref="CreateToken(SecurityTokenDescriptor)"/> to set the default expiration ('exp'). <see cref="DefaultTokenLifetimeInMinutes"/> for the default.</remarks>
-        /// <exception cref="ArgumentOutOfRangeException">'value' less than 1.</exception>
-        public int TokenLifetimeInMinutes
-        {
-            get
-            {
-                return _defaultTokenLifetimeInMinutes;
-            }
-
-            set
-            {
-                if (value < 1)
-                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant(TokenLogMessages.IDX10104, value)));
-
-                _defaultTokenLifetimeInMinutes = value;
-            }
-        }
-
-        /// <summary>
         /// Gets the type of the <see cref="System.IdentityModel.Tokens.Jwt.JwtSecurityToken"/>.
         /// </summary>
         /// <return>The type of <see cref="System.IdentityModel.Tokens.Jwt.JwtSecurityToken"/></return>
@@ -320,7 +292,7 @@ namespace System.IdentityModel.Tokens.Jwt
         /// </remarks>
         /// <returns>
         /// <para>'false' if the token is null or whitespace.</para>
-        /// <para>'false' if token.Length is greater than <see cref="SecurityTokenHandler.MaximumTokenSizeInBytes"/>.</para>
+        /// <para>'false' if token.Length is greater than <see cref="TokenHandler.MaximumTokenSizeInBytes"/>.</para>
         /// <para>'true' if the token is in JSON compact serialization format.</para>
         /// </returns>
         public override bool CanReadToken(string token)
@@ -642,7 +614,7 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <param name="token">A 'JSON Web Token' (JWT) in JWS or JWE Compact Serialization Format.</param>
         /// <returns>A <see cref="JwtSecurityToken"/></returns>
         /// <exception cref="ArgumentNullException">'token' is null or empty.</exception>
-        /// <exception cref="ArgumentException">'token.Length' $gt; <see cref="SecurityTokenHandler.MaximumTokenSizeInBytes"/>.</exception>
+        /// <exception cref="ArgumentException">'token.Length' $gt; <see cref="TokenHandler.MaximumTokenSizeInBytes"/>.</exception>
         /// <exception cref="ArgumentException"><see cref="CanReadToken(string)"/></exception>
         /// <remarks><para>If the 'token' is in JWE Compact Serialization format, only the protected header will be deserialized.</para>
         /// This method is unable to decrypt the payload. Use <see cref="ValidateToken(string, TokenValidationParameters, out SecurityToken)"/>to obtain the payload.</remarks>
@@ -668,7 +640,7 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <param name="token">A 'JSON Web Token' (JWT) in JWS or JWE Compact Serialization Format.</param>
         /// <returns>A <see cref="JwtSecurityToken"/></returns>
         /// <exception cref="ArgumentNullException">'token' is null or empty.</exception>
-        /// <exception cref="ArgumentException">'token.Length' is greater than <see cref="SecurityTokenHandler.MaximumTokenSizeInBytes"/>.</exception>
+        /// <exception cref="ArgumentException">'token.Length' is greater than <see cref="TokenHandler.MaximumTokenSizeInBytes"/>.</exception>
         /// <exception cref="ArgumentException"><see cref="CanReadToken(string)"/></exception>
         /// <remarks><para>If the 'token' is in JWE Compact Serialization format, only the protected header will be deserialized.</para>
         /// This method is unable to decrypt the payload. Use <see cref="ValidateToken(string, TokenValidationParameters, out SecurityToken)"/>to obtain the payload.</remarks>
@@ -1490,13 +1462,6 @@ namespace System.IdentityModel.Tokens.Jwt
 
             return null;
         }
-
-        /// <summary>
-        /// Gets or sets a bool that controls if token creation will set default 'exp', 'nbf' and 'iat' if not specified.
-        /// </summary>
-        /// <remarks>See: <see cref="DefaultTokenLifetimeInMinutes"/>, <see cref="TokenLifetimeInMinutes"/> for defaults and configuration.</remarks>
-        [DefaultValue(true)]
-        public bool SetDefaultTimesOnTokenCreation { get; set; } = true;
 
         /// <summary>
         /// Validates the <see cref="JwtSecurityToken.SigningKey"/> is an expected value.

--- a/test/ApiChangeTest/ApiChangeTest.cs
+++ b/test/ApiChangeTest/ApiChangeTest.cs
@@ -63,7 +63,16 @@ namespace ApiChangeTest
         // Full name must be provided, i.e. namespace.className.propertyName
         private static List<string> _allowedApiBreakingChanges = new List<string>()
         {
-            "System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler.MaximumTokenSizeInBytes"
+            "Microsoft.IdentityModel.Tokens.SecurityTokenHandler.MaximumTokenSizeInBytes",
+            "Microsoft.IdentityModel.Tokens.Saml.SamlSecurityTokenHandler.DefaultTokenLifetimeInMinutes",
+            "Microsoft.IdentityModel.Tokens.Saml.SamlSecurityTokenHandler.SetDefaultTimesOnTokenCreation",
+            "Microsoft.IdentityModel.Tokens.Saml.SamlSecurityTokenHandler.TokenLifetimeInMinutes",
+            "Microsoft.IdentityModel.Tokens.Saml2.Saml2SecurityTokenHandler.DefaultTokenLifetimeInMinutes",
+            "Microsoft.IdentityModel.Tokens.Saml2.Saml2SecurityTokenHandler.SetDefaultTimesOnTokenCreation",
+            "Microsoft.IdentityModel.Tokens.Saml2.Saml2SecurityTokenHandler.TokenLifetimeInMinutes",
+            "System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler.DefaultTokenLifetimeInMinutes",
+            "System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler.SetDefaultTimesOnTokenCreation",
+            "System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler.TokenLifetimeInMinutes"
         };
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -458,6 +458,32 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
+        // Test checks to make sure that default times are correctly added to the token
+        // upon token creation.
+        [Fact]
+        public void SetDefaultTimesOnTokenCreation()
+        {
+            TestUtilities.WriteHeader($"{this}.SetDefaultTimesOnTokenCreation");
+            var context = new CompareContext();
+
+            var tokenHandler = new JsonWebTokenHandler();
+            var payloadWithoutTimeValues = new JObject()
+            {
+                { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
+                { JwtRegisteredClaimNames.GivenName, "Bob" },
+                { JwtRegisteredClaimNames.Iss, Default.Issuer },
+                { JwtRegisteredClaimNames.Aud, Default.Audience },
+            };
+
+            var jwtString = tokenHandler.CreateToken(payloadWithoutTimeValues, KeyingMaterial.JsonWebKeyRsa256SigningCredentials);
+            var jwt = new JsonWebToken(jwtString);
+
+            // DateTime.MinValue is returned if the value of a DateTime claim is not found in the payload
+            Assert.NotEqual(DateTime.MinValue, jwt.IssuedAt);
+            Assert.NotEqual(DateTime.MinValue, jwt.ValidFrom);
+            Assert.NotEqual(DateTime.MinValue, jwt.ValidTo);
+        }
+
         // Test checks to make sure that an access token can be successfully validated by the JsonWebTokenHandler.
         // Also ensures that a non-standard claim can be successfully retrieved from the payload and validated.
         [Fact]

--- a/test/Microsoft.IdentityModel.Tests/Default.cs
+++ b/test/Microsoft.IdentityModel.Tests/Default.cs
@@ -377,9 +377,9 @@ namespace Microsoft.IdentityModel.Tests
                 { JwtRegisteredClaimNames.GivenName, "Bob" },
                 { JwtRegisteredClaimNames.Iss, Default.Issuer },
                 { JwtRegisteredClaimNames.Aud, Default.Audience },
-                { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(DateTime.UtcNow).ToString()},
+                { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(Default.NotBefore).ToString() },
                 { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(Default.NotBefore).ToString()},
-                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Default.Expires).ToString() }
+                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Default.Expires).ToString() },
             };
         }
 
@@ -391,7 +391,7 @@ namespace Microsoft.IdentityModel.Tests
                 new Claim(JwtRegisteredClaimNames.GivenName, "Bob", ClaimValueTypes.String, Issuer, Issuer),
                 new Claim(JwtRegisteredClaimNames.Iss, Default.Issuer, ClaimValueTypes.String, Issuer, Issuer),
                 new Claim(JwtRegisteredClaimNames.Aud, Default.Audience, ClaimValueTypes.String, Issuer, Issuer),
-                new Claim(JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(DateTime.UtcNow).ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(Default.NotBefore).ToString(), ClaimValueTypes.String, Issuer, Issuer),
                 new Claim(JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(Default.NotBefore).ToString(), ClaimValueTypes.String, Issuer, Issuer),
                 new Claim(JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Default.Expires).ToString(), ClaimValueTypes.String, Issuer, Issuer),
             };

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
@@ -589,6 +589,30 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             };
         }
 
+        // Test checks to make sure that default times are correctly added to the token
+        // upon token creation.
+        [Fact]
+        public void SetDefaultTimesOnTokenCreation()
+        {
+            TestUtilities.WriteHeader($"{this}.SetDefaultTimesOnTokenCreation");
+            var context = new CompareContext();
+
+            var tokenHandler = new Saml2SecurityTokenHandler();
+            var descriptorNoTimeValues = new SecurityTokenDescriptor()
+            {
+                Issuer = Default.Issuer,
+                Audience = Default.Audience,
+                SigningCredentials = Default.AsymmetricSigningCredentials,
+                Subject = new ClaimsIdentity()
+            };
+
+            var token = tokenHandler.CreateToken(descriptorNoTimeValues);
+            var saml2SecurityToken = token as Saml2SecurityToken;
+
+            Assert.NotEqual(DateTime.MinValue, saml2SecurityToken.ValidFrom);
+            Assert.NotEqual(DateTime.MinValue, saml2SecurityToken.ValidTo);
+        }
+
         [Theory, MemberData(nameof(ValidateAudienceTheoryData))]
         public void ValidateAudience(Saml2TheoryData theoryData)
         {

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
@@ -326,6 +326,29 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             };
         }
 
+        // Test checks to make sure that default times are correctly added to the token
+        // upon token creation.
+        [Fact]
+        public void SetDefaultTimesOnTokenCreation()
+        {
+            TestUtilities.WriteHeader($"{this}.SetDefaultTimesOnTokenCreation");
+            var context = new CompareContext();
+
+            var tokenHandler = new SamlSecurityTokenHandler();
+            var descriptorNoTimeValues = new SecurityTokenDescriptor()
+            {
+                Issuer = Default.Issuer,
+                Audience = Default.Audience,
+                SigningCredentials = Default.AsymmetricSigningCredentials
+            };
+
+            var token = tokenHandler.CreateToken(descriptorNoTimeValues);
+            var samlSecurityToken = token as SamlSecurityToken;
+
+            Assert.NotEqual(DateTime.MinValue, samlSecurityToken.ValidFrom);
+            Assert.NotEqual(DateTime.MinValue, samlSecurityToken.ValidTo);
+        }
+
         [Theory, MemberData(nameof(ValidateAudienceTheoryData))]
         public void ValidateAudience(SamlTheoryData theoryData)
         {

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -710,6 +710,30 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
         }
 
+        // Test checks to make sure that default times are correctly added to the token
+        // upon token creation.
+        [Fact]
+        public void SetDefaultTimesOnTokenCreation()
+        {
+            TestUtilities.WriteHeader($"{this}.SetDefaultTimesOnTokenCreation");
+            var context = new CompareContext();
+
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var descriptorNoTimeValues = new SecurityTokenDescriptor()
+            {
+                Issuer = Default.Issuer,
+                Audience = Default.Audience,
+                SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials
+            };
+
+            var token = tokenHandler.CreateJwtSecurityToken(descriptorNoTimeValues);
+            var jwt = token as JwtSecurityToken;
+
+            Assert.NotNull(jwt.Payload.Iat);
+            Assert.NotNull(jwt.Payload.Nbf);
+            Assert.NotNull(jwt.Payload.Exp);
+        }
+
         [Fact]
         public void ValidateTokenReplay()
         {


### PR DESCRIPTION
Addresses #963.

This PR also adds default time setting functionality (during token creation) to the JsonWebTokenHandler.

Exceptions had to be added to the ApiBreakingChangeTest because it does not take base class methods/properties into account.

Also fixes a small typo mentioned in this issue: #999