### PR TITLE
Support Signature as an inner element with EnvelopedSignatureWriter

### DIFF
--- a/src/Microsoft.IdentityModel.Xml/DelegatingXmlDictionaryWriter.cs
+++ b/src/Microsoft.IdentityModel.Xml/DelegatingXmlDictionaryWriter.cs
@@ -37,6 +37,7 @@ namespace Microsoft.IdentityModel.Xml
     public class DelegatingXmlDictionaryWriter : XmlDictionaryWriter
     {
         private XmlDictionaryWriter _innerWriter;
+        private XmlDictionaryWriter _internalWriter;
         private XmlDictionaryWriter _tracingWriter;
 
         /// <summary>
@@ -66,6 +67,16 @@ namespace Microsoft.IdentityModel.Xml
             set => _innerWriter = value ?? throw LogArgumentNullException(nameof(value));
         }
 
+        /// <summary>
+        /// Gets or sets the InternalWriter.
+        /// </summary>
+        /// <exception cref="ArgumentNullException"> if 'value' is null.</exception>
+        internal XmlDictionaryWriter InternalWriter
+        {
+            get => _internalWriter;
+            set => _internalWriter = value ?? throw LogArgumentNullException(nameof(value));
+        }
+
 #if NET45 || NET451
         /// <summary>
         /// Closes the underlying stream.
@@ -73,8 +84,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void Close()
         {
             UseInnerWriter.Close();
-            if (TracingWriter != null)
-                TracingWriter.Close();
+            TracingWriter?.Close();
+            InternalWriter?.Close();
         }
 #endif
 
@@ -84,8 +95,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void Flush()
         {
             UseInnerWriter.Flush();
-            if (TracingWriter != null)
-                TracingWriter.Flush();
+            TracingWriter?.Flush();
+            InternalWriter?.Flush();
         }
 
         /// <summary>
@@ -97,8 +108,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteBase64(byte[] buffer, int index, int count)
         {
             UseInnerWriter.WriteBase64(buffer, index, count);
-            if (TracingWriter != null)
-                TracingWriter.WriteBase64(buffer, index, count);
+            TracingWriter?.WriteBase64(buffer, index, count);
+            InternalWriter?.WriteBase64(buffer, index, count);
         }
 
         /// <summary>
@@ -108,8 +119,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteCData(string text)
         {
             UseInnerWriter.WriteCData(text);
-            if (TracingWriter != null)
-                TracingWriter.WriteCData(text);
+            TracingWriter?.WriteCData(text);
+            InternalWriter?.WriteCData(text);
         }
 
         /// <summary>
@@ -119,8 +130,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteCharEntity(char ch)
         {
             UseInnerWriter.WriteCharEntity(ch);
-            if (TracingWriter != null)
-                TracingWriter.WriteCharEntity(ch);
+            TracingWriter?.WriteCharEntity(ch);
+            InternalWriter?.WriteCharEntity(ch);
         }
 
         /// <summary>
@@ -132,8 +143,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteChars(char[] buffer, int index, int count)
         {
             UseInnerWriter.WriteChars(buffer, index, count);
-            if (TracingWriter != null)
-                TracingWriter.WriteChars(buffer, index, count);
+            TracingWriter?.WriteChars(buffer, index, count);
+            InternalWriter?.WriteChars(buffer, index, count);
         }
 
         /// <summary>
@@ -143,8 +154,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteComment(string text)
         {
             UseInnerWriter.WriteComment(text);
-            if (TracingWriter != null)
-                TracingWriter.WriteComment(text);
+            TracingWriter?.WriteComment(text);
+            InternalWriter?.WriteComment(text);
         }
 
         /// <summary>
@@ -160,8 +171,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteDocType(string name, string pubid, string sysid, string subset)
         {
             UseInnerWriter.WriteDocType(name, pubid, sysid, subset);
-            if (TracingWriter != null)
-                TracingWriter.WriteDocType(name, pubid, sysid, subset);
+            TracingWriter?.WriteDocType(name, pubid, sysid, subset);
+            InternalWriter?.WriteDocType(name, pubid, sysid, subset);
         }
 
         /// <summary>
@@ -170,8 +181,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteEndAttribute()
         {
             UseInnerWriter.WriteEndAttribute();
-            if (TracingWriter != null)
-                TracingWriter.WriteEndAttribute();
+            TracingWriter?.WriteEndAttribute();
+            InternalWriter?.WriteEndAttribute();
         }
 
         /// <summary>
@@ -180,8 +191,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteEndDocument()
         {
             UseInnerWriter.WriteEndDocument();
-            if (TracingWriter != null)
-                TracingWriter.WriteEndDocument();
+            TracingWriter?.WriteEndDocument();
+            InternalWriter?.WriteEndDocument();
         }
 
         /// <summary>
@@ -190,8 +201,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteEndElement()
         {
             UseInnerWriter.WriteEndElement();
-            if (TracingWriter != null)
-                TracingWriter.WriteEndElement();
+            TracingWriter?.WriteEndElement();
+            InternalWriter?.WriteEndElement();
         }
 
         /// <summary>
@@ -201,8 +212,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteEntityRef(string name)
         {
             UseInnerWriter.WriteEntityRef(name);
-            if (TracingWriter != null)
-                TracingWriter.WriteEntityRef(name);
+            TracingWriter?.WriteEntityRef(name);
+            InternalWriter?.WriteEntityRef(name);
         }
 
         /// <summary>
@@ -211,8 +222,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteFullEndElement()
         {
             UseInnerWriter.WriteFullEndElement();
-            if (TracingWriter != null)
-                TracingWriter.WriteFullEndElement();
+            TracingWriter?.WriteFullEndElement();
+            InternalWriter?.WriteFullEndElement();
         }
 
         /// <summary>
@@ -223,8 +234,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteProcessingInstruction(string name, string text)
         {
             UseInnerWriter.WriteProcessingInstruction(name, text);
-            if (TracingWriter != null)
-                TracingWriter.WriteProcessingInstruction(name, text);
+            TracingWriter?.WriteProcessingInstruction(name, text);
+            InternalWriter?.WriteProcessingInstruction(name, text);
         }
 
         /// <summary>
@@ -236,8 +247,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteRaw(char[] buffer, int index, int count)
         {
             UseInnerWriter.WriteRaw(buffer, index, count);
-            if (TracingWriter != null)
-                TracingWriter.WriteRaw(buffer, index, count);
+            TracingWriter?.WriteRaw(buffer, index, count);
+            InternalWriter?.WriteRaw(buffer, index, count);
         }
 
         /// <summary>
@@ -247,8 +258,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteRaw(string data)
         {
             UseInnerWriter.WriteRaw(data);
-            if (TracingWriter != null)
-                TracingWriter.WriteRaw(data);
+            TracingWriter?.WriteRaw(data);
+            InternalWriter?.WriteRaw(data);
         }
 
         /// <summary>
@@ -260,8 +271,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteStartAttribute(string prefix, string localName, string @namespace)
         {
             UseInnerWriter.WriteStartAttribute(prefix, localName, @namespace);
-            if (TracingWriter != null)
-                TracingWriter.WriteStartAttribute(prefix, localName, @namespace);
+            TracingWriter?.WriteStartAttribute(prefix, localName, @namespace);
+            InternalWriter?.WriteStartAttribute(prefix, localName, @namespace);
         }
 
         /// <summary>
@@ -270,8 +281,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteStartDocument()
         {
             UseInnerWriter.WriteStartDocument();
-            if (TracingWriter != null)
-                TracingWriter.WriteStartDocument();
+            TracingWriter?.WriteStartDocument();
+            InternalWriter?.WriteStartDocument();
         }
 
         /// <summary>
@@ -282,8 +293,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteStartDocument(bool standalone)
         {
             UseInnerWriter.WriteStartDocument(standalone);
-            if (TracingWriter != null)
-                TracingWriter.WriteStartDocument(standalone);
+            TracingWriter?.WriteStartDocument(standalone);
+            InternalWriter?.WriteStartDocument(standalone);
         }
 
         /// <summary>
@@ -296,8 +307,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteStartElement(string prefix, string localName, string @namespace)
         {
             UseInnerWriter.WriteStartElement(prefix, localName, @namespace);
-            if (TracingWriter != null)
-                TracingWriter.WriteStartElement(prefix, localName, @namespace);
+            TracingWriter?.WriteStartElement(prefix, localName, @namespace);
+            InternalWriter?.WriteStartElement(prefix, localName, @namespace);
         }
 
         /// <summary>
@@ -315,8 +326,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteString(string text)
         {
             UseInnerWriter.WriteString(text);
-            if (TracingWriter != null)
-                TracingWriter.WriteString(text);
+            TracingWriter?.WriteString(text);
+            InternalWriter?.WriteString(text);
         }
 
         /// <summary>
@@ -327,8 +338,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteSurrogateCharEntity(char lowChar, char highChar)
         {
             UseInnerWriter.WriteSurrogateCharEntity(lowChar, highChar);
-            if (TracingWriter != null)
-                TracingWriter.WriteSurrogateCharEntity(lowChar, highChar);
+            TracingWriter?.WriteSurrogateCharEntity(lowChar, highChar);
+            InternalWriter?.WriteSurrogateCharEntity(lowChar, highChar);
         }
 
         /// <summary>
@@ -338,8 +349,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteWhitespace(string ws)
         {
             UseInnerWriter.WriteWhitespace(ws);
-            if (TracingWriter != null)
-                TracingWriter.WriteWhitespace(ws);
+            TracingWriter?.WriteWhitespace(ws);
+            InternalWriter?.WriteWhitespace(ws);
         }
 
         /// <summary>
@@ -350,8 +361,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteXmlAttribute(string localName, string value)
         {
             UseInnerWriter.WriteXmlAttribute(localName, value);
-            if (TracingWriter != null)
-                TracingWriter.WriteAttributeString(localName, value);
+            TracingWriter?.WriteAttributeString(localName, value);
+            InternalWriter?.WriteAttributeString(localName, value);
         }
 
         /// <summary>
@@ -362,8 +373,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteXmlnsAttribute(string prefix, string @namespace)
         {
             UseInnerWriter.WriteXmlnsAttribute(prefix, @namespace);
-            if (TracingWriter != null)
-                TracingWriter.WriteAttributeString(prefix, String.Empty, @namespace, String.Empty);
+            TracingWriter?.WriteAttributeString(prefix, String.Empty, @namespace, String.Empty);
+            InternalWriter?.WriteAttributeString(prefix, String.Empty, @namespace, String.Empty);
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Xml/EnvelopedSignatureReader.cs
+++ b/src/Microsoft.IdentityModel.Xml/EnvelopedSignatureReader.cs
@@ -124,7 +124,11 @@ namespace Microsoft.IdentityModel.Xml
                     }
                 }
 
-                result = InnerReader.Read();
+                // If reading of an element will be completed in this pass, allow the InnerReader to record the signature position.
+                if (completed && InnerReader is XmlTokenStreamReader xmlTokenStreamReader)
+                    result = xmlTokenStreamReader.Read(true);
+                else
+                    result = InnerReader.Read();
             }
 
             if (result

--- a/src/Microsoft.IdentityModel.Xml/XmlTokenStreamReader.cs
+++ b/src/Microsoft.IdentityModel.Xml/XmlTokenStreamReader.cs
@@ -85,8 +85,7 @@ namespace Microsoft.IdentityModel.Xml
         {
             if (_innerTokenStreamReader != null)
             {
-                // if the inner reader is a XmlTokenStreamReader tell it to skip recording the signature position
-                if (!_innerTokenStreamReader.Read(false))
+                if (!_innerTokenStreamReader.Read(recordSignaturePosition))
                     return false;
             }
             else if (!InnerReader.Read())
@@ -113,7 +112,6 @@ namespace Microsoft.IdentityModel.Xml
 
             if (!_recordDone)
                 Record(true);
-
 
             return true;
         }

--- a/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
@@ -428,7 +428,7 @@ namespace Microsoft.IdentityModel.TestUtils
             RsaSigningCreds_2048_Public = new SigningCredentials(RsaSecurityKey_2048_Public, SecurityAlgorithms.RsaSha256Signature);
             RsaSigningCreds_2048_FromRsa = new SigningCredentials(RsaSecurityKey_2048_FromRsa, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256);
             RsaSigningCreds_2048_FromRsa_Public = new SigningCredentials(RsaSecurityKey_2048_FromRsa_Public, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256);
-            RsaSigningCreds_4096 = new SigningCredentials(RsaSecurityKey_2048, SecurityAlgorithms.RsaSha256Signature);
+            RsaSigningCreds_4096 = new SigningCredentials(RsaSecurityKey_2048, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256);
             RsaSigningCreds_4096_Public = new SigningCredentials(RsaSecurityKey_2048_Public, SecurityAlgorithms.RsaSha256Signature);
 
 #if !NET_CORE

--- a/test/Microsoft.IdentityModel.Xml.Tests/EnvelopedSignatureTheoryData.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/EnvelopedSignatureTheoryData.cs
@@ -25,6 +25,8 @@
 //
 //------------------------------------------------------------------------------
 
+using System;
+using System.IO;
 using System.Xml;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Xml;
@@ -33,6 +35,8 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
 {
     public class EnvelopedSignatureTheoryData : TheoryDataBase
     {
+        public Action<EnvelopedSignatureWriter> Action { get; set; }
+
         public CryptoProviderFactory CryptoProviderFactory { get; set; } = CryptoProviderFactory.Default;
 
         public bool ExpectSignature { get; set; } = true;

--- a/test/Microsoft.IdentityModel.Xml.Tests/EnvelopedSignatureWriterTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/EnvelopedSignatureWriterTests.cs
@@ -28,9 +28,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Xml;
+using Microsoft.IdentityModel.Protocols.WsFederation;
 using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens.Saml;
 using Microsoft.IdentityModel.Tokens.Saml2;
 using Microsoft.IdentityModel.Xml;
 using Xunit;
@@ -87,7 +90,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
         public void RoundTripSaml2(EnvelopedSignatureTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RoundTripSaml2", theoryData);
-            context.PropertiesToIgnoreWhenComparing.Add( typeof(Saml2Assertion), new List<string> { "CanonicalString" });
+            context.PropertiesToIgnoreWhenComparing.Add(typeof(Saml2Assertion), new List<string> { "CanonicalString" });
 
             try
             {
@@ -134,6 +137,345 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
                     }
                 };
             }
+        }
+
+        [Theory, MemberData(nameof(RoundTripWsMetadataTheoryData))]
+        public void RoundTripWsMetadata(EnvelopedSignatureTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.RoundTripWsMetadata", theoryData);
+
+            try
+            {
+                var settings = new XmlWriterSettings
+                {
+                    Encoding = new UTF8Encoding(false)
+                };
+                var buffer = new MemoryStream();
+                var esw = new EnvelopedSignatureWriter(XmlWriter.Create(buffer, settings), theoryData.SigningCredentials, theoryData.ReferenceId);
+
+                foreach (var action in theoryData.Action.GetInvocationList())
+                {
+                    action.DynamicInvoke(esw);
+                }
+
+                var metadata = Encoding.UTF8.GetString(buffer.ToArray());
+                var configuration = new WsFederationConfiguration();
+                var reader = XmlReader.Create(new StringReader(metadata));
+                configuration = new WsFederationMetadataSerializer().ReadMetadata(reader);
+                configuration.Signature.Verify(theoryData.SigningCredentials.Key, theoryData.SigningCredentials.Key.CryptoProviderFactory);
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<EnvelopedSignatureTheoryData> RoundTripWsMetadataTheoryData
+        {
+            get
+            {
+                return new TheoryData<EnvelopedSignatureTheoryData>()
+                {
+                    new EnvelopedSignatureTheoryData
+                    {
+                        First = true,
+                        Action = (EnvelopedSignatureWriter esw) =>
+                        {
+                            esw.WriteStartElement("EntityDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteAttributeString("entityID", "issuer");
+                            esw.WriteEndElement();
+                        },
+                        ReferenceId = Default.ReferenceUriWithOutPrefix,
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                        TestId = "WriteSignatureAsLastElement",
+                    },
+                    new EnvelopedSignatureTheoryData
+                    {
+                        Action = (EnvelopedSignatureWriter esw) =>
+                        {
+                            esw.WriteStartElement("EntityDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteAttributeString("entityID", "issuer");
+                            esw.WriteStartElement("RoleDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteEndElement();
+                            esw.WriteEndElement();
+                        },
+                        ReferenceId = Default.ReferenceUriWithOutPrefix,
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                        TestId = "WriteSignatureAsLastElement2",
+                    },
+                    new EnvelopedSignatureTheoryData
+                    {
+                        Action = (EnvelopedSignatureWriter esw) =>
+                        {
+                            esw.WriteStartElement("EntityDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteAttributeString("entityID", "issuer");
+                            esw.WriteSignature();
+                            esw.WriteStartElement("RoleDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteEndElement();
+                            esw.WriteEndElement();
+                        },
+                        ReferenceId = Default.ReferenceUriWithOutPrefix,
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                        TestId = "WriteSignatureInTheMiddle",
+                    },
+                    new EnvelopedSignatureTheoryData
+                    {
+                        Action = (EnvelopedSignatureWriter esw) =>
+                        {
+                            esw.WriteStartElement("EntityDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteAttributeString("entityID", "issuer");
+                            esw.WriteStartElement("RoleDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteSignature();
+                            esw.WriteEndElement();
+                            esw.WriteEndElement();
+                        },
+                        ReferenceId = Default.ReferenceUriWithOutPrefix,
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                        TestId = "WriteSignatureInTheMiddle2",
+                    },
+                    new EnvelopedSignatureTheoryData
+                    {
+                        Action = (EnvelopedSignatureWriter esw) =>
+                        {
+                            esw.WriteStartElement("EntityDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteAttributeString("entityID", "issuer");
+                            esw.WriteStartElement("RoleDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteStartElement("KeyDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteSignature();
+                            esw.WriteEndElement();
+                            esw.WriteEndElement();
+                            esw.WriteEndElement();
+                        },
+                        ReferenceId = Default.ReferenceUriWithOutPrefix,
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                        TestId = "WriteSignatureInTheMiddle3",
+                    },
+                    new EnvelopedSignatureTheoryData
+                    {
+                        Action = (EnvelopedSignatureWriter esw) =>
+                        {
+                            esw.WriteStartElement("EntityDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteAttributeString("entityID", "issuer");
+                            esw.WriteStartElement("RoleDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteEndElement();
+                            esw.WriteSignature();
+                            esw.WriteEndElement();
+                        },
+                        ReferenceId = Default.ReferenceUriWithOutPrefix,
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                        TestId = "WriteSignatureAsLastElementExplicitly",
+                    },
+                    new EnvelopedSignatureTheoryData
+                    {
+                        Action = (EnvelopedSignatureWriter esw) =>
+                        {
+                            esw.WriteStartElement("EntityDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteAttributeString("entityID", "issuer");
+                            esw.WriteStartElement("RoleDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteEndElement();
+                            esw.WriteEndElement();
+                            esw.WriteSignature();
+                        },
+                        ReferenceId = Default.ReferenceUriWithOutPrefix,
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                        TestId = "WriteSignatureAfterLastElementIsIgnored",
+                    },
+                    new EnvelopedSignatureTheoryData
+                    {
+                        Action = (EnvelopedSignatureWriter esw) =>
+                        {
+                            esw.WriteStartElement("EntityDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteSignature();
+                            esw.WriteAttributeString("entityID", "issuer");
+                            esw.WriteStartElement("RoleDescriptor", "urn:oasis:names:tc:SAML:2.0:metadata");
+                            esw.WriteEndElement();
+                            esw.WriteEndElement();
+                        },
+                        ReferenceId = Default.ReferenceUriWithOutPrefix,
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                        ExpectedException = new ExpectedException(typeof(System.Reflection.TargetInvocationException), null, typeof(System.InvalidOperationException)),
+                        TestId = "WriteSignatureInTheMiddleBeforeAttributeInvalid",
+                    }
+                };
+            }
+        }
+
+        [Fact]
+        public void RoundTripSamlP()
+        {
+            var context = new CompareContext($"{this}.RoundTripSamlP");
+            ExpectedException expectedException = ExpectedException.NoExceptionExpected;
+            var samlpTokenKey = KeyingMaterial.RsaSigningCreds_4096_Public.Key;
+            var samlpTokenSigningCredentials = KeyingMaterial.RsaSigningCreds_4096;
+            var samlpKey = KeyingMaterial.RsaSigningCreds_2048_Public.Key;
+            var samlpSigningCredentials = KeyingMaterial.RsaSigningCreds_2048;
+
+            try
+            {
+                // write samlp
+                var settings = new XmlWriterSettings
+                {
+                    Encoding = new UTF8Encoding(false)
+                };
+                var buffer = new MemoryStream();
+                var esw = new EnvelopedSignatureWriter(XmlWriter.Create(buffer, settings), samlpSigningCredentials, "id-uAOhNLe7abGB6WGPk");
+                esw.WriteStartElement("ns0", "Response", "urn:oasis:names:tc:SAML:2.0:protocol");
+
+                esw.WriteAttributeString("ns1", "urn:oasis:names:tc:SAML:2.0:assertion");
+                esw.WriteAttributeString("ns2", "http://www.w3.org/2000/09/xmldsig#");
+                esw.WriteAttributeString("Destination", "https://tnia.eidentita.cz/fpsts/processRequest.aspx");
+                esw.WriteAttributeString("ID", "id-uAOhNLe7abGB6WGPk");
+                esw.WriteAttributeString("InResponseTo", "ida5714d006fcc430c92aacf34ab30b166");
+                esw.WriteAttributeString("IssueInstant", "2019-04-08T10:30:49Z");
+                esw.WriteAttributeString("Version", "2.0");
+                esw.WriteSignature();
+                esw.WriteStartElement("ns1", "Issuer");
+                esw.WriteAttributeString("Format", "urn:oasis:names:tc:SAML:2.0:nameid-format:entity");
+                esw.WriteString("https://mojeid.regtest.nic.cz/saml/idp.xml");
+                esw.WriteEndElement();
+                esw.WriteStartElement("ns0", "Status", null);
+                esw.WriteStartElement("ns0", "StatusCode", null);
+                esw.WriteAttributeString("Value", "urn:oasis:names:tc:SAML:2.0:status:Success");
+                esw.WriteEndElement();
+                esw.WriteEndElement();
+                Saml2Serializer samlSerializer = new Saml2Serializer();
+                Saml2Assertion assertion = CreateAssertion(samlpTokenSigningCredentials);
+                samlSerializer.WriteAssertion(esw, assertion);
+                esw.WriteEndElement();
+                var xml = Encoding.UTF8.GetString(buffer.ToArray());
+
+                // read samlp and verify signatures
+                XmlReader reader = XmlUtilities.CreateDictionaryReader(xml);
+                IXmlElementReader tokenReaders = new TokenReaders(new List<SecurityTokenHandler> { new Saml2SecurityTokenHandler() });
+                EnvelopedSignatureReader envelopedReader = new EnvelopedSignatureReader(reader, tokenReaders);
+
+                while (envelopedReader.Read()) ;
+
+                foreach (var item in tokenReaders.Items)
+                {
+                    if (item is Saml2SecurityToken samlToken)
+                        samlToken.Assertion.Signature.Verify(samlpTokenKey);
+                }
+
+                envelopedReader.Signature.Verify(samlpKey, samlpKey.CryptoProviderFactory);
+                expectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                expectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Fact]
+        public void RoundTripSamlPSignatureAfterAssertion()
+        {
+            var context = new CompareContext($"{this}.RoundTripSamlPSignatureAfterAssertion");
+            ExpectedException expectedException = ExpectedException.NoExceptionExpected;
+            var samlpTokenKey = KeyingMaterial.RsaSigningCreds_4096_Public.Key;
+            var samlpTokenSigningCredentials = KeyingMaterial.RsaSigningCreds_4096;
+            var samlpKey = KeyingMaterial.RsaSigningCreds_2048_Public.Key;
+            var samlpSigningCredentials = KeyingMaterial.RsaSigningCreds_2048;
+
+            try
+            {
+                // write samlp
+                var settings = new XmlWriterSettings
+                {
+                    Encoding = new UTF8Encoding(false)
+                };
+                var buffer = new MemoryStream();
+                var esw = new EnvelopedSignatureWriter(XmlWriter.Create(buffer, settings), samlpSigningCredentials, "id-uAOhNLe7abGB6WGPk");
+                esw.WriteStartElement("ns0", "Response", "urn:oasis:names:tc:SAML:2.0:protocol");
+
+                esw.WriteAttributeString("ns1", "urn:oasis:names:tc:SAML:2.0:assertion");
+                esw.WriteAttributeString("ns2", "http://www.w3.org/2000/09/xmldsig#");
+                esw.WriteAttributeString("Destination", "https://tnia.eidentita.cz/fpsts/processRequest.aspx");
+                esw.WriteAttributeString("ID", "id-uAOhNLe7abGB6WGPk");
+                esw.WriteAttributeString("InResponseTo", "ida5714d006fcc430c92aacf34ab30b166");
+                esw.WriteAttributeString("IssueInstant", "2019-04-08T10:30:49Z");
+                esw.WriteAttributeString("Version", "2.0");
+                esw.WriteStartElement("ns1", "Issuer");
+                esw.WriteAttributeString("Format", "urn:oasis:names:tc:SAML:2.0:nameid-format:entity");
+                esw.WriteString("https://mojeid.regtest.nic.cz/saml/idp.xml");
+                esw.WriteEndElement();
+                esw.WriteStartElement("ns0", "Status", null);
+                esw.WriteStartElement("ns0", "StatusCode", null);
+                esw.WriteAttributeString("Value", "urn:oasis:names:tc:SAML:2.0:status:Success");
+                esw.WriteEndElement();
+                esw.WriteEndElement();
+                Saml2Serializer samlSerializer = new Saml2Serializer();
+                Saml2Assertion assertion = CreateAssertion(samlpTokenSigningCredentials);
+                samlSerializer.WriteAssertion(esw, assertion);
+                esw.WriteSignature();
+                esw.WriteEndElement();
+                var xml = Encoding.UTF8.GetString(buffer.ToArray());
+
+                // read samlp and verify signatures
+                XmlReader reader = XmlUtilities.CreateDictionaryReader(xml);
+                IXmlElementReader tokenReaders = new TokenReaders(new List<SecurityTokenHandler> { new Saml2SecurityTokenHandler() });
+                EnvelopedSignatureReader envelopedReader = new EnvelopedSignatureReader(reader, tokenReaders);
+
+                while (envelopedReader.Read()) ;
+
+                foreach (var item in tokenReaders.Items)
+                {
+                    if (item is Saml2SecurityToken samlToken)
+                        samlToken.Assertion.Signature.Verify(samlpTokenKey);
+                }
+
+                envelopedReader.Signature.Verify(samlpKey, samlpKey.CryptoProviderFactory);
+                expectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                expectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        private static Saml2Assertion CreateAssertion(SigningCredentials samlpTokenSigningCredentials)
+        {
+            var assertion = new Saml2Assertion(new Saml2NameIdentifier("https://mojeid.regtest.nic.cz/saml/idp.xml", new Uri("urn:oasis:names:tc:SAML:2.0:nameid-format:entity")))
+            {
+                InclusiveNamespacesPrefixList = "ns1 ns2",
+                IssueInstant = DateTime.Parse("2019-04-08T10:30:49Z"),
+                SigningCredentials = samlpTokenSigningCredentials,
+                Id = new Saml2Id("id-2bMsOPOKIqeVIDLqJ")
+            };
+
+            var saml2SubjectConfirmationData = new Saml2SubjectConfirmationData
+            {
+                InResponseTo = new Saml2Id("ida5714d006fcc430c92aacf34ab30b166"),
+                NotOnOrAfter = DateTime.Parse("2019-04-08T10:45:49Z"),
+                Recipient = new Uri("https://tnia.eidentita.cz/fpsts/processRequest.aspx")
+            };
+            var saml2SubjectConfirmation = new Saml2SubjectConfirmation(new Uri("urn:oasis:names:tc:SAML:2.0:cm:bearer"), saml2SubjectConfirmationData);
+            var saml2Subject = new Saml2Subject(new Saml2NameIdentifier("6dfe0399103d11411b1fa00772b6a13e0858605b80c20ea845769c57b41479ed", new Uri("urn:oasis:names:tc:SAML:2.0:nameid-format:persistent")));
+            saml2Subject.SubjectConfirmations.Add(saml2SubjectConfirmation);
+            assertion.Subject = saml2Subject;
+
+            var saml2AudienceRestrictions = new Saml2AudienceRestriction("urn:microsoft: cgg2010: fpsts");
+            var saml2Conditions = new Saml2Conditions();
+            saml2Conditions.AudienceRestrictions.Add(saml2AudienceRestrictions);
+            saml2Conditions.NotBefore = DateTime.Parse("2019-04-08T10:30:49Z");
+            saml2Conditions.NotOnOrAfter = DateTime.Parse("2019-04-08T10:45:49Z");
+            assertion.Conditions = saml2Conditions;
+
+            var saml2AuthenticationContext = new Saml2AuthenticationContext(new Uri("urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"), null);
+            var saml2Statement = new Saml2AuthenticationStatement(saml2AuthenticationContext)
+            {
+                AuthenticationInstant = DateTime.Parse("2019-04-08T10:30:49Z"),
+                SessionIndex = "id-oTnhrqWtcTTEntvMy"
+            };
+            assertion.Statements.Add(saml2Statement);
+
+            return assertion;
         }
     }
 }


### PR DESCRIPTION
* Use InnerWriter to write canonical bytes (without signature).
* Use InternalWriter to write non-canonical xml (including signature).
* When WriteSignature() method is called, write only a placeholder signature element using InternalWriter.
* After writing the last (end) element, create XmlTokenStream out of the InternalWriter's stream and write that XmlTokenStream into the original writer. When writing the XmlTokenStream, replace signature [placeholder] element with the real signature (using DSigSerializer). This behavior is followed only if WriteSignature method was invoked explicitly. Otherwise, the default behavior is to generate the signature at the end and to write it directly to the original stream.
* Improve EnvelopedSignatureReader and XmlTokenStreamReader to allow reading an xml where an outer signature is written right after an assertion.
* Add RoundTripWsMetadata test with a signature placed at different positions.
* Add RountTripSamlp* tests to showcase writing an xml with multiple signatures and later reading it at with an EnvelopedSignatureReader and validating both inner and outer signature.

Resolves: #1083 