### PR TITLE
Added new APIs to JsonWebTokenHandler for encrypting existing JWS tokens

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
@@ -45,7 +45,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         internal const string IDX14101 = "IDX14101: Unable to decode the payload '{0}' as Base64Url encoded string. jwtEncodedString: '{1}'.";
         internal const string IDX14102 = "IDX14102: Unable to decode the header '{0}' as Base64Url encoded string. jwtEncodedString: '{1}'.";
         internal const string IDX14103 = "IDX14103: Failed to create the token encryption provider.";
-        internal const string IDX14104 = "IDX14104: Unable to obtain a CryptoProviderFactory, both EncryptingCredentials.CryptoProviderFactory and EncryptingCredentials.Key.CrypoProviderFactory are both null.";
+        internal const string IDX14104 = "IDX14104: Unable to obtain a CryptoProviderFactory, EncryptingCredentials.CryptoProviderFactory and EncryptingCredentials.Key.CrypoProviderFactory are both null.";
         internal const string IDX14105 = "IDX14105: Header.Cty != null, assuming JWS. Cty: '{0}'.";
         internal const string IDX14106 = "IDX14106: Decoding token: '{0}' into header, payload and signature.";
         internal const string IDX14107 = "IDX14107: Token string does not match the token formats: JWE (header.encryptedKey.iv.ciphertext.tag) or JWS (header.payload.signature)";

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -371,7 +371,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-
         public static TheoryData<CreateTokenTheoryData> CreateJWSTheoryData
         {
             get
@@ -644,9 +643,41 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(RoundTripJWEDirectEncryptionTheoryData))]
+        public void RoundTripEncryptExistingJWSUsingDirectEncryption(CreateTokenTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.RoundTripEncryptExistingJWSUsingDirectEncryption", theoryData);
+            var jsonWebTokenHandler = new JsonWebTokenHandler();
+            var innerJwt = jsonWebTokenHandler.CreateToken(theoryData.Payload, theoryData.SigningCredentials);
+            var jweCreatedInMemory = jsonWebTokenHandler.EncryptToken(innerJwt, theoryData.EncryptingCredentials);
+            try
+            {
+                var tokenValidationResult = jsonWebTokenHandler.ValidateToken(jweCreatedInMemory, theoryData.ValidationParameters);
+                IdentityComparer.AreEqual(tokenValidationResult.IsValid, theoryData.IsValid, context);
+                if (tokenValidationResult.Exception != null)
+                    throw tokenValidationResult.Exception;
+
+                var outerToken = tokenValidationResult.SecurityToken as JsonWebToken;
+
+                Assert.True(outerToken != null, "ValidateToken should not return a null token for the JWE token.");
+                TestUtilities.CallAllPublicInstanceAndStaticPropertyGets(outerToken, theoryData.TestId);
+
+                Assert.True(outerToken.InnerToken != null, "ValidateToken should not return a null token for the inner JWE token.");
+                TestUtilities.CallAllPublicInstanceAndStaticPropertyGets(outerToken.InnerToken, theoryData.TestId);
+
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Theory, MemberData(nameof(RoundTripJWEDirectEncryptionTheoryData))]
         public void RoundTripJWEDirectEncryption(CreateTokenTheoryData theoryData)
         {
-            var context = TestUtilities.WriteHeader($"{this}.RoundTripJWE", theoryData);
+            var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEDirectEncryption", theoryData);
             var jsonWebTokenHandler = new JsonWebTokenHandler();
             var jwtSecurityTokenHandler = new JwtSecurityTokenHandler();
             jwtSecurityTokenHandler.InboundClaimTypeMap.Clear();
@@ -655,6 +686,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             {
                 var tokenValidationResult = jsonWebTokenHandler.ValidateToken(jweCreatedInMemory, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(tokenValidationResult.IsValid, theoryData.IsValid, context);
+                if (tokenValidationResult.Exception != null)
+                    throw tokenValidationResult.Exception;
+
                 var outerToken = tokenValidationResult.SecurityToken as JsonWebToken;
                 var claimsPrincipal = jwtSecurityTokenHandler.ValidateToken(jweCreatedInMemory, theoryData.ValidationParameters, out SecurityToken validatedTokenFromJwtHandler);
 
@@ -724,11 +758,42 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
+        [Theory, MemberData(nameof(RoundTripJWEKeyWrappingTheoryData))]
+        public void RoundTripEncryptExistingJWSUsingKeyWrapping(CreateTokenTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.RoundTripEncryptExistingJWSUsingKeyWrapping", theoryData);
+            var jsonWebTokenHandler = new JsonWebTokenHandler();
+            var innerJws = jsonWebTokenHandler.CreateToken(theoryData.Payload, theoryData.SigningCredentials);
+            var jweCreatedInMemory = jsonWebTokenHandler.EncryptToken(innerJws, theoryData.EncryptingCredentials);
+            try
+            {
+                var tokenValidationResult = jsonWebTokenHandler.ValidateToken(jweCreatedInMemory, theoryData.ValidationParameters);
+                IdentityComparer.AreEqual(tokenValidationResult.IsValid, theoryData.IsValid, context);
+                if (tokenValidationResult.Exception != null)
+                    throw tokenValidationResult.Exception;
+
+                var outerToken = tokenValidationResult.SecurityToken as JsonWebToken;
+
+                Assert.True(outerToken != null, "ValidateToken should not return a null token for the JWE token.");
+                TestUtilities.CallAllPublicInstanceAndStaticPropertyGets(outerToken, theoryData.TestId);
+
+                Assert.True(outerToken.InnerToken != null, "ValidateToken should not return a null token for the inner JWE token.");
+                TestUtilities.CallAllPublicInstanceAndStaticPropertyGets(outerToken.InnerToken, theoryData.TestId);
+
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
 
         [Theory, MemberData(nameof(RoundTripJWEKeyWrappingTheoryData))]
         public void RoundTripJWEKeyWrapping(CreateTokenTheoryData theoryData)
         {
-            var context = TestUtilities.WriteHeader($"{this}.RoundTripJWE", theoryData);
+            var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEKeyWrapping", theoryData);
             var jsonWebTokenHandler = new JsonWebTokenHandler();
             var jwtSecurityTokenHandler = new JwtSecurityTokenHandler();
             jwtSecurityTokenHandler.InboundClaimTypeMap.Clear();
@@ -737,6 +802,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             {
                 var tokenValidationResult = jsonWebTokenHandler.ValidateToken(jweCreatedInMemory, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(tokenValidationResult.IsValid, theoryData.IsValid, context);
+                if (tokenValidationResult.Exception != null)
+                    throw tokenValidationResult.Exception;
+
                 var outerToken = tokenValidationResult.SecurityToken as JsonWebToken;
                 var claimsPrincipal = jwtSecurityTokenHandler.ValidateToken(jweCreatedInMemory, theoryData.ValidationParameters, out SecurityToken validatedTokenFromJwtHandler);
 
@@ -913,6 +981,33 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
             if (!email.Equals("Bob@contoso.com"))
                 throw new SecurityTokenException("Token does not contain the correct value for the 'email' claim.");
+        }
+
+        [Theory, MemberData(nameof(JWECompressionTheoryData))]
+        public void EncryptExistingJWSWithCompressionTest(CreateTokenTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.EncryptExistingJWSWithCompressionTest", theoryData);
+
+            try
+            {
+                var handler = new JsonWebTokenHandler();
+                CompressionProviderFactory.Default = theoryData.CompressionProviderFactory;
+                var innerJwt = handler.CreateToken(theoryData.Payload, theoryData.SigningCredentials);
+                var jwtToken = handler.EncryptToken(innerJwt, theoryData.EncryptingCredentials, theoryData.CompressionAlgorithm);
+                var validationResult = handler.ValidateToken(jwtToken, theoryData.ValidationParameters);
+                if (validationResult.Exception != null)
+                    throw validationResult.Exception;
+
+                IdentityComparer.AreEqual(theoryData.Payload, (validationResult.SecurityToken as JsonWebToken).InnerToken.Payload.ToString(), context);
+
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
         }
 
         [Theory, MemberData(nameof(JWECompressionTheoryData))]


### PR DESCRIPTION
Fixes #1130.

Added two new APIs for encrypting existing JWS tokens, as well as corresponding tests.