### PR TITLE
Changed the X509SecurityKey.KeyId property so that it's equal to the X5t property

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -240,6 +240,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     { JwtHeaderParameterNames.Typ, JwtConstants.HeaderType }
                 };
 
+                if (signingCredentials.Key is X509SecurityKey x509SecurityKey)
+                    header[JwtHeaderParameterNames.X5t] = x509SecurityKey.X5t;
+
                 rawHeader = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(header.ToString(Formatting.None)));
                 JsonWebTokenManager.KeyToHeaderCache.TryAdd(JsonWebTokenManager.GetHeaderCacheKey(signingCredentials), rawHeader);
             }

--- a/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
@@ -50,7 +50,7 @@ namespace Microsoft.IdentityModel.Tokens
         public X509SecurityKey(X509Certificate2 certificate)
         {
             _certificate = certificate ?? throw LogHelper.LogExceptionMessage(new ArgumentNullException(nameof(certificate)));
-            KeyId = certificate.Thumbprint;
+            KeyId = Base64UrlEncoder.Encode(certificate.GetCertHash());
             X5t = Base64UrlEncoder.Encode(certificate.GetCertHash());
         }
 

--- a/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
@@ -54,6 +54,7 @@ namespace Microsoft.IdentityModel.TestUtils
         private static readonly Dictionary<string, Func<object, object, CompareContext, bool>> _equalityDict =
             new Dictionary<string, Func<object, object, CompareContext, bool>>
             {
+                { typeof(bool).ToString(), AreBoolsEqual },
                 { typeof(Collection<SecurityKey>).ToString(), ContinueCheckingEquality },
                 { typeof(Dictionary<string, object>).ToString(), AreObjectDictionariesEqual },
                 { typeof(Dictionary<string, object>.ValueCollection).ToString(), AreValueCollectionsEqual },
@@ -160,6 +161,28 @@ namespace Microsoft.IdentityModel.TestUtils
                 { typeof(X509Data).ToString(), CompareAllPublicProperties },
                 { typeof(X509SigningCredentials).ToString(), CompareAllPublicProperties },
             };
+
+        public static bool AreBoolsEqual(object object1, object object2, CompareContext context)
+        {
+            var bool1 = (bool)object1;
+            var bool2 = (bool)object2;
+
+            var localContext = new CompareContext(context);
+            if (!ContinueCheckingEquality(bool1, bool2, localContext))
+                return context.Merge(localContext);
+
+            if (bool1 == bool2)
+                return true;
+
+            if (bool1 != bool2)
+            {
+                localContext.Diffs.Add($"'{bool1}'");
+                localContext.Diffs.Add($"!=");
+                localContext.Diffs.Add($"'{bool2}'");
+            }
+
+            return context.Merge(localContext);
+        }
 
 #if !CrossVersionTokenValidation
         public static bool AreJsonWebKeyEnumsEqual(object object1, object object2, CompareContext context)

--- a/test/Microsoft.IdentityModel.Tokens.Tests/X509SecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/X509SecurityKeyTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         public void Constructor()
         {
             X509SecurityKey x509SecurityKey;
+            var context = new CompareContext();
             ExpectedException expectedException = new ExpectedException(typeExpected: typeof(ArgumentNullException), substringExpected: "certificate");
             try
             {
@@ -56,12 +57,15 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             try
             {
                 x509SecurityKey = new X509SecurityKey(x509Certificate2);
-                Assert.Same(x509Certificate2, x509SecurityKey.Certificate);
+                IdentityComparer.AreEqual(x509SecurityKey.X5t, x509SecurityKey.KeyId);
+                IdentityComparer.AreEqual(x509Certificate2, x509SecurityKey.Certificate, context);
             }
             catch (Exception exception)
             {
                 expectedException.ProcessException(exception);
             }
+
+            TestUtilities.AssertFailIfErrors(context);
         }
 
         [Theory, MemberData(nameof(IsSupportedAlgDataSet))]


### PR DESCRIPTION
Other changes:

- JsonWebTokenHandler now adds the 'x5t' parameter to the header by default if the security key being used is an X509SecurityKey.
- The IdentityComparer can now be used to compare boolean values.
- Fixed some of JsonWebTokenHandler tests that had incorrect TheoryData.