### PR TITLE
JsonWebKey and Related fixes.

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -114,7 +114,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
             else if (key is JsonWebKey ecdsaWebKey && ecdsaWebKey.Kty == JsonWebAlgorithmsKeyTypes.EllipticCurve)
             {
-                var ecdsaAdapter = new ECDsaAdapter();
+                var ecdsaAdapter = ECDsaAdapter.Instance;
                 ECDsa = ecdsaAdapter.CreateECDsa(ecdsaWebKey, requirePrivateKey);
                 SignatureFunction = SignWithECDsa;
                 VerifyFunction = VerifyWithECDsa;
@@ -185,8 +185,7 @@ namespace Microsoft.IdentityModel.Tokens
                 }
                 else if (jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.EllipticCurve)
                 {
-                    var ecdsaAdapter = new ECDsaAdapter();
-                    ECDsa = ecdsaAdapter.CreateECDsa(jsonWebKey, requirePrivateKey);
+                    ECDsa = ECDsaAdapter.Instance.CreateECDsa(jsonWebKey, requirePrivateKey);
                     SignatureFunction = SignWithECDsa;
                     VerifyFunction = VerifyWithECDsa;
                     _disposeCryptoOperators = true;

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSecurityKey.cs
@@ -33,6 +33,18 @@ namespace Microsoft.IdentityModel.Tokens
     public abstract class AsymmetricSecurityKey : SecurityKey
     {
         /// <summary>
+        /// Default constructor
+        /// </summary>
+        public AsymmetricSecurityKey()
+        {
+        }
+
+        internal AsymmetricSecurityKey(SecurityKey key)
+            : base(key)
+        {
+        }
+
+        /// <summary>
         /// This must be overridden to get a bool indicating if a private key exists.
         /// </summary>
         /// <return>true if it has a private key; otherwise, false.</return>

--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -389,7 +389,7 @@ namespace Microsoft.IdentityModel.Tokens
             // types are checked in order of expected occurrence
             string typeofSignatureProvider = null;
             bool createAsymmetric = true;
-            if (key is AsymmetricSecurityKey asymmetricSecurityKey)
+            if (key is AsymmetricSecurityKey)
             {
                 typeofSignatureProvider = typeof(AsymmetricSignatureProvider).ToString();
             }
@@ -398,16 +398,17 @@ namespace Microsoft.IdentityModel.Tokens
                 if (jsonWebKey.Kty != null)
                 {
                     if (jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.RSA || jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.EllipticCurve)
+                    {
                         typeofSignatureProvider = typeof(AsymmetricSignatureProvider).ToString();
-
-                    if (jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.Octet)
+                    }
+                    else if (jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.Octet)
                     {
                         typeofSignatureProvider = typeof(SymmetricSignatureProvider).ToString();
                         createAsymmetric = false;
                     }
                 }
             }
-            else if (key is SymmetricSecurityKey symmetricSecurityKey)
+            else if (key is SymmetricSecurityKey)
             {
                 typeofSignatureProvider = typeof(SymmetricSignatureProvider).ToString();
                 createAsymmetric = false;
@@ -473,7 +474,11 @@ namespace Microsoft.IdentityModel.Tokens
             if (CustomCryptoProvider != null && CustomCryptoProvider.IsSupportedAlgorithm(algorithm, key))
                 return true;
 
-            return SupportedAlgorithms.IsSupportedAlgorithm(algorithm, key);
+            return SupportedAlgorithms.IsSupportedAlgorithm(
+                        algorithm,
+                        (key is JsonWebKey jsonWebKey && jsonWebKey.ConvertedSecurityKey != null)
+                        ? jsonWebKey.ConvertedSecurityKey
+                        : key);
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/ECDsaAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ECDsaAdapter.cs
@@ -40,7 +40,13 @@ namespace Microsoft.IdentityModel.Tokens
     /// </summary>
     internal class ECDsaAdapter
     {
-        private readonly CreateECDsaDelegate CreateECDsaFunction;
+        internal readonly CreateECDsaDelegate CreateECDsaFunction = null;
+        internal static ECDsaAdapter Instance;
+
+        static ECDsaAdapter()
+        {
+            Instance = new ECDsaAdapter();
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ECDsaAdapter"/> class.
@@ -59,8 +65,6 @@ namespace Microsoft.IdentityModel.Tokens
 #elif NETSTANDARD1_4
             if (SupportsCNGKey())
                 CreateECDsaFunction = CreateECDsaUsingCNGKey;
-            else
-                throw LogHelper.LogExceptionMessage(new PlatformNotSupportedException(LogMessages.IDX10690));
 #elif DESKTOP
             CreateECDsaFunction = CreateECDsaUsingCNGKey;
 #endif
@@ -74,8 +78,8 @@ namespace Microsoft.IdentityModel.Tokens
             if (CreateECDsaFunction != null)
                 return CreateECDsaFunction(jsonWebKey, usePrivateKey);
 
-            // we should never get here, it's a bug if we do
-            throw LogHelper.LogExceptionMessage(new NotSupportedException(LogMessages.IDX10691));
+            // we will get here on platforms that are not supported.
+            throw LogHelper.LogExceptionMessage(new PlatformNotSupportedException(LogMessages.IDX10690));
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/ECDsaSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ECDsaSecurityKey.cs
@@ -37,6 +37,13 @@ namespace Microsoft.IdentityModel.Tokens
     {
         private bool? _hasPrivateKey;
 
+        internal ECDsaSecurityKey(JsonWebKey webKey, bool usePrivateKey)
+            : base(webKey)
+        {
+            ECDsa = ECDsaAdapter.Instance.CreateECDsa(webKey, usePrivateKey);
+            webKey.ConvertedSecurityKey = this;
+        }
+
         /// <summary>
         /// Returns a new instance of <see cref="ECDsaSecurityKey"/>.
         /// </summary>

--- a/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
+++ b/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
@@ -81,7 +81,12 @@ namespace Microsoft.IdentityModel.Tokens
 
         private string GetCacheKeyPrivate(SecurityKey securityKey, string algorithm, string typeofProvider)
         {
-            return string.Format(CultureInfo.InvariantCulture, "{0}-{1}-{2}-{3}", securityKey.GetType(), securityKey.KeyId, algorithm, typeofProvider);
+            return string.Format(CultureInfo.InvariantCulture,
+                                 "{0}-{1}-{2}-{3}",
+                                 securityKey.GetType(),
+                                 string.IsNullOrEmpty(securityKey.KeyId) ? securityKey.InternalId : securityKey.KeyId,
+                                 algorithm,
+                                 typeofProvider);
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
@@ -86,6 +86,12 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
+        /// If this was converted to or from a SecurityKey, this field will be set.
+        /// </summary>
+        [JsonIgnore]
+        internal SecurityKey ConvertedSecurityKey { get; set; }
+
+        /// <summary>
         /// When deserializing from JSON any properties that are not defined will be placed here.
         /// </summary>
         [JsonExtensionData]
@@ -306,33 +312,32 @@ namespace Microsoft.IdentityModel.Tokens
 
         internal RSAParameters CreateRsaParameters()
         {
-            if (N == null || E == null)
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10700, this)));
+            if (string.IsNullOrEmpty(N))
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10700, this, "Modulus")));
 
-            RSAParameters parameters = new RSAParameters();
+            if(string.IsNullOrEmpty(E))
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10700, this), "Exponent"));
 
-            if (D != null)
-                parameters.D = Base64UrlEncoder.DecodeBytes(D);
+            return new RSAParameters
+            {
+                Modulus = Base64UrlEncoder.DecodeBytes(N),
+                Exponent = Base64UrlEncoder.DecodeBytes(E),
+                D = string.IsNullOrEmpty(D) ? null : Base64UrlEncoder.DecodeBytes(D),
+                P = string.IsNullOrEmpty(P) ? null : Base64UrlEncoder.DecodeBytes(P),
+                Q = string.IsNullOrEmpty(Q) ? null : Base64UrlEncoder.DecodeBytes(Q),
+                DP = string.IsNullOrEmpty(DP) ? null : Base64UrlEncoder.DecodeBytes(DP),
+                DQ = string.IsNullOrEmpty(DQ) ? null : Base64UrlEncoder.DecodeBytes(DQ),
+                InverseQ = string.IsNullOrEmpty(QI) ? null : Base64UrlEncoder.DecodeBytes(QI)
+            };
+        }
 
-            if (DP != null)
-                parameters.DP = Base64UrlEncoder.DecodeBytes(DP);
-
-            if (DQ != null)
-                parameters.DQ = Base64UrlEncoder.DecodeBytes(DQ);
-
-            if (QI != null)
-                parameters.InverseQ = Base64UrlEncoder.DecodeBytes(QI);
-
-            if (P != null)
-                parameters.P = Base64UrlEncoder.DecodeBytes(P);
-
-            if (Q != null)
-                parameters.Q = Base64UrlEncoder.DecodeBytes(Q);
-
-            parameters.Exponent = Base64UrlEncoder.DecodeBytes(E);
-            parameters.Modulus = Base64UrlEncoder.DecodeBytes(N);
-
-            return parameters;
+        /// <summary>
+        /// Returns the formatted string: GetType(), Use: 'value', Kid: 'value', Kty: 'value', InternalId: 'value'.
+        /// </summary>
+        /// <returns>string</returns>
+        public override string ToString()
+        {
+            return $"{GetType()}, Use: '{Use}',  Kid: '{Kid}', Kty: '{Kty}', InternalId: '{InternalId}'.";
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
@@ -28,8 +28,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 using Microsoft.IdentityModel.Logging;
 using Newtonsoft.Json;
 
@@ -62,24 +60,6 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         public JsonWebKeySet()
         {
-        }
-
-        /// <summary>
-        /// Initializes an ECDsa Adapter.
-        /// </summary>
-        /// <remarks>
-        /// As ECDsa Adapter is not supported on some platforms, PlatformNotSupported exception will be swallowed and logged.
-        /// </remarks>
-        static JsonWebKeySet()
-        {
-            try
-            {
-                ECDsaAdapter = new ECDsaAdapter();
-            }
-            catch (Exception ex)
-            {
-                LogHelper.LogExceptionMessage(ex);
-            }
         }
 
         /// <summary>
@@ -129,11 +109,6 @@ namespace Microsoft.IdentityModel.Tokens
         public virtual IDictionary<string, object> AdditionalData { get; } = new Dictionary<string, object>();
 
         /// <summary>
-        /// This adapter abstracts the <see cref="ECDsa"/> differences between versions of .Net targets.
-        /// </summary>
-        internal static ECDsaAdapter ECDsaAdapter;
-
-        /// <summary>
         /// Gets the <see cref="IList{JsonWebKey}"/>.
         /// </summary>       
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore, PropertyName = JsonWebKeySetParameterNames.Keys, Required = Required.Default)]
@@ -160,53 +135,59 @@ namespace Microsoft.IdentityModel.Tokens
         public IList<SecurityKey> GetSigningKeys()
         {
             var signingKeys = new List<SecurityKey>();
-
             foreach (var webKey in Keys)
             {
-                // skip if "use" (Public Key Use) parameter is not empty or "sig"
+                // skip if "use" (Public Key Use) parameter is not empty or "sig".
                 // https://tools.ietf.org/html/rfc7517#section-4.2
-                if (!(string.IsNullOrWhiteSpace(webKey.Use) || webKey.Use.Equals(JsonWebKeyUseNames.Sig, StringComparison.Ordinal)))
+                if (!string.IsNullOrEmpty(webKey.Use) && !webKey.Use.Equals(JsonWebKeyUseNames.Sig, StringComparison.Ordinal))
                 {
-                    LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10808, webKey.KeyId ?? "null" , webKey.Use ?? "null"));
-
+                    LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10808, webKey, webKey.Use));
                     if (!SkipUnresolvedJsonWebKeys)
                         signingKeys.Add(webKey);
 
                     continue;
                 }
 
-                if (webKey.Kty != null && webKey.Kty.Equals(JsonWebAlgorithmsKeyTypes.RSA, StringComparison.Ordinal))
+                if (JsonWebAlgorithmsKeyTypes.RSA.Equals(webKey.Kty, StringComparison.Ordinal))
                 {
-                    var isResolved = false;
+                    var rsaKeyResolved = true;
 
-                    if (webKey.X5c != null && webKey.X5c.Count != 0)
+                    // in this case, even though RSA was specified, we can't resolve.
+                    if ((webKey.X5c == null || webKey.X5c.Count == 0) && (string.IsNullOrEmpty(webKey.E) && string.IsNullOrEmpty(webKey.N)))
                     {
-                        AddX509SecurityKey(signingKeys, webKey);
-                        isResolved = true;
+                        rsaKeyResolved = false;
+                    }
+                    else
+                    {
+
+                        // in this case X509SecurityKey should be resolved.
+                        if (webKey.X5c != null && webKey.X5c.Count != 0)
+                            if (JsonWebKeyConverter.TryConvertToX509SecurityKey(webKey, out SecurityKey securityKey))
+                                signingKeys.Add(securityKey);
+                            else
+                                rsaKeyResolved = false;
+
+                        // in this case RsaSecurityKey should be resolved.
+                        if (!string.IsNullOrEmpty(webKey.E) && !string.IsNullOrEmpty(webKey.N))
+                            if (JsonWebKeyConverter.TryCreateToRsaSecurityKey(webKey, out SecurityKey securityKey))
+                                signingKeys.Add(securityKey);
+                            else
+                                rsaKeyResolved = false;
                     }
 
-                    if (!string.IsNullOrWhiteSpace(webKey.E) && !string.IsNullOrWhiteSpace(webKey.N))
-                    {
-                        AddRsaSecurityKey(signingKeys, webKey);
-                        isResolved = true;
-                    }
-
-                    if (!isResolved)
-                    {
-                        LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10810, webKey.KeyId ?? "null"));
-
-                        if(!SkipUnresolvedJsonWebKeys)
-                            signingKeys.Add(webKey);
-                    }
+                    if (!rsaKeyResolved && !SkipUnresolvedJsonWebKeys)
+                        signingKeys.Add(webKey);
                 }
-                else if (webKey.Kty != null && webKey.Kty.Equals(JsonWebAlgorithmsKeyTypes.EllipticCurve, StringComparison.Ordinal))
+                else if (JsonWebAlgorithmsKeyTypes.EllipticCurve.Equals(webKey.Kty, StringComparison.Ordinal))
                 {
-                    AddECDsaSecurityKey(signingKeys, webKey);
+                    if (JsonWebKeyConverter.TryConvertToECDsaSecurityKey(webKey, out SecurityKey securityKey))
+                        signingKeys.Add(securityKey);
+                    else if (!SkipUnresolvedJsonWebKeys)
+                        signingKeys.Add(webKey);
                 }
                 else
                 {
-                    // kty is not 'EC' or 'RSA'
-                    LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10809, webKey.Kty ?? "null"));
+                    LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10810, webKey));
 
                     if (!SkipUnresolvedJsonWebKeys)
                         signingKeys.Add(webKey);
@@ -214,85 +195,6 @@ namespace Microsoft.IdentityModel.Tokens
             }
 
             return signingKeys;
-        }
-
-        private void AddX509SecurityKey(ICollection<SecurityKey> signingKeys, JsonWebKey jsonWebKey)
-        {
-            try
-            {
-                // only the first certificate should be used to perform signing operations
-                // https://tools.ietf.org/html/rfc7517#section-4.7
-                var x509SecurityKey =  new X509SecurityKey(new X509Certificate2(Convert.FromBase64String(jsonWebKey.X5c[0])))
-                {
-                    KeyId = jsonWebKey.Kid
-                };
-
-                signingKeys.Add(x509SecurityKey);
-            }
-            catch (Exception ex)
-            {
-                LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10802, jsonWebKey.X5c[0], ex), ex));
-
-                if (!SkipUnresolvedJsonWebKeys)
-                    signingKeys.Add(jsonWebKey);
-            }
-        }
-
-        private void AddRsaSecurityKey(ICollection<SecurityKey> signingKeys, JsonWebKey jsonWebKey)
-        {
-            try
-            {
-                var rsaParams = new RSAParameters
-                {
-                    Exponent = Base64UrlEncoder.DecodeBytes(jsonWebKey.E),
-                    Modulus = Base64UrlEncoder.DecodeBytes(jsonWebKey.N),
-                };
-
-                var rsaSecurityKey = new RsaSecurityKey(rsaParams)
-                {
-                    KeyId = jsonWebKey.Kid
-                };
-
-                signingKeys.Add(rsaSecurityKey);
-            }
-            catch (Exception ex)
-            {
-                LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10801, jsonWebKey.E, jsonWebKey.N, ex), ex));
-
-                if (!SkipUnresolvedJsonWebKeys)
-                    signingKeys.Add(jsonWebKey);
-            }
-        }
-
-        private void AddECDsaSecurityKey(ICollection<SecurityKey> signingKeys, JsonWebKey jsonWebKey)
-        {
-            // ECDsa adapter is null when a platform is not supported i.e. when ECDsaAdapter is not successfully initialized.
-            if (ECDsaAdapter == null)
-            {
-                LogHelper.LogInformation(LogHelper.FormatInvariant(LogMessages.IDX10690));
-                if (!SkipUnresolvedJsonWebKeys)
-                    signingKeys.Add(jsonWebKey);
-
-                return;
-            }
-
-            try
-            {
-                var ecdsa = ECDsaAdapter.CreateECDsa(jsonWebKey, false);
-                var ecdsaSecurityKey = new ECDsaSecurityKey(ecdsa)
-                {
-                    KeyId = jsonWebKey.Kid
-                };
-
-                signingKeys.Add(ecdsaSecurityKey);
-            }
-            catch (Exception ex)
-            {
-                LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10807, ex), ex));
-
-                if (!SkipUnresolvedJsonWebKeys)
-                    signingKeys.Add(jsonWebKey);
-            }
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -113,7 +113,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10610 = "IDX10610: Decryption failed. Could not create decryption provider. Key: '{0}', Algorithm: '{1}'.";
         public const string IDX10611 = "IDX10611: Decryption failed. Encryption is not supported for: Algorithm: '{0}', SecurityKey: '{1}'.";
         public const string IDX10612 = "IDX10612: Decryption failed. Header.Enc is null or empty, it must be specified.";
-        //public const string IDX10613 = "IDX10613: Decryption failed. JwtHeader (tokenParts[0]) is null or empty.";
+        //public const string IDX10613 = "IDX10613:"
         public const string IDX10614 = "IDX10614: Decryption failed. JwtHeader.Base64UrlDeserialize(tokenParts[0]): '{0}'. Inner exception: '{1}'.";
         public const string IDX10615 = "IDX10615: Encryption failed. No support for: Algorithm: '{0}', SecurityKey: '{1}'.";
         public const string IDX10616 = "IDX10616: Encryption failed. EncryptionProvider failed for: Algorithm: '{0}', SecurityKey: '{1}'. See inner exception.";
@@ -192,21 +192,25 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10693 = "IDX10693: RSACryptoServiceProvider doesn't support the RSASSA-PSS signature algorithm. The list of supported algorithms is available here: https://aka.ms/IdentityModel/supported-algorithms";
 
         // security keys
-        public const string IDX10700 = "IDX10700: Invalid RsaParameters: '{0}'. Both modulus and exponent should be present";
-        public const string IDX10701 = "IDX10701: Invalid JsonWebKey rsa keying material: '{0}'. Both modulus and exponent should be present";
-        public const string IDX10702 = "IDX10702: One or more private RSA key parts are null in the JsonWebKey: '{0}'";
-        public const string IDX10703 = "IDX10703: Cannot create symmetric security key. Key length is zero.";
+        public const string IDX10700 = "IDX10700: {0} is unable to use 'rsaParameters'. {1} is null.";
+        //public const string IDX10701 = "IDX10701:"
+        //public const string IDX10702 = "IDX10702:"
+        public const string IDX10703 = "IDX10703: Cannot create a '{0}', key length is zero.";
 
         // Json specific errors
-        public const string IDX10801 = "IDX10801: Unable to create an RSA public key from the Exponent and Modulus found in the JsonWebKey: E: '{0}', N: '{1}'. Inner exception: '{2}'.";
-        public const string IDX10802 = "IDX10802: Unable to create an X509Certificate2 from the X509Data: '{0}'. Inner exception '{1}'.";
+        //public const string IDX10801 = "IDX10801:"
+        //public const string IDX10802 = "IDX10802:"
         public const string IDX10804 = "IDX10804: Unable to retrieve document from: '{0}'.";
         public const string IDX10805 = "IDX10805: Error deserializing json: '{0}' into '{1}'.";
         public const string IDX10806 = "IDX10806: Deserializing json: '{0}' into '{1}'.";
-        public const string IDX10807 = "IDX10807: Unable to create an ECDsa from the parameters found in the JsonWebKey. Inner exception: '{0}'.";
-        public const string IDX10808 = "IDX10808: The 'use' parameter of a JsonWebKey with a 'kid': '{0}' should be 'sig' or empty, but was '{1}'.";
-        public const string IDX10809 = "IDX10809: The 'kty' parameter '{0}' is not supported. Supported 'kty' parameters are 'RSA' and 'EC'.";
-        public const string IDX10810 = "IDX10810: JsonWebKey with a 'kid': '{0}' was not resolved into an X509SecurityKey or into an RsaSecurityKey.";
+        //public const string IDX10807 = "IDX10807:"
+        public const string IDX10808 = "IDX10808: The 'use' parameter of a JsonWebKey: '{0}' was expected to be 'sig' or empty, but was '{1}'.";
+        //public const string IDX10809 = "IDX10809:"
+        public const string IDX10810 = "IDX10810: Unable to convert the JsonWebKey: '{0}' to a X509SecurityKey, RsaSecurityKey or ECDSASecurityKey.";
+        //public const string IDX10811 = "IDX10811:"
+        public const string IDX10812 = "IDX10812: Unable to create a {0} from the properties found in the JsonWebKey: '{1}'.";
+        public const string IDX10813 = "IDX10813: Unable to create a {0} from the properties found in the JsonWebKey: '{1}', Exception '{2}'.";
+
 #pragma warning restore 1591
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/RsaSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaSecurityKey.cs
@@ -42,15 +42,30 @@ namespace Microsoft.IdentityModel.Tokens
 
         private PrivateKeyStatus _foundPrivateKey;
 
+        internal RsaSecurityKey(JsonWebKey webKey)
+            : base(webKey)
+        {
+            IntializeWithRsaParameters(webKey.CreateRsaParameters());
+            webKey.ConvertedSecurityKey = this;
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RsaSecurityKey"/> class.
         /// </summary>
         /// <param name="rsaParameters"><see cref="RSAParameters"/></param>
         public RsaSecurityKey(RSAParameters rsaParameters)
         {
+            IntializeWithRsaParameters(rsaParameters);
+        }
+
+        internal void IntializeWithRsaParameters(RSAParameters rsaParameters)
+        {
             // must have modulus and exponent otherwise the crypto operations fail later
-            if (rsaParameters.Modulus == null || rsaParameters.Exponent == null)
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10700, rsaParameters.ToString())));
+            if (rsaParameters.Modulus == null)
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10700, this, "Modulus")));
+
+            if (rsaParameters.Exponent == null)
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10700, this, "Exponent")));
 
             _hasPrivateKey = rsaParameters.D != null && rsaParameters.DP != null && rsaParameters.DQ != null && rsaParameters.P != null && rsaParameters.Q != null && rsaParameters.InverseQ != null;
             _foundPrivateKey = _hasPrivateKey.Value ? PrivateKeyStatus.Exists : PrivateKeyStatus.DoesNotExist;

--- a/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
@@ -25,6 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
+using System;
 using Microsoft.IdentityModel.Logging;
 using Newtonsoft.Json;
 
@@ -35,7 +36,24 @@ namespace Microsoft.IdentityModel.Tokens
     /// </summary>
     public abstract class SecurityKey
     {
-        private CryptoProviderFactory _cryptoProviderFactory = new CryptoProviderFactory(CryptoProviderFactory.Default);
+        private CryptoProviderFactory _cryptoProviderFactory;
+
+        internal SecurityKey(SecurityKey key)
+        {
+            _cryptoProviderFactory = key._cryptoProviderFactory;
+            KeyId = key.KeyId;
+        }
+
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public SecurityKey()
+        {
+            _cryptoProviderFactory = CryptoProviderFactory.Default;
+        }
+
+        [JsonIgnore]
+        internal string InternalId { get; } = Guid.NewGuid().ToString();
 
         /// <summary>
         /// This must be overridden to get the size of this <see cref="SecurityKey"/>.
@@ -60,13 +78,17 @@ namespace Microsoft.IdentityModel.Tokens
             }
             set
             {
-                if (value == null)
-                {
-                    throw LogHelper.LogArgumentNullException("value");
-                };
-
-                _cryptoProviderFactory = value;
+                _cryptoProviderFactory = value ?? throw LogHelper.LogArgumentNullException(nameof(value));
             }
+        }
+
+        /// <summary>
+        /// Returns the formatted string: GetType(), KeyId: 'value', InternalId: 'value'.
+        /// </summary>
+        /// <returns>string</returns>
+        public override string ToString()
+        {
+            return $"{GetType()}, KeyId: '{KeyId}', InternalId: '{InternalId}'.";
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/SupportedAlgorithms.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SupportedAlgorithms.cs
@@ -58,17 +58,17 @@ namespace Microsoft.IdentityModel.Tokens
 
             if (key is JsonWebKey jsonWebKey)
             {
-                if (jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.RSA)
+                if (JsonWebAlgorithmsKeyTypes.RSA.Equals(jsonWebKey.Kty, StringComparison.Ordinal))
                     return IsSupportedRsaAlgorithm(algorithm, key);
-                else if (jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.EllipticCurve)
+                else if (JsonWebAlgorithmsKeyTypes.EllipticCurve.Equals(jsonWebKey.Kty, StringComparison.Ordinal))
                     return IsSupportedEcdsaAlgorithm(algorithm);
-                else if (jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.Octet)
+                else if (JsonWebAlgorithmsKeyTypes.Octet.Equals(jsonWebKey.Kty, StringComparison.Ordinal))
                     return IsSupportedSymmetricAlgorithm(algorithm);
 
                 return false;
             }
 
-            if (key is ECDsaSecurityKey ecdsaSecurityKey)
+            if (key is ECDsaSecurityKey)
                 return IsSupportedEcdsaAlgorithm(algorithm);
 
             if (key as SymmetricSecurityKey != null)
@@ -205,8 +205,7 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 return true;
             }
-#else // NETSTANDARD1_4
-            // .NET Standard 1.4 doesn't know about RSACryptoServiceProvider type
+#else
             return true;
 #endif
         }

--- a/src/Microsoft.IdentityModel.Tokens/SymmetricSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SymmetricSecurityKey.cs
@@ -38,6 +38,17 @@ namespace Microsoft.IdentityModel.Tokens
         int _keySize;
         byte[] _key;
 
+        internal SymmetricSecurityKey(JsonWebKey webKey)
+            : base(webKey)
+        {
+            if (string.IsNullOrEmpty(webKey.K))
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10703, typeof(SymmetricSecurityKey))));
+
+            _key = Base64UrlEncoder.DecodeBytes(webKey.K);
+            _keySize = _key.Length * 8;
+            webKey.ConvertedSecurityKey = this;
+        }
+
         /// <summary>
         /// Returns a new instance of <see cref="SymmetricSecurityKey"/> instance.
         /// </summary>
@@ -48,7 +59,7 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogArgumentNullException(nameof(key));
 
             if (key.Length == 0)
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogMessages.IDX10703));
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10703, typeof(SymmetricSecurityKey))));
 
             _key = key.CloneByteArray();
             _keySize = _key.Length * 8;

--- a/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
@@ -42,6 +42,14 @@ namespace Microsoft.IdentityModel.Tokens
         AsymmetricAlgorithm _publicKey;
         object _thisLock = new Object();
 
+        internal X509SecurityKey(JsonWebKey webKey)
+            : base(webKey)
+        {
+            Certificate = new X509Certificate2(Convert.FromBase64String(webKey.X5c[0]));
+            X5t = Base64UrlEncoder.Encode(Certificate.GetCertHash());
+            webKey.ConvertedSecurityKey = this;
+        }
+
         /// <summary>
         /// Instantiates a <see cref="X509SecurityKey"/> using a <see cref="X509Certificate2"/>
         /// </summary>

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/End2EndTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/End2EndTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                             ValidIssuer = configuration.Issuer,
                         };
 
-                tokenHandler.ValidateToken(jwtToken.RawData, validationParameters, out SecurityToken securityToken);
+                tokenHandler.ValidateToken(jwtToken.RawData, validationParameters, out SecurityToken _);
                 theoryData.ExpectedException.ProcessNoException(context);
             }
             catch (Exception ex)

--- a/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
@@ -766,20 +766,20 @@ namespace Microsoft.IdentityModel.TestUtils
         }
 
         //json web key
-        public static JsonWebKey JsonWebKeyRsa256
+        public static JsonWebKey JsonWebKeyRsa_2048
         {
             get
             {
                 return new JsonWebKey
                 {
-                    D = "C6EGZYf9U6RI5Z0BBoSlwy_gKumVqRx-dBMuAfPM6KVbwIUuSJKT3ExeL5P0Ky1b4p-j2S3u7Afnvrrj4HgVLnC1ks6rEOc2ne5DYQq8szST9FMutyulcsNUKLOM5cVromALPz3PAqE2OCLChTiQZ5XZ0AiH-KcG-3hKMa-g1MVnGW-SSmm27XQwRtUtFQFfxDuL0E0fyA9O9ZFBV5201ledBaLdDcPBF8cHC53Gm5G6FRX3QVpoewm3yGk28Wze_YvNl8U3hvbxei2Koc_b9wMbFxvHseLQrxvFg_2byE2em8FrxJstxgN7qhMsYcAyw1qGJY-cYX-Ab_1bBCpdcQ",
-                    DP = "ErP3OpudePAY3uGFSoF16Sde69PnOra62jDEZGnPx_v3nPNpA5sr-tNc8bQP074yQl5kzSFRjRlstyW0TpBVMP0ocbD8RsN4EKsgJ1jvaSIEoP87OxduGkim49wFA0Qxf_NyrcYUnz6XSidY3lC_pF4JDJXg5bP_x0MUkQCTtQE",
-                    DQ = "YbBsthPt15Pshb8rN8omyfy9D7-m4AGcKzqPERWuX8bORNyhQ5M8JtdXcu8UmTez0j188cNMJgkiN07nYLIzNT3Wg822nhtJaoKVwZWnS2ipoFlgrBgmQiKcGU43lfB5e3qVVYUebYY0zRGBM1Fzetd6Yertl5Ae2g2CakQAcPs",
-                    E = "AQAB",
-                    QI = "lbljWyVY-DD_Zuii2ifAz0jrHTMvN-YS9l_zyYyA_Scnalw23fQf5WIcZibxJJll5H0kNTIk8SCxyPzNShKGKjgpyZHsJBKgL3iAgmnwk6k8zrb_lqa0sd1QWSB-Rqiw7AqVqvNUdnIqhm-v3R8tYrxzAqkUsGcFbQYj4M5_F_4",
-                    N = "6-FrFkt_TByQ_L5d7or-9PVAowpswxUe3dJeYFTY0Lgq7zKI5OQ5RnSrI0T9yrfnRzE9oOdd4zmVj9txVLI-yySvinAu3yQDQou2Ga42ML_-K4Jrd5clMUPRGMbXdV5Rl9zzB0s2JoZJedua5dwoQw0GkS5Z8YAXBEzULrup06fnB5n6x5r2y1C_8Ebp5cyE4Bjs7W68rUlyIlx1lzYvakxSnhUxSsjx7u_mIdywyGfgiT3tw0FsWvki_KYurAPR1BSMXhCzzZTkMWKE8IaLkhauw5MdxojxyBVuNY-J_elq-HgJ_dZK6g7vMNvXz2_vT-SykIkzwiD9eSI9UWfsjw",
-                    P = "_avCCyuo7hHlqu9Ec6R47ub_Ul_zNiS-xvkkuYwW-4lNnI66A5zMm_BOQVMnaCkBua1OmOgx7e63-jHFvG5lyrhyYEmkA2CS3kMCrI-dx0fvNMLEXInPxd4np_7GUd1_XzPZEkPxBhqf09kqryHMj_uf7UtPcrJNvFY-GNrzlJk",
-                    Q = "7gvYRkpqM-SC883KImmy66eLiUrGE6G6_7Y8BS9oD4HhXcZ4rW6JJKuBzm7FlnsVhVGro9M-QQ_GSLaDoxOPQfHQq62ERt-y_lCzSsMeWHbqOMci_pbtvJknpMv4ifsQXKJ4Lnk_AlGr-5r5JR5rUHgPFzCk9dJt69ff3QhzG2c",
+                    N = Base64UrlEncoder.Encode(RsaParameters_2048.Modulus),
+                    E = Base64UrlEncoder.Encode(RsaParameters_2048.Exponent),
+                    D = Base64UrlEncoder.Encode(RsaParameters_2048.D),
+                    P = Base64UrlEncoder.Encode(RsaParameters_2048.P),
+                    Q = Base64UrlEncoder.Encode(RsaParameters_2048.Q),
+                    DP = Base64UrlEncoder.Encode(RsaParameters_2048.DP),
+                    DQ = Base64UrlEncoder.Encode(RsaParameters_2048.DQ),
+                    QI = Base64UrlEncoder.Encode(RsaParameters_2048.InverseQ),
                     Kty = JsonWebAlgorithmsKeyTypes.RSA,
                     Kid = "RsaSecurityKey_2048"
                 };
@@ -788,17 +788,17 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static SigningCredentials JsonWebKeyRsa256SigningCredentials
         {
-            get => new SigningCredentials(JsonWebKeyRsa256, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256);
+            get => new SigningCredentials(JsonWebKeyRsa_2048, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256);
         }
 
-        public static JsonWebKey JsonWebKeyRsa256Public
+        public static JsonWebKey JsonWebKeyRsa_2048_Public
         {
             get
             {
                 return new JsonWebKey
                 {
-                    E = "AQAB",
-                    N = "6-FrFkt_TByQ_L5d7or-9PVAowpswxUe3dJeYFTY0Lgq7zKI5OQ5RnSrI0T9yrfnRzE9oOdd4zmVj9txVLI-yySvinAu3yQDQou2Ga42ML_-K4Jrd5clMUPRGMbXdV5Rl9zzB0s2JoZJedua5dwoQw0GkS5Z8YAXBEzULrup06fnB5n6x5r2y1C_8Ebp5cyE4Bjs7W68rUlyIlx1lzYvakxSnhUxSsjx7u_mIdywyGfgiT3tw0FsWvki_KYurAPR1BSMXhCzzZTkMWKE8IaLkhauw5MdxojxyBVuNY-J_elq-HgJ_dZK6g7vMNvXz2_vT-SykIkzwiD9eSI9UWfsjw",
+                    E = Base64UrlEncoder.Encode(RsaParameters_2048_Public.Exponent),
+                    N = Base64UrlEncoder.Encode(RsaParameters_2048_Public.Modulus),
                     Kty = JsonWebAlgorithmsKeyTypes.RSA,
                     Kid = "RsaSecurityKey_2048_Public"
                 };
@@ -807,7 +807,7 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static SigningCredentials JsonWebKeyRsa256PublicSigningCredentials
         {
-            get => new SigningCredentials(JsonWebKeyRsa256Public, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256);
+            get => new SigningCredentials(JsonWebKeyRsa_2048_Public, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256);
         }
 
         public static JsonWebKey JsonWebKeyP521WrongX_Public
@@ -1019,11 +1019,46 @@ namespace Microsoft.IdentityModel.TestUtils
         {
             get
             {
-                var jsonWebKey = new JsonWebKey();
-                jsonWebKey.Kty = JsonWebAlgorithmsKeyTypes.RSA;
-                jsonWebKey.X5c.Add(DefaultX509Data_2048);
-                jsonWebKey.X5t = DefaultX509Key_2048_Thumbprint;
-                jsonWebKey.Kid = DefaultX509Key_2048_KeyId;
+                var jsonWebKey = new JsonWebKey
+                {
+                    Kty = JsonWebAlgorithmsKeyTypes.RSA,
+                    Kid = DefaultCert_2048.Thumbprint,
+                    X5t = Base64UrlEncoder.Encode(DefaultCert_2048.GetCertHash())
+                };
+
+                jsonWebKey.X5c.Add(Convert.ToBase64String(DefaultCert_2048.RawData));
+                return jsonWebKey;
+            }
+        }
+
+        public static JsonWebKey JsonWebKeyX509_2048_Public
+        {
+            get
+            {
+                var jsonWebKey = new JsonWebKey
+                {
+                    Kty = JsonWebAlgorithmsKeyTypes.RSA,
+                    Kid = DefaultCert_2048_Public.Thumbprint,
+                    X5t = Base64UrlEncoder.Encode(DefaultCert_2048_Public.GetCertHash())
+                };
+
+                jsonWebKey.X5c.Add(Convert.ToBase64String(DefaultCert_2048_Public.RawData));
+                return jsonWebKey;
+            }
+        }
+
+        public static JsonWebKey JsonWebKeyX509_2048_With_KeyId
+        {
+            get
+            {
+                var jsonWebKey = new JsonWebKey
+                {
+                    Kty = JsonWebAlgorithmsKeyTypes.RSA,
+                    Kid = DefaultX509Key_2048_KeyId,
+                    X5t = DefaultX509Key_2048_Thumbprint
+                };
+
+                jsonWebKey.X5c.Add(Convert.ToBase64String(DefaultCert_2048.RawData));
                 return jsonWebKey;
             }
         }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTestData.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTestData.cs
@@ -56,7 +56,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
         public static readonly List<Tuple<JsonWebKey, JsonWebKey, string>> JsonRsaSecurityKeys = new List<Tuple<JsonWebKey, JsonWebKey, string>>
         {
-            { KeyingMaterial.JsonWebKeyRsa256, KeyingMaterial.JsonWebKeyRsa256Public, "JsonKey1" },
+            { KeyingMaterial.JsonWebKeyRsa_2048, KeyingMaterial.JsonWebKeyRsa_2048_Public, "JsonKey1" },
         };
 
         public static readonly List<Tuple<JsonWebKey, JsonWebKey, string>> JsonX509SecurityKeys = new List<Tuple<JsonWebKey, JsonWebKey, string>>

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ECDsaAdapterTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ECDsaAdapterTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     Y = theoryData.Y,
                     D = theoryData.D,
                 };
-                var ecdsaAdapter = new ECDsaAdapter();
+                var ecdsaAdapter = ECDsaAdapter.Instance;
                 ecdsaAdapter.CreateECDsa(jsonWebKey, theoryData.UsePrivateKey);
                 theoryData.ExpectedException.ProcessNoException(context);
             }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyTests.cs
@@ -155,8 +155,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 var dataset = new TheoryData<JsonWebKey, string, bool>();
                 dataset.Add(KeyingMaterial.JsonWebKeyP256, SecurityAlgorithms.EcdsaSha256, true);
                 dataset.Add(KeyingMaterial.JsonWebKeyP256, SecurityAlgorithms.RsaSha256Signature, false);
-                dataset.Add(KeyingMaterial.JsonWebKeyRsa256, SecurityAlgorithms.RsaSha256, true);
-                dataset.Add(KeyingMaterial.JsonWebKeyRsa256, SecurityAlgorithms.EcdsaSha256, false);
+                dataset.Add(KeyingMaterial.JsonWebKeyRsa_2048, SecurityAlgorithms.RsaSha256, true);
+                dataset.Add(KeyingMaterial.JsonWebKeyRsa_2048, SecurityAlgorithms.EcdsaSha256, false);
                 dataset.Add(KeyingMaterial.JsonWebKeySymmetric256, SecurityAlgorithms.HmacSha256, true);
                 dataset.Add(KeyingMaterial.JsonWebKeySymmetric256, SecurityAlgorithms.RsaSha256Signature, false);
                 JsonWebKey testKey = new JsonWebKey

--- a/test/Microsoft.IdentityModel.Tokens.Tests/MultiThreadingTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/MultiThreadingTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 }
             }
 
-            Action[] actions = new Action[10000];
+            var actions = new Action[1000];
             for (int i = 0; i < actions.Length; i++)
                 actions[i] = action;
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaKeyWrapProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaKeyWrapProviderTests.cs
@@ -147,13 +147,13 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     TestId = "JwkRSA",
                     WillUnwrap = false,
-                    WrapKey = KeyingMaterial.JsonWebKeyRsa256,
+                    WrapKey = KeyingMaterial.JsonWebKeyRsa_2048,
                     WrapAlgorithm = SecurityAlgorithms.RsaPKCS1,
                 },
                 new KeyWrapTheoryData
                 {
                     TestId = "RsaPublicKey",
-                    UnwrapKey = KeyingMaterial.JsonWebKeyRsa256Public,
+                    UnwrapKey = KeyingMaterial.JsonWebKeyRsa_2048_Public,
                     UnwrapAlgorithm = SecurityAlgorithms.RsaPKCS1,
                     WillUnwrap = true
                 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -187,9 +187,9 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 new SignatureProviderTheoryData("JsonWebKeyEcdsa5", ALG.EcdsaSha384, ALG.EcdsaSha384, KEY.JsonWebKeyP384, KEY.JsonWebKeyP384_Public),
                 new SignatureProviderTheoryData("JsonWebKeyEcdsa6", ALG.EcdsaSha512, ALG.EcdsaSha512, KEY.JsonWebKeyP521, KEY.JsonWebKeyP521_Public),
                 new SignatureProviderTheoryData("JsonWebKeyEcdsa7", ALG.EcdsaSha256, ALG.EcdsaSha256, KEY.JsonWebKeyP256_BadPrivateKey, KEY.JsonWebKeyP256_Public, EE.CryptographicException(ignoreInnerException: true)),
-                new SignatureProviderTheoryData("JsonWebKeyRsa1", ALG.RsaSha256, ALG.RsaSha256, KEY.JsonWebKeyRsa256, KEY.JsonWebKeyRsa256Public),
-                new SignatureProviderTheoryData("JsonWebKeyRsa2", ALG.RsaSha256Signature, ALG.RsaSha256Signature, KEY.JsonWebKeyRsa256, KEY.JsonWebKeyRsa256Public),
-                new SignatureProviderTheoryData("JsonWebKeyRsa3", ALG.Aes192KeyWrap, ALG.RsaSha256Signature, KEY.JsonWebKeyRsa256, KEY.JsonWebKeyRsa256Public, EE.NotSupportedException("IDX10634:")),
+                new SignatureProviderTheoryData("JsonWebKeyRsa1", ALG.RsaSha256, ALG.RsaSha256, KEY.JsonWebKeyRsa_2048, KEY.JsonWebKeyRsa_2048_Public),
+                new SignatureProviderTheoryData("JsonWebKeyRsa2", ALG.RsaSha256Signature, ALG.RsaSha256Signature, KEY.JsonWebKeyRsa_2048, KEY.JsonWebKeyRsa_2048_Public),
+                new SignatureProviderTheoryData("JsonWebKeyRsa3", ALG.Aes192KeyWrap, ALG.RsaSha256Signature, KEY.JsonWebKeyRsa_2048, KEY.JsonWebKeyRsa_2048_Public, EE.NotSupportedException("IDX10634:")),
 
                 new SignatureProviderTheoryData("RsaSecurityKey1", ALG.RsaSha256, ALG.RsaSha256, KEY.RsaSecurityKey_2048, KEY.RsaSecurityKey_2048_Public),
                 new SignatureProviderTheoryData("RsaSecurityKey2", ALG.RsaSha256Signature, ALG.RsaSha256Signature, KEY.RsaSecurityKey_2048, KEY.RsaSecurityKey_2048_Public),
@@ -219,7 +219,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
                 // Private keys missing
                 new SignatureProviderTheoryData("PrivateKeyMissing1", ALG.EcdsaSha256, ALG.EcdsaSha256, KEY.JsonWebKeyP256_Public, KEY.JsonWebKeyP256_Public, EE.InvalidOperationException("IDX10638:")),
-                new SignatureProviderTheoryData("PrivateKeyMissing2", ALG.RsaSha256, ALG.RsaSha256, KEY.JsonWebKeyRsa256Public, KEY.JsonWebKeyRsa256Public, EE.InvalidOperationException("IDX10638:")),
+                new SignatureProviderTheoryData("PrivateKeyMissing2", ALG.RsaSha256, ALG.RsaSha256, KEY.JsonWebKeyRsa_2048_Public, KEY.JsonWebKeyRsa_2048_Public, EE.InvalidOperationException("IDX10638:")),
                 new SignatureProviderTheoryData("PrivateKeyMissing3", ALG.RsaSha256Signature, ALG.RsaSha256Signature, KEY.RsaSecurityKey_2048_Public,KEY.RsaSecurityKey_2048_Public, EE.InvalidOperationException("IDX10638:")),
                 new SignatureProviderTheoryData("PrivateKeyMissing4", ALG.RsaSha256, ALG.RsaSha256, KEY.X509SecurityKeySelfSigned2048_SHA256_Public, KEY.X509SecurityKeySelfSigned2048_SHA256_Public, EE.InvalidOperationException("IDX10638:")),
 #if NET452
@@ -264,8 +264,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 // JsonWebKey
                 new SignatureProviderTheoryData("JsonWebKeySymmetric1", ALG.HmacSha256, ALG.HmacSha256, KEY.JsonWebKeySymmetric256, KEY.JsonWebKeySymmetric256),
                 new SignatureProviderTheoryData("JsonWebKeySymmetric2", ALG.HmacSha256Signature, ALG.HmacSha256Signature, KEY.JsonWebKeySymmetric256, KEY.JsonWebKeySymmetric256),
-                new SignatureProviderTheoryData("JsonWebKeySymmetric3", ALG.RsaSha256Signature, ALG.RsaSha256Signature, KEY.JsonWebKeySymmetric256, KEY.JsonWebKeyRsa256Public, EE.NotSupportedException("IDX10634:")),
-                new SignatureProviderTheoryData("JsonWebKeySymmetric4", ALG.EcdsaSha512Signature, ALG.EcdsaSha512Signature, KEY.JsonWebKeySymmetric256, KEY.JsonWebKeyRsa256Public, EE.NotSupportedException("IDX10634:")),
+                new SignatureProviderTheoryData("JsonWebKeySymmetric3", ALG.RsaSha256Signature, ALG.RsaSha256Signature, KEY.JsonWebKeySymmetric256, KEY.JsonWebKeyRsa_2048_Public, EE.NotSupportedException("IDX10634:")),
+                new SignatureProviderTheoryData("JsonWebKeySymmetric4", ALG.EcdsaSha512Signature, ALG.EcdsaSha512Signature, KEY.JsonWebKeySymmetric256, KEY.JsonWebKeyRsa_2048_Public, EE.NotSupportedException("IDX10634:")),
 
                 new SignatureProviderTheoryData("SymmetricSecurityKey1", ALG.HmacSha256, ALG.HmacSha256, KEY.SymmetricSecurityKey2_256, KEY.SymmetricSecurityKey2_256),
                 new SignatureProviderTheoryData("SymmetricSecurityKey2", ALG.HmacSha256, ALG.HmacSha256, Default.SymmetricSigningKey256,  Default.SymmetricSigningKey256),
@@ -704,7 +704,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 },
                 {
                     "Test3",
-                    KEY.JsonWebKeyRsa256,
+                    KEY.JsonWebKeyRsa_2048,
                     ALG.RsaSha256,
                     EE.NoExceptionExpected
                 },

--- a/test/Microsoft.IdentityModel.Tokens.Tests/X509SecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/X509SecurityKeyTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             var expectedException = new ExpectedException(typeExpected: typeof(ArgumentNullException), substringExpected: "certificate");
             try
             {
-                new X509SecurityKey(null);
+                new X509SecurityKey((X509Certificate2)null);
                 expectedException.ProcessNoException(context);
             }
             catch (Exception exception)


### PR DESCRIPTION
Moved converting JsonWebKey to a usable SecurityKey to single location
Convert JsonWebKey before checking key details such as KeySize
Maintain a singleton ECDAdapter
When creating cacheKey use internalId if keyid is null or empty
Use default CryptoProviderFactory on SecurityKey rather than create new one