### PR TITLE
Updated build.ps1 so that VerifyResourceUsage.pl is run at build time

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -97,6 +97,18 @@ WriteSectionFooter("End Environment");
 
 $ErrorActionPreference = "Stop"
 
+WriteSectionHeader("VerifyResourceUsage.pl");
+
+Write-Host ">>> Start-Process -Wait -PassThru -NoNewWindow perl $root\src\VerifyResourceUsage.pl"
+$verifyResourceUsageResult = Start-Process -Wait -PassThru -NoNewWindow perl $root\src\VerifyResourceUsage.pl
+
+if($verifyResourceUsageResult.ExitCode -ne 0)
+{
+	throw "VerifyResourceUsage.pl failed."
+}
+
+WriteSectionFooter("End VerifyResourceUsage.pl");
+
 WriteSectionHeader("Build");
 
 $projects = $buildConfiguration.SelectNodes("root/projects/src/project");


### PR DESCRIPTION
Our local build will now fail if VerifyResourceUsage.pl fails. 

This will make it easier for us to ensure that we have no duplicate, reused, or improperly formatted log message ids.