### PR TITLE
Added a property to AuthenticationProtocolMessage that returns the script used in the post string

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/AuthenticationProtocolMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols/AuthenticationProtocolMessage.cs
@@ -79,7 +79,9 @@ namespace Microsoft.IdentityModel.Protocols
             strBuilder.Append("</p><input type=\"submit\" value=\"");
             strBuilder.Append(HtmlEncode(ScriptButtonText));
             strBuilder.Append("\" /></noscript>");
-            strBuilder.Append("</form><script language=\"javascript\">window.setTimeout('document.forms[0].submit()', 0);</script></body></html>");
+            strBuilder.Append("</form>");
+            strBuilder.Append(Script);
+            strBuilder.Append("</body></html>");
             return strBuilder.ToString();
         }
 
@@ -233,6 +235,11 @@ namespace Microsoft.IdentityModel.Protocols
                 SetParameter(key, nameValueCollection[key]);
             };
         }
+
+        /// <summary>
+        /// Gets the script used when constructing the post string.
+        /// </summary>
+        public string Script { get; } = "<script language=\"javascript\">window.setTimeout('document.forms[0].submit()', 0);</script>";
 
         /// <summary>
         /// Gets or sets the script button text used when constructing the post string.

--- a/test/Microsoft.IdentityModel.Protocols.Tests/AuthenticationProtocolMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/AuthenticationProtocolMessageTests.cs
@@ -40,28 +40,26 @@ namespace Microsoft.IdentityModel.Protocols.Tests
         [Fact]
         public void Defaults()
         {
-            List<string> errors = new List<string>();
+            var context = new CompareContext();
             string issuerAddress = "http://www.gotjwt.com";
+            var script = "<script language=\"javascript\">window.setTimeout('document.forms[0].submit()', 0);</script>";
 
             AuthenticationProtocolMessage authenticationProtocolMessage = new DerivedAuthenticationProtocolMessage();
-            if (!IdentityComparer.AreStringsEqual(authenticationProtocolMessage.IssuerAddress, string.Empty, CompareContext.Default))
-            {
-                errors.Add("authenticationProtocolMessage.IssuerAddress != string.Empty: " + authenticationProtocolMessage.IssuerAddress ?? "null");
-            }
+            IdentityComparer.AreStringsEqual(authenticationProtocolMessage.IssuerAddress, string.Empty, context);
 
             authenticationProtocolMessage = new DerivedAuthenticationProtocolMessage() { IssuerAddress = issuerAddress };
-            if (!IdentityComparer.AreStringsEqual(authenticationProtocolMessage.IssuerAddress, issuerAddress, CompareContext.Default))
-            {
-                errors.Add("authenticationProtocolMessage.IssuerAddress != issuerAddress: " + authenticationProtocolMessage.IssuerAddress ?? "null" + " , " + issuerAddress);
-            }
+            IdentityComparer.AreStringsEqual(authenticationProtocolMessage.IssuerAddress, issuerAddress, context);
+
+            if (!authenticationProtocolMessage.Script.Equals(script))
+                context.Diffs.Add("The value of authenticationProtocolMessage.Script should be '" + script + "'.");
 
             if (authenticationProtocolMessage.Parameters == null)
-            {
-                errors.Add("uthenticationProtocolMessage.Parameters .IssuerAddress != issuerAddress: " + authenticationProtocolMessage.IssuerAddress ?? "null" + " , " + issuerAddress);
-            }
+                context.Diffs.Add("authenticationProtocolMessage.Parameters == null");
 
-            Assert.NotNull(authenticationProtocolMessage.Parameters);
-            Assert.Equal(0, authenticationProtocolMessage.Parameters.Count);
+            if (authenticationProtocolMessage.Parameters.Count != 0)
+                context.Diffs.Add("authenticationProtocolMessage.Parameters.Count != 0");
+
+            TestUtilities.AssertFailIfErrors(context);
         }
 
         [Fact]

--- a/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/WsFederationMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/WsFederationMessageTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
         {
             var type = typeof(WsFederationMessage);
             var properties = type.GetProperties();
-            Assert.True(properties.Length == 27, $"Number of properties has changed from 27 to: {properties.Length}, adjust tests");
+            Assert.True(properties.Length == 28, $"Number of properties has changed from 28 to: {properties.Length}, adjust tests");
 
             var context = new GetSetContext
             {


### PR DESCRIPTION
Addresses #1178.

A script hash can be used in a CSP in order to indicate whether a particular JavaScript script is allowed to run. By providing the string representation of the script we're using, we can make it easier for users to obtain this value.

I also refactored AuthenticationProtocolMessageTests.Defaults() to make use of CompareContext.