### PR TITLE
Make LifetimeValidation optional -ConfirmationData

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -284,7 +284,10 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
             if (validationParameters == null)
                 throw LogArgumentNullException(nameof(validationParameters));
 
-            Validators.ValidateLifetime(confirmationData.NotBefore, confirmationData.NotOnOrAfter, samlToken, validationParameters);
+            // NotBefore and NotOnOrAfter are optional elements (saml-core-2.0 - 2.4.1.2)
+            // validate lifetime only if lifetime information is present in the SubjectConfirmationData
+            if (confirmationData.NotBefore.HasValue || confirmationData.NotOnOrAfter.HasValue)
+                Validators.ValidateLifetime(confirmationData.NotBefore, confirmationData.NotOnOrAfter, samlToken, validationParameters);
         }
 
         /// <summary>


### PR DESCRIPTION
Lifetime validation for SubjectConfirmationData will be invoked only
if lifetime information (NotBefore or NotOnOrAfter) is present under
SubjectConfirmationData.

NotBefore and NotOnOrAfter are optional elements under
SubjectConfirmationData element ([saml-core-2.0 ](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf)- 2.4.1.2).

Resolves: #1006