### PR TITLE
 Modified the M.IM.Protocols.OpenIdConnect assembly to use M.IM.JsonWebTokens instead of S.IM.Tokens.Jwt

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -40,7 +40,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
     /// <summary>
     /// A <see cref="SecurityToken"/> designed for representing a JSON Web Token (JWT). 
     /// </summary>
-    public class JsonWebToken : SecurityToken
+    public class JsonWebToken : SecurityToken, IJsonWebToken
     {
         /// <summary>
         /// Initializes a new instance of <see cref="JsonWebToken"/> from a string in JWS or JWE Compact serialized format.
@@ -146,7 +146,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <summary>
         /// Gets a <see cref="IEnumerable{Claim}"/><see cref="Claim"/> for each JSON { name, value }.
         /// </summary>
-        public virtual IEnumerable<Claim> Claims
+        public IEnumerable<Claim> Claims
         {
             get
             {

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
@@ -47,12 +47,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         internal const string IDX21303 = "IDX21303: Validating hash of OIDC protocol message. Expected: '{0}'.";
         internal const string IDX21304 = "IDX21304: Validating 'c_hash' using id_token and code.";
         internal const string IDX21305 = "IDX21305: OpenIdConnectProtocolValidationContext.ProtocolMessage.Code is null, there is no 'code' in the OpenIdConnect Response to validate.";
-        // internal const string IDX21306 = "IDX21306:";
+        internal const string IDX21306 = "IDX21306: The 'c_hash' claim was not a string in the 'id_token', but a 'code' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
         internal const string IDX21307 = "IDX21307: The 'c_hash' claim was not found in the id_token, but a 'code' was in the OpenIdConnectMessage, id_token: '{0}'";
         internal const string IDX21308 = "IDX21308: 'Azp' claim exists in the 'id_token' but 'ciient_id' is null. Cannot validate the 'azp' claim.";
         internal const string IDX21309 = "IDX21309: Validating 'at_hash' using id_token and access_token.";
         internal const string IDX21310 = "IDX21310: OpenIdConnectProtocolValidationContext.ProtocolMessage.AccessToken is null, there is no 'token' in the OpenIdConnect Response to validate.";
-        // internal const string IDX21311 = "IDX21311:";
+        internal const string IDX21311 = "IDX21311: The 'at_hash' claim was not a string in the 'id_token', but an 'access_token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
         internal const string IDX21312 = "IDX21312: The 'at_hash' claim was not found in the 'id_token', but a 'access_token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
         internal const string IDX21313 = "IDX21313: The id_token: '{0}' is not valid. Delegate threw exception, see inner exception for more details.";
         internal const string IDX21314 = "IDX21314: OpenIdConnectProtocol requires the jwt token to have an '{0}' claim. The jwt did not contain an '{0}' claim, jwt: '{1}'.";
@@ -73,7 +73,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         internal const string IDX21329 = "IDX21329: RequireState is '{0}' but the OpenIdConnectProtocolValidationContext.State is null. State cannot be validated.";
         internal const string IDX21330 = "IDX21330: RequireState is '{0}', the OpenIdConnect Request contained 'state', but the Response does not contain 'state'.";
         internal const string IDX21331 = "IDX21331: The 'state' parameter in the message: '{0}', does not equal the 'state' in the context: '{1}'.";
-        internal const string IDX21332 = "IDX21332: OpenIdConnectProtocolValidationContext.ValidatedIdToken is null. There is no 'id_token' to validate against.";
+        internal const string IDX21332 = "IDX21332: OpenIdConnectProtocolValidationContext.ValidatedJsonWebToken and OpenIdConnectProtocolValidationContext.ValidatedIdToken are both null. There is no 'id_token' to validate against.";
         internal const string IDX21333 = "IDX21333: OpenIdConnectProtocolValidationContext.ProtocolMessage is null, there is no OpenIdConnect Response to validate.";
         internal const string IDX21334 = "IDX21334: Both 'id_token' and 'code' are null in OpenIdConnectProtocolValidationContext.ProtocolMessage received from Authorization Endpoint. Cannot process the message.";
         internal const string IDX21335 = "IDX21335: 'refresh_token' cannot be present in a response message received from Authorization Endpoint.";
@@ -91,7 +91,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         internal const string IDX21348 = "IDX21348: Validating the 'at_hash' failed, see inner exception.";
         internal const string IDX21349 = "IDX21349: RequireNonce is '{0}'. OpenIdConnectProtocolValidationContext.Nonce was not null, OpenIdConnectProtocol.ValidatedIdToken.Payload.Nonce was null or empty. The nonce cannot be validated. If you don't need to check the nonce, set OpenIdConnectProtocolValidator.RequireNonce to 'false'. Note if a 'nonce' is found it will be evaluated.";
         internal const string IDX21350 = "IDX21350: The algorithm specified in the jwt header is null or empty.";
-        internal const string IDX21351 = "IDX21351: OpenIdConnectProtocolValidationContext.ValidatedIdToken is is not a '{0}' but rather a '{1}'.";
 
         // configuration retrieval errors
         internal const string IDX21806 = "IDX21806: Deserializing json string into json web keys.";

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
@@ -47,12 +47,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         internal const string IDX21303 = "IDX21303: Validating hash of OIDC protocol message. Expected: '{0}'.";
         internal const string IDX21304 = "IDX21304: Validating 'c_hash' using id_token and code.";
         internal const string IDX21305 = "IDX21305: OpenIdConnectProtocolValidationContext.ProtocolMessage.Code is null, there is no 'code' in the OpenIdConnect Response to validate.";
-        internal const string IDX21306 = "IDX21306: The 'c_hash' claim was not a string in the 'id_token', but a 'code' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
+        // internal const string IDX21306 = "IDX21306:";
         internal const string IDX21307 = "IDX21307: The 'c_hash' claim was not found in the id_token, but a 'code' was in the OpenIdConnectMessage, id_token: '{0}'";
         internal const string IDX21308 = "IDX21308: 'Azp' claim exists in the 'id_token' but 'ciient_id' is null. Cannot validate the 'azp' claim.";
         internal const string IDX21309 = "IDX21309: Validating 'at_hash' using id_token and access_token.";
         internal const string IDX21310 = "IDX21310: OpenIdConnectProtocolValidationContext.ProtocolMessage.AccessToken is null, there is no 'token' in the OpenIdConnect Response to validate.";
-        internal const string IDX21311 = "IDX21311: The 'at_hash' claim was not a string in the 'id_token', but an 'access_token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
+        // internal const string IDX21311 = "IDX21311:";
         internal const string IDX21312 = "IDX21312: The 'at_hash' claim was not found in the 'id_token', but a 'access_token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
         internal const string IDX21313 = "IDX21313: The id_token: '{0}' is not valid. Delegate threw exception, see inner exception for more details.";
         internal const string IDX21314 = "IDX21314: OpenIdConnectProtocol requires the jwt token to have an '{0}' claim. The jwt did not contain an '{0}' claim, jwt: '{1}'.";
@@ -91,6 +91,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         internal const string IDX21348 = "IDX21348: Validating the 'at_hash' failed, see inner exception.";
         internal const string IDX21349 = "IDX21349: RequireNonce is '{0}'. OpenIdConnectProtocolValidationContext.Nonce was not null, OpenIdConnectProtocol.ValidatedIdToken.Payload.Nonce was null or empty. The nonce cannot be validated. If you don't need to check the nonce, set OpenIdConnectProtocolValidator.RequireNonce to 'false'. Note if a 'nonce' is found it will be evaluated.";
         internal const string IDX21350 = "IDX21350: The algorithm specified in the jwt header is null or empty.";
+        internal const string IDX21351 = "IDX21351: OpenIdConnectProtocolValidationContext.ValidatedIdToken is is not a '{0}' but rather a '{1}'.";
 
         // configuration retrieval errors
         internal const string IDX21806 = "IDX21806: Deserializing json string into json web keys.";

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Microsoft.IdentityModel.Protocols.OpenIdConnect.csproj
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Microsoft.IdentityModel.Protocols.OpenIdConnect.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.IdentityModel.Protocols\Microsoft.IdentityModel.Protocols.csproj" />
-    <ProjectReference Include="..\System.IdentityModel.Tokens.Jwt\System.IdentityModel.Tokens.Jwt.csproj" />
+    <ProjectReference Include="..\Microsoft.IdentityModel.JsonWebTokens\Microsoft.IdentityModel.JsonWebTokens.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4'">

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Microsoft.IdentityModel.Protocols.OpenIdConnect.csproj
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Microsoft.IdentityModel.Protocols.OpenIdConnect.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.IdentityModel.Protocols\Microsoft.IdentityModel.Protocols.csproj" />
     <ProjectReference Include="..\Microsoft.IdentityModel.JsonWebTokens\Microsoft.IdentityModel.JsonWebTokens.csproj" />
+    <ProjectReference Include="..\System.IdentityModel.Tokens.Jwt\System.IdentityModel.Tokens.Jwt.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4'">

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidationContext.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidationContext.cs
@@ -71,12 +71,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         /// <summary>
         /// This id_token is assumed to have audience, issuer, lifetime and signature validated.
         /// </summary>
-        [Obsolete("The 'ValidatedIdToken' property is obsolete. Please use 'ValidatedJsonWebToken' instead.")]
+        [Obsolete("The 'ValidatedIdToken' property is obsolete. Please use 'ValidatedJwtToken' instead.")]
         public JwtSecurityToken ValidatedIdToken { get; set; }
 
         /// <summary>
         /// This JWT security token is assumed to have audience, issuer, lifetime and signature validated.
         /// </summary>
-        public JsonWebToken ValidatedJsonWebToken { get; set; }
+        public IJsonWebToken ValidatedJsonWebToken { get; set; }
     }
 }

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidationContext.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidationContext.cs
@@ -25,8 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
-using System;
-using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 {
@@ -69,6 +68,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         /// <summary>
         /// This id_token is assumed to have audience, issuer, lifetime and signature validated.
         /// </summary>
-        public JwtSecurityToken ValidatedIdToken { get; set; }
+        public SecurityToken ValidatedIdToken { get; set; }
     }
 }

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidationContext.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidationContext.cs
@@ -25,6 +25,9 @@
 //
 //------------------------------------------------------------------------------
 
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
@@ -68,6 +71,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         /// <summary>
         /// This id_token is assumed to have audience, issuer, lifetime and signature validated.
         /// </summary>
-        public SecurityToken ValidatedIdToken { get; set; }
+        [Obsolete("The 'ValidatedIdToken' property is obsolete. Please use 'ValidatedJsonWebToken' instead.")]
+        public JwtSecurityToken ValidatedIdToken { get; set; }
+
+        /// <summary>
+        /// This JWT security token is assumed to have audience, issuer, lifetime and signature validated.
+        /// </summary>
+        public JsonWebToken ValidatedJsonWebToken { get; set; }
     }
 }

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -42,11 +42,11 @@ using JwtRegisteredClaimNames = Microsoft.IdentityModel.JsonWebTokens.JwtRegiste
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 {
     /// <summary>
-    /// Delegate for validating additional claims in 'id_token' (of type <see cref="JsonWebToken"/>).
+    /// Delegate for validating additional claims in 'id_token' (of type <see cref="IJsonWebToken"/>).
     /// </summary>
-    /// <param name="idToken"><see cref="JsonWebToken"/> to validate</param>
+    /// <param name="idToken"><see cref="IJsonWebToken"/> to validate</param>
     /// <param name="context"><see cref="OpenIdConnectProtocolValidationContext"/> used for validation</param>
-    public delegate void JsonWebTokenValidator(JsonWebToken idToken, OpenIdConnectProtocolValidationContext context);
+    public delegate void JsonWebTokenValidator(IJsonWebToken idToken, OpenIdConnectProtocolValidationContext context);
 
     /// <summary>
     /// Delegate for validating additional claims in 'id_token' (of type <see cref="JwtSecurityToken"/>).

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -441,7 +441,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 if (idToken.IssuedAt.Equals(DateTime.MinValue))
                     throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Iat.ToLowerInvariant(), idToken)));
 
-                if (idToken.Issuer == null)
+                if (idToken.Issuer.Equals(string.Empty))
                     throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Iss.ToLowerInvariant(), idToken)));
 
                 // sub is required in OpenID spec; but we don't want to block valid idTokens provided by some identity providers
@@ -665,8 +665,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             }
             else // validationContext.ValidatedIdToken != null
             {
-                object cHashClaim;
-                if (!validationContext.ValidatedIdToken.Payload.TryGetValue(JwtRegisteredClaimNames.CHash, out cHashClaim))
+                if (!validationContext.ValidatedIdToken.Payload.TryGetValue(JwtRegisteredClaimNames.CHash, out var cHashClaim))
                     throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogHelper.FormatInvariant(LogMessages.IDX21307, validationContext.ValidatedIdToken)));
                 chash = cHashClaim as string;
                 if (chash == null)
@@ -725,8 +724,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             }
             else // validationContext.ValidatedIdToken != null
             {
-                object atHashClaim;
-                if (!validationContext.ValidatedIdToken.Payload.TryGetValue(JwtRegisteredClaimNames.AtHash, out atHashClaim))
+                if (!validationContext.ValidatedIdToken.Payload.TryGetValue(JwtRegisteredClaimNames.AtHash, out var atHashClaim))
                     throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidAtHashException(LogHelper.FormatInvariant(LogMessages.IDX21312, validationContext.ValidatedIdToken)));
 
                 atHash = atHashClaim as string;

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -53,6 +53,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
     /// </summary>
     /// <param name="idToken"><see cref="JwtSecurityToken"/> to validate</param>
     /// <param name="context"><see cref="OpenIdConnectProtocolValidationContext"/> used for validation</param>
+    [Obsolete("The 'IdTokenValidator' is used for validating 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' which is now obsolete. " +
+        "Please use the 'OpenIdConnectProtocolValidationContext.ValidatedJsonWebToken' and the corresponding 'JsonWebTokenValidator'.")]
     public delegate void IdTokenValidator(JwtSecurityToken idToken, OpenIdConnectProtocolValidationContext context);
 
     /// <summary>
@@ -230,7 +232,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         /// <summary>
         /// Gets or sets the delegate for validating 'id_token' (of type <see cref="JwtSecurityToken"/>).
         /// </summary>
+#pragma warning disable 0618 // 'IdTokenValidator' is obsolete.
         public IdTokenValidator IdTokenValidator { get; set; }
+#pragma warning restore 0618 // 'IdTokenValidator' is obsolete.
 
         /// <summary>
         /// Gets or sets the delegate for validating 'id_token' (of type <see cref="JsonWebToken"/>).

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -29,6 +29,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -36,15 +37,23 @@ using Microsoft.IdentityModel.Json.Linq;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
+using JwtRegisteredClaimNames = Microsoft.IdentityModel.JsonWebTokens.JwtRegisteredClaimNames;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 {
     /// <summary>
-    /// Delegate for validating additional claims in 'id_token' 
+    /// Delegate for validating additional claims in 'id_token' (of type <see cref="JsonWebToken"/>).
     /// </summary>
-    /// <param name="idToken"><see cref="SecurityToken"/> to validate</param>
+    /// <param name="idToken"><see cref="JsonWebToken"/> to validate</param>
     /// <param name="context"><see cref="OpenIdConnectProtocolValidationContext"/> used for validation</param>
-    public delegate void IdTokenValidator(SecurityToken idToken, OpenIdConnectProtocolValidationContext context);
+    public delegate void JsonWebTokenValidator(JsonWebToken idToken, OpenIdConnectProtocolValidationContext context);
+
+    /// <summary>
+    /// Delegate for validating additional claims in 'id_token' (of type <see cref="JwtSecurityToken"/>).
+    /// </summary>
+    /// <param name="idToken"><see cref="JwtSecurityToken"/> to validate</param>
+    /// <param name="context"><see cref="OpenIdConnectProtocolValidationContext"/> used for validation</param>
+    public delegate void IdTokenValidator(JwtSecurityToken idToken, OpenIdConnectProtocolValidationContext context);
 
     /// <summary>
     /// <see cref="OpenIdConnectProtocolValidator"/> is used to ensure that an <see cref="OpenIdConnectMessage"/>
@@ -219,9 +228,14 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         public bool RequireTimeStampInNonce { get; set; }
 
         /// <summary>
-        /// Gets or sets the delegate for validating 'id_token'
+        /// Gets or sets the delegate for validating 'id_token' (of type <see cref="JwtSecurityToken"/>).
         /// </summary>
         public IdTokenValidator IdTokenValidator { get; set; }
+
+        /// <summary>
+        /// Gets or sets the delegate for validating 'id_token' (of type <see cref="JsonWebToken"/>).
+        /// </summary>
+        public JsonWebTokenValidator JsonWebTokenValidator { get; set; }
 
         /// <summary>
         /// Validates that an OpenIdConnect Response from 'authorization_endpoint" is valid as per http://openid.net/specs/openid-connect-core-1_0.html
@@ -253,8 +267,10 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 return;
             }
 
-            if (validationContext.ValidatedIdToken == null)
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
 
             // 'refresh_token' should not be returned from 'authorization_endpoint'. http://tools.ietf.org/html/rfc6749#section-4.2.2.
             if (!string.IsNullOrEmpty(validationContext.ProtocolMessage.RefreshToken))
@@ -286,24 +302,25 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             // both 'id_token' and 'access_token' are required
             if (string.IsNullOrEmpty(validationContext.ProtocolMessage.IdToken) || string.IsNullOrEmpty(validationContext.ProtocolMessage.AccessToken))
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21336));
-
-            if (validationContext.ValidatedIdToken == null)
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
 
             ValidateIdToken(validationContext);
             ValidateNonce(validationContext);
 
-            var validatedIdJwt = validationContext.ValidatedIdToken as JsonWebToken;
-            if (validatedIdJwt == null)
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21351, typeof(JsonWebToken), validationContext.ValidatedIdToken.GetType())));
-
             // only if 'at_hash' claim exist. 'at_hash' is not required in token response.
             object atHashClaim;
-            if (validatedIdJwt.TryGetPayloadValue(JwtRegisteredClaimNames.AtHash, out atHashClaim))
+            if (validationContext.ValidatedJsonWebToken != null)
             {
-                ValidateAtHash(validationContext);
+                if (validationContext.ValidatedJsonWebToken.TryGetPayloadValue(JwtRegisteredClaimNames.AtHash, out atHashClaim))
+                    ValidateAtHash(validationContext);
+            } else // validationContext.ValidatedIdToken != null
+            {
+                if (validationContext.ValidatedIdToken.Payload.TryGetValue(JwtRegisteredClaimNames.AtHash, out atHashClaim))
+                    ValidateAtHash(validationContext);
             }
-
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
         }
 
         /// <summary>
@@ -320,8 +337,10 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             if (string.IsNullOrEmpty(validationContext.UserInfoEndpointResponse))
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21337));
 
-            if (validationContext.ValidatedIdToken == null)
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
 
             string sub = string.Empty;
             try
@@ -349,15 +368,24 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             if (string.IsNullOrEmpty(sub))
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21345));
 
-            var validatedIdJwt = validationContext.ValidatedIdToken as JsonWebToken;
-            if (validatedIdJwt == null)
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21351, typeof(JsonWebToken), validationContext.ValidatedIdToken.GetType())));
+            if (validationContext.ValidatedJsonWebToken != null)
+            {
+                if (string.IsNullOrEmpty(validationContext.ValidatedJsonWebToken.Subject))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21346));
 
-            if (string.IsNullOrEmpty(validatedIdJwt.Subject))
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21346));
+                if (!string.Equals(validationContext.ValidatedJsonWebToken.Subject, sub, StringComparison.Ordinal))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21338, validationContext.ValidatedJsonWebToken.Subject, sub)));
+            }
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            else // validationContext.ValidatedIdToken != null
+            {
+                if (string.IsNullOrEmpty(validationContext.ValidatedIdToken.Payload.Sub))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21346));
 
-            if (!string.Equals(validatedIdJwt.Subject, sub, StringComparison.Ordinal))
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21338, validatedIdJwt.Subject, sub)));
+                if (!string.Equals(validationContext.ValidatedIdToken.Payload.Sub, sub, StringComparison.Ordinal))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21338, validationContext.ValidatedIdToken.Payload.Sub, sub)));
+            }
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
         }
 
         /// <summary>
@@ -369,9 +397,91 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             if (validationContext == null)
                 throw LogHelper.LogArgumentNullException("validationContext");
 
-            if (validationContext.ValidatedIdToken == null)
-                throw LogHelper.LogArgumentNullException("validationContext.ValidatedIdToken");
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
+                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
 
+            if (validationContext.ValidatedJsonWebToken != null)
+                ValidateIdJsonWebToken(validationContext);
+            else // validationContext.ValidatedIdToken != null
+                ValidateIdJwtSecurityToken(validationContext);
+        }
+
+        private void ValidateIdJsonWebToken(OpenIdConnectProtocolValidationContext validationContext)
+        {
+            // if user sets the custom validator, we call the delegate. The default checks for multiple audiences and azp are not executed.
+            if (JsonWebTokenValidator != null)
+            {
+                try
+                {
+                    JsonWebTokenValidator(validationContext.ValidatedJsonWebToken, validationContext);
+                }
+                catch (Exception ex)
+                {
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21313, validationContext.ValidatedJsonWebToken), ex));
+                }
+                return;
+            }
+            else
+            {
+                var idToken = validationContext.ValidatedJsonWebToken;
+
+                // required claims
+                if (!idToken.Audiences.Any())
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Aud.ToLowerInvariant(), idToken)));
+
+                if (idToken.ValidTo.Equals(DateTime.MinValue))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Exp.ToLowerInvariant(), idToken)));
+
+                if (idToken.IssuedAt.Equals(DateTime.MinValue))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Iat.ToLowerInvariant(), idToken)));
+
+                if (idToken.Issuer == null)
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Iss.ToLowerInvariant(), idToken)));
+
+                // sub is required in OpenID spec; but we don't want to block valid idTokens provided by some identity providers
+                if (RequireSub && (string.IsNullOrWhiteSpace(idToken.Subject)))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Sub.ToLowerInvariant(), idToken)));
+
+                // optional claims
+                if (RequireAcr && !idToken.TryGetPayloadValue(JwtRegisteredClaimNames.Acr, out string _))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21315, idToken)));
+
+                if (RequireAmr && !idToken.TryGetPayloadValue(JwtRegisteredClaimNames.Amr, out string _))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21316, idToken)));
+
+                if (RequireAuthTime && !idToken.TryGetPayloadValue(JwtRegisteredClaimNames.AuthTime, out string _))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21317, idToken)));
+
+                string azp = null;
+                if (RequireAzp && !idToken.TryGetPayloadValue(JwtRegisteredClaimNames.Azp, out azp))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21318, idToken)));
+
+                // if multiple audiences are present in the id_token, 'azp' claim should be present
+                if (Enumerable.Count(idToken.Audiences) > 1 && string.IsNullOrEmpty(azp))
+                {
+                    LogHelper.LogWarning(LogMessages.IDX21339);
+                }
+
+                // if 'azp' claim exist, it should be equal to 'client_id' of the application
+                if (!string.IsNullOrEmpty(azp))
+                {
+                    if (string.IsNullOrEmpty(validationContext.ClientId))
+                    {
+                        throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21308));
+                    }
+                    else if (!string.Equals(azp, validationContext.ClientId, StringComparison.Ordinal))
+                    {
+                        throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21340, azp, validationContext.ClientId)));
+                    }
+                }
+            }
+        }
+
+        private void ValidateIdJwtSecurityToken(OpenIdConnectProtocolValidationContext validationContext)
+        {
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
             // if user sets the custom validator, we call the delegate. The default checks for multiple audiences and azp are not executed.
             if (this.IdTokenValidator != null)
             {
@@ -387,57 +497,54 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             }
             else
             {
-                var validatedIdJwt = validationContext.ValidatedIdToken as JsonWebToken;
-                if (validatedIdJwt == null)
-                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21351, typeof(JsonWebToken), validationContext.ValidatedIdToken.GetType())));
-
+                JwtSecurityToken idToken = validationContext.ValidatedIdToken;
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
                 // required claims
-                if (!validatedIdJwt.Audiences.Any())
-                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Aud.ToLowerInvariant(), validatedIdJwt)));
+                if (idToken.Payload.Aud.Count == 0)
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Aud.ToLowerInvariant(), idToken)));
 
-                if (validatedIdJwt.ValidTo.Equals(DateTime.MinValue))
-                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Exp.ToLowerInvariant(), validatedIdJwt)));
+                if (!idToken.Payload.Exp.HasValue)
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Exp.ToLowerInvariant(), idToken)));
 
-                if (validatedIdJwt.IssuedAt.Equals(DateTime.MinValue))
-                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Iat.ToLowerInvariant(), validatedIdJwt)));
+                if (!idToken.Payload.Iat.HasValue)
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Iat.ToLowerInvariant(), idToken)));
 
-                if (validatedIdJwt.Issuer == null)
-                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Iss.ToLowerInvariant(), validatedIdJwt)));
+                if (idToken.Payload.Iss == null)
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Iss.ToLowerInvariant(), idToken)));
 
                 // sub is required in OpenID spec; but we don't want to block valid idTokens provided by some identity providers
-                if (RequireSub && (string.IsNullOrWhiteSpace(validatedIdJwt.Subject)))
-                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Sub.ToLowerInvariant(), validatedIdJwt)));
+                if (RequireSub && (string.IsNullOrWhiteSpace(idToken.Payload.Sub)))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Sub.ToLowerInvariant(), idToken)));
 
                 // optional claims
-                if (RequireAcr && !validatedIdJwt.TryGetPayloadValue(JwtRegisteredClaimNames.Acr, out string _))
-                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21315, validatedIdJwt)));
+                if (RequireAcr && string.IsNullOrWhiteSpace(idToken.Payload.Acr))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21315, idToken)));
 
-                if (RequireAmr && !validatedIdJwt.TryGetPayloadValue(JwtRegisteredClaimNames.Amr, out string _))
-                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21316, validatedIdJwt)));
+                if (RequireAmr && idToken.Payload.Amr.Count == 0)
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21316, idToken)));
 
-                if (RequireAuthTime && !validatedIdJwt.TryGetPayloadValue(JwtRegisteredClaimNames.AuthTime, out string _))
-                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21317, validatedIdJwt)));
+                if (RequireAuthTime && !(idToken.Payload.AuthTime.HasValue))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21317, idToken)));
 
-                string azp = null;
-                if (RequireAzp && !validatedIdJwt.TryGetPayloadValue(JwtRegisteredClaimNames.Azp, out azp))
-                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21318, validatedIdJwt)));
+                if (RequireAzp && string.IsNullOrWhiteSpace(idToken.Payload.Azp))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21318, idToken)));
 
                 // if multiple audiences are present in the id_token, 'azp' claim should be present
-                if (Enumerable.Count(validatedIdJwt.Audiences) > 1 && string.IsNullOrEmpty(azp))
+                if (idToken.Payload.Aud.Count > 1 && string.IsNullOrEmpty(idToken.Payload.Azp))
                 {
                     LogHelper.LogWarning(LogMessages.IDX21339);
                 }
 
                 // if 'azp' claim exist, it should be equal to 'client_id' of the application
-                if (!string.IsNullOrEmpty(azp))
+                if (!string.IsNullOrEmpty(idToken.Payload.Azp))
                 {
                     if (string.IsNullOrEmpty(validationContext.ClientId))
                     {
                         throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21308));
                     }
-                    else if (!string.Equals(azp, validationContext.ClientId, StringComparison.Ordinal))
+                    else if (!string.Equals(idToken.Payload.Azp, validationContext.ClientId, StringComparison.Ordinal))
                     {
-                        throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21340, azp, validationContext.ClientId)));
+                        throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21340, idToken.Payload.Azp, validationContext.ClientId)));
                     }
                 }
             }
@@ -533,9 +640,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 
             if (validationContext == null)
                 throw LogHelper.LogArgumentNullException(nameof(validationContext));
-
-            if (validationContext.ValidatedIdToken == null)
-                throw LogHelper.LogArgumentNullException(nameof(validationContext.ValidatedIdToken));
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
+                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
 
             if (validationContext.ProtocolMessage == null)
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21333));
@@ -546,20 +653,31 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 return;
             }
 
-            var validatedIdJwt = validationContext.ValidatedIdToken as JsonWebToken;
-            if (validatedIdJwt == null)
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21351, typeof(JsonWebToken), validationContext.ValidatedIdToken.GetType())));
-
-            if (!validatedIdJwt.TryGetPayloadValue(JwtRegisteredClaimNames.CHash, out string chash))
+            string chash;
+            if (validationContext.ValidatedJsonWebToken != null)
             {
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogHelper.FormatInvariant(LogMessages.IDX21307, validationContext.ValidatedIdToken)));
+                if (!validationContext.ValidatedJsonWebToken.TryGetPayloadValue(JwtRegisteredClaimNames.CHash, out  chash))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogHelper.FormatInvariant(LogMessages.IDX21307, validationContext.ValidatedJsonWebToken)));
+            }
+            else // validationContext.ValidatedIdToken != null
+            {
+                object cHashClaim;
+                if (!validationContext.ValidatedIdToken.Payload.TryGetValue(JwtRegisteredClaimNames.CHash, out cHashClaim))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogHelper.FormatInvariant(LogMessages.IDX21307, validationContext.ValidatedIdToken)));
+                chash = cHashClaim as string;
+                if (chash == null)
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogHelper.FormatInvariant(LogMessages.IDX21306, validationContext.ValidatedIdToken)));
             }
 
             try
             {
-                ValidateHash(chash, validationContext.ProtocolMessage.Code, validatedIdJwt.Alg);
+                if (validationContext.ValidatedJsonWebToken != null)
+                    ValidateHash(chash, validationContext.ProtocolMessage.Code, validationContext.ValidatedJsonWebToken.Alg);
+                else // validationContext.ValidatedIdToken != null
+                    ValidateHash(chash, validationContext.ProtocolMessage.Code, validationContext.ValidatedIdToken.Header.Alg);
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
             }
-            catch(OpenIdConnectProtocolException ex)
+            catch (OpenIdConnectProtocolException ex)
             {
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogMessages.IDX21347, ex));
             }
@@ -581,8 +699,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             if (validationContext == null)
                 throw LogHelper.LogArgumentNullException("validationContext");
 
-            if (validationContext.ValidatedIdToken == null)
-                throw LogHelper.LogArgumentNullException("validationContext.ValidatedIdToken");
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
+                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
 
             if (validationContext.ProtocolMessage == null)
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21333));
@@ -593,16 +712,31 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 return;
             }
 
-            var validatedIdJwt = validationContext.ValidatedIdToken as JsonWebToken;
-            if (validatedIdJwt == null)
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21351, typeof(JsonWebToken), validationContext.ValidatedIdToken.GetType())));
+            string atHash;
+            if (validationContext.ValidatedJsonWebToken != null)
+            {
+                if (!validationContext.ValidatedJsonWebToken.TryGetPayloadValue(JwtRegisteredClaimNames.AtHash, out atHash))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidAtHashException(LogHelper.FormatInvariant(LogMessages.IDX21312, validationContext.ValidatedJsonWebToken)));
 
-            if (!validatedIdJwt.TryGetPayloadValue(JwtRegisteredClaimNames.AtHash, out string atHash))
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidAtHashException(LogHelper.FormatInvariant(LogMessages.IDX21312, validationContext.ValidatedIdToken)));
+            }
+            else // validationContext.ValidatedIdToken != null
+            {
+                object atHashClaim;
+                if (!validationContext.ValidatedIdToken.Payload.TryGetValue(JwtRegisteredClaimNames.AtHash, out atHashClaim))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidAtHashException(LogHelper.FormatInvariant(LogMessages.IDX21312, validationContext.ValidatedIdToken)));
 
+                atHash = atHashClaim as string;
+                if (atHash == null)
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidAtHashException(LogHelper.FormatInvariant(LogMessages.IDX21311, validationContext.ValidatedIdToken)));
+            }
+           
             try
             {
-                ValidateHash(atHash, validationContext.ProtocolMessage.AccessToken, validatedIdJwt.Alg);
+                if (validationContext.ValidatedJsonWebToken != null)
+                    ValidateHash(atHash, validationContext.ProtocolMessage.AccessToken, validationContext.ValidatedJsonWebToken.Alg);
+                else if (validationContext.ValidatedIdToken != null)
+                    ValidateHash(atHash, validationContext.ProtocolMessage.AccessToken, validationContext.ValidatedIdToken.Header.Alg);
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
             }
             catch (OpenIdConnectProtocolException ex)
             {
@@ -611,7 +745,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         }
 
         /// <summary>
-        /// Validates that the <see cref="JsonWebToken"/> contains the nonce.
+        /// Validates that the <see cref="SecurityToken"/> contains the nonce.
         /// </summary>
         /// <param name="validationContext">A <see cref="OpenIdConnectProtocolValidationContext"/> that contains the 'nonce' to validate.</param>
         /// <exception cref="ArgumentNullException">If 'validationContext' is null.</exception>
@@ -628,14 +762,16 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             if (validationContext == null)
                 throw LogHelper.LogArgumentNullException(nameof(validationContext));
 
-            if (validationContext.ValidatedIdToken == null)
-                throw LogHelper.LogArgumentNullException(nameof(validationContext.ValidatedIdToken));
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
+                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
 
-            var validatedIdJwt = validationContext.ValidatedIdToken as JsonWebToken;
-            if (validatedIdJwt == null)
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21351, typeof(JsonWebToken), validationContext.ValidatedIdToken.GetType())));
-
-            validatedIdJwt.TryGetPayloadValue(JwtRegisteredClaimNames.Nonce, out string nonceFoundInJwt);
+            string nonceFoundInJwt;
+            if (validationContext.ValidatedJsonWebToken != null)
+                validationContext.ValidatedJsonWebToken.TryGetPayloadValue(JwtRegisteredClaimNames.Nonce, out nonceFoundInJwt);
+            else // validationContext.ValidatedIdToken != null
+               nonceFoundInJwt = validationContext.ValidatedIdToken.Payload.Nonce;
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
 
             // if a nonce is not required AND there is no nonce in the context (which represents what was returned from the IDP) and the token log and return
             if (!RequireNonce && string.IsNullOrEmpty(validationContext.Nonce) && string.IsNullOrEmpty(nonceFoundInJwt))
@@ -653,7 +789,14 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidNonceException(LogHelper.FormatInvariant(LogMessages.IDX21349, RequireNonce)));
 
             if (!string.Equals(nonceFoundInJwt, validationContext.Nonce, StringComparison.Ordinal))
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidNonceException(LogHelper.FormatInvariant(LogMessages.IDX21321, validationContext.Nonce, nonceFoundInJwt, validationContext.ValidatedIdToken)));
+            {
+                if (validationContext.ValidatedJsonWebToken != null)
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidNonceException(LogHelper.FormatInvariant(LogMessages.IDX21321, validationContext.Nonce, nonceFoundInJwt, validationContext.ValidatedJsonWebToken)));
+                else // validationContext.ValidatedIdToken != null
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidNonceException(LogHelper.FormatInvariant(LogMessages.IDX21321, validationContext.Nonce, nonceFoundInJwt, validationContext.ValidatedIdToken)));
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            }
 
             if (RequireTimeStampInNonce)
             {

--- a/src/Microsoft.IdentityModel.Tokens/IJsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.Tokens/IJsonWebToken.cs
@@ -1,0 +1,117 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Interface for a json web token (JWT).
+    /// </summary>
+    public interface IJsonWebToken : ISecurityToken
+    {
+        /// <summary>
+        /// This must be implemented to get the Actor of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Actor { get; }
+
+        /// <summary>
+        /// This must be implemented to get the Algorithm used when signing this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Alg { get; }
+
+        /// <summary>
+        /// This must be implemented to get the Audiences of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        IEnumerable<string> Audiences { get; }
+
+        /// <summary>
+        /// This must be implemented to get the <see cref="Claim"/>s for each value in the JWT payload.
+        /// </summary>
+        IEnumerable<Claim> Claims { get; }
+
+        /// <summary>
+        /// This must be implemented to get the Content Type of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Cty { get; }
+
+        /// <summary>
+        /// This must be implemented to get the Encryption Algorithm of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Enc { get; }
+
+        /// <summary>
+        /// This must be implemented to get the time this <see cref="IJsonWebToken"/> was issued at.
+        /// </summary>
+        DateTime IssuedAt { get; }
+
+        /// <summary>
+        /// This must be implemented to get the key ID of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Kid { get; }
+
+        /// <summary>
+        /// This must be implemented to get the Subject of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Subject { get; }
+
+        /// <summary>
+        /// This must be implemented to get the Type of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Typ { get; }
+
+        /// <summary>
+        /// This must be implemented to get the X509 Certificate Thumbprint associated with this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string X5t { get; }
+
+        /// <summary>
+        /// This must be implemented to obtain a 'value' corresponding to the provided key from the JWT payload { key, 'value' }.
+        /// </summary>
+        T GetPayloadValue<T>(string key);
+
+        /// <summary>
+        /// This must be implemented to get the 'value' corresponding to the provided key from the JWT payload { key, 'value' }.
+        /// </summary>
+        /// <remarks>This should return 'true' if 'value' is found, and 'false' otherwise.</remarks>
+
+        bool TryGetPayloadValue<T>(string key, out T value);
+
+        /// <summary>
+        /// This must be implemented to get the 'value' corresponding to the provided key from the JWT header { key, 'value' }.
+        /// </summary>
+        T GetHeaderValue<T>(string key);
+
+        /// <summary>
+        /// This must be implemented to get the 'value' corresponding to the provided key from the JWT header { key, 'value' }.
+        /// </summary>
+        /// <remarks>This should return 'true' if 'value' is found, and 'false' otherwise.</remarks>
+        bool TryGetHeaderValue<T>(string key, out T value);
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/ISecurityToken.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ISecurityToken.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------------------------
+﻿//------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -30,39 +30,39 @@ using System;
 namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
-    /// Base class for security token.
+    /// Interface for a security token.
     /// </summary>
-    public abstract class SecurityToken : ISecurityToken
+    public interface ISecurityToken
     {
         /// <summary>
-        /// This must be overridden to get the Id of this <see cref="SecurityToken"/>.
+        /// This must be implemented to get the Id of this <see cref="SecurityToken"/>.
         /// </summary>
-        public abstract string Id { get; }
+        string Id { get; }
 
         /// <summary>
-        /// This must be overridden to get the issuer of this <see cref="SecurityToken"/>.
+        /// This must be implemented to get the issuer of this <see cref="SecurityToken"/>.
         /// </summary>
-        public abstract string Issuer { get; }
+        string Issuer { get; }
 
         /// <summary>
-        /// This must be overridden to get the <see cref="SecurityKey"/>.
+        /// This must be implemented to get the <see cref="SecurityKey"/>.
         /// </summary>
-        public abstract SecurityKey SecurityKey { get; }
+        SecurityKey SecurityKey { get; }
 
         /// <summary>
-        /// This must be overridden to get or set the <see cref="SecurityKey"/> that signed this instance.
+        /// This must be implemented to get or set the <see cref="SecurityKey"/> that signed this instance.
         /// </summary>
         /// <remarks><see cref="ISecurityTokenValidator"/>.ValidateToken(...) can this value when a <see cref="SecurityKey"/> is used to successfully validate a signature.</remarks>
-        public abstract SecurityKey SigningKey { get; set; }
+        SecurityKey SigningKey { get; set; }
 
         /// <summary>
-        /// This must be overridden to get the time when this <see cref="SecurityToken"/> was Valid.
+        /// This must be implemented to get the time when this <see cref="SecurityToken"/> was Valid.
         /// </summary>
-        public abstract DateTime ValidFrom { get; }
+        DateTime ValidFrom { get; }
 
         /// <summary>
-        /// This must be overridden to get the time when this <see cref="SecurityToken"/> is no longer Valid.
+        /// This must be implemented to get the time when this <see cref="SecurityToken"/> is no longer Valid.
         /// </summary>
-        public abstract DateTime ValidTo { get; }
+        DateTime ValidTo { get; }
     }
 }

--- a/src/System.IdentityModel.Tokens.Jwt/LogMessages.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/LogMessages.cs
@@ -65,6 +65,11 @@ namespace System.IdentityModel.Tokens.Jwt
         internal const string IDX12739 = "IDX12739: JWT: '{0}' has three segments but is not in proper JWS format.";
         internal const string IDX12740 = "IDX12740: JWT: '{0}' has five segments but is not in proper JWE format.";
         internal const string IDX12741 = "IDX12741: JWT: '{0}' must have three segments (JWS) or five segments (JWE).";
+
+        //parsing
+        internal const string IDX12800 = "IDX12800: Claim with name '{0}' does not exist in the header.";
+        internal const string IDX12801 = "IDX12801: Claim with name '{0}' does not exist in the payload.";
+        internal const string IDX12802 = "IDX12802: Unable to convert the '{0}' claim to the following type: '{1}'. Claim type was: '{2}'.";
 #pragma warning restore 1591
     }
 }


### PR DESCRIPTION
Rather than incorporating these changes directly, we may also want to consider creating a new OpenIdConnect assembly that uses M.IM.JsonWebTokens instead of S.IM.Tokens.Jwt.

Addresses #1160.