### PR TITLE
Address NuGet compliance issues

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <Authors>Microsoft</Authors>
-    <Copyright>Copyright (c) Microsoft Corporation. All rights reserved.</Copyright>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Company>Microsoft Corporation.</Company>
     <DelaySign>true</DelaySign>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>

--- a/build/commonTest.props
+++ b/build/commonTest.props
@@ -3,7 +3,7 @@
   <Import Project="version.props" />
 
   <PropertyGroup>
-    <Copyright>Copyright (c) Microsoft Corporation. All rights reserved.</Copyright>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <DelaySign>false</DelaySign>
     <DotNetCoreAppRuntimeVersion>2.0.0</DotNetCoreAppRuntimeVersion>
     <OutputTypeEx>library</OutputTypeEx>


### PR DESCRIPTION
Addressed _copyright_ as that is the only check that would fail validation.