### PR TITLE
 Add RSA-PSS support

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -290,10 +290,30 @@ namespace Microsoft.IdentityModel.Tokens
 
 #if NET461 || NETSTANDARD1_4 || NETSTANDARD2_0
         private HashAlgorithmName HashAlgorithmName { get; set; }
+
+        private RSASignaturePadding RSASignaturePadding { get; set; }
 #endif
 
         private void Initialize(RSA rsa, string algorithm)
         {
+
+#if NET461 || NETSTANDARD1_4 || NETSTANDARD2_0
+            if (algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha256) ||
+                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha256Signature) ||
+                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha384) ||
+                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha384Signature) ||
+                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha512) ||
+                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha512Signature))
+            {
+                RSASignaturePadding = RSASignaturePadding.Pss;
+            }
+            else
+            {
+                // default RSASignaturePadding for other supported RSA algorithms is Pkcs1
+                RSASignaturePadding = RSASignaturePadding.Pkcs1;
+            }
+#endif
+
             // This case is the result of a calling
             // X509Certificate2.GetPrivateKey OR X509Certificate2.GetPublicKey.Key
             // These calls return an AsymmetricAlgorithm which doesn't have API's to do much and need to be cast.
@@ -366,7 +386,7 @@ namespace Microsoft.IdentityModel.Tokens
 #if NET461 || NETSTANDARD1_4 || NETSTANDARD2_0
         private byte[] SignWithRsa(byte[] bytes)
         {
-            return RSA.SignHash(HashAlgorithm.ComputeHash(bytes), HashAlgorithmName, RSASignaturePadding.Pkcs1);
+            return RSA.SignHash(HashAlgorithm.ComputeHash(bytes), HashAlgorithmName, RSASignaturePadding);
         }
 #endif
 
@@ -394,7 +414,7 @@ namespace Microsoft.IdentityModel.Tokens
 #if NET461 || NETSTANDARD1_4 || NETSTANDARD2_0
         private bool VerifyWithRsa(byte[] bytes, byte[] signature)
         {
-            return RSA.VerifyHash(HashAlgorithm.ComputeHash(bytes), signature, HashAlgorithmName, RSASignaturePadding.Pkcs1);
+            return RSA.VerifyHash(HashAlgorithm.ComputeHash(bytes), signature, HashAlgorithmName, RSASignaturePadding);
         }
 #endif
 

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -197,7 +197,6 @@ namespace Microsoft.IdentityModel.Tokens
                 case SecurityAlgorithms.RsaSha256Signature:
                 case SecurityAlgorithms.RsaSsaPssSha256:
                 case SecurityAlgorithms.RsaSsaPssSha256Signature:
-
                     return HashAlgorithmName.SHA256;
 
                 case SecurityAlgorithms.EcdsaSha384:

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -57,12 +57,12 @@ namespace Microsoft.IdentityModel.Tokens
             { SecurityAlgorithms.RsaSha256Signature, 2048 },
             { SecurityAlgorithms.RsaSha384Signature, 2048 },
             { SecurityAlgorithms.RsaSha512Signature, 2048 },
-            { SecurityAlgorithms.RsaSsaPssSha256, 2048 },
-            { SecurityAlgorithms.RsaSsaPssSha384, 2048 },
-            { SecurityAlgorithms.RsaSsaPssSha512, 2048 },
-            { SecurityAlgorithms.RsaSsaPssSha256Signature, 2048 },
-            { SecurityAlgorithms.RsaSsaPssSha384Signature, 2048 },
-            { SecurityAlgorithms.RsaSsaPssSha512Signature, 2048 }
+            { SecurityAlgorithms.RsaSsaPssSha256, 528 },
+            { SecurityAlgorithms.RsaSsaPssSha384, 784 },
+            { SecurityAlgorithms.RsaSsaPssSha512, 1040 },
+            { SecurityAlgorithms.RsaSsaPssSha256Signature, 528 },
+            { SecurityAlgorithms.RsaSsaPssSha384Signature, 784 },
+            { SecurityAlgorithms.RsaSsaPssSha512Signature, 1040 }
         };
 
         /// <summary>
@@ -79,12 +79,12 @@ namespace Microsoft.IdentityModel.Tokens
             { SecurityAlgorithms.RsaSha256Signature, 1024 },
             { SecurityAlgorithms.RsaSha384Signature, 1024 },
             { SecurityAlgorithms.RsaSha512Signature, 1024 },
-            { SecurityAlgorithms.RsaSsaPssSha256, 1024 },
-            { SecurityAlgorithms.RsaSsaPssSha384, 1024 },
-            { SecurityAlgorithms.RsaSsaPssSha512, 1024 },
-            { SecurityAlgorithms.RsaSsaPssSha256Signature, 1024 },
-            { SecurityAlgorithms.RsaSsaPssSha384Signature, 1024 },
-            { SecurityAlgorithms.RsaSsaPssSha512Signature, 1024 }
+            { SecurityAlgorithms.RsaSsaPssSha256, 528 },
+            { SecurityAlgorithms.RsaSsaPssSha384, 784 },
+            { SecurityAlgorithms.RsaSsaPssSha512, 1040 },
+            { SecurityAlgorithms.RsaSsaPssSha256Signature, 528 },
+            { SecurityAlgorithms.RsaSsaPssSha384Signature, 784 },
+            { SecurityAlgorithms.RsaSsaPssSha512Signature, 1040 }
         };
 
         internal AsymmetricSignatureProvider(SecurityKey key, string algorithm, CryptoProviderFactory cryptoProviderFactory)

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -56,7 +56,13 @@ namespace Microsoft.IdentityModel.Tokens
             { SecurityAlgorithms.RsaSha512, 2048 },
             { SecurityAlgorithms.RsaSha256Signature, 2048 },
             { SecurityAlgorithms.RsaSha384Signature, 2048 },
-            { SecurityAlgorithms.RsaSha512Signature, 2048 }
+            { SecurityAlgorithms.RsaSha512Signature, 2048 },
+            { SecurityAlgorithms.RsaSsaPssSha256, 2048 },
+            { SecurityAlgorithms.RsaSsaPssSha384, 2048 },
+            { SecurityAlgorithms.RsaSsaPssSha512, 2048 },
+            { SecurityAlgorithms.RsaSsaPssSha256Signature, 2048 },
+            { SecurityAlgorithms.RsaSsaPssSha384Signature, 2048 },
+            { SecurityAlgorithms.RsaSsaPssSha512Signature, 2048 }
         };
 
         /// <summary>
@@ -72,7 +78,13 @@ namespace Microsoft.IdentityModel.Tokens
             { SecurityAlgorithms.RsaSha512, 1024 },
             { SecurityAlgorithms.RsaSha256Signature, 1024 },
             { SecurityAlgorithms.RsaSha384Signature, 1024 },
-            { SecurityAlgorithms.RsaSha512Signature, 1024 }
+            { SecurityAlgorithms.RsaSha512Signature, 1024 },
+            { SecurityAlgorithms.RsaSsaPssSha256, 1024 },
+            { SecurityAlgorithms.RsaSsaPssSha384, 1024 },
+            { SecurityAlgorithms.RsaSsaPssSha512, 1024 },
+            { SecurityAlgorithms.RsaSsaPssSha256Signature, 1024 },
+            { SecurityAlgorithms.RsaSsaPssSha384Signature, 1024 },
+            { SecurityAlgorithms.RsaSsaPssSha512Signature, 1024 }
         };
 
         internal AsymmetricSignatureProvider(SecurityKey key, string algorithm, CryptoProviderFactory cryptoProviderFactory)
@@ -183,18 +195,25 @@ namespace Microsoft.IdentityModel.Tokens
                 case SecurityAlgorithms.EcdsaSha256Signature:
                 case SecurityAlgorithms.RsaSha256:
                 case SecurityAlgorithms.RsaSha256Signature:
+                case SecurityAlgorithms.RsaSsaPssSha256:
+                case SecurityAlgorithms.RsaSsaPssSha256Signature:
+
                     return HashAlgorithmName.SHA256;
 
                 case SecurityAlgorithms.EcdsaSha384:
                 case SecurityAlgorithms.EcdsaSha384Signature:
                 case SecurityAlgorithms.RsaSha384:
                 case SecurityAlgorithms.RsaSha384Signature:
+                case SecurityAlgorithms.RsaSsaPssSha384:
+                case SecurityAlgorithms.RsaSsaPssSha384Signature:
                     return HashAlgorithmName.SHA384;
 
                 case SecurityAlgorithms.EcdsaSha512:
                 case SecurityAlgorithms.EcdsaSha512Signature:
                 case SecurityAlgorithms.RsaSha512:
                 case SecurityAlgorithms.RsaSha512Signature:
+                case SecurityAlgorithms.RsaSsaPssSha512:
+                case SecurityAlgorithms.RsaSsaPssSha512Signature:
                     return HashAlgorithmName.SHA512;
             }
 

--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -173,15 +173,15 @@ namespace Microsoft.IdentityModel.Tokens
                 return keyWrapProvider;
             }
 
-            if (key is RsaSecurityKey rsaKey && SupportedAlgorithms.IsSupportedRsaAlgorithm(algorithm))
+            if (key is RsaSecurityKey rsaKey && SupportedAlgorithms.IsSupportedRsaAlgorithm(algorithm, rsaKey))
                 return new RsaKeyWrapProvider(key, algorithm, willUnwrap);
 
-            if (key is X509SecurityKey x509Key && SupportedAlgorithms.IsSupportedRsaAlgorithm(algorithm))
+            if (key is X509SecurityKey x509Key && SupportedAlgorithms.IsSupportedRsaAlgorithm(algorithm, x509Key))
                 return new RsaKeyWrapProvider(x509Key, algorithm, willUnwrap);
 
             if (key is JsonWebKey jsonWebKey)
             {
-                if (jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.RSA && SupportedAlgorithms.IsSupportedRsaAlgorithm(algorithm))
+                if (jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.RSA && SupportedAlgorithms.IsSupportedRsaAlgorithm(algorithm, key))
                 {
                     return new RsaKeyWrapProvider(jsonWebKey, algorithm, willUnwrap);
                 }

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -185,7 +185,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10689 = "IDX10689: Unable to create an ECDsa object. See inner exception for more details.";
         public const string IDX10690 = "IDX10690: ECDsa creation is not supported by NETSTANDARD1.4, when running on platforms other than Windows. For more details, see https://aka.ms/IdentityModel/create-ecdsa";
         public const string IDX10691 = "IDX10691: Unable to create an ECDsa object, internal CreateECDsaFunction is not available.";
-        public const string IDX10692 = "IDX10692: The RSASSA-PSS signature algorithm is not supported on NET45 and NET451 targets. The list of supported algorithms is available here: https://aka.ms/IdentityModel/supported-algorithms";
+        public const string IDX10692 = "IDX10692: The RSASS-PSS signature algorithm is not available on .NET 4.5 and .NET 4.5.1 targets. The list of supported algorithms is available here: https://aka.ms/IdentityModel/supported-algorithms";
         public const string IDX10693 = "IDX10693: RSACryptoServiceProvider doesn't support the RSASSA-PSS signature algorithm. The list of supported algorithms is available here: https://aka.ms/IdentityModel/supported-algorithms";
 
         // security keys

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -129,7 +129,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10628 = "IDX10628: Cannot set the MinimumSymmetricKeySizeInBits to less than '{0}'.";
         public const string IDX10630 = "IDX10630: The '{0}' for signing cannot be smaller than '{1}' bits. KeySize: '{2}'.";
         public const string IDX10631 = "IDX10631: The '{0}' for verifying cannot be smaller than '{1}' bits. KeySize: '{2}'.";
-        public const string IDX10634 = "IDX10634: Unable to create the SignatureProvider.\nAlgorithm: '{0}', SecurityKey: '{1}'\n is not supported.";
+        public const string IDX10634 = "IDX10634: Unable to create the SignatureProvider.\nAlgorithm: '{0}', SecurityKey: '{1}'\n is not supported. The list of supported algorithms is available here: https://aka.ms/IdentityModel/supported-algorithms";
         public const string IDX10635 = "IDX10635: Unable to create signature. '{0}' returned a null '{1}'. SecurityKey: '{2}', Algorithm: '{3}'";
         public const string IDX10636 = "IDX10636: CryptoProviderFactory.CreateForVerifying returned null for key: '{0}', signatureAlgorithm: '{1}'.";
         public const string IDX10638 = "IDX10638: Cannot create the SignatureProvider, 'key.HasPrivateKey' is false, cannot create signatures. Key: {0}.";
@@ -185,6 +185,8 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10689 = "IDX10689: Unable to create an ECDsa object. See inner exception for more details.";
         public const string IDX10690 = "IDX10690: ECDsa creation is not supported by NETSTANDARD1.4, when running on platforms other than Windows. For more details, see https://aka.ms/IdentityModel/create-ecdsa";
         public const string IDX10691 = "IDX10691: Unable to create an ECDsa object, internal CreateECDsaFunction is not available.";
+        public const string IDX10692 = "IDX10692: The RSASSA-PSS signature algorithm is not supported on NET45 and NET451 targets. The list of supported algorithms is available here: https://aka.ms/IdentityModel/supported-algorithms";
+        public const string IDX10693 = "IDX10693: RSACryptoServiceProvider doesn't support the RSASSA-PSS signature algorithm. The list of supported algorithms is available here: https://aka.ms/IdentityModel/supported-algorithms";
 
         // security keys
         public const string IDX10700 = "IDX10700: Invalid RsaParameters: '{0}'. Both modulus and exponent should be present";

--- a/src/Microsoft.IdentityModel.Tokens/SupportedAlgorithms.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SupportedAlgorithms.cs
@@ -201,7 +201,7 @@ namespace Microsoft.IdentityModel.Tokens
                 LogHelper.LogExceptionMessage(new PlatformNotSupportedException(LogMessages.IDX10693));
                 return false;
             }
-            else if (key is X509SecurityKey x509P && x509P.PublicKey is RSACryptoServiceProvider)
+            else if (key is X509SecurityKey x509SecurityKey && x509SecurityKey.PublicKey is RSACryptoServiceProvider)
             {
                 LogHelper.LogExceptionMessage(new PlatformNotSupportedException(LogMessages.IDX10693));
                 return false;

--- a/src/Microsoft.IdentityModel.Tokens/SupportedAlgorithms.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SupportedAlgorithms.cs
@@ -187,23 +187,18 @@ namespace Microsoft.IdentityModel.Tokens
         {
 #if NET45 || NET451
             // RSA-PSS is not available on .NET 4.5 and .NET 4.5.1
-            LogHelper.LogExceptionMessage(new PlatformNotSupportedException(LogMessages.IDX10692));
+            LogHelper.LogInformation(LogMessages.IDX10692);
             return false;
 #elif NET461 || NETSTANDARD2_0
             // RSACryptoServiceProvider doesn't support RSA-PSS
             if (key is RsaSecurityKey rsa && rsa.Rsa is RSACryptoServiceProvider)
             {
-                LogHelper.LogExceptionMessage(new PlatformNotSupportedException(LogMessages.IDX10693));
-                return false;
-            }
-            else if (key is X509SecurityKey x509 && x509.PrivateKey is RSACryptoServiceProvider)
-            {
-                LogHelper.LogExceptionMessage(new PlatformNotSupportedException(LogMessages.IDX10693));
+                LogHelper.LogInformation(LogMessages.IDX10693);
                 return false;
             }
             else if (key is X509SecurityKey x509SecurityKey && x509SecurityKey.PublicKey is RSACryptoServiceProvider)
             {
-                LogHelper.LogExceptionMessage(new PlatformNotSupportedException(LogMessages.IDX10693));
+                LogHelper.LogInformation(LogMessages.IDX10693);
                 return false;
             }
             else

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -586,7 +586,34 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             ValidAudience = "Audience",
                             ValidIssuer = "Issuer"
                         }
+                    },
+
+ #if NET461 || NETCOREAPP2_0
+                    // RsaPss is not supported on .NET < 4.6
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "RsaPss",
+                        Payload = Default.PayloadString,
+                        //RsaPss produces different signatures
+                        PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
+                        {
+                            { typeof(JsonWebToken), new List<string> { "EncodedToken", "EncodedSignature" } },
+                        },
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Claims = Default.PayloadDictionary,
+                            SigningCredentials = new SigningCredentials(Default.AsymmetricSigningKey, SecurityAlgorithms.RsaSsaPssSha256),
+                        },
+                        JsonWebTokenHandler = new JsonWebTokenHandler(),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = Default.AsymmetricSigningKey,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            ValidateIssuer = false,
+                        }
                     }
+#endif
                 };
             }
         }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTestData.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTestData.cs
@@ -102,6 +102,22 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             { SecurityAlgorithms.RsaSha512Signature, SecurityAlgorithms.RsaSha512Signature },
         };
 
+        public static List<Tuple<string, string>> RsaPssSigningAlgorithms = new List<Tuple<string, string>>
+        {
+            { SecurityAlgorithms.RsaSsaPssSha256, SecurityAlgorithms.RsaSsaPssSha256 },
+            { SecurityAlgorithms.RsaSsaPssSha256, SecurityAlgorithms.RsaSsaPssSha256Signature },
+            { SecurityAlgorithms.RsaSsaPssSha256Signature, SecurityAlgorithms.RsaSsaPssSha256 },
+            { SecurityAlgorithms.RsaSsaPssSha256Signature, SecurityAlgorithms.RsaSsaPssSha256Signature },
+            { SecurityAlgorithms.RsaSsaPssSha384, SecurityAlgorithms.RsaSsaPssSha384 },
+            { SecurityAlgorithms.RsaSsaPssSha384, SecurityAlgorithms.RsaSsaPssSha384Signature },
+            { SecurityAlgorithms.RsaSsaPssSha384Signature, SecurityAlgorithms.RsaSsaPssSha384 },
+            { SecurityAlgorithms.RsaSsaPssSha384Signature, SecurityAlgorithms.RsaSsaPssSha384Signature },
+            { SecurityAlgorithms.RsaSsaPssSha512, SecurityAlgorithms.RsaSsaPssSha512 },
+            { SecurityAlgorithms.RsaSsaPssSha512, SecurityAlgorithms.RsaSsaPssSha512Signature },
+            { SecurityAlgorithms.RsaSsaPssSha512Signature, SecurityAlgorithms.RsaSsaPssSha512 },
+            { SecurityAlgorithms.RsaSsaPssSha512Signature, SecurityAlgorithms.RsaSsaPssSha512Signature },
+        };
+
         public static readonly List<Tuple<X509SecurityKey, X509SecurityKey, string>> X509SecurityKeys = new List<Tuple<X509SecurityKey, X509SecurityKey, string>>
         {
             { KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256_Public, "X509Key1" },
@@ -132,6 +148,20 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = theoryData.TestId + algorithm.Item1 + algorithm.Item2,
                     VerifyAlgorithm = algorithm.Item2,
                     VerifyKey = theoryData.VerifyKey
+                });
+        }
+
+        public static void AddRsaPssAlgorithmVariations(SignatureProviderTheoryData theoryData, TheoryData<SignatureProviderTheoryData> variations)
+        {
+            foreach (var algorithm in RsaPssSigningAlgorithms)
+                variations.Add(new SignatureProviderTheoryData
+                {
+                    SigningAlgorithm = algorithm.Item1,
+                    SigningKey = theoryData.SigningKey,
+                    TestId = theoryData.TestId + algorithm.Item1 + algorithm.Item2,
+                    VerifyAlgorithm = algorithm.Item2,
+                    VerifyKey = theoryData.VerifyKey,
+                    ExpectedException = theoryData.ExpectedException,
                 });
         }
     }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
@@ -137,7 +137,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     theoryData);
 
 #if NET461 || NETCOREAPP2_0
-
                 theoryData.Add(new SignatureProviderTheoryData()
                 {
                     SigningAlgorithm = SecurityAlgorithms.RsaSsaPssSha512,

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
@@ -39,8 +39,11 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     {
         // Throw for NET45 and NET451 targets for derived RSA types.
         [Fact]
-        public void UnsupportedRSAType()
+        public void UnsupportedRSATypes()
         {
+            var context = new CompareContext("UnsupportedRSATypes");
+            TestUtilities.WriteHeader($"{this}.UnsupportedRSATypes");
+
 #if NET452
             var expectedException = ExpectedException.NotSupportedException();
 #endif
@@ -52,12 +55,33 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             try
             {
                 new AsymmetricSignatureProvider(new RsaSecurityKey(new DerivedRsa(2048)), SecurityAlgorithms.RsaSha256, false);
-                expectedException.ProcessNoException();
+                expectedException.ProcessNoException(context);
             }
             catch (Exception ex)
             {
-                expectedException.ProcessException(ex);
+                expectedException.ProcessException(ex, context);
             }
+
+#if NET452
+            // RSA-PSS is not available on .NET 4.5.2
+            expectedException = ExpectedException.NotSupportedException("IDX10634:");
+#endif
+
+#if NET461 || NETCOREAPP2_0
+            expectedException = ExpectedException.NoExceptionExpected;
+#endif
+
+            try
+            {
+                new AsymmetricSignatureProvider(KeyingMaterial.DefaultRsaSecurityKey1, SecurityAlgorithms.RsaSsaPssSha256, false);
+                expectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                expectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
         }
 
         [Theory, MemberData(nameof(SignVerifyTheoryData))]
@@ -65,8 +89,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             var context = TestUtilities.WriteHeader($"{this}.SignVerify", theoryData);
             var bytes = Guid.NewGuid().ToByteArray();
-            byte[] signatureDirect = null;
-            byte[] signatureFromFactory = null;
             try
             {
                 var providerForSigningDirect = new AsymmetricSignatureProvider(theoryData.SigningKey, theoryData.SigningAlgorithm, true);
@@ -74,8 +96,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 var providerForSigningFromFactory = theoryData.SigningKey.CryptoProviderFactory.CreateForSigning(theoryData.SigningKey, theoryData.SigningAlgorithm);
                 var providerForVerifyingFromFactory = theoryData.VerifyKey.CryptoProviderFactory.CreateForVerifying(theoryData.VerifyKey, theoryData.VerifyAlgorithm);
 
-                signatureDirect = providerForSigningDirect.Sign(bytes);
-                signatureFromFactory = providerForSigningFromFactory.Sign(bytes);
+                byte[] signatureDirect = providerForSigningDirect.Sign(bytes);
+                byte[] signatureFromFactory = providerForSigningFromFactory.Sign(bytes);
 
                 if (!providerForVerifyingDirect.Verify(bytes, signatureDirect))
                     context.AddDiff($"providerForVerifyingDirect.Verify (signatureDirect) - FAILED. signingKey : signingAlgorithm '{theoryData.SigningKey}' : '{theoryData.SigningAlgorithm}. verifyKey : verifyAlgorithm '{theoryData.VerifyKey}' : '{theoryData.VerifyAlgorithm}");
@@ -141,6 +163,84 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         VerifyKey = new RsaSecurityKey(certTuple.Item2.GetRSAPublicKey())
                     },
                     theoryData);
+
+                 foreach (var certTuple in AsymmetricSignatureTestData.Certificates)
+                    AsymmetricSignatureTestData.AddRsaPssAlgorithmVariations(new SignatureProviderTheoryData
+                    {
+                        SigningKey = new RsaSecurityKey(certTuple.Item1.PrivateKey as RSA),
+                        TestId = "CapiCapi" + certTuple.Item3,
+                        VerifyKey = new RsaSecurityKey(certTuple.Item2.PublicKey.Key as RSA),
+#if NET461
+                        ExpectedException = ExpectedException.NotSupportedException("IDX10634:"),
+#elif NETCOREAPP2_0
+                        ExpectedException = ExpectedException.NoExceptionExpected,
+#endif
+                    },
+                    theoryData);
+
+                foreach (var certTuple in AsymmetricSignatureTestData.Certificates)
+                    AsymmetricSignatureTestData.AddRsaPssAlgorithmVariations(new SignatureProviderTheoryData
+                    {
+                        SigningKey = new RsaSecurityKey(certTuple.Item1.PrivateKey as RSA),
+                        TestId = "CapiCng" + certTuple.Item3,
+                        VerifyKey = new RsaSecurityKey(certTuple.Item2.GetRSAPublicKey()),
+#if NET461
+                        ExpectedException = ExpectedException.NotSupportedException("IDX10634:"),
+#elif NETCOREAPP2_0
+                        ExpectedException = ExpectedException.NoExceptionExpected,
+#endif
+                    },
+                    theoryData);
+
+                foreach (var certTuple in AsymmetricSignatureTestData.Certificates)
+                    AsymmetricSignatureTestData.AddRsaPssAlgorithmVariations(new SignatureProviderTheoryData
+                    {
+                        SigningKey = new RsaSecurityKey(certTuple.Item1.GetRSAPrivateKey()),
+                        TestId = "CngCapi" + certTuple.Item3,
+                        VerifyKey = new RsaSecurityKey(certTuple.Item2.PublicKey.Key as RSA),
+#if NET461
+                        ExpectedException = ExpectedException.NotSupportedException("IDX10634:"),
+#elif NETCOREAPP2_0
+                        ExpectedException = ExpectedException.NoExceptionExpected,
+#endif
+                    },
+                    theoryData);
+
+                foreach (var certTuple in AsymmetricSignatureTestData.Certificates)
+                    AsymmetricSignatureTestData.AddRsaPssAlgorithmVariations(new SignatureProviderTheoryData
+                    {
+                        SigningKey = new RsaSecurityKey(certTuple.Item1.GetRSAPrivateKey()),
+                        TestId = "CngCng" + certTuple.Item3,
+                        VerifyKey = new RsaSecurityKey(certTuple.Item2.GetRSAPublicKey())
+                    },
+                    theoryData);
+
+                foreach (var jsonKeyTuple in AsymmetricSignatureTestData.JsonRsaSecurityKeys)
+                    AsymmetricSignatureTestData.AddRsaPssAlgorithmVariations(new SignatureProviderTheoryData
+                    {
+                        SigningKey = jsonKeyTuple.Item1,
+                        TestId = jsonKeyTuple.Item3,
+                        VerifyKey = jsonKeyTuple.Item2
+                    },
+                    theoryData);
+
+                foreach (var rsaKeyTuple in AsymmetricSignatureTestData.RsaSecurityKeys)
+                    AsymmetricSignatureTestData.AddRsaPssAlgorithmVariations(new SignatureProviderTheoryData
+                    {
+                        SigningKey = rsaKeyTuple.Item1,
+                        TestId = rsaKeyTuple.Item3,
+                        VerifyKey = rsaKeyTuple.Item2
+                    },
+                    theoryData);
+
+                foreach (var x509KeyTuple in AsymmetricSignatureTestData.X509SecurityKeys)
+                    AsymmetricSignatureTestData.AddRsaPssAlgorithmVariations(new SignatureProviderTheoryData
+                    {
+                        SigningKey = x509KeyTuple.Item1,
+                        TestId = x509KeyTuple.Item3,
+                        VerifyKey = x509KeyTuple.Item2
+                    },
+                    theoryData);
 #endif
 
                 foreach (var ecdsaKeyTuple in AsymmetricSignatureTestData.ECDsaSecurityKeys)
@@ -188,6 +288,18 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     },
                     theoryData);
 
+#if NET452
+                // RSA-PSS is not available on .NET 4.5.2
+                foreach (var certTuple in AsymmetricSignatureTestData.Certificates)
+                    AsymmetricSignatureTestData.AddRsaPssAlgorithmVariations(new SignatureProviderTheoryData
+                    {
+                        SigningKey = new RsaSecurityKey(certTuple.Item1.PrivateKey as RSA),
+                        TestId = "CapiCapi" + certTuple.Item3,
+                        VerifyKey = new RsaSecurityKey(certTuple.Item2.PublicKey.Key as RSA),
+                        ExpectedException = ExpectedException.NotSupportedException("IDX10634:"),
+                    },
+                    theoryData);
+#endif
                 return theoryData;
             }
         }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
@@ -137,6 +137,15 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     theoryData);
 
 #if NET461 || NETCOREAPP2_0
+
+                theoryData.Add(new SignatureProviderTheoryData()
+                {
+                    SigningAlgorithm = SecurityAlgorithms.RsaSsaPssSha512,
+                    SigningKey = KeyingMaterial.RsaSecurityKey_1024,
+                    ExpectedException = ExpectedException.ArgumentOutOfRangeException(),
+                    TestId = "KeySizeSmallerThanRequiredSize"
+                });
+
                 foreach (var certTuple in AsymmetricSignatureTestData.Certificates)
                     AsymmetricSignatureTestData.AddRsaAlgorithmVariations(new SignatureProviderTheoryData
                     {


### PR DESCRIPTION
* RSA-PSS support matrix is available [here](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Supported-Algorithms):
  - Rsa-Pss is not available on .NET 4.5 and .NET 4.5.1 targets
  - Rsa-Pss is available on .NET 4.6.1 target but only byt Windows CNG
  - Rsa-Pss is avaliable on .NET Core on Windows
  - Rsa-Pss is available on .NET Core on Unix on SDK versions >= 2.1
* Added new log messages
* Added tests

Resolves: #1117 