### PR TITLE
Mark JsonWebKeyset and OpenIdConnectMessage constructors as obsolete

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs
@@ -132,6 +132,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         /// Initializes a new instance of the <see cref="OpenIdConnectMessage"/> class.
         /// </summary>
         /// <param name="json">the json object from which the instance is created.</param>
+        [Obsolete("This constructor is obsolete and will be removed in a future release. Please use OpenIdConnectMessage(string json) instead.")]
         public OpenIdConnectMessage(JObject json)
         {
             SetJsonParameters(json);

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
@@ -63,6 +63,7 @@ namespace Microsoft.IdentityModel.Tokens
         {
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         /// <summary>
         /// Initializes an new instance of <see cref="JsonWebKeySet"/> from a json string.
         /// </summary>
@@ -72,6 +73,7 @@ namespace Microsoft.IdentityModel.Tokens
         public JsonWebKeySet(string json) : this(json, null)
         {
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// Initializes an new instance of <see cref="JsonWebKeySet"/> from a json string.
@@ -80,6 +82,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="jsonSerializerSettings">jsonSerializerSettings</param>
         /// <exception cref="ArgumentNullException">If 'json' is null or empty.</exception>
         /// <exception cref="ArgumentException">If 'json' fails to deserialize.</exception>
+        [Obsolete("This constructor is obsolete and will be removed in a future release.")]
         public JsonWebKeySet(string json, JsonSerializerSettings jsonSerializerSettings)
         {
             if (string.IsNullOrEmpty(json))

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
@@ -53,7 +53,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             try
             {
                 messageFromJson = new OpenIdConnectMessage(theoryData.Json);
+#pragma warning disable CS0618 // Type or member is obsolete
                 messageFromJsonObj = new OpenIdConnectMessage(theoryData.JObject);
+#pragma warning restore CS0618 // Type or member is obsolete
                 IdentityComparer.AreEqual(messageFromJson, messageFromJsonObj, context);
                 IdentityComparer.AreEqual(messageFromJson, theoryData.Message, context);
                 theoryData.ExpectedException.ProcessNoException();

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
@@ -52,7 +52,9 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             var context = new CompareContext();
             try
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 var jsonWebKeys = new JsonWebKeySet(json, settings);
+#pragma warning restore CS0618 // Type or member is obsolete
                 var keys = jsonWebKeys.GetSigningKeys();
                 ee.ProcessNoException(context);
                 if (compareTo != null)


### PR DESCRIPTION
* OpenIdConnectMessage constructor exposes JObject
* JsonWebKeySet constructor exposes JsonSerializerSettings