### PR TITLE
JwtHeader default constructor now sets the 'Alg' property to SecurityAlgorithms.None

### DIFF
--- a/src/System.IdentityModel.Tokens.Jwt/JwtHeader.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtHeader.cs
@@ -45,6 +45,11 @@ namespace System.IdentityModel.Tokens.Jwt
         public JwtHeader()
             : base(StringComparer.Ordinal)
         {
+            // Since this constructor is used by JsonConvert.DeserializeObject, it is possible that the serialization order of the JwtHeader
+            // will be different from the original JSON that was used for deserialization. This can occur because setting the 'Alg' property
+            // explicitly results in it being the first to be serialized, even though it may not necessarily be the first claim present in the 
+            // original JWT header.
+            Alg = SecurityAlgorithms.None;
         }
 
         /// <summary>

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtHeaderTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtHeaderTests.cs
@@ -45,7 +45,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             var jwtHeader = new JwtHeader();
 
             Assert.True(jwtHeader.Typ == null, "jwtHeader.Typ != null");
-            Assert.True(jwtHeader.Alg == null, "jwtHeader.Alg != null");
+            Assert.True(jwtHeader.Alg.Equals(SecurityAlgorithms.None), "!jwtHeader.Alg.Equals(SecurityAlgorithms.None)");
             Assert.True(jwtHeader.SigningCredentials == null, "jwtHeader.SigningCredentials != null");
             Assert.True(jwtHeader.Kid == null, "jwtHeader.Kid == null");
             Assert.True(jwtHeader.Comparer.GetType() == StringComparer.Ordinal.GetType(), "jwtHeader.Comparer.GetType() != StringComparer.Ordinal.GetType()");


### PR DESCRIPTION
Fixes #1092.

The 'Alg' header claim is required according to the [JWS RFC](https://tools.ietf.org/html/rfc7515#section-4.1.1), so we should not be allowing the creation of an empty JWT header.

Suggested fix for the 6x release: #1144.