### PR TITLE
Support JsonWebKeys with the Elliptic Curve key type (#1143)

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.IdentityModel.Json;
@@ -48,7 +49,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns><see cref="JsonWebKeySet"/></returns>
         /// <exception cref="ArgumentNullException">If 'json' is null or empty.</exception>
         /// <exception cref="ArgumentException">If 'json' fails to deserialize.</exception>
-        static public JsonWebKeySet Create(string json)
+        public static JsonWebKeySet Create(string json)
         {
             if (string.IsNullOrEmpty(json))
                 throw LogHelper.LogArgumentNullException(nameof(json));
@@ -61,6 +62,24 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         public JsonWebKeySet()
         {
+        }
+
+        /// <summary>
+        /// Initializes an ECDsa Adapter.
+        /// </summary>
+        /// <remarks>
+        /// As ECDsa Adapter is not supported on some platforms, PlatformNotSupported exception will be swallowed and logged.
+        /// </remarks>
+        static JsonWebKeySet()
+        {
+            try
+            {
+                ECDsaAdapter = new ECDsaAdapter();
+            }
+            catch (Exception ex)
+            {
+                LogHelper.LogExceptionMessage(ex);
+            }
         }
 
         /// <summary>
@@ -92,78 +111,170 @@ namespace Microsoft.IdentityModel.Tokens
         public virtual IDictionary<string, object> AdditionalData { get; } = new Dictionary<string, object>();
 
         /// <summary>
+        /// This adapter abstracts the <see cref="ECDsa"/> differences between versions of .Net targets.
+        /// </summary>
+        internal static ECDsaAdapter ECDsaAdapter;
+
+        /// <summary>
         /// Gets the <see cref="IList{JsonWebKey}"/>.
         /// </summary>       
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore, PropertyName = JsonWebKeySetParameterNames.Keys, Required = Required.Default)]
         public IList<JsonWebKey> Keys { get; private set; } = new List<JsonWebKey>();
 
         /// <summary>
+        /// Default value for the flag that controls whether unresolved JsonWebKeys will be included in the resulting collection of <see cref="GetSigningKeys"/> method.
+        /// </summary>
+        [DefaultValue(true)]
+        public static bool DefaultSkipUnresolvedJsonWebKeys = true;
+
+        /// <summary>
+        /// Flag that controls whether unresolved JsonWebKeys will be included in the resulting collection of <see cref="GetSigningKeys"/> method.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool SkipUnresolvedJsonWebKeys { get; set; } = DefaultSkipUnresolvedJsonWebKeys;
+
+        /// <summary>
         /// Returns the JsonWebKeys as a <see cref="IList{SecurityKey}"/>.
         /// </summary>
+        /// <remarks>
+        /// To include unresolved JsonWebKeys in the resulting <see cref="SecurityKey"/> collection, set <see cref="SkipUnresolvedJsonWebKeys"/> to <c>false</c>.
+        /// </remarks>
         public IList<SecurityKey> GetSigningKeys()
         {
-            List<SecurityKey> keys = new List<SecurityKey>();
-            for (int i = 0; i < Keys.Count; i++)
+            var signingKeys = new List<SecurityKey>();
+
+            foreach (var webKey in Keys)
             {
-                JsonWebKey webKey = Keys[i];
-
-                if (!StringComparer.Ordinal.Equals(webKey.Kty, JsonWebAlgorithmsKeyTypes.RSA))
-                    continue;
-
-                if ((string.IsNullOrWhiteSpace(webKey.Use) || (StringComparer.Ordinal.Equals(webKey.Use, JsonWebKeyUseNames.Sig))))
+                // skip if "use" (Public Key Use) parameter is not empty or "sig"
+                // https://tools.ietf.org/html/rfc7517#section-4.2
+                if (!(string.IsNullOrWhiteSpace(webKey.Use) || webKey.Use.Equals(JsonWebKeyUseNames.Sig, StringComparison.Ordinal)))
                 {
-                    if (webKey.X5c != null)
+                    LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10808, webKey.KeyId ?? "null" , webKey.Use ?? "null"));
+
+                    if (!SkipUnresolvedJsonWebKeys)
+                        signingKeys.Add(webKey);
+
+                    continue;
+                }
+
+                if (webKey.Kty != null && webKey.Kty.Equals(JsonWebAlgorithmsKeyTypes.RSA, StringComparison.Ordinal))
+                {
+                    var isResolved = false;
+
+                    if (webKey.X5c != null && webKey.X5c.Count != 0)
                     {
-                        foreach (var certString in webKey.X5c)
-                        {
-                            try
-                            {
-                                // Add chaining
-                                SecurityKey key = new X509SecurityKey(new X509Certificate2(Convert.FromBase64String(certString)));
-                                key.KeyId = webKey.Kid;
-                                keys.Add(key);
-                            }
-                            catch (CryptographicException ex)
-                            {
-                                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10802, webKey.X5c[0]), ex));
-                            }
-                            catch (FormatException fex)
-                            {
-                                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10802, webKey.X5c[0]), fex));
-                            }
-                        }
+                        AddX509SecurityKey(signingKeys, webKey);
+                        isResolved = true;
                     }
 
                     if (!string.IsNullOrWhiteSpace(webKey.E) && !string.IsNullOrWhiteSpace(webKey.N))
                     {
-                        try
-                        {
-                            SecurityKey key =
-                                 new RsaSecurityKey
-                                 (
-                                    new RSAParameters
-                                    {
-                                        Exponent = Base64UrlEncoder.DecodeBytes(webKey.E),
-                                        Modulus = Base64UrlEncoder.DecodeBytes(webKey.N),
-                                    }
-
-                                );
-                            key.KeyId = webKey.Kid;
-                            keys.Add(key);
-                        }
-                        catch (CryptographicException ex)
-                        {
-                            throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10801, webKey.E, webKey.N), ex));
-                        }
-                        catch (FormatException ex)
-                        {
-                            throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10801, webKey.E, webKey.N), ex));
-                        }
+                        AddRsaSecurityKey(signingKeys, webKey);
+                        isResolved = true;
                     }
+
+                    if (!isResolved)
+                    {
+                        LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10810, webKey.KeyId ?? "null"));
+
+                        if(!SkipUnresolvedJsonWebKeys)
+                            signingKeys.Add(webKey);
+                    }
+                }
+                else if (webKey.Kty != null && webKey.Kty.Equals(JsonWebAlgorithmsKeyTypes.EllipticCurve, StringComparison.Ordinal))
+                {
+                    AddECDsaSecurityKey(signingKeys, webKey);
+                }
+                else
+                {
+                    // kty is not 'EC' or 'RSA'
+                    LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10809, webKey.Kty ?? "null"));
+
+                    if (!SkipUnresolvedJsonWebKeys)
+                        signingKeys.Add(webKey);
                 }
             }
 
-            return keys;
+            return signingKeys;
+        }
+
+        private void AddX509SecurityKey(ICollection<SecurityKey> signingKeys, JsonWebKey jsonWebKey)
+        {
+            try
+            {
+                // only the first certificate should be used to perform signing operations
+                // https://tools.ietf.org/html/rfc7517#section-4.7
+                var x509SecurityKey =  new X509SecurityKey(new X509Certificate2(Convert.FromBase64String(jsonWebKey.X5c[0])))
+                {
+                    KeyId = jsonWebKey.Kid
+                };
+
+                signingKeys.Add(x509SecurityKey);
+            }
+            catch (Exception ex)
+            {
+                LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10802, jsonWebKey.X5c[0], ex), ex));
+
+                if (!SkipUnresolvedJsonWebKeys)
+                    signingKeys.Add(jsonWebKey);
+            }
+        }
+
+        private void AddRsaSecurityKey(ICollection<SecurityKey> signingKeys, JsonWebKey jsonWebKey)
+        {
+            try
+            {
+                var rsaParams = new RSAParameters
+                {
+                    Exponent = Base64UrlEncoder.DecodeBytes(jsonWebKey.E),
+                    Modulus = Base64UrlEncoder.DecodeBytes(jsonWebKey.N),
+                };
+
+                var rsaSecurityKey = new RsaSecurityKey(rsaParams)
+                {
+                    KeyId = jsonWebKey.Kid
+                };
+
+                signingKeys.Add(rsaSecurityKey);
+            }
+            catch (Exception ex)
+            {
+                LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10801, jsonWebKey.E, jsonWebKey.N, ex), ex));
+
+                if (!SkipUnresolvedJsonWebKeys)
+                    signingKeys.Add(jsonWebKey);
+            }
+        }
+
+        private void AddECDsaSecurityKey(ICollection<SecurityKey> signingKeys, JsonWebKey jsonWebKey)
+        {
+            // ECDsa adapter is null when a platform is not supported i.e. when ECDsaAdapter is not successfully initialized.
+            if (ECDsaAdapter == null)
+            {
+                LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10690));
+                if (!SkipUnresolvedJsonWebKeys)
+                    signingKeys.Add(jsonWebKey);
+
+                return;
+            }
+
+            try
+            {
+                var ecdsa = ECDsaAdapter.CreateECDsa(jsonWebKey, false);
+                var ecdsaSecurityKey = new ECDsaSecurityKey(ecdsa)
+                {
+                    KeyId = jsonWebKey.Kid
+                };
+
+                signingKeys.Add(ecdsaSecurityKey);
+            }
+            catch (Exception ex)
+            {
+                LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10807, ex), ex));
+
+                if (!SkipUnresolvedJsonWebKeys)
+                    signingKeys.Add(jsonWebKey);
+            }
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -197,11 +197,15 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10703 = "IDX10703: Cannot create symmetric security key. Key length is zero.";
 
         // Json specific errors
-        public const string IDX10801 = "IDX10801: Unable to create an RSA public key from the Exponent and Modulus found in the JsonWebKey: E: '{0}', N: '{1}'. See inner exception for additional details.";
-        public const string IDX10802 = "IDX10802: Unable to create an X509Certificate2 from the X509Data: '{0}'. See inner exception for additional details.";
+        public const string IDX10801 = "IDX10801: Unable to create an RSA public key from the Exponent and Modulus found in the JsonWebKey: E: '{0}', N: '{1}'. Inner exception: '{2}'.";
+        public const string IDX10802 = "IDX10802: Unable to create an X509Certificate2 from the X509Data: '{0}'. Inner exception '{1}'.";
         // public const string IDX10804 = "IDX10804:";
         public const string IDX10805 = "IDX10805: Error deserializing json: '{0}' into '{1}'.";
         public const string IDX10806 = "IDX10806: Deserializing json: '{0}' into '{1}'.";
+        public const string IDX10807 = "IDX10807: Unable to create an ECDsa from the parameters found in the JsonWebKey. Inner exception: '{0}'.";
+        public const string IDX10808 = "IDX10808: The 'use' parameter of a JsonWebKey with a 'kid': '{0}' should be 'sig' or empty, but was '{1}'.";
+        public const string IDX10809 = "IDX10809: The 'kty' parameter '{0}' is not supported. Supported 'kty' parameters are 'RSA' and 'EC'.";
+        public const string IDX10810 = "IDX10810: JsonWebKey with a 'kid': '{0}' was not resolved into an X509SecurityKey or into an RsaSecurityKey.";
 #pragma warning restore 1591
     }
 }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/JsonWebKeySetEnd2EndEC.json
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/JsonWebKeySetEnd2EndEC.json
@@ -1,0 +1,31 @@
+﻿{
+  "keys": [
+    {
+      "kty": "EC",
+      "alg": "ES256",
+      "use": "sig",
+      "crv": "P-256",
+      "kid": "JsonWebKeyEcdsa256",
+      "x": "luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA",
+      "y": "tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ"
+    },
+    {
+      "kty": "EC",
+      "alg": "ES384",
+      "use": "sig",
+      "crv": "P-384",
+      "kid": "JsonWebKeyEcdsa384",
+      "x": "5mn3HaDoUgdNTFCACaWIvrpriQTloEbMbx4eUu_XvB4pyExig45VIozMnj7FedJg",
+      "y": "Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l"
+    },
+    {
+      "kty": "EC",
+      "alg": "ES521",
+      "use": "sig",
+      "crv": "P-521",
+      "kid": "JsonWebKeyEcdsa521",
+      "x": "AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr",
+      "y": "AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW"
+    }
+  ]
+}

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="JsonWebKeySet.json;JsonWebKeySetBadBase64Data.json;JsonWebKeySetBadX509Data.json;JsonWebKeySetEnd2End.json;JsonWebKeySetSingleX509Data.json;OpenIdConnectMetadata.json;OpenIdConnectMetadata2.json;OpenIdConnectMetadataBadBase64Data.json;OpenIdConnectMetadataBadX509Data.json;OpenIdConnectMetadataEnd2End.json;OpenIdConnectMetadataJsonWebKeySetBadUri.json;PingLabsJWKS.json;PingLabs-openid-configuration.json">
+    <None Update="JsonWebKeySet.json;JsonWebKeySetBadBase64Data.json;JsonWebKeySetBadX509Data.json;JsonWebKeySetEnd2End.json;JsonWebKeySetSingleX509Data.json;OpenIdConnectMetadata.json;OpenIdConnectMetadata2.json;OpenIdConnectMetadataBadBase64Data.json;OpenIdConnectMetadataBadX509Data.json;OpenIdConnectMetadataEnd2End.json;OpenIdConnectMetadataJsonWebKeySetBadUri.json;PingLabsJWKS.json;PingLabs-openid-configuration.json;;JsonWebKeySetEnd2EndEC.json;OpenIdConnectMetadataEnd2EndEC.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
@@ -80,6 +80,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
         public static string JsonFile = @"OpenIdConnectMetadata.json";
         public static string OpenIdConnectMetadataFileEnd2End = @"OpenIdConnectMetadataEnd2End.json";
+        public static string OpenIdConnectMetadataFileEnd2EndEC = @"OpenIdConnectMetadataEnd2EndEC.json";
         public static string JsonWebKeySetBadUriFile = @"OpenIdConnectMetadataJsonWebKeySetBadUri.json";
         public static string JsonAllValues =
                                             @"{ ""acr_values_supported"" : [""acr_value1"", ""acr_value2"", ""acr_value3""],
@@ -180,8 +181,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             SingleX509Data.JsonWebKeySet = DataSets.JsonWebKeySetX509Data;
             SingleX509Data.JwksUri = "JsonWebKeySetSingleX509Data.json";
             SingleX509Data.IdTokenSigningAlgValuesSupported.Add("RS256");
-            AddToCollection(SingleX509Data.ResponseTypesSupported, new string[]{"code", "id_token", "code id_token"});
-            AddToCollection(SingleX509Data.ResponseModesSupported, new string[]{"query", "fragment", "form_post"});
+            AddToCollection(SingleX509Data.ResponseTypesSupported, new string[] { "code", "id_token", "code id_token" });
+            AddToCollection(SingleX509Data.ResponseModesSupported, new string[] { "query", "fragment", "form_post" });
             SingleX509Data.ScopesSupported.Add("openid");
             SingleX509Data.SigningKeys.Add(KeyingMaterial.X509SecurityKey1);
             SingleX509Data.SubjectTypesSupported.Add("pairwise");
@@ -210,7 +211,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             AddToCollection(config.GrantTypesSupported, "authorization_code", "implicit");
             config.HttpLogoutSupported = true;
             AddToCollection(config.IdTokenEncryptionAlgValuesSupported, "RSA1_5", "A256KW");
-            AddToCollection(config.IdTokenEncryptionEncValuesSupported, "A128CBC-HS256","A256CBC-HS512");
+            AddToCollection(config.IdTokenEncryptionEncValuesSupported, "A128CBC-HS256", "A256CBC-HS512");
             AddToCollection(config.IdTokenSigningAlgValuesSupported, "RS256");
             config.Issuer = "https://sts.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/";
             config.JwksUri = "JsonWebKeySet.json";
@@ -233,7 +234,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             AddToCollection(config.TokenEndpointAuthSigningAlgValuesSupported, "ES192", "ES256");
             AddToCollection(config.UILocalesSupported, "hak-CN", "en-us");
             config.UserInfoEndpoint = "https://login.microsoftonline.com/add29489-7269-41f4-8841-b63c95564420/openid/userinfo";
-            AddToCollection(config.UserInfoEndpointEncryptionAlgValuesSupported, "ECDH-ES+A128KW","ECDH-ES+A192KW");
+            AddToCollection(config.UserInfoEndpointEncryptionAlgValuesSupported, "ECDH-ES+A128KW", "ECDH-ES+A192KW");
             AddToCollection(config.UserInfoEndpointEncryptionEncValuesSupported, "A256CBC-HS512", "A128CBC-HS256");
             AddToCollection(config.UserInfoEndpointSigningAlgValuesSupported, "ES384", "ES512");
 

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationRetrieverTests.cs
@@ -92,8 +92,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             // for now turn off checking for inner
             var ee = ExpectedException.InvalidOperationException(inner: typeof(CryptographicException));
             ee.IgnoreInnerException = true;
-            await GetConfigurationFromMixedAsync(OpenIdConfigData.OpenIdConnectMetadataBadX509DataString, expectedException: ee);
-            await GetConfigurationFromMixedAsync(OpenIdConfigData.OpenIdConnectMetadataBadBase64DataString, expectedException: ExpectedException.InvalidOperationException(inner: typeof(FormatException)));
+
+            await GetConfigurationFromMixedAsync(OpenIdConfigData.OpenIdConnectMetadataBadX509DataString, expectedException: ExpectedException.NoExceptionExpected);
+            await GetConfigurationFromMixedAsync(OpenIdConfigData.OpenIdConnectMetadataBadBase64DataString, expectedException: ExpectedException.NoExceptionExpected);
 
             TestUtilities.AssertFailIfErrors(context);
         }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMetadataEnd2EndEC.json
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMetadataEnd2EndEC.json
@@ -1,0 +1,15 @@
+﻿{
+  "issuer": "https://sts.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/",
+  "authorization_endpoint": "https://login.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/oauth2/authorize",
+  "token_endpoint": "https://login.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/oauth2/token",
+  "token_endpoint_auth_methods_supported": [ "client_secret_post", "private_key_jwt" ],
+  "jwks_uri": "JsonWebKeySetEnd2EndEC.json",
+  "response_types_supported": [ "code", "id_token", "code id_token" ],
+  "response_modes_supported": [ "query", "fragment", "form_post" ],
+  "subject_types_supported": [ "pairwise" ],
+  "scopes_supported": [ "openid" ],
+  "id_token_signing_alg_values_supported": [ "RS256", "ES256" ],
+  "microsoft_multi_refresh_token": true,
+  "check_session_iframe": "https://login.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/oauth2/checksession",
+  "end_session_endpoint": "https://login.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/oauth2/logout"
+}

--- a/test/Microsoft.IdentityModel.TestUtils/DataSets.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/DataSets.cs
@@ -41,11 +41,16 @@ namespace Microsoft.IdentityModel.TestUtils
         public static JsonWebKey JsonWebKey2;
         public static JsonWebKey JsonWebKeyAdditionalData1;
         public static JsonWebKey JsonWebKeyBadX509Data;
+        public static JsonWebKey JsonWebKeyES256;
+        public static JsonWebKey JsonWebKeyES384;
+        public static JsonWebKey JsonWebKeyES512;
 
         public static JsonWebKeySet JsonWebKeySet1;
         public static JsonWebKeySet JsonWebKeySet2;
         public static JsonWebKeySet JsonWebKeySetX509Data;
         public static JsonWebKeySet JsonWebKeySetAdditionalData1;
+        public static JsonWebKeySet JsonWebKeySetEC;
+        public static JsonWebKeySet JsonWebKeySetOnlyX5t;
 
         // interop
         public static string GoogleCertsFile = "google-certs.json";
@@ -157,6 +162,14 @@ namespace Microsoft.IdentityModel.TestUtils
                                             ""use"":""sigg""
                                         }";
 
+        public static string JsonWebKeyX509DataString =
+                                        @"{ ""kid"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
+                                            ""kty"":""RSA"",
+                                            ""use"":""sig"",
+                                            ""x5t"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
+                                            ""x5c"":[""MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng""]
+                                        }";
+
         public static string JsonWebKeyBadX509String =
                                         @"{ ""e"":""AQAB"",
                                             ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
@@ -167,19 +180,85 @@ namespace Microsoft.IdentityModel.TestUtils
                                             ""use"":""sig""
                                         }";
 
+        public static string JsonWebKeyBadECCurveString =
+                                       @"{
+                                            ""kty"": ""EC"",
+                                            ""alg"": ""ES521"",
+                                            ""use"": ""sig"",
+                                            ""crv"": ""P-999"",
+                                            ""kid"": ""unknownCrv"",
+                                            ""x"": ""AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr"",
+                                            ""y"": ""AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW""
+                                        }";
+
+        public static string JsonWebKeyES256String =
+                                        @"{
+                                            ""kty"": ""EC"",
+                                            ""alg"": ""ES256"",
+                                            ""use"": ""sig"",
+                                            ""crv"": ""P-256"",
+                                            ""kid"": ""JsonWebKeyEcdsa256"",
+                                            ""x"": ""luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA"",
+                                            ""y"": ""tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ""
+                                        }";
+
+        public static string JsonWebKeyES384String =
+                                        @"{
+                                            ""kty"": ""EC"",
+                                            ""alg"": ""ES384"",
+                                            ""use"": ""sig"",
+                                            ""crv"": ""P-384"",
+                                            ""kid"": ""JsonWebKeyEcdsa384"",
+                                            ""x"": ""5mn3HaDoUgdNTFCACaWIvrpriQTloEbMbx4eUu_XvB4pyExig45VIozMnj7FedJg"",
+                                            ""y"": ""Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l""
+                                        }";
+
+        public static string JsonWebKeyES512String =
+                                        @"{
+                                            ""kty"": ""EC"",
+                                            ""alg"": ""ES512"",
+                                            ""use"": ""sig"",
+                                            ""crv"": ""P-521"",
+                                            ""kid"": ""JsonWebKeyEcdsa521"",
+                                            ""x"": ""AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr"",
+                                            ""y"": ""AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW""
+                                        }";
+
+        public static string JsonWebKeyOnlyX5tString =
+                                        @"{
+                                            ""kty"": ""RSA"",
+                                            ""use"": ""sig"",
+                                            ""kid"":""pqoeamb2e5YVzR6_rqFpiCrFZgw"",
+                                            ""x5t"":""pqoeamb2e5YVzR6_rqFpiCrFZgw""
+                                        }";
+
+        public static string JsonWebKeyNoKtyString =
+                                        @"{ ""e"":""AQAB"",
+                                            ""kid"":""20am7"",
+                                            ""n"":""mhupHfUtg_gHIqwu2wm8CprXY-gKqbPMV6tEYVqkyYrHugzQ_YDYAHr7vWo5Pe_3gIujSFwpqIfXaP8-Fl3O5fQhMo1lMv4DdRabyDLEpv7YO9qoVKTmDOZqYZx-AYBr5x1Zh2xWByI6_0dsPtCjD1pFZfg_SxNEcLPyH1aY6dT8CWYu32qG4O0WF4EihZzMkzSn8fyh8RXbMf5U9Wm2kgb0g8jK62S7MoF4IlhFaJreq898wgUohhPwR8P3X-gk0XQJAFcogEf04Fw4UmKo3z1B6mcNbPRfImhWw4wtLkhp_KIqKNOkMsSpYGSLrCvqQpgK56EJZExrmb7WozjwHw"",
+                                            ""use"":""sig""
+                                        }";
 
         public static string JsonWebKeySetBadRsaExponentString = @"{ ""keys"":[" + JsonWebKeyBadRsaExponentString + "]}";
         public static string JsonWebKeySetBadRsaModulusString = @"{ ""keys"":[" + JsonWebKeyBadRsaModulusString + "]}";
         public static string JsonWebKeySetUseNoKidString = @"{ ""keys"":[" + JsonWebKeyRsaNoKidString + "]}";
         public static string JsonWebKeySetKtyNotRsaString = @"{ ""keys"":[" + JsonWebKeyKtyNotRsaString + "]}";
         public static string JsonWebKeySetUseNotSigString = @"{ ""keys"":[" + JsonWebKeyUseNotSigString + "]}";
+        public static string JsonWebKeySetX509DataString = @"{ ""keys"":[" + JsonWebKeyX509DataString + "]}";
         public static string JsonWebKeySetBadX509String = @"{ ""keys"":[" + JsonWebKeyBadX509String + "]}";
+        public static string JsonWebKeySetBadECCurveString = @"{ ""keys"":[" + JsonWebKeyBadECCurveString + "]}";
+        public static string JsonWebKeySetOnlyX5tString = @"{ ""keys"":[" + JsonWebKeyOnlyX5tString + "]}";
+        public static string JsonWebKeySetUseNoKtyString = @"{ ""keys"":[" + JsonWebKeyNoKtyString + "]}";
 
         // Key Sets
         public static string JsonWebKeySet = "JsonWebKeySet.json";
         public static string JsonWebKeySetString1 = @"{ ""keys"":[" + JsonWebKeyString1 + "," + JsonWebKeyString2 + "]}";
         public static string JsonWebKeySetString2 = @"{ ""keys"":[" + JsonWebKeyString2 + "]}";
+        public static string JsonWebKeySetECCString = @"{ ""keys"":[" + JsonWebKeyES256String + "," + JsonWebKeyES384String + "," + JsonWebKeyES512String + "]}";
         public static string JsonWebKeySetAdditionalDataString1 = @"{ ""keys"":[" + JsonWebKeyAdditionalDataString1 + "]" + @", ""additionalProperty"":""additionalValue""}";
+        public static string JsonWebKeySetOneValidRsaOneInvalidRsaString = @"{ ""keys"":[" + JsonWebKeyFromPingString1 + "," + JsonWebKeyBadRsaExponentString + "]}";
+        public static string JsonWebKeySetOneInvalidEcOneValidEcString = @"{ ""keys"":[" + JsonWebKeyBadECCurveString + "," + JsonWebKeyES256String + "]}";
+        public static string JsonWebKeySetOneValidRsaOneInvalidEcString = @"{ ""keys"":[" + JsonWebKeyFromPingString1 + "," + JsonWebKeyBadECCurveString + "]}";
         public static string JsonWebKeySetBadFormatingString =
                                             @"{ ""keys"":[
                                                 {   ""e"":""AQAB"",
@@ -203,6 +282,22 @@ namespace Microsoft.IdentityModel.TestUtils
                                                     ""use"":""sig""
                                                }
                                             ]}";
+
+        public static string JsonWebKeySetEvoString =
+                                           @"{ ""keys"":[
+                                               {
+                                                   ""kty"":""RSA"",
+                                                   ""use"":""sig"",
+                                                   ""kid"":""HBxl9mAe6gxavCkcoOU2THsDNa0"",
+                                                   ""x5t"":""HBxl9mAe6gxavCkcoOU2THsDNa0"",
+                                                   ""n"":""0afCaiPd_xl_ewZGfOkxKwYPfI4Efu0COfzajK_gnviWk7w3R-88Dmb0j24DSn1qVR3ptCnA1-QUfUMyhvl8pT5-t7oRkLNPzp0hVV-dAG3ZoMaSEMW0wapshA6LVGROpBncDmc66hx5-t3eOFA24fiKfQiv2TJth3Y9jhHnLe7GBOoomWYx_pJiEG3mhYFIt7shaEwNcEjo34vr1WWzRm8D8gogjrJWd1moyeGftWLzvfp9e79QwHYJv907vQbFrT7LYuy8g7-Rpxujgumw2mx7CewcCZXwPiZ-raM3Ap1FhINiGpd5mbbYrFDDFIWAjWPUY6KNvXtc24yUfZr4MQ"",
+                                                   ""e"":""AQAB"",
+                                                   ""x5c"":[
+                                                      ""MIIDBTCCAe2gAwIBAgIQWcq84CdVhKVEcKbZdMOMGjANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDMxNDAwMDAwMFoXDTIxMDMxNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANGnwmoj3f8Zf3sGRnzpMSsGD3yOBH7tAjn82oyv4J74lpO8N0fvPA5m9I9uA0p9alUd6bQpwNfkFH1DMob5fKU+fre6EZCzT86dIVVfnQBt2aDGkhDFtMGqbIQOi1RkTqQZ3A5nOuocefrd3jhQNuH4in0Ir9kybYd2PY4R5y3uxgTqKJlmMf6SYhBt5oWBSLe7IWhMDXBI6N+L69Vls0ZvA/IKII6yVndZqMnhn7Vi8736fXu/UMB2Cb/dO70Gxa0+y2LsvIO/kacbo4LpsNpsewnsHAmV8D4mfq2jNwKdRYSDYhqXeZm22KxQwxSFgI1j1GOijb17XNuMlH2a+DECAwEAAaMhMB8wHQYDVR0OBBYEFIkZ5wrSV8lohIsreOmig7h5wQDkMA0GCSqGSIb3DQEBCwUAA4IBAQAd8sKZLwZBocM4pMIRKarK60907jQCOi1m449WyToUcYPXmU7wrjy9fkYwJdC5sniItVBJ3RIQbF/hyjwnRoIaEcWYMAftBnH+c19WIuiWjR3EHnIdxmSopezl/9FaTNghbKjZtrKK+jL/RdkMY9uWxwUFLjTAtMm24QOt2+CGntBA9ohQUgiML/mlUpf4qEqa2/Lh+bjiHl3smg4TwuIl0i/TMN9Rg7UgQ6BnqfgiuMl6BtBiatNollwgGNI2zJEi47MjdeMf8+C3tXs//asqqlqJCyVLwN7AN47ynYmkl89MleOfKIojhrGRxryZG2nRjD9u/kZbPJ8e3JE9px67""
+                                                   ],
+                                                   ""issuer"":""https://login.microsoftonline.com/{tenantid}/v2.0""
+                                               }
+                                           ]}";
 
         static DataSets()
         {
@@ -260,9 +355,47 @@ namespace Microsoft.IdentityModel.TestUtils
 
             JsonWebKey2.X5c.Add(JsonWebKey_X5c_2);
 
+            JsonWebKeyES256 = new JsonWebKey
+            {
+                Alg = "ES256",
+                Crv = "P-256",
+                Kid = "JsonWebKeyEcdsa256",
+                Kty = "EC",
+                Use = "sig",
+                X = "luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA",
+                Y = "tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ"
+            };
+
+            JsonWebKeyES384 = new JsonWebKey
+            {
+                Alg = "ES384",
+                Crv = "P-384",
+                Kid = "JsonWebKeyEcdsa384",
+                Kty = "EC",
+                Use = "sig",
+                X = "5mn3HaDoUgdNTFCACaWIvrpriQTloEbMbx4eUu_XvB4pyExig45VIozMnj7FedJg",
+                Y = "Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l"
+            };
+
+            JsonWebKeyES512 = new JsonWebKey
+            {
+                Alg = "ES512",
+                Crv = "P-521",
+                Kid = "JsonWebKeyEcdsa521",
+                Kty = "EC",
+                Use = "sig",
+                X = "AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr",
+                Y = "AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW"
+            };
+
             JsonWebKeySet1 = new JsonWebKeySet();
             JsonWebKeySet1.Keys.Add(JsonWebKey1);
             JsonWebKeySet1.Keys.Add(JsonWebKey2);
+
+            JsonWebKeySetEC = new JsonWebKeySet();
+            JsonWebKeySetEC.Keys.Add(JsonWebKeyES256);
+            JsonWebKeySetEC.Keys.Add(JsonWebKeyES384);
+            JsonWebKeySetEC.Keys.Add(JsonWebKeyES512);
 
             var jwk = new JsonWebKey
             {
@@ -328,6 +461,16 @@ namespace Microsoft.IdentityModel.TestUtils
                      N = "ANLFuJO6EoKczde+YP3b1yuz2b46D7Rd7CjrbvKrzbjkH29iRFLBagT7nojwdMOPrsV+WLp/C8lfkRT7UJ38lnQh3m4oEy98HdRRMZh5Vtpbotgt4S/ugh5ansJdHSXSBTxk+X1ZnTzMOUH7ZROpxw3NcX/IFl0sshFlTbebPrDj",
                      Use = "sig",
                  });
+
+            var JsonWebKeyOnlyX5t = new JsonWebKey
+            {
+                Kid = "pqoeamb2e5YVzR6_rqFpiCrFZgw",
+                Kty = "RSA",
+                Use = "sig",
+                X5t = "pqoeamb2e5YVzR6_rqFpiCrFZgw"
+            };
+            JsonWebKeySetOnlyX5t = new JsonWebKeySet();
+            JsonWebKeySetOnlyX5t.Keys.Add(JsonWebKeyOnlyX5t);
         }
     }
 }

--- a/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
@@ -118,7 +118,7 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static SigningCredentials DefaultX509SigningCreds_2048_RsaSha2_Sha2_Public = new SigningCredentials(DefaultX509Key_2048_Public, SecurityAlgorithms.RsaSha256Signature);
 
-        public static string ExpiredX509Data_Public = @"MIIDKTCCAhGgAwIBAgIQWYE2RAW22K1AwRf9VBgsLDANBgkqhkiG9w0BAQsFADAkMSIwIAYDVQQDDBlodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tMB4XDTE3MTEwMjIyNTMwNloXDTE3MTEwMjIzMDI0NVowJDEiMCAGA1UEAwwZaHR0cDovL0RlZmF1bHQuSXNzdWVyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK79bBjoH2zMR2poFZDm7wJjzgp+Nidk8jkrps3iqzqqf1YVFtEtFBng4KE+2jfyaQxS4FO3dnd1Nh7wdCBH/60A0e6uROEBe4L/kydyJS3u2wsz+aabCBJ2M8FVUWziGZ4o2NKwAvRbCWFbsA9irhXTEw3hjqP7DDdjAayztmczG7vgeU10GnEPcYanyrraNRWkVaZGAI6EeFOy4QEYtFLd7N7gb84ScW/h2edVKm5VoYaVXF6KE7gfbMp+uflqJ8hBaLXjFSoXxN3Y6BQqxUGxX4qdAnpuRqDJzYQjDUm81MtD2XIfY46duJDDZOwpRPyXRe2YeJp5rVG5Pr0i7gECAwEAAaNXMFUwDgYDVR0PAQH/BAQDAgWgMCQGA1UdEQQdMBuCGWh0dHA6Ly9EZWZhdWx0Lklzc3Vlci5jb20wHQYDVR0OBBYEFJI/4wsmVjLpK1tRYJ96zKoBULBzMA0GCSqGSIb3DQEBCwUAA4IBAQBUToqoMJ0QJciKd+GRzivq3idPzCEyo4/V2V7B/H5czwzVx+lhn2e/EwCaMBPk3x9C5DQbJdmSp6DoX9VvD2XNOiFFeabBu/w9jhkRiDpOtNnWMJwzjHMAD0f4z8fSO5ZXcvFr2Ze3zGDTEY1vdXkAK2k9WuKu7c9kcoZO55Tads5T15vg4e8OmBq9kcGNEZRt2xBHkjlef0v6gBZ/lFeJHe0qTuKNCiTxJvUfAPnP0sTAdFdsDBt9bqLBHx+Wz/ALj535dUpCi5tXv4bI/t6qgh8toQNvJ7lNMv34W4+CiRYAPR9fK5bGsua+tb1FvfEqXx17yOLLgHgsu8oOsaZo"; 
+        public static string ExpiredX509Data_Public = @"MIIDKTCCAhGgAwIBAgIQWYE2RAW22K1AwRf9VBgsLDANBgkqhkiG9w0BAQsFADAkMSIwIAYDVQQDDBlodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tMB4XDTE3MTEwMjIyNTMwNloXDTE3MTEwMjIzMDI0NVowJDEiMCAGA1UEAwwZaHR0cDovL0RlZmF1bHQuSXNzdWVyLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK79bBjoH2zMR2poFZDm7wJjzgp+Nidk8jkrps3iqzqqf1YVFtEtFBng4KE+2jfyaQxS4FO3dnd1Nh7wdCBH/60A0e6uROEBe4L/kydyJS3u2wsz+aabCBJ2M8FVUWziGZ4o2NKwAvRbCWFbsA9irhXTEw3hjqP7DDdjAayztmczG7vgeU10GnEPcYanyrraNRWkVaZGAI6EeFOy4QEYtFLd7N7gb84ScW/h2edVKm5VoYaVXF6KE7gfbMp+uflqJ8hBaLXjFSoXxN3Y6BQqxUGxX4qdAnpuRqDJzYQjDUm81MtD2XIfY46duJDDZOwpRPyXRe2YeJp5rVG5Pr0i7gECAwEAAaNXMFUwDgYDVR0PAQH/BAQDAgWgMCQGA1UdEQQdMBuCGWh0dHA6Ly9EZWZhdWx0Lklzc3Vlci5jb20wHQYDVR0OBBYEFJI/4wsmVjLpK1tRYJ96zKoBULBzMA0GCSqGSIb3DQEBCwUAA4IBAQBUToqoMJ0QJciKd+GRzivq3idPzCEyo4/V2V7B/H5czwzVx+lhn2e/EwCaMBPk3x9C5DQbJdmSp6DoX9VvD2XNOiFFeabBu/w9jhkRiDpOtNnWMJwzjHMAD0f4z8fSO5ZXcvFr2Ze3zGDTEY1vdXkAK2k9WuKu7c9kcoZO55Tads5T15vg4e8OmBq9kcGNEZRt2xBHkjlef0v6gBZ/lFeJHe0qTuKNCiTxJvUfAPnP0sTAdFdsDBt9bqLBHx+Wz/ALj535dUpCi5tXv4bI/t6qgh8toQNvJ7lNMv34W4+CiRYAPR9fK5bGsua+tb1FvfEqXx17yOLLgHgsu8oOsaZo";
         public static X509Certificate2 ExpiredX509Cert_Public = new X509Certificate2(Convert.FromBase64String(ExpiredX509Data_Public));
         public static X509SecurityKey ExpiredX509SecurityKey_Public = new X509SecurityKey(ExpiredX509Cert_Public);
         public static SigningCredentials ExpiredX509SigningCreds_Public = new SigningCredentials(ExpiredX509SecurityKey_Public, SecurityAlgorithms.RsaSha256Signature);
@@ -867,7 +867,7 @@ namespace Microsoft.IdentityModel.TestUtils
                     ""y"": ""AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1"",
                     ""d"": ""{{0}}""
                     }}", curvePointParameter);
-                
+
                 return new JsonWebKey(jsonString);
             }
         }
@@ -901,8 +901,8 @@ namespace Microsoft.IdentityModel.TestUtils
                     X = "luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA",
                     Y = "tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ",
                     D = badPrivateKey,
-                    KeyId = "JsonWebKeyP256_BadPrivateKey",
-                    Kid = "JsonWebKeyP256_BadPrivateKey",
+                    KeyId = "JsonWebKeyEcdsa256_BadPrivateKey",
+                    Kid = "JsonWebKeyEcdsa256_BadPrivateKey",
                     Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
                 };
             }
@@ -950,8 +950,8 @@ namespace Microsoft.IdentityModel.TestUtils
                     Crv = "P-384",
                     X = "5mn3HaDoUgdNTFCACaWIvrpriQTloEbMbx4eUu_XvB4pyExig45VIozMnj7FedJg",
                     Y = "Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l",
-                    KeyId = "JsonWebKeyP384_Public",
-                    Kid = "JsonWebKeyP384_Public",
+                    KeyId = "JsonWebKeyEcdsa384_Public",
+                    Kid = "JsonWebKeyEcdsa384_Public",
                     Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
                 };
             }
@@ -967,8 +967,8 @@ namespace Microsoft.IdentityModel.TestUtils
                     X = "AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr",
                     Y = "AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW",
                     D = "AWAduQ9Eu0fw2X_jBfYcSCc3jLfUuQY9Un3pQXHay4BlIhRObnNZAWPWOZccbP0ApfQLPHEAuByMtHv5D6sMVbCz",
-                    KeyId = "JsonWebKeyP521",
-                    Kid = "JsonWebKeyP521",
+                    KeyId = "JsonWebKeyEcdsa521",
+                    Kid = "JsonWebKeyEcdsa521",
                     Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
                 };
             }
@@ -983,8 +983,8 @@ namespace Microsoft.IdentityModel.TestUtils
                     Crv = "P-521",
                     X = "AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr",
                     Y = "AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW",
-                    KeyId = "JsonWebKeyP521_Public",
-                    Kid = "JsonWebKeyP521_Public",
+                    KeyId = "JsonWebKeyEcdsa521_Public",
+                    Kid = "JsonWebKeyEcdsa521_Public",
                     Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
                 };
             }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
@@ -26,7 +26,11 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.IdentityModel.Json;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
@@ -72,11 +76,15 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 dataset.Add(DataSets.JsonWebKeySetString1, DataSets.JsonWebKeySet1, ExpectedException.NoExceptionExpected);
                 dataset.Add(DataSets.JsonWebKeySetBadFormatingString, null, ExpectedException.ArgumentException(substringExpected: "IDX10805:", inner: typeof(JsonReaderException)));
                 dataset.Add(File.ReadAllText(DataSets.GoogleCertsFile), DataSets.GoogleCertsExpected, ExpectedException.NoExceptionExpected);
-                dataset.Add(DataSets.JsonWebKeySetBadRsaExponentString, null, ExpectedException.InvalidOperationException(substringExpected: "IDX10801:", inner: typeof(FormatException)));
-                dataset.Add(DataSets.JsonWebKeySetBadRsaModulusString, null, ExpectedException.InvalidOperationException(substringExpected: "IDX10801:", inner: typeof(FormatException)));
+                dataset.Add(DataSets.JsonWebKeySetBadRsaExponentString, null, ExpectedException.NoExceptionExpected);
+                dataset.Add(DataSets.JsonWebKeySetBadRsaModulusString, null, ExpectedException.NoExceptionExpected);
                 dataset.Add(DataSets.JsonWebKeySetKtyNotRsaString, null, ExpectedException.NoExceptionExpected);
                 dataset.Add(DataSets.JsonWebKeySetUseNotSigString, null, ExpectedException.NoExceptionExpected);
-                dataset.Add(DataSets.JsonWebKeySetBadX509String, null, ExpectedException.InvalidOperationException(substringExpected: "IDX10802:", inner: typeof(FormatException)));
+                dataset.Add(DataSets.JsonWebKeySetBadX509String, null, ExpectedException.NoExceptionExpected);
+                dataset.Add(DataSets.JsonWebKeySetECCString, DataSets.JsonWebKeySetEC, ExpectedException.NoExceptionExpected);
+                dataset.Add(DataSets.JsonWebKeySetBadECCurveString, null, ExpectedException.NoExceptionExpected);
+                dataset.Add(DataSets.JsonWebKeySetOnlyX5tString, DataSets.JsonWebKeySetOnlyX5t, ExpectedException.NoExceptionExpected);
+                dataset.Add(DataSets.JsonWebKeySetX509DataString, DataSets.JsonWebKeySetX509Data, ExpectedException.NoExceptionExpected);
 
                 return dataset;
             }
@@ -110,6 +118,322 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         public void Publics()
         {
         }
+
+        [Fact]
+        public void SigningKeysExtensibility()
+        {
+            var context = new CompareContext($"{this}.SigningKeysExtensibility");
+            TestUtilities.WriteHeader($"{this}.SigningKeysExtensibility");
+
+            try
+            {
+                // Received json web key only has an x5t property and it can't be used for signature validation as it can't be resolved into a SecurityKey, without user's custom code.
+                // This test proves that the scenario described above is possible using extensibility.
+                JsonWebKeySet.DefaultSkipUnresolvedJsonWebKeys = false;
+                var signingKeys = new JsonWebKeySet(DataSets.JsonWebKeySetOnlyX5tString).GetSigningKeys();
+
+                var tokenValidationParameters = new TokenValidationParameters()
+                {
+                    IssuerSigningKeys = signingKeys,
+                    IssuerSigningKeyResolver = (token, securityToken, keyIdentifier, tvp) => { return new List<SecurityKey> { ResolveX509Certificate(token, securityToken, keyIdentifier, tvp) }; },
+                    ValidateIssuer = false,
+                    ValidateAudience = false,
+                    ValidateLifetime = false,
+                };
+
+                var tokenValidationResult = new JsonWebTokens.JsonWebTokenHandler().ValidateToken(Default.AsymmetricJwt, tokenValidationParameters);
+
+                if (tokenValidationResult.IsValid != true)
+                    context.Diffs.Add("tokenValidationResult.IsValid != true");
+            }
+            catch (Exception ex)
+            {
+                context.Diffs.Add($"TokenValidationFailed: {ex}");
+            }
+
+            finally
+            {
+                // revert back to default
+                JsonWebKeySet.DefaultSkipUnresolvedJsonWebKeys = true;
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        private SecurityKey ResolveX509Certificate(string token, SecurityToken securityToken, string keyIdentifier, TokenValidationParameters tvp)
+        {
+            // example: get a certificate from a cert store
+
+            if (tvp.IssuerSigningKeys.First() is JsonWebKey jsonWebKey)
+            {
+                if (!string.IsNullOrEmpty(jsonWebKey.X5t))
+                {
+                    // X509Store store = new X509Store(StoreLocation.CurrentUser);
+                    // store.Open(OpenFlags.ReadOnly);
+                    // X509Certificate2Collection certs = store.Certificates.Find(X509FindType.FindByThumbprint, Base64UrlEncoder.Decode(jsonWebKey.X5t), true);
+                    // return new X509SecurityKey(certs[0]);
+
+                    return new X509SecurityKey(KeyingMaterial.DefaultCert_2048);
+                }
+            }
+
+            return null;
+        }
+
+        [Theory, MemberData(nameof(GetSigningKeysTheoryData))]
+        public void GetSigningKeys(JsonWebKeySetTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.GetSigningKeys", theoryData);
+            try
+            {
+                if (theoryData.SetEcdsaAdapterToNull)
+                    JsonWebKeySet.ECDsaAdapter = null;
+
+                var signingKeys = theoryData.JsonWebKeySet.GetSigningKeys();
+
+                IdentityComparer.AreEqual(signingKeys, theoryData.ExpectedSigningKeys, context);
+
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            // revert to default
+            if (theoryData.SetEcdsaAdapterToNull)
+            {
+                try
+                {
+                    JsonWebKeySet.ECDsaAdapter = new ECDsaAdapter();
+                }
+                catch
+                {
+                    // ECDsaAdapter is not supported by NETSTANDARD1.4, when running on platforms other than Windows
+                }
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<JsonWebKeySetTheoryData> GetSigningKeysTheoryData
+        {
+            get
+            {
+                var ecdsaAdapter = new ECDsaAdapter();
+                var theoryData = new TheoryData<JsonWebKeySetTheoryData>();
+
+                var jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNotSigString) { SkipUnresolvedJsonWebKeys = true };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    First = true,
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>(),
+                    TestId = "ZeroKeysWithSigAsUseSkipUnresolved",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNotSigString) { SkipUnresolvedJsonWebKeys = false };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
+                    TestId = "ZeroKeysWithSigAsUse",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNoKtyString) { SkipUnresolvedJsonWebKeys = true };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>(),
+                    TestId = "KeysWithoutKtySkipUnresolved",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetUseNoKtyString) { SkipUnresolvedJsonWebKeys = false };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
+                    TestId = "KeysWithoutKty",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetEvoString) { SkipUnresolvedJsonWebKeys = false };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0), CreateX509SecurityKey(jsonWebKeySet, 0) },
+                    TestId = "EvoSigningKey",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetKtyNotRsaString) { SkipUnresolvedJsonWebKeys = true };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>(),
+                    TestId = "NonRsaNonEcKeySkipUnresolved",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetKtyNotRsaString) { SkipUnresolvedJsonWebKeys = false };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
+                    TestId = "NonRsaNonEcKey",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOnlyX5tString) { SkipUnresolvedJsonWebKeys = true };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>(),
+                    TestId = "JsonWebKeyNotInvalidNotResolvedSkipUnresolved"
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOnlyX5tString) { SkipUnresolvedJsonWebKeys = false };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
+                    TestId = "JsonWebKeyNotInvalidNotResolved"
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidRsaString) { SkipUnresolvedJsonWebKeys = true };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0) },
+                    TestId = "OneValidAndOneInvalidRsaSkipUnresolved",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidRsaString) { SkipUnresolvedJsonWebKeys = false };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0], (jsonWebKeySet.Keys as List<JsonWebKey>)[1] },
+                    TestId = "OneValidAndOneInvalidRsa",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString) { SkipUnresolvedJsonWebKeys = true };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { CreateEcdsaSecurityKey(jsonWebKeySet, 1, ecdsaAdapter) },
+                    TestId = "OneValidAndOneInvalidEcSkipUnresolved",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString) { SkipUnresolvedJsonWebKeys = false };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0], CreateEcdsaSecurityKey(jsonWebKeySet, 1, ecdsaAdapter) },
+                    TestId = "OneValidAndOneInvalidEC",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidEcString) { SkipUnresolvedJsonWebKeys = true };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0) },
+                    TestId = "ValidRsaInvalidEcSkipUnresolved",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneValidRsaOneInvalidEcString) { SkipUnresolvedJsonWebKeys = false };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0), (jsonWebKeySet.Keys as List<JsonWebKey>)[1] },
+                    TestId = "ValidRsaInvalidEc",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetX509DataString) { SkipUnresolvedJsonWebKeys = false };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { CreateX509SecurityKey(jsonWebKeySet, 0) },
+                    TestId = "ValidX5c",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetBadX509String) { SkipUnresolvedJsonWebKeys = true };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0) },
+                    TestId = "InvalidX5cSkipUnresolvedAddRsa",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetBadX509String) { SkipUnresolvedJsonWebKeys = false };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { CreateRsaSecurityKey(jsonWebKeySet, 0), (jsonWebKeySet.Keys as List<JsonWebKey>)[0] },
+                    TestId = "InvalidX5c",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString) { SkipUnresolvedJsonWebKeys = true };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>(),
+                    SetEcdsaAdapterToNull = true,
+                    TestId = "ECDsaAdapterIsNotSupportedSkipUnresolved",
+                });
+
+                jsonWebKeySet = new JsonWebKeySet(DataSets.JsonWebKeySetOneInvalidEcOneValidEcString) { SkipUnresolvedJsonWebKeys = false };
+                theoryData.Add(new JsonWebKeySetTheoryData
+                {
+                    JsonWebKeySet = jsonWebKeySet,
+                    ExpectedSigningKeys = new List<SecurityKey>() { (jsonWebKeySet.Keys as List<JsonWebKey>)[0], (jsonWebKeySet.Keys as List<JsonWebKey>)[1] },
+                    SetEcdsaAdapterToNull = true,
+                    TestId = "ECDsaAdapterIsNotSupported",
+                });
+
+                return theoryData;
+            }
+        }
+
+        private static X509SecurityKey CreateX509SecurityKey(JsonWebKeySet webKeySet, int keyIndex)
+        {
+            var webKey = (webKeySet.Keys as List<JsonWebKey>)[keyIndex];
+
+            return new X509SecurityKey(new X509Certificate2(Convert.FromBase64String(webKey.X5c[0])))
+            {
+                KeyId = webKey.KeyId
+            };
+        }
+
+        private static RsaSecurityKey CreateRsaSecurityKey(JsonWebKeySet webKeySet, int keyIndex)
+        {
+            var webKey = (webKeySet.Keys as List<JsonWebKey>)[keyIndex];
+
+            var rsaParams = new RSAParameters()
+            {
+                Exponent = Base64UrlEncoder.DecodeBytes(webKey.E),
+                Modulus = Base64UrlEncoder.DecodeBytes(webKey.N),
+            };
+
+            return new RsaSecurityKey(rsaParams)
+            {
+                KeyId = webKey.KeyId,
+            };
+        }
+
+        private static ECDsaSecurityKey CreateEcdsaSecurityKey(JsonWebKeySet webKeySet, int keyIndex, ECDsaAdapter ecdsaAdapter)
+        {
+            var webKey = (webKeySet.Keys as List<JsonWebKey>)[keyIndex];
+
+            return new ECDsaSecurityKey(ecdsaAdapter.CreateECDsa(webKey, false))
+            {
+                KeyId = webKey.KeyId
+            };
+        }
+
+        public class JsonWebKeySetTheoryData : TheoryDataBase
+        {
+            public JsonWebKeySet JsonWebKeySet { get; set; }
+
+            public List<SecurityKey> ExpectedSigningKeys { get; set; }
+
+            public bool SetEcdsaAdapterToNull { get; set; } = false;
+         }
     }
 }
 


### PR DESCRIPTION
Cherry-picked from the dev5x branch.
Had a couple of conflicts, hence the PR.

Conflicts were in these files:
```
src/Microsoft.IdentityModel.Tokens/LogMessages.cs (one log message removed and one edited)
src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs (constructor that takes Newtonsoft.Json object in 5x)
test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs (related to the JsonWebKeySet constructor)
```

---

* Refactored JsonWebKeySet.GetSigningKeys() method and added support
for JWKs with 'kty' = 'EC'.
* Unresolved JsonWebKeys will be skipped by default.
SkipUnresolvedJsonWebKeys flag controls whether unresolved JsonWebKeys
will be included in the resulting collection of GetSigningKeys method.
* Adding only the first certificate from the x5c certificate chain as a
SecurityKey.