### PR TITLE
Support JsonWebKeys with the Elliptic Curve key type

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
@@ -76,7 +76,7 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 ECDsaAdapter = new ECDsaAdapter();
             }
-            catch (PlatformNotSupportedException ex)
+            catch (Exception ex)
             {
                 LogHelper.LogExceptionMessage(ex);
             }
@@ -162,6 +162,10 @@ namespace Microsoft.IdentityModel.Tokens
                 if (!(string.IsNullOrWhiteSpace(webKey.Use) || webKey.Use.Equals(JsonWebKeyUseNames.Sig, StringComparison.Ordinal)))
                 {
                     LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10808, webKey.KeyId ?? "" , webKey.Use));
+
+                    if (!SkipUnresolvedJsonWebKeys)
+                        signingKeys.Add(webKey);
+
                     continue;
                 }
 

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
@@ -161,7 +161,7 @@ namespace Microsoft.IdentityModel.Tokens
                 // https://tools.ietf.org/html/rfc7517#section-4.2
                 if (!(string.IsNullOrWhiteSpace(webKey.Use) || webKey.Use.Equals(JsonWebKeyUseNames.Sig, StringComparison.Ordinal)))
                 {
-                    LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10808, webKey.KeyId ?? "" , webKey.Use));
+                    LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10808, webKey.KeyId ?? "null" , webKey.Use ?? "null"));
 
                     if (!SkipUnresolvedJsonWebKeys)
                         signingKeys.Add(webKey);
@@ -187,7 +187,7 @@ namespace Microsoft.IdentityModel.Tokens
 
                     if (!isResolved)
                     {
-                        LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10810, webKey.KeyId ?? ""));
+                        LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10810, webKey.KeyId ?? "null"));
 
                         if(!SkipUnresolvedJsonWebKeys)
                             signingKeys.Add(webKey);
@@ -200,7 +200,7 @@ namespace Microsoft.IdentityModel.Tokens
                 else
                 {
                     // kty is not 'EC' or 'RSA'
-                    LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10809, webKey.Kty ?? ""));
+                    LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10809, webKey.Kty ?? "null"));
 
                     if (!SkipUnresolvedJsonWebKeys)
                         signingKeys.Add(webKey);

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
@@ -42,6 +42,8 @@ namespace Microsoft.IdentityModel.Tokens
     [JsonObject]
     public class JsonWebKeySet
     {
+        private readonly bool _skipUnresolvedJsonWebKeys = SkipUnresolvedJsonWebKeys;
+
         /// <summary>
         /// Returns a new instance of <see cref="JsonWebKeySet"/>.
         /// </summary>
@@ -123,15 +125,15 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
-        /// This adapter abstracts the <see cref="ECDsa"/> differences between versions of .Net targets.
-        /// </summary>
-        internal static ECDsaAdapter ECDsaAdapter;
-
-        /// <summary>
         /// When deserializing from JSON any properties that are not defined will be placed here.
         /// </summary>
         [JsonExtensionData]
         public virtual IDictionary<string, object> AdditionalData { get; } = new Dictionary<string, object>();
+
+        /// <summary>
+        /// This adapter abstracts the <see cref="ECDsa"/> differences between versions of .Net targets.
+        /// </summary>
+        internal static ECDsaAdapter ECDsaAdapter;
 
         /// <summary>
         /// Gets the <see cref="IList{JsonWebKey}"/>.
@@ -163,7 +165,7 @@ namespace Microsoft.IdentityModel.Tokens
                 {
                     LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10808, webKey.KeyId ?? "null" , webKey.Use ?? "null"));
 
-                    if (!SkipUnresolvedJsonWebKeys)
+                    if (!_skipUnresolvedJsonWebKeys)
                         signingKeys.Add(webKey);
 
                     continue;
@@ -189,7 +191,7 @@ namespace Microsoft.IdentityModel.Tokens
                     {
                         LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10810, webKey.KeyId ?? "null"));
 
-                        if(!SkipUnresolvedJsonWebKeys)
+                        if(!_skipUnresolvedJsonWebKeys)
                             signingKeys.Add(webKey);
                     }
                 }
@@ -202,7 +204,7 @@ namespace Microsoft.IdentityModel.Tokens
                     // kty is not 'EC' or 'RSA'
                     LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10809, webKey.Kty ?? "null"));
 
-                    if (!SkipUnresolvedJsonWebKeys)
+                    if (!_skipUnresolvedJsonWebKeys)
                         signingKeys.Add(webKey);
                 }
             }
@@ -227,7 +229,7 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10802, jsonWebKey.X5c[0], ex), ex));
 
-                if (!SkipUnresolvedJsonWebKeys)
+                if (!_skipUnresolvedJsonWebKeys)
                     signingKeys.Add(jsonWebKey);
             }
         }
@@ -253,7 +255,7 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10801, jsonWebKey.E, jsonWebKey.N, ex), ex));
 
-                if (!SkipUnresolvedJsonWebKeys)
+                if (!_skipUnresolvedJsonWebKeys)
                     signingKeys.Add(jsonWebKey);
             }
         }
@@ -264,7 +266,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (ECDsaAdapter == null)
             {
                 LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10690));
-                if (!SkipUnresolvedJsonWebKeys)
+                if (!_skipUnresolvedJsonWebKeys)
                     signingKeys.Add(jsonWebKey);
 
                 return;
@@ -284,7 +286,7 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10807, ex), ex));
 
-                if (!SkipUnresolvedJsonWebKeys)
+                if (!_skipUnresolvedJsonWebKeys)
                     signingKeys.Add(jsonWebKey);
             }
         }

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
@@ -63,7 +63,6 @@ namespace Microsoft.IdentityModel.Tokens
         {
         }
 
-#pragma warning disable CS0618 // Type or member is obsolete
         /// <summary>
         /// Initializes an new instance of <see cref="JsonWebKeySet"/> from a json string.
         /// </summary>
@@ -73,7 +72,6 @@ namespace Microsoft.IdentityModel.Tokens
         public JsonWebKeySet(string json) : this(json, null)
         {
         }
-#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// Initializes an new instance of <see cref="JsonWebKeySet"/> from a json string.
@@ -122,68 +120,100 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         public IList<SecurityKey> GetSigningKeys()
         {
-            List<SecurityKey> keys = new List<SecurityKey>();
-            for (int i = 0; i < Keys.Count; i++)
+            var signingKeys = new List<SecurityKey>();
+
+            foreach (var webKey in Keys)
             {
-                JsonWebKey webKey = Keys[i];
-
-                if (!StringComparer.Ordinal.Equals(webKey.Kty, JsonWebAlgorithmsKeyTypes.RSA))
+                // skip if "use" (Public Key Use) parameter is not empty or "sig"
+                if (!(string.IsNullOrWhiteSpace(webKey.Use) || webKey.Use.Equals(JsonWebKeyUseNames.Sig, StringComparison.Ordinal)))
+                {
+                    LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10808, webKey.Use));
                     continue;
+                }
 
-                if ((string.IsNullOrWhiteSpace(webKey.Use) || (StringComparer.Ordinal.Equals(webKey.Use, JsonWebKeyUseNames.Sig))))
+                if (webKey.Kty.Equals(JsonWebAlgorithmsKeyTypes.RSA, StringComparison.Ordinal))
                 {
                     if (webKey.X5c != null)
-                    {
-                        foreach (var certString in webKey.X5c)
-                        {
-                            try
-                            {
-                                // Add chaining
-                                SecurityKey key = new X509SecurityKey(new X509Certificate2(Convert.FromBase64String(certString)));
-                                key.KeyId = webKey.Kid;
-                                keys.Add(key);
-                            }
-                            catch (CryptographicException ex)
-                            {
-                                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10802, webKey.X5c[0]), ex));
-                            }
-                            catch (FormatException fex)
-                            {
-                                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10802, webKey.X5c[0]), fex));
-                            }
-                        }
-                    }
+                        signingKeys.AddRange(CreateX509SecurityKeys(webKey));
 
                     if (!string.IsNullOrWhiteSpace(webKey.E) && !string.IsNullOrWhiteSpace(webKey.N))
-                    {
-                        try
-                        {
-                            SecurityKey key =
-                                 new RsaSecurityKey
-                                 (
-                                    new RSAParameters
-                                    {
-                                        Exponent = Base64UrlEncoder.DecodeBytes(webKey.E),
-                                        Modulus = Base64UrlEncoder.DecodeBytes(webKey.N),
-                                    }
-
-                                );
-                            key.KeyId = webKey.Kid;
-                            keys.Add(key);
-                        }
-                        catch (CryptographicException ex)
-                        {
-                            throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10801, webKey.E, webKey.N), ex));
-                        }
-                        catch (FormatException ex)
-                        {
-                            throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10801, webKey.E, webKey.N), ex));
-                        }
-                    }
+                        signingKeys.Add(CreateRsaSecurityKey(webKey));
+                }
+                else if (webKey.Kty.Equals(JsonWebAlgorithmsKeyTypes.EllipticCurve, StringComparison.Ordinal))
+                {
+                    signingKeys.Add(CreateECDsaSecurityKey(webKey));
+                }
+                else
+                {
+                    //kty is not 'EC' or 'RSA'
+                    LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10809, webKey.Kty));
                 }
             }
 
-            return keys;
+            return signingKeys;
+        }
+
+        private IList<SecurityKey> CreateX509SecurityKeys(JsonWebKey jsonWebKey)
+        {
+            try
+            {
+                var keys = new List<SecurityKey>();
+
+                foreach (var certString in jsonWebKey.X5c)
+                {
+                    var key = new X509SecurityKey(new X509Certificate2(Convert.FromBase64String(certString)))
+                    {
+                        KeyId = jsonWebKey.Kid
+                    };
+
+                    keys.Add(key);
+                }
+
+                return keys;
+            }
+            catch (Exception ex)
+            {
+                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10802, jsonWebKey.X5c[0]), ex));
+            }
+        }
+
+        private SecurityKey CreateRsaSecurityKey(JsonWebKey jsonWebKey)
+        {
+            try
+            {
+                var rsaParams = new RSAParameters
+                {
+                    Exponent = Base64UrlEncoder.DecodeBytes(jsonWebKey.E),
+                    Modulus = Base64UrlEncoder.DecodeBytes(jsonWebKey.N),
+                };
+
+                return new RsaSecurityKey(rsaParams)
+                {
+                    KeyId = jsonWebKey.Kid
+                };
+            }
+            catch (Exception ex)
+            {
+                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10801, jsonWebKey.E, jsonWebKey.N), ex));
+            }
+        }
+
+        private SecurityKey CreateECDsaSecurityKey(JsonWebKey jsonWebKey)
+        {
+            try
+            {
+                var ecdsaAdapter = new ECDsaAdapter();
+                var ecdsa = ecdsaAdapter.CreateECDsa(jsonWebKey, false);
+
+                return new ECDsaSecurityKey(ecdsa)
+                {
+                    KeyId = jsonWebKey.Kid
+                };
+            }
+            catch (Exception ex)
+            {
+                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10807), ex));
+            }
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
@@ -42,8 +42,6 @@ namespace Microsoft.IdentityModel.Tokens
     [JsonObject]
     public class JsonWebKeySet
     {
-        private readonly bool _skipUnresolvedJsonWebKeys = SkipUnresolvedJsonWebKeys;
-
         /// <summary>
         /// Returns a new instance of <see cref="JsonWebKeySet"/>.
         /// </summary>
@@ -142,10 +140,16 @@ namespace Microsoft.IdentityModel.Tokens
         public IList<JsonWebKey> Keys { get; private set; } = new List<JsonWebKey>();
 
         /// <summary>
+        /// Default value for the flag that controls whether unresolved JsonWebKeys will be included in the resulting collection of <see cref="GetSigningKeys"/> method.
+        /// </summary>
+        [DefaultValue(true)]
+        public static bool DefaultSkipUnresolvedJsonWebKeys = true;
+
+        /// <summary>
         /// Flag that controls whether unresolved JsonWebKeys will be included in the resulting collection of <see cref="GetSigningKeys"/> method.
         /// </summary>
         [DefaultValue(true)]
-        public static bool SkipUnresolvedJsonWebKeys { get; set; } = true;
+        public bool SkipUnresolvedJsonWebKeys { get; set; } = DefaultSkipUnresolvedJsonWebKeys;
 
         /// <summary>
         /// Returns the JsonWebKeys as a <see cref="IList{SecurityKey}"/>.
@@ -165,7 +169,7 @@ namespace Microsoft.IdentityModel.Tokens
                 {
                     LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10808, webKey.KeyId ?? "null" , webKey.Use ?? "null"));
 
-                    if (!_skipUnresolvedJsonWebKeys)
+                    if (!SkipUnresolvedJsonWebKeys)
                         signingKeys.Add(webKey);
 
                     continue;
@@ -191,7 +195,7 @@ namespace Microsoft.IdentityModel.Tokens
                     {
                         LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10810, webKey.KeyId ?? "null"));
 
-                        if(!_skipUnresolvedJsonWebKeys)
+                        if(!SkipUnresolvedJsonWebKeys)
                             signingKeys.Add(webKey);
                     }
                 }
@@ -204,7 +208,7 @@ namespace Microsoft.IdentityModel.Tokens
                     // kty is not 'EC' or 'RSA'
                     LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10809, webKey.Kty ?? "null"));
 
-                    if (!_skipUnresolvedJsonWebKeys)
+                    if (!SkipUnresolvedJsonWebKeys)
                         signingKeys.Add(webKey);
                 }
             }
@@ -229,7 +233,7 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10802, jsonWebKey.X5c[0], ex), ex));
 
-                if (!_skipUnresolvedJsonWebKeys)
+                if (!SkipUnresolvedJsonWebKeys)
                     signingKeys.Add(jsonWebKey);
             }
         }
@@ -255,7 +259,7 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10801, jsonWebKey.E, jsonWebKey.N, ex), ex));
 
-                if (!_skipUnresolvedJsonWebKeys)
+                if (!SkipUnresolvedJsonWebKeys)
                     signingKeys.Add(jsonWebKey);
             }
         }
@@ -266,7 +270,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (ECDsaAdapter == null)
             {
                 LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10690));
-                if (!_skipUnresolvedJsonWebKeys)
+                if (!SkipUnresolvedJsonWebKeys)
                     signingKeys.Add(jsonWebKey);
 
                 return;
@@ -286,7 +290,7 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10807, ex), ex));
 
-                if (!_skipUnresolvedJsonWebKeys)
+                if (!SkipUnresolvedJsonWebKeys)
                     signingKeys.Add(jsonWebKey);
             }
         }

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -195,14 +195,15 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10703 = "IDX10703: Cannot create symmetric security key. Key length is zero.";
 
         // Json specific errors
-        public const string IDX10801 = "IDX10801: Unable to create an RSA public key from the Exponent and Modulus found in the JsonWebKey: E: '{0}', N: '{1}'. See inner exception for additional details.";
-        public const string IDX10802 = "IDX10802: Unable to create an X509Certificate2 from the X509Data: '{0}'. See inner exception for additional details.";
+        public const string IDX10801 = "IDX10801: Unable to create an RSA public key from the Exponent and Modulus found in the JsonWebKey: E: '{0}', N: '{1}'. Inner exception: '{2}'.";
+        public const string IDX10802 = "IDX10802: Unable to create an X509Certificate2 from the X509Data: '{0}'. Inner exception '{1}'.";
         public const string IDX10804 = "IDX10804: Unable to retrieve document from: '{0}'.";
         public const string IDX10805 = "IDX10805: Error deserializing json: '{0}' into '{1}'.";
         public const string IDX10806 = "IDX10806: Deserializing json: '{0}' into '{1}'.";
-        public const string IDX10807 = "IDX10807: Unable to create an ECDsa from the parameters found in the JsonWebKey. See inner exception for additional details.";
-        public const string IDX10808 = "IDX10808: The 'use' parameter should be 'sig' or empty, but was '{0}'.";
+        public const string IDX10807 = "IDX10807: Unable to create an ECDsa from the parameters found in the JsonWebKey. Inner exception: '{0}'.";
+        public const string IDX10808 = "IDX10808: The 'use' parameter of a JsonWebKey with a 'kid': '{0}' should be 'sig' or empty, but was '{1}'.";
         public const string IDX10809 = "IDX10809: The 'kty' parameter '{0}' is not supported. Supported 'kty' parameters are 'RSA' and 'EC'.";
+        public const string IDX10810 = "IDX10810: JsonWebKey with a 'kid': '{0}' was not resolved into an X509SecurityKey or into an RsaSecurityKey.";
 #pragma warning restore 1591
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -200,6 +200,9 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10804 = "IDX10804: Unable to retrieve document from: '{0}'.";
         public const string IDX10805 = "IDX10805: Error deserializing json: '{0}' into '{1}'.";
         public const string IDX10806 = "IDX10806: Deserializing json: '{0}' into '{1}'.";
+        public const string IDX10807 = "IDX10807: Unable to create an ECDsa from the parameters found in the JsonWebKey. See inner exception for additional details.";
+        public const string IDX10808 = "IDX10808: The 'use' parameter should be 'sig' or empty, but was '{0}'.";
+        public const string IDX10809 = "IDX10809: The 'kty' parameter '{0}' is not supported. Supported 'kty' parameters are 'RSA' and 'EC'.";
 #pragma warning restore 1591
     }
 }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/End2EndTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/End2EndTests.cs
@@ -86,8 +86,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 new OpenIdConnectTheoryData
                 {
                     OpenIdConnectMetadataFileName = OpenIdConfigData.OpenIdConnectMetadataFileEnd2End,
-                    SigningCredentials =
-                        new SigningCredentials(
+                    SigningCredentials = new SigningCredentials(
                             KeyingMaterial.RsaSecurityKey_2048,
                             SecurityAlgorithms.RsaSha256
                         ),

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/End2EndTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/End2EndTests.cs
@@ -32,6 +32,8 @@ using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
 using Xunit;
 
+#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
+
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 {
     /// <summary>
@@ -39,40 +41,104 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
     /// </summary>
     public class End2EndTests
     {
-        [Fact]
-        public void OpenIdConnect()
+        [Theory, MemberData(nameof(OpenIdConnectTheoryData))]
+        public void OpenIdConnect(OpenIdConnectTheoryData theoryData)
         {
-            SigningCredentials rsaSigningCredentials =
-                new SigningCredentials(
-                    KeyingMaterial.RsaSecurityKey_2048,
-                    SecurityAlgorithms.RsaSha256Signature
-                    );
+            var context = TestUtilities.WriteHeader($"{this}.OpenIdConnect", theoryData);
+            try
+            {
+                OpenIdConnectConfiguration configuration = OpenIdConnectConfigurationRetriever.GetAsync(theoryData.OpenIdConnectMetadataFileName, new FileDocumentRetriever(), CancellationToken.None).Result;
+                JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
+                JwtSecurityToken jwtToken =
+                    tokenHandler.CreateJwtSecurityToken(
+                        configuration.Issuer,
+                        Default.Audience,
+                        ClaimSets.DefaultClaimsIdentity,
+                        DateTime.UtcNow,
+                        DateTime.UtcNow + TimeSpan.FromHours(1),
+                        DateTime.UtcNow + TimeSpan.FromHours(1),
+                        theoryData.SigningCredentials);
 
-            //"<RSAKeyValue><Modulus>rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==</Modulus><Exponent>AQAB</Exponent></RSAKeyValue>"
-            OpenIdConnectConfiguration configuration = OpenIdConnectConfigurationRetriever.GetAsync(OpenIdConfigData.OpenIdConnectMetadataFileEnd2End, new FileDocumentRetriever(), CancellationToken.None).Result;
-            JwtSecurityTokenHandler tokenHandler = new JwtSecurityTokenHandler();
-            JwtSecurityToken jwtToken = 
-                tokenHandler.CreateJwtSecurityToken(
-                    configuration.Issuer,
-                    Default.Audience,
-                    ClaimSets.DefaultClaimsIdentity,
-                    DateTime.UtcNow,
-                    DateTime.UtcNow + TimeSpan.FromHours(1),
-                    DateTime.UtcNow + TimeSpan.FromHours(1),
-                    rsaSigningCredentials);
+                tokenHandler.WriteToken(jwtToken);
 
-            tokenHandler.WriteToken(jwtToken);
+                TokenValidationParameters validationParameters =
+                        new TokenValidationParameters
+                        {
+                            IssuerSigningKeys = configuration.SigningKeys,
+                            ValidAudience = Default.Audience,
+                            ValidIssuer = configuration.Issuer,
+                        };
 
-            TokenValidationParameters validationParameters =
-                new TokenValidationParameters
+                tokenHandler.ValidateToken(jwtToken.RawData, validationParameters, out SecurityToken securityToken);
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<OpenIdConnectTheoryData> OpenIdConnectTheoryData()
+        {
+            return new TheoryData<OpenIdConnectTheoryData>() {
+                new OpenIdConnectTheoryData
                 {
-                    IssuerSigningKeys = configuration.SigningKeys,
-                    ValidAudience = Default.Audience,
-                    ValidIssuer = configuration.Issuer,
-                };
-
-            SecurityToken securityToken = null;
-            tokenHandler.ValidateToken(jwtToken.RawData, validationParameters, out securityToken);
+                    OpenIdConnectMetadataFileName = OpenIdConfigData.OpenIdConnectMetadataFileEnd2End,
+                    SigningCredentials =
+                        new SigningCredentials(
+                            KeyingMaterial.RsaSecurityKey_2048,
+                            SecurityAlgorithms.RsaSha256
+                        ),
+                    TestId = "validRS256"
+                },
+                new OpenIdConnectTheoryData
+                {
+                    OpenIdConnectMetadataFileName = OpenIdConfigData.OpenIdConnectMetadataFileEnd2EndEC,
+                    SigningCredentials = new SigningCredentials(
+                            KeyingMaterial.JsonWebKeyP256,
+                            SecurityAlgorithms.EcdsaSha256
+                        ),
+                    TestId = "validES256"
+                },
+                new OpenIdConnectTheoryData
+                {
+                    OpenIdConnectMetadataFileName = OpenIdConfigData.OpenIdConnectMetadataFileEnd2EndEC,
+                    SigningCredentials = new SigningCredentials(
+                            KeyingMaterial.JsonWebKeyP384,
+                            SecurityAlgorithms.EcdsaSha384
+                        ),
+                    TestId = "validES384"
+                },
+                new OpenIdConnectTheoryData
+                {
+                    OpenIdConnectMetadataFileName = OpenIdConfigData.OpenIdConnectMetadataFileEnd2EndEC,
+                    SigningCredentials = new SigningCredentials(
+                            KeyingMaterial.JsonWebKeyP521,
+                            SecurityAlgorithms.EcdsaSha512
+                        ),
+                    TestId = "validES521"
+                },
+                new OpenIdConnectTheoryData
+                {
+                    OpenIdConnectMetadataFileName = OpenIdConfigData.OpenIdConnectMetadataFileEnd2EndEC,
+                    SigningCredentials = new SigningCredentials(
+                            KeyingMaterial.Ecdsa384Key,
+                            SecurityAlgorithms.EcdsaSha384
+                        ),
+                    ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException(),
+                    TestId = "Ecdsa384KeyNotPartOfJWKS"
+                }
+            };
         }
     }
+
+    public class OpenIdConnectTheoryData : TheoryDataBase
+    {
+        public string OpenIdConnectMetadataFileName { get; set; }
+
+        public SigningCredentials SigningCredentials { get; set; }
+    }
 }
+#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/JsonWebKeySetEnd2EndEC.json
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/JsonWebKeySetEnd2EndEC.json
@@ -1,0 +1,31 @@
+﻿{
+  "keys": [
+    {
+      "kty": "EC",
+      "alg": "ES256",
+      "use": "sig",
+      "crv": "P-256",
+      "kid": "JsonWebKeyEcdsa256",
+      "x": "luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA",
+      "y": "tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ"
+    },
+    {
+      "kty": "EC",
+      "alg": "ES384",
+      "use": "sig",
+      "crv": "P-384",
+      "kid": "JsonWebKeyEcdsa384",
+      "x": "5mn3HaDoUgdNTFCACaWIvrpriQTloEbMbx4eUu_XvB4pyExig45VIozMnj7FedJg",
+      "y": "Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l"
+    },
+    {
+      "kty": "EC",
+      "alg": "ES521",
+      "use": "sig",
+      "crv": "P-521",
+      "kid": "JsonWebKeyEcdsa521",
+      "x": "AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr",
+      "y": "AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW"
+    }
+  ]
+}

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="JsonWebKeySet.json;JsonWebKeySetBadBase64Data.json;JsonWebKeySetBadX509Data.json;JsonWebKeySetEnd2End.json;JsonWebKeySetSingleX509Data.json;OpenIdConnectMetadata.json;OpenIdConnectMetadata2.json;OpenIdConnectMetadataBadBase64Data.json;OpenIdConnectMetadataBadX509Data.json;OpenIdConnectMetadataEnd2End.json;OpenIdConnectMetadataJsonWebKeySetBadUri.json;PingLabsJWKS.json;PingLabs-openid-configuration.json">
+    <None Update="JsonWebKeySet.json;JsonWebKeySetBadBase64Data.json;JsonWebKeySetBadX509Data.json;JsonWebKeySetEnd2End.json;JsonWebKeySetSingleX509Data.json;OpenIdConnectMetadata.json;OpenIdConnectMetadata2.json;OpenIdConnectMetadataBadBase64Data.json;OpenIdConnectMetadataBadX509Data.json;OpenIdConnectMetadataEnd2End.json;OpenIdConnectMetadataJsonWebKeySetBadUri.json;PingLabsJWKS.json;PingLabs-openid-configuration.json;;JsonWebKeySetEnd2EndEC.json;OpenIdConnectMetadataEnd2EndEC.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
@@ -80,6 +80,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
         public static string JsonFile = @"OpenIdConnectMetadata.json";
         public static string OpenIdConnectMetadataFileEnd2End = @"OpenIdConnectMetadataEnd2End.json";
+        public static string OpenIdConnectMetadataFileEnd2EndEC = @"OpenIdConnectMetadataEnd2EndEC.json";
         public static string JsonWebKeySetBadUriFile = @"OpenIdConnectMetadataJsonWebKeySetBadUri.json";
         public static string JsonAllValues =
                                             @"{ ""acr_values_supported"" : [""acr_value1"", ""acr_value2"", ""acr_value3""],
@@ -180,8 +181,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             SingleX509Data.JsonWebKeySet = DataSets.JsonWebKeySetX509Data;
             SingleX509Data.JwksUri = "JsonWebKeySetSingleX509Data.json";
             SingleX509Data.IdTokenSigningAlgValuesSupported.Add("RS256");
-            AddToCollection(SingleX509Data.ResponseTypesSupported, new string[]{"code", "id_token", "code id_token"});
-            AddToCollection(SingleX509Data.ResponseModesSupported, new string[]{"query", "fragment", "form_post"});
+            AddToCollection(SingleX509Data.ResponseTypesSupported, new string[] { "code", "id_token", "code id_token" });
+            AddToCollection(SingleX509Data.ResponseModesSupported, new string[] { "query", "fragment", "form_post" });
             SingleX509Data.ScopesSupported.Add("openid");
             SingleX509Data.SigningKeys.Add(KeyingMaterial.X509SecurityKey1);
             SingleX509Data.SubjectTypesSupported.Add("pairwise");
@@ -210,7 +211,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             AddToCollection(config.GrantTypesSupported, "authorization_code", "implicit");
             config.HttpLogoutSupported = true;
             AddToCollection(config.IdTokenEncryptionAlgValuesSupported, "RSA1_5", "A256KW");
-            AddToCollection(config.IdTokenEncryptionEncValuesSupported, "A128CBC-HS256","A256CBC-HS512");
+            AddToCollection(config.IdTokenEncryptionEncValuesSupported, "A128CBC-HS256", "A256CBC-HS512");
             AddToCollection(config.IdTokenSigningAlgValuesSupported, "RS256");
             config.Issuer = "https://sts.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/";
             config.JwksUri = "JsonWebKeySet.json";
@@ -233,7 +234,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             AddToCollection(config.TokenEndpointAuthSigningAlgValuesSupported, "ES192", "ES256");
             AddToCollection(config.UILocalesSupported, "hak-CN", "en-us");
             config.UserInfoEndpoint = "https://login.microsoftonline.com/add29489-7269-41f4-8841-b63c95564420/openid/userinfo";
-            AddToCollection(config.UserInfoEndpointEncryptionAlgValuesSupported, "ECDH-ES+A128KW","ECDH-ES+A192KW");
+            AddToCollection(config.UserInfoEndpointEncryptionAlgValuesSupported, "ECDH-ES+A128KW", "ECDH-ES+A192KW");
             AddToCollection(config.UserInfoEndpointEncryptionEncValuesSupported, "A256CBC-HS512", "A128CBC-HS256");
             AddToCollection(config.UserInfoEndpointSigningAlgValuesSupported, "ES384", "ES512");
 

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationRetrieverTests.cs
@@ -91,8 +91,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             // for now turn off checking for inner
             var ee = ExpectedException.InvalidOperationException(inner: typeof(CryptographicException));
             ee.IgnoreInnerException = true;
-            await GetConfigurationFromMixedAsync(OpenIdConfigData.OpenIdConnectMetadataBadX509DataString, expectedException: ee);
-            await GetConfigurationFromMixedAsync(OpenIdConfigData.OpenIdConnectMetadataBadBase64DataString, expectedException: ExpectedException.InvalidOperationException(inner: typeof(FormatException)));
+
+            await GetConfigurationFromMixedAsync(OpenIdConfigData.OpenIdConnectMetadataBadX509DataString, expectedException: ExpectedException.NoExceptionExpected);
+            await GetConfigurationFromMixedAsync(OpenIdConfigData.OpenIdConnectMetadataBadBase64DataString, expectedException: ExpectedException.NoExceptionExpected);
 
             TestUtilities.AssertFailIfErrors(context);
         }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMetadataEnd2EndEC.json
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMetadataEnd2EndEC.json
@@ -1,0 +1,15 @@
+﻿{
+  "issuer": "https://sts.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/",
+  "authorization_endpoint": "https://login.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/oauth2/authorize",
+  "token_endpoint": "https://login.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/oauth2/token",
+  "token_endpoint_auth_methods_supported": [ "client_secret_post", "private_key_jwt" ],
+  "jwks_uri": "JsonWebKeySetEnd2EndEC.json",
+  "response_types_supported": [ "code", "id_token", "code id_token" ],
+  "response_modes_supported": [ "query", "fragment", "form_post" ],
+  "subject_types_supported": [ "pairwise" ],
+  "scopes_supported": [ "openid" ],
+  "id_token_signing_alg_values_supported": [ "RS256", "ES256" ],
+  "microsoft_multi_refresh_token": true,
+  "check_session_iframe": "https://login.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/oauth2/checksession",
+  "end_session_endpoint": "https://login.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/oauth2/logout"
+}

--- a/test/Microsoft.IdentityModel.TestUtils/DataSets.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/DataSets.cs
@@ -41,11 +41,15 @@ namespace Microsoft.IdentityModel.TestUtils
         public static JsonWebKey JsonWebKey2;
         public static JsonWebKey JsonWebKeyAdditionalData1;
         public static JsonWebKey JsonWebKeyBadX509Data;
+        public static JsonWebKey JsonWebKeyES256;
+        public static JsonWebKey JsonWebKeyES384;
+        public static JsonWebKey JsonWebKeyES512;
 
         public static JsonWebKeySet JsonWebKeySet1;
         public static JsonWebKeySet JsonWebKeySet2;
         public static JsonWebKeySet JsonWebKeySetX509Data;
         public static JsonWebKeySet JsonWebKeySetAdditionalData1;
+        public static JsonWebKeySet JsonWebKeySetEC;
 
         // interop
         public static string GoogleCertsFile = "google-certs.json";
@@ -167,6 +171,49 @@ namespace Microsoft.IdentityModel.TestUtils
                                             ""use"":""sig""
                                         }";
 
+        public static string JsonWebKeyBadECCurveString =
+                                       @"{
+                                            ""kty"": ""EC"",
+                                            ""alg"": ""ES521"",
+                                            ""use"": ""sig"",
+                                            ""crv"": ""P-999"",
+                                            ""kid"": ""unknownCrv"",
+                                            ""x"": ""AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr"",
+                                            ""y"": ""AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW""
+                                        }";
+
+        public static string JsonWebKeyES256String =
+                                        @"{
+                                            ""kty"": ""EC"",
+                                            ""alg"": ""ES256"",
+                                            ""use"": ""sig"",
+                                            ""crv"": ""P-256"",
+                                            ""kid"": ""JsonWebKeyEcdsa256"",
+                                            ""x"": ""luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA"",
+                                            ""y"": ""tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ""
+                                        }";
+
+        public static string JsonWebKeyES384String =
+                                        @"{
+                                            ""kty"": ""EC"",
+                                            ""alg"": ""ES384"",
+                                            ""use"": ""sig"",
+                                            ""crv"": ""P-384"",
+                                            ""kid"": ""JsonWebKeyEcdsa384"",
+                                            ""x"": ""5mn3HaDoUgdNTFCACaWIvrpriQTloEbMbx4eUu_XvB4pyExig45VIozMnj7FedJg"",
+                                            ""y"": ""Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l""
+                                        }";
+
+        public static string JsonWebKeyES512String =
+                                        @"{
+                                            ""kty"": ""EC"",
+                                            ""alg"": ""ES512"",
+                                            ""use"": ""sig"",
+                                            ""crv"": ""P-521"",
+                                            ""kid"": ""JsonWebKeyEcdsa521"",
+                                            ""x"": ""AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr"",
+                                            ""y"": ""AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW""
+                                        }";
 
         public static string JsonWebKeySetBadRsaExponentString = @"{ ""keys"":[" + JsonWebKeyBadRsaExponentString + "]}";
         public static string JsonWebKeySetBadRsaModulusString = @"{ ""keys"":[" + JsonWebKeyBadRsaModulusString + "]}";
@@ -174,11 +221,13 @@ namespace Microsoft.IdentityModel.TestUtils
         public static string JsonWebKeySetKtyNotRsaString = @"{ ""keys"":[" + JsonWebKeyKtyNotRsaString + "]}";
         public static string JsonWebKeySetUseNotSigString = @"{ ""keys"":[" + JsonWebKeyUseNotSigString + "]}";
         public static string JsonWebKeySetBadX509String = @"{ ""keys"":[" + JsonWebKeyBadX509String + "]}";
+        public static string JsonWebKeySetBadECCurveString = @"{ ""keys"":[" + JsonWebKeyBadECCurveString + "]}";
 
         // Key Sets
         public static string JsonWebKeySet = "JsonWebKeySet.json";
         public static string JsonWebKeySetString1 = @"{ ""keys"":[" + JsonWebKeyString1 + "," + JsonWebKeyString2 + "]}";
         public static string JsonWebKeySetString2 = @"{ ""keys"":[" + JsonWebKeyString2 + "]}";
+        public static string JsonWebKeySetECCString = @"{ ""keys"":[" + JsonWebKeyES256String + "," + JsonWebKeyES384String + "," + JsonWebKeyES512String + "]}";
         public static string JsonWebKeySetAdditionalDataString1 = @"{ ""keys"":[" + JsonWebKeyAdditionalDataString1 + "]" + @", ""additionalProperty"":""additionalValue""}";
         public static string JsonWebKeySetBadFormatingString =
                                             @"{ ""keys"":[
@@ -260,9 +309,47 @@ namespace Microsoft.IdentityModel.TestUtils
 
             JsonWebKey2.X5c.Add(JsonWebKey_X5c_2);
 
+            JsonWebKeyES256 = new JsonWebKey
+            {
+                Alg = "ES256",
+                Crv = "P-256",
+                Kid = "JsonWebKeyEcdsa256",
+                Kty = "EC",
+                Use = "sig",
+                X = "luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA",
+                Y = "tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ"
+            };
+
+            JsonWebKeyES384 = new JsonWebKey
+            {
+                Alg = "ES384",
+                Crv = "P-384",
+                Kid = "JsonWebKeyEcdsa384",
+                Kty = "EC",
+                Use = "sig",
+                X = "5mn3HaDoUgdNTFCACaWIvrpriQTloEbMbx4eUu_XvB4pyExig45VIozMnj7FedJg",
+                Y = "Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l"
+            };
+
+            JsonWebKeyES512 = new JsonWebKey
+            {
+                Alg = "ES512",
+                Crv = "P-521",
+                Kid = "JsonWebKeyEcdsa521",
+                Kty = "EC",
+                Use = "sig",
+                X = "AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr",
+                Y = "AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW"
+            };
+
             JsonWebKeySet1 = new JsonWebKeySet();
             JsonWebKeySet1.Keys.Add(JsonWebKey1);
             JsonWebKeySet1.Keys.Add(JsonWebKey2);
+
+            JsonWebKeySetEC = new JsonWebKeySet();
+            JsonWebKeySetEC.Keys.Add(JsonWebKeyES256);
+            JsonWebKeySetEC.Keys.Add(JsonWebKeyES384);
+            JsonWebKeySetEC.Keys.Add(JsonWebKeyES512);
 
             var jwk = new JsonWebKey
             {

--- a/test/Microsoft.IdentityModel.TestUtils/DataSets.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/DataSets.cs
@@ -50,6 +50,7 @@ namespace Microsoft.IdentityModel.TestUtils
         public static JsonWebKeySet JsonWebKeySetX509Data;
         public static JsonWebKeySet JsonWebKeySetAdditionalData1;
         public static JsonWebKeySet JsonWebKeySetEC;
+        public static JsonWebKeySet JsonWebKeySetOnlyX5t;
 
         // interop
         public static string GoogleCertsFile = "google-certs.json";
@@ -215,6 +216,21 @@ namespace Microsoft.IdentityModel.TestUtils
                                             ""y"": ""AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW""
                                         }";
 
+        public static string JsonWebKeyOnlyX5tString =
+                                        @"{
+                                            ""kty"": ""RSA"",
+                                            ""use"": ""sig"",
+                                            ""kid"":""pqoeamb2e5YVzR6_rqFpiCrFZgw"",
+                                            ""x5t"":""pqoeamb2e5YVzR6_rqFpiCrFZgw""
+                                        }";
+
+        public static string JsonWebKeyNoKtyString =
+                                        @"{ ""e"":""AQAB"",
+                                            ""kid"":""20am7"",
+                                            ""n"":""mhupHfUtg_gHIqwu2wm8CprXY-gKqbPMV6tEYVqkyYrHugzQ_YDYAHr7vWo5Pe_3gIujSFwpqIfXaP8-Fl3O5fQhMo1lMv4DdRabyDLEpv7YO9qoVKTmDOZqYZx-AYBr5x1Zh2xWByI6_0dsPtCjD1pFZfg_SxNEcLPyH1aY6dT8CWYu32qG4O0WF4EihZzMkzSn8fyh8RXbMf5U9Wm2kgb0g8jK62S7MoF4IlhFaJreq898wgUohhPwR8P3X-gk0XQJAFcogEf04Fw4UmKo3z1B6mcNbPRfImhWw4wtLkhp_KIqKNOkMsSpYGSLrCvqQpgK56EJZExrmb7WozjwHw"",
+                                            ""use"":""sig""
+                                        }";
+
         public static string JsonWebKeySetBadRsaExponentString = @"{ ""keys"":[" + JsonWebKeyBadRsaExponentString + "]}";
         public static string JsonWebKeySetBadRsaModulusString = @"{ ""keys"":[" + JsonWebKeyBadRsaModulusString + "]}";
         public static string JsonWebKeySetUseNoKidString = @"{ ""keys"":[" + JsonWebKeyRsaNoKidString + "]}";
@@ -222,6 +238,8 @@ namespace Microsoft.IdentityModel.TestUtils
         public static string JsonWebKeySetUseNotSigString = @"{ ""keys"":[" + JsonWebKeyUseNotSigString + "]}";
         public static string JsonWebKeySetBadX509String = @"{ ""keys"":[" + JsonWebKeyBadX509String + "]}";
         public static string JsonWebKeySetBadECCurveString = @"{ ""keys"":[" + JsonWebKeyBadECCurveString + "]}";
+        public static string JsonWebKeySetOnlyX5tString = @"{ ""keys"":[" + JsonWebKeyOnlyX5tString + "]}";
+        public static string JsonWebKeySetUseNoKtyString = @"{ ""keys"":[" + JsonWebKeyNoKtyString + "]}";
 
         // Key Sets
         public static string JsonWebKeySet = "JsonWebKeySet.json";
@@ -229,6 +247,9 @@ namespace Microsoft.IdentityModel.TestUtils
         public static string JsonWebKeySetString2 = @"{ ""keys"":[" + JsonWebKeyString2 + "]}";
         public static string JsonWebKeySetECCString = @"{ ""keys"":[" + JsonWebKeyES256String + "," + JsonWebKeyES384String + "," + JsonWebKeyES512String + "]}";
         public static string JsonWebKeySetAdditionalDataString1 = @"{ ""keys"":[" + JsonWebKeyAdditionalDataString1 + "]" + @", ""additionalProperty"":""additionalValue""}";
+        public static string JsonWebKeySetOneValidRsaOneInvalidRsaString = @"{ ""keys"":[" + JsonWebKeyFromPingString1 + "," + JsonWebKeyBadRsaExponentString + "]}";
+        public static string JsonWebKeySetOneInvalidEcOneValidEcString = @"{ ""keys"":[" + JsonWebKeyBadECCurveString + "," + JsonWebKeyES256String + "]}";
+        public static string JsonWebKeySetOneValidRsaOneInvalidEcString = @"{ ""keys"":[" + JsonWebKeyFromPingString1 + "," + JsonWebKeyBadECCurveString + "]}";
         public static string JsonWebKeySetBadFormatingString =
                                             @"{ ""keys"":[
                                                 {   ""e"":""AQAB"",
@@ -252,6 +273,22 @@ namespace Microsoft.IdentityModel.TestUtils
                                                     ""use"":""sig""
                                                }
                                             ]}";
+
+        public static string JsonWebKeySetEvoString =
+                                           @"{ ""keys"":[
+                                               {
+                                                   ""kty"":""RSA"",
+                                                   ""use"":""sig"",
+                                                   ""kid"":""HBxl9mAe6gxavCkcoOU2THsDNa0"",
+                                                   ""x5t"":""HBxl9mAe6gxavCkcoOU2THsDNa0"",
+                                                   ""n"":""0afCaiPd_xl_ewZGfOkxKwYPfI4Efu0COfzajK_gnviWk7w3R-88Dmb0j24DSn1qVR3ptCnA1-QUfUMyhvl8pT5-t7oRkLNPzp0hVV-dAG3ZoMaSEMW0wapshA6LVGROpBncDmc66hx5-t3eOFA24fiKfQiv2TJth3Y9jhHnLe7GBOoomWYx_pJiEG3mhYFIt7shaEwNcEjo34vr1WWzRm8D8gogjrJWd1moyeGftWLzvfp9e79QwHYJv907vQbFrT7LYuy8g7-Rpxujgumw2mx7CewcCZXwPiZ-raM3Ap1FhINiGpd5mbbYrFDDFIWAjWPUY6KNvXtc24yUfZr4MQ"",
+                                                   ""e"":""AQAB"",
+                                                   ""x5c"":[
+                                                      ""MIIDBTCCAe2gAwIBAgIQWcq84CdVhKVEcKbZdMOMGjANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDMxNDAwMDAwMFoXDTIxMDMxNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANGnwmoj3f8Zf3sGRnzpMSsGD3yOBH7tAjn82oyv4J74lpO8N0fvPA5m9I9uA0p9alUd6bQpwNfkFH1DMob5fKU+fre6EZCzT86dIVVfnQBt2aDGkhDFtMGqbIQOi1RkTqQZ3A5nOuocefrd3jhQNuH4in0Ir9kybYd2PY4R5y3uxgTqKJlmMf6SYhBt5oWBSLe7IWhMDXBI6N+L69Vls0ZvA/IKII6yVndZqMnhn7Vi8736fXu/UMB2Cb/dO70Gxa0+y2LsvIO/kacbo4LpsNpsewnsHAmV8D4mfq2jNwKdRYSDYhqXeZm22KxQwxSFgI1j1GOijb17XNuMlH2a+DECAwEAAaMhMB8wHQYDVR0OBBYEFIkZ5wrSV8lohIsreOmig7h5wQDkMA0GCSqGSIb3DQEBCwUAA4IBAQAd8sKZLwZBocM4pMIRKarK60907jQCOi1m449WyToUcYPXmU7wrjy9fkYwJdC5sniItVBJ3RIQbF/hyjwnRoIaEcWYMAftBnH+c19WIuiWjR3EHnIdxmSopezl/9FaTNghbKjZtrKK+jL/RdkMY9uWxwUFLjTAtMm24QOt2+CGntBA9ohQUgiML/mlUpf4qEqa2/Lh+bjiHl3smg4TwuIl0i/TMN9Rg7UgQ6BnqfgiuMl6BtBiatNollwgGNI2zJEi47MjdeMf8+C3tXs//asqqlqJCyVLwN7AN47ynYmkl89MleOfKIojhrGRxryZG2nRjD9u/kZbPJ8e3JE9px67""
+                                                   ],
+                                                   ""issuer"":""https://login.microsoftonline.com/{tenantid}/v2.0""
+                                               }
+                                           ]}";
 
         static DataSets()
         {
@@ -415,6 +452,16 @@ namespace Microsoft.IdentityModel.TestUtils
                      N = "ANLFuJO6EoKczde+YP3b1yuz2b46D7Rd7CjrbvKrzbjkH29iRFLBagT7nojwdMOPrsV+WLp/C8lfkRT7UJ38lnQh3m4oEy98HdRRMZh5Vtpbotgt4S/ugh5ansJdHSXSBTxk+X1ZnTzMOUH7ZROpxw3NcX/IFl0sshFlTbebPrDj",
                      Use = "sig",
                  });
+
+            var JsonWebKeyOnlyX5t = new JsonWebKey
+            {
+                Kid = "pqoeamb2e5YVzR6_rqFpiCrFZgw",
+                Kty = "RSA",
+                Use = "sig",
+                X5t = "pqoeamb2e5YVzR6_rqFpiCrFZgw"
+            };
+            JsonWebKeySetOnlyX5t = new JsonWebKeySet();
+            JsonWebKeySetOnlyX5t.Keys.Add(JsonWebKeyOnlyX5t);
         }
     }
 }

--- a/test/Microsoft.IdentityModel.TestUtils/DataSets.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/DataSets.cs
@@ -162,6 +162,14 @@ namespace Microsoft.IdentityModel.TestUtils
                                             ""use"":""sigg""
                                         }";
 
+        public static string JsonWebKeyX509DataString =
+                                        @"{ ""kid"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
+                                            ""kty"":""RSA"",
+                                            ""use"":""sig"",
+                                            ""x5t"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
+                                            ""x5c"":[""MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng""]
+                                        }";
+
         public static string JsonWebKeyBadX509String =
                                         @"{ ""e"":""AQAB"",
                                             ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
@@ -236,6 +244,7 @@ namespace Microsoft.IdentityModel.TestUtils
         public static string JsonWebKeySetUseNoKidString = @"{ ""keys"":[" + JsonWebKeyRsaNoKidString + "]}";
         public static string JsonWebKeySetKtyNotRsaString = @"{ ""keys"":[" + JsonWebKeyKtyNotRsaString + "]}";
         public static string JsonWebKeySetUseNotSigString = @"{ ""keys"":[" + JsonWebKeyUseNotSigString + "]}";
+        public static string JsonWebKeySetX509DataString = @"{ ""keys"":[" + JsonWebKeyX509DataString + "]}";
         public static string JsonWebKeySetBadX509String = @"{ ""keys"":[" + JsonWebKeyBadX509String + "]}";
         public static string JsonWebKeySetBadECCurveString = @"{ ""keys"":[" + JsonWebKeyBadECCurveString + "]}";
         public static string JsonWebKeySetOnlyX5tString = @"{ ""keys"":[" + JsonWebKeyOnlyX5tString + "]}";

--- a/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
@@ -118,7 +118,7 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static SigningCredentials DefaultX509SigningCreds_2048_RsaSha2_Sha2_Public = new SigningCredentials(DefaultX509Key_2048_Public, SecurityAlgorithms.RsaSha256Signature);
 
-        public static string ExpiredX509Data_Public = @"MIIDKTCCAhGgAwIBAgIQWYE2RAW22K1AwRf9VBgsLDANBgkqhkiG9w0BAQsFADAkMSIwIAYDVQQDDBlodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tMB4XDTE3MTEwMjIyNTMwNloXDTE3MTEwMjIzMDI0NVowJDEiMCAGA1UEAwwZaHR0cDovL0RlZmF1bHQuSXNzdWVyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK79bBjoH2zMR2poFZDm7wJjzgp+Nidk8jkrps3iqzqqf1YVFtEtFBng4KE+2jfyaQxS4FO3dnd1Nh7wdCBH/60A0e6uROEBe4L/kydyJS3u2wsz+aabCBJ2M8FVUWziGZ4o2NKwAvRbCWFbsA9irhXTEw3hjqP7DDdjAayztmczG7vgeU10GnEPcYanyrraNRWkVaZGAI6EeFOy4QEYtFLd7N7gb84ScW/h2edVKm5VoYaVXF6KE7gfbMp+uflqJ8hBaLXjFSoXxN3Y6BQqxUGxX4qdAnpuRqDJzYQjDUm81MtD2XIfY46duJDDZOwpRPyXRe2YeJp5rVG5Pr0i7gECAwEAAaNXMFUwDgYDVR0PAQH/BAQDAgWgMCQGA1UdEQQdMBuCGWh0dHA6Ly9EZWZhdWx0Lklzc3Vlci5jb20wHQYDVR0OBBYEFJI/4wsmVjLpK1tRYJ96zKoBULBzMA0GCSqGSIb3DQEBCwUAA4IBAQBUToqoMJ0QJciKd+GRzivq3idPzCEyo4/V2V7B/H5czwzVx+lhn2e/EwCaMBPk3x9C5DQbJdmSp6DoX9VvD2XNOiFFeabBu/w9jhkRiDpOtNnWMJwzjHMAD0f4z8fSO5ZXcvFr2Ze3zGDTEY1vdXkAK2k9WuKu7c9kcoZO55Tads5T15vg4e8OmBq9kcGNEZRt2xBHkjlef0v6gBZ/lFeJHe0qTuKNCiTxJvUfAPnP0sTAdFdsDBt9bqLBHx+Wz/ALj535dUpCi5tXv4bI/t6qgh8toQNvJ7lNMv34W4+CiRYAPR9fK5bGsua+tb1FvfEqXx17yOLLgHgsu8oOsaZo"; 
+        public static string ExpiredX509Data_Public = @"MIIDKTCCAhGgAwIBAgIQWYE2RAW22K1AwRf9VBgsLDANBgkqhkiG9w0BAQsFADAkMSIwIAYDVQQDDBlodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tMB4XDTE3MTEwMjIyNTMwNloXDTE3MTEwMjIzMDI0NVowJDEiMCAGA1UEAwwZaHR0cDovL0RlZmF1bHQuSXNzdWVyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK79bBjoH2zMR2poFZDm7wJjzgp+Nidk8jkrps3iqzqqf1YVFtEtFBng4KE+2jfyaQxS4FO3dnd1Nh7wdCBH/60A0e6uROEBe4L/kydyJS3u2wsz+aabCBJ2M8FVUWziGZ4o2NKwAvRbCWFbsA9irhXTEw3hjqP7DDdjAayztmczG7vgeU10GnEPcYanyrraNRWkVaZGAI6EeFOy4QEYtFLd7N7gb84ScW/h2edVKm5VoYaVXF6KE7gfbMp+uflqJ8hBaLXjFSoXxN3Y6BQqxUGxX4qdAnpuRqDJzYQjDUm81MtD2XIfY46duJDDZOwpRPyXRe2YeJp5rVG5Pr0i7gECAwEAAaNXMFUwDgYDVR0PAQH/BAQDAgWgMCQGA1UdEQQdMBuCGWh0dHA6Ly9EZWZhdWx0Lklzc3Vlci5jb20wHQYDVR0OBBYEFJI/4wsmVjLpK1tRYJ96zKoBULBzMA0GCSqGSIb3DQEBCwUAA4IBAQBUToqoMJ0QJciKd+GRzivq3idPzCEyo4/V2V7B/H5czwzVx+lhn2e/EwCaMBPk3x9C5DQbJdmSp6DoX9VvD2XNOiFFeabBu/w9jhkRiDpOtNnWMJwzjHMAD0f4z8fSO5ZXcvFr2Ze3zGDTEY1vdXkAK2k9WuKu7c9kcoZO55Tads5T15vg4e8OmBq9kcGNEZRt2xBHkjlef0v6gBZ/lFeJHe0qTuKNCiTxJvUfAPnP0sTAdFdsDBt9bqLBHx+Wz/ALj535dUpCi5tXv4bI/t6qgh8toQNvJ7lNMv34W4+CiRYAPR9fK5bGsua+tb1FvfEqXx17yOLLgHgsu8oOsaZo";
         public static X509Certificate2 ExpiredX509Cert_Public = new X509Certificate2(Convert.FromBase64String(ExpiredX509Data_Public));
         public static X509SecurityKey ExpiredX509SecurityKey_Public = new X509SecurityKey(ExpiredX509Cert_Public);
         public static SigningCredentials ExpiredX509SigningCreds_Public = new SigningCredentials(ExpiredX509SecurityKey_Public, SecurityAlgorithms.RsaSha256Signature);
@@ -867,7 +867,7 @@ namespace Microsoft.IdentityModel.TestUtils
                     ""y"": ""AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1"",
                     ""d"": ""{{0}}""
                     }}", curvePointParameter);
-                
+
                 return new JsonWebKey(jsonString);
             }
         }
@@ -901,8 +901,8 @@ namespace Microsoft.IdentityModel.TestUtils
                     X = "luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA",
                     Y = "tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ",
                     D = badPrivateKey,
-                    KeyId = "JsonWebKeyP256_BadPrivateKey",
-                    Kid = "JsonWebKeyP256_BadPrivateKey",
+                    KeyId = "JsonWebKeyEcdsa256_BadPrivateKey",
+                    Kid = "JsonWebKeyEcdsa256_BadPrivateKey",
                     Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
                 };
             }
@@ -950,8 +950,8 @@ namespace Microsoft.IdentityModel.TestUtils
                     Crv = "P-384",
                     X = "5mn3HaDoUgdNTFCACaWIvrpriQTloEbMbx4eUu_XvB4pyExig45VIozMnj7FedJg",
                     Y = "Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l",
-                    KeyId = "JsonWebKeyP384_Public",
-                    Kid = "JsonWebKeyP384_Public",
+                    KeyId = "JsonWebKeyEcdsa384_Public",
+                    Kid = "JsonWebKeyEcdsa384_Public",
                     Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
                 };
             }
@@ -967,8 +967,8 @@ namespace Microsoft.IdentityModel.TestUtils
                     X = "AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr",
                     Y = "AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW",
                     D = "AWAduQ9Eu0fw2X_jBfYcSCc3jLfUuQY9Un3pQXHay4BlIhRObnNZAWPWOZccbP0ApfQLPHEAuByMtHv5D6sMVbCz",
-                    KeyId = "JsonWebKeyP521",
-                    Kid = "JsonWebKeyP521",
+                    KeyId = "JsonWebKeyEcdsa521",
+                    Kid = "JsonWebKeyEcdsa521",
                     Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
                 };
             }
@@ -983,8 +983,8 @@ namespace Microsoft.IdentityModel.TestUtils
                     Crv = "P-521",
                     X = "AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr",
                     Y = "AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW",
-                    KeyId = "JsonWebKeyP521_Public",
-                    Kid = "JsonWebKeyP521_Public",
+                    KeyId = "JsonWebKeyEcdsa521_Public",
+                    Kid = "JsonWebKeyEcdsa521_Public",
                     Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
                 };
             }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             {
                 // Received json web key only has an x5t property and it can't be used for signature validation as it can't be resolved into a SecurityKey, without user's custom code.
                 // This test proves that the scenario described above is possible using extensibility.
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
+                JsonWebKeySet.DefaultSkipUnresolvedJsonWebKeys = false;
                 var signingKeys = new JsonWebKeySet(DataSets.JsonWebKeySetOnlyX5tString).GetSigningKeys();
 
                 var tokenValidationParameters = new TokenValidationParameters()
@@ -165,7 +165,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             finally
             {
                 // revert back to default
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
+                JsonWebKeySet.DefaultSkipUnresolvedJsonWebKeys = true;
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -212,7 +212,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
 
             // revert to default
-            JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
             if (theoryData.SetEcdsaAdapterToNull)
             {
                 try
@@ -235,8 +234,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 var ecdsaAdapter = new ECDsaAdapter();
                 var theoryData = new TheoryData<JsonWebKeySetTheoryData>();
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
-                var jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNotSigString);
+                var jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNotSigString) { SkipUnresolvedJsonWebKeys = true };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     First = true,
@@ -245,8 +243,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "ZeroKeysWithSigAsUseSkipUnresolved",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNotSigString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNotSigString) { SkipUnresolvedJsonWebKeys = false };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -254,8 +251,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "ZeroKeysWithSigAsUse",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNoKtyString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNoKtyString) { SkipUnresolvedJsonWebKeys = true };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -263,8 +259,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "KeysWithoutKtySkipUnresolved",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNoKtyString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNoKtyString) { SkipUnresolvedJsonWebKeys = false };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -272,8 +267,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "KeysWithoutKty",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetEvoString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetEvoString) { SkipUnresolvedJsonWebKeys = false };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -281,8 +275,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "EvoSigningKey",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetKtyNotRsaString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetKtyNotRsaString) { SkipUnresolvedJsonWebKeys = true };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -290,8 +283,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "NonRsaNonEcKeySkipUnresolved",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetKtyNotRsaString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetKtyNotRsaString) { SkipUnresolvedJsonWebKeys = false };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -299,8 +291,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "NonRsaNonEcKey",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOnlyX5tString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOnlyX5tString) { SkipUnresolvedJsonWebKeys = true };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -308,8 +299,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "JsonWebKeyNotInvalidNotResolvedSkipUnresolved"
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOnlyX5tString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOnlyX5tString) { SkipUnresolvedJsonWebKeys = false };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -317,8 +307,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "JsonWebKeyNotInvalidNotResolved"
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidRsaString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidRsaString) { SkipUnresolvedJsonWebKeys = true };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -326,8 +315,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "OneValidAndOneInvalidRsaSkipUnresolved",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidRsaString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidRsaString) { SkipUnresolvedJsonWebKeys = false };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -335,8 +323,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "OneValidAndOneInvalidRsa",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString) { SkipUnresolvedJsonWebKeys = true };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -344,8 +331,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "OneValidAndOneInvalidEcSkipUnresolved",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString) { SkipUnresolvedJsonWebKeys = false };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -353,8 +339,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "OneValidAndOneInvalidEC",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidEcString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidEcString) { SkipUnresolvedJsonWebKeys = true };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -362,8 +347,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "ValidRsaInvalidEcSkipUnresolved",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidEcString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidEcString) { SkipUnresolvedJsonWebKeys = false };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -371,8 +355,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "ValidRsaInvalidEc",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetX509DataString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetX509DataString) { SkipUnresolvedJsonWebKeys = false };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -380,8 +363,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "ValidX5c",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetBadX509String);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetBadX509String) { SkipUnresolvedJsonWebKeys = true };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -389,8 +371,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "InvalidX5cSkipUnresolvedAddRsa",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetBadX509String);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetBadX509String) { SkipUnresolvedJsonWebKeys = false };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -398,8 +379,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "InvalidX5c",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString) { SkipUnresolvedJsonWebKeys = true };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
@@ -408,8 +388,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "ECDsaAdapterIsNotSupportedSkipUnresolved",
                 });
 
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
-                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString);
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString) { SkipUnresolvedJsonWebKeys = false };
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
@@ -242,7 +242,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     First = true,
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>(),
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "ZeroKeysWithSigAsUseSkipUnresolved",
                 });
 
@@ -252,7 +251,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "ZeroKeysWithSigAsUse",
                 });
 
@@ -262,7 +260,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>(),
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "KeysWithoutKtySkipUnresolved",
                 });
 
@@ -272,7 +269,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "KeysWithoutKty",
                 });
 
@@ -282,7 +278,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0), CreateX509SecurityKey(jsonWebKeySet, 0) },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "EvoSigningKey",
                 });
 
@@ -292,7 +287,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>(),
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "NonRsaNonEcKeySkipUnresolved",
                 });
 
@@ -302,7 +296,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "NonRsaNonEcKey",
                 });
 
@@ -312,7 +305,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>(),
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "JsonWebKeyNotInvalidNotResolvedSkipUnresolved"
                 });
 
@@ -322,7 +314,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "JsonWebKeyNotInvalidNotResolved"
                 });
 
@@ -332,7 +323,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0) },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "OneValidAndOneInvalidRsaSkipUnresolved",
                 });
 
@@ -342,7 +332,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0], (jsonWebKeySet.Keys as List<JsonWebKey>)[1] },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "OneValidAndOneInvalidRsa",
                 });
 
@@ -352,7 +341,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateEcdsaSecurityKey(jsonWebKeySet, 1, ecdsaAdapter) },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "OneValidAndOneInvalidEcSkipUnresolved",
                 });
 
@@ -362,7 +350,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0], CreateEcdsaSecurityKey(jsonWebKeySet, 1, ecdsaAdapter) },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "OneValidAndOneInvalidEC",
                 });
 
@@ -372,7 +359,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0) },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "ValidRsaInvalidEcSkipUnresolved",
                 });
 
@@ -382,7 +368,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0), (jsonWebKeySet.Keys as List<JsonWebKey>)[1] },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "ValidRsaInvalidEc",
                 });
 
@@ -392,7 +377,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateX509SecurityKey(jsonWebKeySet, 0) },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "ValidX5c",
                 });
 
@@ -402,7 +386,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0) },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "InvalidX5cSkipUnresolvedAddRsa",
                 });
 
@@ -412,7 +395,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0), (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "InvalidX5c",
                 });
 
@@ -422,7 +404,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>(),
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     SetEcdsaAdapterToNull = true,
                     TestId = "ECDsaAdapterIsNotSupportedSkipUnresolved",
                 });
@@ -433,7 +414,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0], (jsonWebKeySet.Keys as List<JsonWebKey>)[1] },
-                    ExpectedException = ExpectedException.NoExceptionExpected,
                     SetEcdsaAdapterToNull = true,
                     TestId = "ECDsaAdapterIsNotSupported",
                 });

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
@@ -94,6 +94,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     dataset.Add(DataSets.JsonWebKeySetECCString, DataSets.JsonWebKeySetEC, setting, ExpectedException.NoExceptionExpected);
                     dataset.Add(DataSets.JsonWebKeySetBadECCurveString, null, setting, ExpectedException.NoExceptionExpected);
                     dataset.Add(DataSets.JsonWebKeySetOnlyX5tString, DataSets.JsonWebKeySetOnlyX5t, setting, ExpectedException.NoExceptionExpected);
+                    dataset.Add(DataSets.JsonWebKeySetX509DataString, DataSets.JsonWebKeySetX509Data, setting, ExpectedException.NoExceptionExpected);
                 }
 
                 return dataset;
@@ -140,7 +141,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 // Received json web key only has an x5t property and it can't be used for signature validation as it can't be resolved into a SecurityKey, without user's custom code.
                 // This test proves that the scenario described above is possible using extensibility.
                 JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
-                var signingKeys = DataSets.JsonWebKeySetOnlyX5t.GetSigningKeys();
+                var signingKeys = new JsonWebKeySet(DataSets.JsonWebKeySetOnlyX5tString).GetSigningKeys();
 
                 var tokenValidationParameters = new TokenValidationParameters()
                 {
@@ -196,8 +197,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             var context = TestUtilities.WriteHeader($"{this}.GetSigningKeys", theoryData);
             try
             {
-                JsonWebKeySet.SkipUnresolvedJsonWebKeys = theoryData.SkipUnresolvedJsonWebKeys;
-
                 if (theoryData.SetEcdsaAdapterToNull)
                     JsonWebKeySet.ECDsaAdapter = null;
 
@@ -236,203 +235,203 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 var ecdsaAdapter = new ECDsaAdapter();
                 var theoryData = new TheoryData<JsonWebKeySetTheoryData>();
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
                 var jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNotSigString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     First = true,
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = true,
                     ExpectedSigningKeys = new List<SecurityKey>(),
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "ZeroKeysWithSigAsUseSkipUnresolved",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNotSigString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = false,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "ZeroKeysWithSigAsUse",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNoKtyString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = true,
                     ExpectedSigningKeys = new List<SecurityKey>(),
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "KeysWithoutKtySkipUnresolved",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNoKtyString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = false,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "KeysWithoutKty",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetEvoString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = false,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0), CreateX509SecurityKey(jsonWebKeySet, 0) },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "EvoSigningKey",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetKtyNotRsaString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = true,
                     ExpectedSigningKeys = new List<SecurityKey>(),
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "NonRsaNonEcKeySkipUnresolved",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetKtyNotRsaString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = false,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "NonRsaNonEcKey",
                 });
 
-                jsonWebKeySet = DataSets.JsonWebKeySetOnlyX5t;
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOnlyX5tString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = true,
                     ExpectedSigningKeys = new List<SecurityKey>(),
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "JsonWebKeyNotInvalidNotResolvedSkipUnresolved"
                 });
 
-                jsonWebKeySet = DataSets.JsonWebKeySetOnlyX5t;
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOnlyX5tString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = false,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "JsonWebKeyNotInvalidNotResolved"
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidRsaString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = true,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0) },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "OneValidAndOneInvalidRsaSkipUnresolved",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidRsaString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = false,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0], (jsonWebKeySet.Keys as List<JsonWebKey>)[1] },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "OneValidAndOneInvalidRsa",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = true,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateEcdsaSecurityKey(jsonWebKeySet, 1, ecdsaAdapter) },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "OneValidAndOneInvalidEcSkipUnresolved",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = false,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0], CreateEcdsaSecurityKey(jsonWebKeySet, 1, ecdsaAdapter) },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "OneValidAndOneInvalidEC",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidEcString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = true,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0) },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "ValidRsaInvalidEcSkipUnresolved",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidEcString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = false,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0), (jsonWebKeySet.Keys as List<JsonWebKey>)[1] },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "ValidRsaInvalidEc",
                 });
 
-                jsonWebKeySet = DataSets.JsonWebKeySetX509Data;
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetX509DataString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = false,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateX509SecurityKey(jsonWebKeySet, 0) },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "ValidX5c",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetBadX509String);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = true,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0) },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "InvalidX5cSkipUnresolvedAddRsa",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetBadX509String);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = false,
                     ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0), (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "InvalidX5c",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = true;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = true,
                     ExpectedSigningKeys = new List<SecurityKey>(),
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     SetEcdsaAdapterToNull = true,
                     TestId = "ECDsaAdapterIsNotSupportedSkipUnresolved",
                 });
 
+                JsonWebKeySet.SkipUnresolvedJsonWebKeys = false;
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
                     JsonWebKeySet = jsonWebKeySet,
-                    SkipUnresolvedJsonWebKeys = false,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0], (jsonWebKeySet.Keys as List<JsonWebKey>)[1] },
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     SetEcdsaAdapterToNull = true,
@@ -482,8 +481,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         public class JsonWebKeySetTheoryData : TheoryDataBase
         {
             public JsonWebKeySet JsonWebKeySet { get; set; }
-
-            public bool SkipUnresolvedJsonWebKeys { get; set; } = false;
 
             public List<SecurityKey> ExpectedSigningKeys { get; set; }
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.IO;
+using System.Security.Cryptography;
 using Microsoft.IdentityModel.TestUtils;
 using Newtonsoft.Json;
 using Xunit;
@@ -87,6 +88,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     dataset.Add(DataSets.JsonWebKeySetKtyNotRsaString, null, setting, ExpectedException.NoExceptionExpected);
                     dataset.Add(DataSets.JsonWebKeySetUseNotSigString, null, setting, ExpectedException.NoExceptionExpected);
                     dataset.Add(DataSets.JsonWebKeySetBadX509String, null, setting, ExpectedException.InvalidOperationException(substringExpected: "IDX10802:", inner: typeof(FormatException)));
+                    dataset.Add(DataSets.JsonWebKeySetECCString, DataSets.JsonWebKeySetEC, setting, ExpectedException.NoExceptionExpected);
+                    dataset.Add(DataSets.JsonWebKeySetBadECCurveString, null, setting, ExpectedException.InvalidOperationException(substringExpected: "IDX10807:", inner: typeof(CryptographicException)));
                 }
 
                 return dataset;

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
@@ -172,9 +172,9 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNoKtyString);
                 theoryData.Add(new JsonWebKeySetTheoryData
                 {
-                    First = true,
                     JsonWebKeySet = jsonWebKeySet,
                     ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
+                    ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = "KeysWithoutKty",
                 });
 


### PR DESCRIPTION
* Refactored JsonWebKeySet.GetSigningKeys() method and added support for JWKs with 'kty' = 'EC'.
* Unresolved JsonWebKeys will be skipped by default. `SkipUnresolvedJsonWebKeys` flag controls whether unresolved JsonWebKeys will be included in the resulting collection of GetSigningKeys method.
* Adding only the first certificate from the x5c certificate chain as a SecurityKey.