### PR TITLE
ConfigurationManager no longer throws if _configRetriever fails but _currentConfiguration is not null

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -199,7 +199,10 @@ namespace Microsoft.IdentityModel.Protocols
                     catch (Exception ex)
                     {
                         _syncAfter = DateTimeUtil.Add(now.UtcDateTime, _automaticRefreshInterval < _refreshInterval ? _automaticRefreshInterval : _refreshInterval);
-                        throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX20803, (_metadataAddress ?? "null")), ex));
+                        if (_currentConfiguration == null) // Throw an exception if there's no configuration to return.
+                            throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX20803, (_metadataAddress ?? "null")), ex));
+                        else
+                            LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX20806, (_metadataAddress ?? "null")), ex));
                     }
                 }
 

--- a/src/Microsoft.IdentityModel.Protocols/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols/LogMessages.cs
@@ -48,6 +48,8 @@ namespace Microsoft.IdentityModel.Protocols
         internal const string IDX20803 = "IDX20803: Unable to obtain configuration from: '{0}'.";
         internal const string IDX20804 = "IDX20804: Unable to retrieve document from: '{0}'.";
         internal const string IDX20805 = "IDX20805: Obtaining information from metadata endpoint: '{0}'.";
+        internal const string IDX20806 = "IDX20806: Unable to obtain an updated configuration from: '{0}'. Returning the current configuration.";
+        internal const string IDX20807 = "IDX20807: Unable to retrieve document from: '{0}'. HttpResponseMessage: '{1}', HttpResponseMessage.Content: '{2}'.";
 #pragma warning restore 1591
     }
 }


### PR DESCRIPTION
Fixes #1111 and #1112.