### PR TITLE
Got rid of unused log messages and added in logic for checking mismatched braces in strings

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
@@ -38,7 +38,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         #pragma warning disable 1591
 
         // signature creation / validation
-        internal const string IDX14000 = "IDX1400: Signing JWT is not supported for: Algorithm: '{0}', SecurityKey: '{1}'.";
+        internal const string IDX14000 = "IDX14000: Signing JWT is not supported for: Algorithm: '{0}', SecurityKey: '{1}'.";
 
         // JWT messages
         internal const string IDX14100 = "IDX14100: JWT is not well formed: '{0}'.\nThe token needs to be in JWS or JWE Compact Serialization Format. (JWS): 'EncodedHeader.EndcodedPayload.EncodedSignature'. (JWE): 'EncodedProtectedHeader.EncodedEncryptedKey.EncodedInitializationVector.EncodedCiphertext.EncodedAuthenticationTag'.";
@@ -49,9 +49,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         internal const string IDX14105 = "IDX14105: Header.Cty != null, assuming JWS. Cty: '{0}'.";
         internal const string IDX14106 = "IDX14106: Decoding token: '{0}' into header, payload and signature.";
         internal const string IDX14107 = "IDX14107: Token string does not match the token formats: JWE (header.encryptedKey.iv.ciphertext.tag) or JWS (header.payload.signature)";
-        internal const string IDX14108 = "IDX14108: Error found while parsing date time. The '{0}' claim has value '{1}' which is could not be parsed to an integer.";
-        internal const string IDX14109 = "IDX14109: Error found while parsing date time. The '{0}' claim has value '{1}' does not lie in the valid range.";
-        internal const string IDX14110 = "IDX14110: JWT is not well formed: '{0}'.\nThe token needs to be in JWS Compact Serialization Format. (JWS): 'EncodedHeader.EndcodedPayload.EncodedSignature'.";
 
         // logging
         internal const string IDX14200 = "IDX14200: Creating raw signature using the signature credentials.";

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/LogMessages.cs
@@ -54,7 +54,6 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         internal const string IDX22806 = "IDX22806: Key descriptor for signing is missing in security token service type RoleDescriptor.";
         internal const string IDX22807 = "IDX22807: Token endpoint is missing in security token service type RoleDescriptor.";
         internal const string IDX22808 = "IDX22808: 'Use' attribute is missing in KeyDescriptor.";
-        internal const string IDX22809 = "IDX22809: The expected value for attribute '{0}' is '{1}', but the current one is '{2}'.";
         internal const string IDX22810 = "IDX22810: 'Issuer' value is missing in wsfederationconfiguration.";
         internal const string IDX22811 = "IDX22811: 'TokenEndpoint' value is missing in wsfederationconfiguration.";
         internal const string IDX22812 = "IDX22812: Element: '{0}' was an empty element. 'TokenEndpoint' value is missing in wsfederationconfiguration.";

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/LogMessages.cs
@@ -76,7 +76,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         internal const string IDX11135 = "IDX11135: Unable to read SamlSecurityToken. Saml element '{0}' must have value.";
         internal const string IDX11136 = "IDX11136: 'AuthorizationDecisionStatement' cannot be empty.";
         internal const string IDX11137 = "IDX11137: 'SamlAction' must have a value.";
-        internal const string IDX11138 = "IDX11138: 'SamlSubject' requires a 'NameIdentifier' or 'SubjectConfirmation'.";
 
         // Saml writting
         internal const string IDX11501 = "IDX11501: SamlAssertion Id cannot be null or empty.";
@@ -97,12 +96,9 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         internal const string IDX11516 = "IDX11516: We could not write the SamlStatement of type:'{0}'. You will need to override this method to write this statement.";
         internal const string IDX11517 = "IDX11517: Exception thrown while writing '{0}' for SamlSecurityToken. Inner exception: '{1}'.";
         internal const string IDX11518 = "IDX11518: Unable to writen SamlAssertion: SamlSubject.Name and SamlSubject.ConfirmationMethods.Count == 0.";
-        internal const string IDX11519 = "IDX11519: Authentication method is null when creating AuthenticationStatement for SamlSecurityToken.";
-        internal const string IDX11520 = "IDX11520: Authentication instant is null when creating AuthenticationInstant for SamlSecurityToken.";
         internal const string IDX11521 = "IDX11521: Multiple name identifier claim is not allowed in tokenDescriptor.Subject.Claims.";
         internal const string IDX11522 = "IDX11522: More than one delegates acting as an identity are found in Saml attribute.";
         internal const string IDX11523 = "IDX11523: The claim type must have namespace and name which separated by slash. Input claim: '{0}'.";
-        internal const string IDX11524 = "IDX11524: SAML AuthorizationDecision DecisionType must be 'Permit', 'Deny' or 'Indeterminate'.";
 
         // IDX11800 - AuthenticationStatement
         internal const string IDX11800 = "IDX11800: Unable to write SamlAssertion: {0} is required, {1}.{2} is null or empty.";

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/LogMessages.cs
@@ -80,7 +80,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         internal const string IDX13139 = "IDX13139: Uri must be an AbsoluteUri is: '{0}'";
         internal const string IDX13140 = "IDX13140: EncryptedId is not supported. You will need to override ReadEncryptedId and provide support.";
         internal const string IDX13141 = "IDX13141: EncryptedAssertion is not supported. You will need to override ReadAssertion and provide support.";
-        internal const string IDX13311 = "IDX13311: 'Saml2Action' must have a value.";
         internal const string IDX13313 = "IDX13313: 'AuthnStatement' cannot be empty.";
         internal const string IDX13312 = "IDX13312: 'AuthnContext' cannot be empty.";
         internal const string IDX13314 = "IDX13314: 'AuthzDecisionStatement' cannot be empty (must have at least one 'Subject').";
@@ -91,15 +90,11 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         internal const string IDX13150 = "IDX13150: The Saml2SecurityTokenHandler can only write a token was of type: '{0}'.";
         internal const string IDX13151 = "IDX13151: Cannot write '{0}' because '{1}' is null or empty.";
         internal const string IDX13300 = "IDX13300: '{0}' must be an absolute Uri, was: '{1}'";
-        internal const string IDX13301 = "IDX13301: Encryption is not supported in writing saml2 assertion.";
         internal const string IDX13302 = "IDX13302: An assertion with no statements must contain a 'Subject' element.";
         internal const string IDX13303 = "IDX13303: 'Subject' is required in Saml2Assertion for built-in statement type.";
         internal const string IDX13304 = "IDX13304: Encryption is not supported in writing saml2 nameIdentifier.";
         internal const string IDX13305 = "IDX13305: Both id and subjectconfirmation are null in saml2 subject: '{0}'.";
         internal const string IDX13306 = "IDX13306: Multiple name identifier claim is not allowed in tokenDescriptor.Subject.Claims.";
-        internal const string IDX13307 = "IDX13307: Authentication method is null when creating AuthenticationStatement for SamlSecurityToken.";
-        internal const string IDX13308 = "IDX13308: Authentication instant is null when creating AuthenticationInstant for SamlSecurityToken.";
-        internal const string IDX13309 = "IDX13309: Encrypting key cannot be a AsymmetricSecurityKey.";
         internal const string IDX13310 = "IDX13310: SAML2 AuthorizationDecision DecisionType must be 'Permit', 'Deny' or 'Indeterminate'.";
 
         // IDX11900 - AuthorizationDecisionStatement

--- a/src/Microsoft.IdentityModel.Xml/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Xml/LogMessages.cs
@@ -49,8 +49,8 @@ namespace Microsoft.IdentityModel.Xml
         internal const string IDX30024 = "IDX30024: Unable to read XML. Expecting XmlReader to be at element: '{0}', found: '{1}'.";
         internal const string IDX30025 = "IDX30025: Unable to read XML. Expecting XmlReader to be at EndElement: '{0}'. Found XmlNode 'type.name': '{1}.{2}'.";
         internal const string IDX30026 = "IDX30026: The reader must be pointing to a StartElement. NodeType is: '{0}'.";
-        internal const string IDX30027 = "IDX14208: InnerReader is null. It is necessary to set InnerReader before making calls to DelegatingXmlDictionaryReader.";
-        internal const string IDX30028 = "IDX14209: InnerWriter is null. It is necessary to set InnerWriter before making calls to DelegatingXmlDictionaryWriter.";
+        internal const string IDX30027 = "IDX30027: InnerReader is null. It is necessary to set InnerReader before making calls to DelegatingXmlDictionaryReader.";
+        internal const string IDX30028 = "IDX30028: InnerWriter is null. It is necessary to set InnerWriter before making calls to DelegatingXmlDictionaryWriter.";
 
         // XML structure, supported exceptions
         internal const string IDX30100 = "IDX30100: Unable to process the {0} element. This canonicalization method is not supported: '{1}'. Supported methods are: '{2}', '{3}', '{4}'.";
@@ -72,7 +72,6 @@ namespace Microsoft.IdentityModel.Xml
         internal const string IDX30211 = "IDX30211: The TransfromFactory does not support the canonicalizing transform: '{0}'.";
         internal const string IDX30212 = "IDX30212: Unable to verify Signature as Signature.SignedInfo is null.";
         internal const string IDX30213 = "IDX30213: The CryptoProviderFactory: '{0}', CreateForSigning returned null for key: '{1}', SignatureMethod: '{2}'.";
-        internal const string IDX30214 = "IDX30214: The CryptoProviderFactory: '{0}', CreateHashAlgorithm returned null for Digest: '{1}'.";
 
         // logging messages
         internal const string IDX30300 = "IDX30300: KeyInfo skipped unknown element: '{0}'.";
@@ -82,7 +81,7 @@ namespace Microsoft.IdentityModel.Xml
         internal const string IDX30403 = "IDX30403: Unable to write XML. One of the values in Reference.Transforms is null or empty.";
         internal const string IDX30404 = "IDX30404: Unable to write XML. Signature.SignedInfo is null.";
         internal const string IDX30405 = "IDX30405: Unable to write XML. SignedInfo.Reference is null.";
-        internal const string IDX30406 = "IDX14023: Unsupported NodeType: {0}.";
+        internal const string IDX30406 = "IDX30406: Unsupported NodeType: {0}.";
 
         // XML validation
         internal const string IDX30500 = "IDX30500: xsi:type attribute was not found. Expected: '{0}':'{1}'.";

--- a/src/System.IdentityModel.Tokens.Jwt/LogMessages.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/LogMessages.cs
@@ -68,9 +68,6 @@ namespace System.IdentityModel.Tokens.Jwt
         internal const string IDX12739 = "IDX12739: JWT: '{0}' has three segments but is not in proper JWS format.";
         internal const string IDX12740 = "IDX12740: JWT: '{0}' has five segments but is not in proper JWE format.";
         internal const string IDX12741 = "IDX12741: JWT: '{0}' must have three segments (JWS) or five segments (JWE).";
-
-        // logging
-        internal const string IDX12645 = "IDX12645: Creating raw signature using the signature credentials.";
 #pragma warning restore 1591
     }
 }


### PR DESCRIPTION
Addresses #989.

Changes made:

- VerifyResourceUsage.pl now ensures that all log message strings are properly formatted. (specifically that all opening braces have a corresponding closing brace)
- The VerifyResourceUsage.pl task on VSTS will now fail if it finds any errors (previously it just printed the errors but still passed).
- Unused log messages have been removed and any mismatches between log message names and their corresponding string values have been fixed.