### PR TITLE
Make RSACryptoServiceProviderProxy available only on Desktop targets

### DIFF
--- a/Tools/apiCompat/baseline/ApiCompatBaseline.netstandard2.0.txt
+++ b/Tools/apiCompat/baseline/ApiCompatBaseline.netstandard2.0.txt
@@ -1,0 +1,1 @@
+TypesMustExist : Type 'Microsoft.IdentityModel.Tokens.RSACryptoServiceProviderProxy' does not exist in the implementation but it does exist in the contract.

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -61,7 +61,7 @@ namespace Microsoft.IdentityModel.Tokens
         private const string _dsaCngTypeName = "System.Security.Cryptography.DSACng";
 #endif
 
-#if NET45 || NET451 || NET461 || NETSTANDARD2_0
+#if DESKTOP
         private bool _useRSAOeapPadding = false;
 #endif
 
@@ -210,16 +210,16 @@ namespace Microsoft.IdentityModel.Tokens
                 return RSA.DecryptValue(data);
 #endif
 
-            // NET461 or NETSTANDARD2_0 could have been passed RSACryptoServiceProvider
-#if NET461 || NETSTANDARD2_0
+            // NET461 could have been passed RSACryptoServiceProvider
+#if NET461
             if (RsaCryptoServiceProviderProxy != null)
                 return RsaCryptoServiceProviderProxy.Decrypt(data, _useRSAOeapPadding);
             else
                 return RSA.Decrypt(data, _rsaEncryptionPadding);
 #endif
 
-            // NETSTANDARD1_4 doesn't know anything about RSACryptoServiceProvider
-#if NETSTANDARD1_4
+            // NETSTANDARD1_4 and NETSTANDARD2_0 don't use RSACryptoServiceProviderProxy
+#if NETSTANDARD1_4 || NETSTANDARD2_0
             return RSA.Decrypt(data, _rsaEncryptionPadding);
 #endif
         }
@@ -236,7 +236,7 @@ namespace Microsoft.IdentityModel.Tokens
                         if (ECDsa != null)
                             ECDsa.Dispose();
 
-#if NET45 || NET451 || NET461 || NETSTANDARD2_0
+#if DESKTOP
                         if (RsaCryptoServiceProviderProxy != null)
                             RsaCryptoServiceProviderProxy.Dispose();
 #endif
@@ -270,16 +270,16 @@ namespace Microsoft.IdentityModel.Tokens
                 return RSA.EncryptValue(data);
 #endif
 
-            // NET461 or NETSTANDARD2_0 could have been passed RSACryptoServiceProvider
-#if NET461 || NETSTANDARD2_0
+            // NET461 could have been passed RSACryptoServiceProvider
+#if NET461
             if (RsaCryptoServiceProviderProxy != null)
                 return RsaCryptoServiceProviderProxy.Encrypt(data, _useRSAOeapPadding);
 
             return RSA.Encrypt(data, _rsaEncryptionPadding);
 #endif
 
-            // NETSTANDARD1_4 doesn't know anything about RSACryptoServiceProvider
-#if NETSTANDARD1_4
+            // NETSTANDARD1_4 and NETSTANDARD2_0 don't use RSACryptoServiceProviderProxy
+#if NETSTANDARD1_4 || NETSTANDARD2_0
             return RSA.Encrypt(data, _rsaEncryptionPadding);
 #endif
         }
@@ -297,7 +297,7 @@ namespace Microsoft.IdentityModel.Tokens
             // These calls return an AsymmetricAlgorithm which doesn't have API's to do much and need to be cast.
             // RSACryptoServiceProvider is wrapped to support SHA2
             // RSACryptoServiceProviderProxy is only supported on Windows platform
-#if WINDOWS && (NET45 || NET451 || NET461 || NETSTANDARD2_0)
+#if DESKTOP
             _useRSAOeapPadding = algorithm.Equals(SecurityAlgorithms.RsaOAEP, StringComparison.Ordinal)
                               || algorithm.Equals(SecurityAlgorithms.RsaOaepKeyWrap, StringComparison.Ordinal);
 
@@ -343,7 +343,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         private RSA RSA { get; set; }
 
-#if NET45 || NET451 || NET461 || NETSTANDARD2_0
+#if DESKTOP
         private RSACryptoServiceProviderProxy RsaCryptoServiceProviderProxy { get; set; }
 #endif
 
@@ -368,7 +368,7 @@ namespace Microsoft.IdentityModel.Tokens
         }
 #endif
 
-#if NET45 || NET451 || NET461 || NETSTANDARD2_0
+#if DESKTOP
         internal byte[] SignWithRsaCryptoServiceProviderProxy(byte[] bytes)
         {
             return RsaCryptoServiceProviderProxy.SignData(bytes, HashAlgorithm);
@@ -396,7 +396,7 @@ namespace Microsoft.IdentityModel.Tokens
         }
 #endif
 
-#if NET45 || NET451 || NET461 || NETSTANDARD2_0
+#if DESKTOP
         private bool VerifyWithRsaCryptoServiceProviderProxy(byte[] bytes, byte[] signature)
         {
             return RsaCryptoServiceProviderProxy.VerifyData(bytes, HashAlgorithm, signature);

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
@@ -321,9 +321,6 @@ namespace Microsoft.IdentityModel.Tokens
 
         internal ECDsa CreateECDsa(string algorithm, bool usePrivateKey)
         {
-#if !WINDOWS
-            throw new NotImplementedException(LogMessages.IDX10676);
-#endif
             if (Crv == null)
                 throw LogHelper.LogArgumentNullException(nameof(Crv));
 

--- a/src/Microsoft.IdentityModel.Tokens/Microsoft.IdentityModel.Tokens.csproj
+++ b/src/Microsoft.IdentityModel.Tokens/Microsoft.IdentityModel.Tokens.csproj
@@ -12,8 +12,8 @@
     <PackageTags>.NET;Windows;Authentication;Identity;SecurityTokens;Cryptographic operations;Signing;Verifying Signatures;Encryption</PackageTags>
   </PropertyGroup>
   
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <DefineConstants>WINDOWS</DefineConstants>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net451' OR '$(TargetFramework)' == 'net461' ">
+    <DefineConstants>DESKTOP</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net45|AnyCPU'">

--- a/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
@@ -25,7 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
-#if NET45 || NET451 || NET461 || NETSTANDARD2_0
+#if DESKTOP
 
 using System;
 using System.Security.Cryptography;
@@ -67,18 +67,13 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         public override string KeyExchangeAlgorithm => _rsa.KeyExchangeAlgorithm;
 
-#pragma warning disable CS0162 // Disable warning on non-Windows platforms - CS0162: Unreachable code detected
         /// <summary>
         /// Initializes an new instance of <see cref="RSACryptoServiceProviderProxy"/>.
         /// </summary>
         /// <param name="rsa"><see cref="RSACryptoServiceProvider"/></param>
         /// <exception cref="ArgumentNullException">if <paramref name="rsa"/> is null.</exception>
-        /// <exception cref="PlatformNotSupportedException">RSACryptoServiceProviderProxy creation is only supported on Windows.</exception>
         public RSACryptoServiceProviderProxy(RSACryptoServiceProvider rsa)
         {
-#if !WINDOWS
-            throw new PlatformNotSupportedException(LogMessages.IDX10688);
-#endif
             if (rsa == null)
                 throw LogHelper.LogArgumentNullException(nameof(rsa));
 
@@ -109,7 +104,6 @@ namespace Microsoft.IdentityModel.Tokens
                 _rsa = rsa;
             }
         }
-#pragma warning restore CS0162
 
         /// <summary>
         /// Decrypts data with the System.Security.Cryptography.RSA algorithm.

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaCryptoServiceProviderProxyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaCryptoServiceProviderProxyTests.cs
@@ -25,11 +25,11 @@
 //
 //------------------------------------------------------------------------------
 
-#if NET461 || NETCOREAPP2_0
+#if NET461
 using System.Security.Cryptography.X509Certificates;
 #endif
 
-#if NET452 || NET461 || NETCOREAPP2_0
+#if NET452 || NET461
 
 using System;
 using System.Security.Cryptography;
@@ -83,7 +83,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             get
             {
-#if NET461 || NETCOREAPP2_0
+#if NET461
                 var rsaCsp = new RSACryptoServiceProvider();
                 rsaCsp.ImportParameters(KeyingMaterial.RsaParameters_2048);
 #else
@@ -135,7 +135,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             get
             {
-#if NET461 || NETCOREAPP2_0
+#if NET461
                 var rsaFromX509Cert = new RSACryptoServiceProvider();
                 var rsaCng = KeyingMaterial.DefaultCert_2048.GetRSAPrivateKey() as RSACng;
                 var parameters = rsaCng.ExportParameters(true);
@@ -209,7 +209,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             get
             {
-#if NET461 || NETCOREAPP2_0
+#if NET461
                 var rsaCsp = new RSACryptoServiceProvider();
                 rsaCsp.ImportParameters(KeyingMaterial.RsaParameters_2048);
 #else
@@ -278,7 +278,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             get
             {
-#if NET461 || NETCOREAPP2_0
+#if NET461
                 var rsaCsp = new RSACryptoServiceProvider();
                 rsaCsp.ImportParameters(KeyingMaterial.RsaParameters_2048);
 #else
@@ -352,7 +352,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             get
             {
-#if NET461 || NETCOREAPP2_0
+#if NET461
                 var rsaCsp = new RSACryptoServiceProvider();
                 rsaCsp.ImportParameters(KeyingMaterial.RsaParameters_2048);
 #else


### PR DESCRIPTION
* RSACryptoServiceProviderProxy is no longer present in netstandard2.0 target, hence the change in ApiCompatBaseline file for netstandard2.0.
* `#if WINDOWS` construct in JsonWebKey class is incorrect as it's a compile-time construct. Support for ECDsa on non-Windows platforms will be provided in #1058.