### PR TITLE
Moved TokenContext and TokenValidationResult into M.IM.Tokens

### DIFF
--- a/Tools/apiCompat/baseline/ApiCompatBaseline.net45.txt
+++ b/Tools/apiCompat/baseline/ApiCompatBaseline.net45.txt
@@ -1,0 +1,2 @@
+TypesMustExist : Type 'Microsoft.IdentityModel.JsonWebTokens.TokenValidationResult' does not exist in the implementation but it does exist in the contract. 
+MembersMustExist : Member 'Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler.ValidateToken(System.String, Microsoft.IdentityModel.Tokens.TokenValidationParameters)' does not exist in the implementation but it does exist in the contract.

--- a/Tools/apiCompat/baseline/ApiCompatBaseline.net451.txt
+++ b/Tools/apiCompat/baseline/ApiCompatBaseline.net451.txt
@@ -1,0 +1,2 @@
+TypesMustExist : Type 'Microsoft.IdentityModel.JsonWebTokens.TokenValidationResult' does not exist in the implementation but it does exist in the contract. 
+MembersMustExist : Member 'Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler.ValidateToken(System.String, Microsoft.IdentityModel.Tokens.TokenValidationParameters)' does not exist in the implementation but it does exist in the contract.

--- a/Tools/apiCompat/baseline/ApiCompatBaseline.net452.txt
+++ b/Tools/apiCompat/baseline/ApiCompatBaseline.net452.txt
@@ -1,0 +1,2 @@
+TypesMustExist : Type 'Microsoft.IdentityModel.JsonWebTokens.TokenValidationResult' does not exist in the implementation but it does exist in the contract. 
+MembersMustExist : Member 'Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler.ValidateToken(System.String, Microsoft.IdentityModel.Tokens.TokenValidationParameters)' does not exist in the implementation but it does exist in the contract.

--- a/Tools/apiCompat/baseline/ApiCompatBaseline.net461.txt
+++ b/Tools/apiCompat/baseline/ApiCompatBaseline.net461.txt
@@ -1,0 +1,2 @@
+TypesMustExist : Type 'Microsoft.IdentityModel.JsonWebTokens.TokenValidationResult' does not exist in the implementation but it does exist in the contract. 
+MembersMustExist : Member 'Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler.ValidateToken(System.String, Microsoft.IdentityModel.Tokens.TokenValidationParameters)' does not exist in the implementation but it does exist in the contract.

--- a/Tools/apiCompat/baseline/ApiCompatBaseline.netstandard1.4.txt
+++ b/Tools/apiCompat/baseline/ApiCompatBaseline.netstandard1.4.txt
@@ -1,0 +1,2 @@
+TypesMustExist : Type 'Microsoft.IdentityModel.JsonWebTokens.TokenValidationResult' does not exist in the implementation but it does exist in the contract.
+MembersMustExist : Member 'Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler.ValidateToken(System.String, Microsoft.IdentityModel.Tokens.TokenValidationParameters)' does not exist in the implementation but it does exist in the contract. 

--- a/Tools/apiCompat/baseline/ApiCompatBaseline.netstandard2.0.txt
+++ b/Tools/apiCompat/baseline/ApiCompatBaseline.netstandard2.0.txt
@@ -1,1 +1,3 @@
 TypesMustExist : Type 'Microsoft.IdentityModel.Tokens.RSACryptoServiceProviderProxy' does not exist in the implementation but it does exist in the contract.
+TypesMustExist : Type 'Microsoft.IdentityModel.JsonWebTokens.TokenValidationResult' does not exist in the implementation but it does exist in the contract. 
+MembersMustExist : Member 'Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler.ValidateToken(System.String, Microsoft.IdentityModel.Tokens.TokenValidationParameters)' does not exist in the implementation but it does exist in the contract.

--- a/buildConfiguration.xml
+++ b/buildConfiguration.xml
@@ -2,7 +2,7 @@
   <dotnetArchitecture>x64</dotnetArchitecture>
   <nugetVersion>3.5.0-rc-1285</nugetVersion>
   <runtimes>net45,net451,net461,netstandard1.4,netstandard2.0</runtimes>
-  <assemblyVersion>5.3.1</assemblyVersion>
+  <assemblyVersion>5.4.0</assemblyVersion>
   <nugetSuffix>preview</nugetSuffix>
   <projects>
     <src>

--- a/src/Microsoft.IdentityModel.Tokens/TokenContext.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenContext.cs
@@ -25,24 +25,49 @@
 //
 //------------------------------------------------------------------------------
 
-using System.Security.Claims;
-using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
-namespace Microsoft.IdentityModel.JsonWebTokens
+namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
-    /// A class which contains the result of a token validation operation.
+    /// An opaque context used to store work when working with authentication artifacts.
     /// </summary>
-    public class TokenValidationResult
+    public class TokenContext
     {
         /// <summary>
-        /// The <see cref="ClaimsIdentity"/> created from the validated security token.
+        /// Instantiates a new <see cref="TokenContext"/> with a default activityId.
         /// </summary>
-        public ClaimsIdentity ClaimsIdentity { get; set; }
+        public TokenContext()
+        {
+        }
 
         /// <summary>
-        /// The validated security token.
+        /// Instantiates a new <see cref="TokenContext"/> with an activityId.
         /// </summary>
-        public SecurityToken SecurityToken { get; set; }
+        public TokenContext(Guid activityId)
+        {
+            if (activityId == null)
+                throw new ArgumentNullException(nameof(activityId));
+
+            ActivityId = activityId;
+        }
+
+        /// <summary>
+        /// Gets or set a <see cref="Guid"/> that will be used in the call to EventSource.SetCurrentThreadActivityId before logging.
+        /// </summary>
+        public Guid ActivityId { get; set; } = Guid.Empty;
+
+        /// <summary>
+        /// Gets or sets a boolean controlling if logs are written into the context.
+        /// Useful when debugging.
+        /// </summary>
+        public bool CaptureLogs { get; set; } = false;
+
+        /// <summary>
+        /// The collection of logs associated with a request. Use <see cref="CaptureLogs"/> to control capture.
+        /// </summary>
+        public ICollection<string> Logs { get; private set; } = new Collection<string>();
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
@@ -1,0 +1,73 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Security.Claims;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Contains artifacts obtained when a SecurityToken is validated.
+    /// </summary>
+    public class TokenValidationResult
+    {
+        /// <summary>
+        /// The <see cref="ClaimsIdentity"/> created from the validated security token.
+        /// </summary>
+        public ClaimsIdentity ClaimsIdentity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Exception"/> that occurred during validation.
+        /// </summary>
+        public Exception Exception { get; set; }
+
+        /// <summary>
+        /// Gets or sets the issuer that was found in the token.
+        /// </summary>
+        public string Issuer { get; set; }
+
+        /// <summary>
+        /// True if the token was successfully validated, false otherwise.
+        /// </summary>
+        public bool IsValid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="SecurityToken"/> that was validated.
+        /// </summary>
+        public SecurityToken SecurityToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="TokenContext"/> that contains call information.
+        /// </summary>
+        public TokenContext TokenContext { get; set; }
+
+        /// <summary>
+        /// Gets or sets the token type of the <see cref="SecurityToken"/> that was validated.
+        /// </summary>
+        public string TokenType { get; set; }
+    }
+}


### PR DESCRIPTION
- TokenValidationResult has been moved to M.IM.Tokens from M.IM.JsonWebTokens.
- The version has been bumped to 5.4.0 as moving TokenValidationResult to a different namespace is a breaking change.