### PR TITLE
Make RSACryptoServiceProviderProxy Windows-specific (#1038)

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -296,7 +296,8 @@ namespace Microsoft.IdentityModel.Tokens
             // X509Certificate2.GetPrivateKey OR X509Certificate2.GetPublicKey.Key
             // These calls return an AsymmetricAlgorithm which doesn't have API's to do much and need to be cast.
             // RSACryptoServiceProvider is wrapped to support SHA2
-#if NET45 || NET451 || NET461 || NETSTANDARD2_0
+            // RSACryptoServiceProviderProxy is only supported on Windows platform
+#if WINDOWS && (NET45 || NET451 || NET461 || NETSTANDARD2_0)
             _useRSAOeapPadding = algorithm.Equals(SecurityAlgorithms.RsaOAEP, StringComparison.Ordinal)
                               || algorithm.Equals(SecurityAlgorithms.RsaOaepKeyWrap, StringComparison.Ordinal);
 
@@ -338,7 +339,7 @@ namespace Microsoft.IdentityModel.Tokens
             SignatureFunction = SignWithRsa;
             VerifyFunction = VerifyWithRsa;
 #endif
-            }
+        }
 
         private RSA RSA { get; set; }
 

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -181,6 +181,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10685 = "IDX10685: Unable to Sign, Internal SignFunction is not available.";
         public const string IDX10686 = "IDX10686: Unable to Verify, Internal VerifyFunction is not available.";
         public const string IDX10687 = "IDX10687: Unable to create a AsymmetricAdapter. For NET45 or NET451 only types: '{0}' or '{1}' are supported. RSA is of type: '{2}'..";
+        public const string IDX10688 = "IDX10688: RSACryptoServiceProviderProxy creation is only supported on Windows.";
 
         // security keys
         public const string IDX10700 = "IDX10700: Invalid RsaParameters: '{0}'. Both modulus and exponent should be present";

--- a/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
@@ -37,6 +37,9 @@ namespace Microsoft.IdentityModel.Tokens
     /// The purpose of this class is to ensure that we obtain an RsaCryptoServiceProvider that supports SHA-256 signatures.
     /// If the original RsaCryptoServiceProvider doesn't support SHA-256, we create a new one using the same KeyContainer.
     /// </summary>
+    /// <remarks>
+    /// There is no support for <see cref="CspParameters"/> and <see cref="CspKeyContainerInfo"/> on non-Windows platforms which makes <see cref="RSACryptoServiceProviderProxy"/> a Windows-specific class.
+    /// </remarks>
     public class RSACryptoServiceProviderProxy : RSA
     {
         // CryptoApi provider type for an RSA provider supporting sha-256 digital signatures
@@ -64,13 +67,18 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         public override string KeyExchangeAlgorithm => _rsa.KeyExchangeAlgorithm;
 
+#pragma warning disable CS0162 // Disable warning on non-Windows platforms - CS0162: Unreachable code detected
         /// <summary>
         /// Initializes an new instance of <see cref="RSACryptoServiceProviderProxy"/>.
         /// </summary>
         /// <param name="rsa"><see cref="RSACryptoServiceProvider"/></param>
         /// <exception cref="ArgumentNullException">if <paramref name="rsa"/> is null.</exception>
+        /// <exception cref="PlatformNotSupportedException">RSACryptoServiceProviderProxy creation is only supported on Windows.</exception>
         public RSACryptoServiceProviderProxy(RSACryptoServiceProvider rsa)
         {
+#if !WINDOWS
+            throw new PlatformNotSupportedException(LogMessages.IDX10688);
+#endif
             if (rsa == null)
                 throw LogHelper.LogArgumentNullException(nameof(rsa));
 
@@ -101,6 +109,7 @@ namespace Microsoft.IdentityModel.Tokens
                 _rsa = rsa;
             }
         }
+#pragma warning restore CS0162
 
         /// <summary>
         /// Decrypts data with the System.Security.Cryptography.RSA algorithm.


### PR DESCRIPTION
Fixes issue that users are facing on non-Windows platforms when using RSACrpytoServiceProvider.
* There is NO support for CspParameters and CspKeyContainerInfo on non-Windows platforms which makes RSACryptoServiceProviderProxy class Windows-specific.
* NETSTANDARD1_4 doesn't not support RSACryptoServiceProvider so there is no need for the proxy.
* Disabled warning _CS0162 Unreachable code detected_ on non-Windows platforms as it's treated as an error during build.