### PR TITLE
JsonWebTokenHandler.CreateToken(SecurityTokenDescriptor) no longer copies SecurityTokenDescriptor.Claims into a new Dictionary

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -135,7 +135,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (tokenDescriptor.SigningCredentials == null)
                 throw LogHelper.LogArgumentNullException(nameof(tokenDescriptor.SigningCredentials));
 
-            var payload = tokenDescriptor.Claims == null ? new Dictionary<string, object>() : new Dictionary<string, object>(tokenDescriptor.Claims);
+            // JObject needs to be upcast to an IDictionary<string, JToken> so that we can access the ContainsKey() and Any() methods
+            IDictionary<string, JToken> payload = tokenDescriptor.Claims == null ? new JObject() : JObject.FromObject(tokenDescriptor.Claims);
 
             if (tokenDescriptor.Audience != null)
             {
@@ -180,7 +181,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (!payload.Any())
                 throw LogHelper.LogExceptionMessage(new SecurityTokenException(LogMessages.IDX14115));
 
-            return CreateTokenPrivate(JObject.FromObject(payload), tokenDescriptor.SigningCredentials, tokenDescriptor.EncryptingCredentials, tokenDescriptor.CompressionAlgorithm);
+            return CreateTokenPrivate(payload as JObject, tokenDescriptor.SigningCredentials, tokenDescriptor.EncryptingCredentials, tokenDescriptor.CompressionAlgorithm);
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
@@ -51,7 +51,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         internal const string IDX14107 = "IDX14107: Token string does not match the token formats: JWE (header.encryptedKey.iv.ciphertext.tag) or JWS (header.payload.signature)";
         internal const string IDX14111 = "IDX14111: JWT: '{0}' must have three segments (JWS) or five segments (JWE).";
         internal const string IDX14112 = "IDX14112: Only a single 'Actor' is supported. Found second claim of type: '{0}', value: '{1}'";
-        internal const string IDX14113 = "IDX14113: A duplicate value for 'SecurityTokenDescriptor.{0}' exists in 'SecurityTokenDescriptor.Payload'. \nThe value of 'SecurityTokenDescriptor.{0}' is used.";
+        internal const string IDX14113 = "IDX14113: A duplicate value for 'SecurityTokenDescriptor.{0}' exists in 'SecurityTokenDescriptor.Claims'. \nThe value of 'SecurityTokenDescriptor.{0}' is used.";
         internal const string IDX14114 = "IDX14114: No claims were added to the SecurityTokenDescriptor.";
         internal const string IDX14115 = "IDX14115: A JWT cannot be created with an empty payload.";
 


### PR DESCRIPTION
Fixes #1082.

Previously we were copying SecurityTokenDescriptor.Claims into a new Dictionary, updating that copy with the other properties set on the SecurityTokenDescriptor (e.g. SecurityTokenDescriptor.Audience), and then converting that dictionary into a JObject.

Now we create a JObject from SecurityTokenDescriptor.Claims directly and update it with the other properties set on the SecurityTokenDescriptor (so creating a Dictionary copy is not necessary).