### PR TITLE
Use JsonWebKeyConvertor consistently

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeyConverter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeyConverter.cs
@@ -151,6 +151,12 @@ namespace Microsoft.IdentityModel.Tokens
 
         internal static bool TryConvertToSecurityKey(JsonWebKey webKey, out SecurityKey key)
         {
+            if (webKey.ConvertedSecurityKey != null)
+            {
+                key = webKey.ConvertedSecurityKey;
+                return true;
+            }
+
             key = null;
             try
             {
@@ -177,6 +183,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
 
             LogHelper.LogWarning(LogHelper.FormatInvariant(LogMessages.IDX10812, typeof(SecurityKey), webKey));
+
             return false;
         }
 
@@ -202,7 +209,6 @@ namespace Microsoft.IdentityModel.Tokens
                 LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10813, typeof(SymmetricSecurityKey), webKey, ex), ex));
             }
 
-            LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10812, typeof(SymmetricSecurityKey), webKey)));
             return false;
         }
 
@@ -230,7 +236,6 @@ namespace Microsoft.IdentityModel.Tokens
                 LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10813, typeof(X509SecurityKey), webKey, ex), ex));
             }
 
-            LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10812, typeof(X509SecurityKey), webKey)));
             return false;
         }
 
@@ -256,7 +261,6 @@ namespace Microsoft.IdentityModel.Tokens
                 LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10813, typeof(RsaSecurityKey), webKey, ex), ex));
             }
 
-            LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10812, typeof(RsaSecurityKey), webKey)));
             return false;
         }
 
@@ -282,7 +286,6 @@ namespace Microsoft.IdentityModel.Tokens
                 LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10813, typeof(ECDsaSecurityKey), webKey, ex), ex));
             }
 
-            LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10812, typeof(ECDsaSecurityKey), webKey)));
             return false;
         }
     }

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -180,7 +180,7 @@ namespace Microsoft.IdentityModel.Tokens
         // public const string IDX10681 = "IDX10681:";
         public const string IDX10682 = "IDX10682: Compression algorithm '{0}' is not supported.";
         // public const string IDX10683 = "IDX10683:";
-        public const string IDX10684 = "IDX10684: Unable to create a AsymmetricAdapter, Algorithm: '{0}', Key: '{1}'.";
+        public const string IDX10684 = "IDX10684: Unable to convert the JsonWebKey to an AsymmetricSecurityKey. Algorithm: '{0}', Key: '{1}'.";
         public const string IDX10685 = "IDX10685: Unable to Sign, Internal SignFunction is not available.";
         public const string IDX10686 = "IDX10686: Unable to Verify, Internal VerifyFunction is not available.";
         public const string IDX10687 = "IDX10687: Unable to create a AsymmetricAdapter. For NET45 or NET451 only types: '{0}' or '{1}' are supported. RSA is of type: '{2}'..";
@@ -190,12 +190,14 @@ namespace Microsoft.IdentityModel.Tokens
         //public const string IDX10691 = "IDX10691:"
         public const string IDX10692 = "IDX10692: The RSASS-PSS signature algorithm is not available on .NET 4.5 and .NET 4.5.1 targets. The list of supported algorithms is available here: https://aka.ms/IdentityModel/supported-algorithms";
         public const string IDX10693 = "IDX10693: RSACryptoServiceProvider doesn't support the RSASSA-PSS signature algorithm. The list of supported algorithms is available here: https://aka.ms/IdentityModel/supported-algorithms";
+        public const string IDX10694 = "IDX10694: JsonWebKeyConverter threw attempting to convert JsonWebKey: '{0}'. Exception: '{1}'.";
 
         // security keys
         public const string IDX10700 = "IDX10700: {0} is unable to use 'rsaParameters'. {1} is null.";
         //public const string IDX10701 = "IDX10701:"
         //public const string IDX10702 = "IDX10702:"
         public const string IDX10703 = "IDX10703: Cannot create a '{0}', key length is zero.";
+        public const string IDX10704 = "IDX10704: Cannot verify the key size. The SecurityKey is not or cannot be converted to an AsymmetricSecuritKey. SecurityKey: '{0}'.";
 
         // Json specific errors
         //public const string IDX10801 = "IDX10801:"

--- a/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
@@ -250,7 +250,6 @@ namespace Microsoft.IdentityModel.Tokens
                     if (_disposeRsa)
                     {
                         _rsa.Dispose();
-
                     }
                 }
             }

--- a/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
@@ -102,7 +102,7 @@ namespace Microsoft.IdentityModel.Tokens
                     {
                         if (!_privateKeyAvailabilityDetermined)
                         {
-#if NETSTANDARD1_4 || NET461
+#if NET461 || NETSTANDARD1_4 || NETSTANDARD2_0
                             _privateKey = RSACertificateExtensions.GetRSAPrivateKey(Certificate);
 #else
                             _privateKey = Certificate.PrivateKey;
@@ -129,7 +129,7 @@ namespace Microsoft.IdentityModel.Tokens
                     {
                         if (_publicKey == null)
                         {
-#if NETSTANDARD1_4 || NET461
+#if NET461 || NETSTANDARD1_4 || NETSTANDARD2_0
                             _publicKey = RSACertificateExtensions.GetRSAPublicKey(Certificate);
 #else
                             _publicKey = Certificate.PublicKey.Key;

--- a/test/Microsoft.IdentityModel.KeyVaultExtensions.Tests/Microsoft.IdentityModel.KeyVaultExtensions.Tests.csproj
+++ b/test/Microsoft.IdentityModel.KeyVaultExtensions.Tests/Microsoft.IdentityModel.KeyVaultExtensions.Tests.csproj
@@ -10,7 +10,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.IdentityModel.KeyVaultExtensions.Tests</PackageId>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net452;netcoreapp2.2</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 

--- a/test/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.Tests/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.Tests.csproj
+++ b/test/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.Tests/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.Tests.csproj
@@ -10,7 +10,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.Tests</PackageId>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net452;netcoreapp2.2</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 

--- a/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
@@ -293,6 +293,20 @@ namespace Microsoft.IdentityModel.TestUtils
         public static X509SecurityKey X509SecurityKey1;
         public static X509SecurityKey X509SecurityKey2;
 
+        public static string P256_D = "OOX7PnYlSTE41BSclDj5Gi_sx_SPgEqStjY3doku4TQ";
+        public static string P256_X = "luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA";
+        public static string P256_Y = "tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ";
+        public static string P256_Invalid_D = "OOX7PnYlSTE41BSclDj5Gi_sx_SPgEqStjY3doku4QA";
+
+        public static string P384_D = "lJ44FtBCW4DyyGmRwAwFqjrpuet3BiL_VdYqOsywNjvoMDAVvgQ6SGTwIh4Qi7Yl";
+        public static string P384_X = "5mn3HaDoUgdNTFCACaWIvrpriQTloEbMbx4eUu_XvB4pyExig45VIozMnj7FedJg";
+        public static string P384_Y = "Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l";
+
+        public static string P521_D = "AWAduQ9Eu0fw2X_jBfYcSCc3jLfUuQY9Un3pQXHay4BlIhRObnNZAWPWOZccbP0ApfQLPHEAuByMtHv5D6sMVbCz";
+        public static string P521_X = "AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr";
+        public static string P521_Y = "AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW";
+        public static string P521_Invalid = "AAAAAAA----Z8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW";
+
         static KeyingMaterial()
         {
             X509Certificate1 = new X509Certificate2(Convert.FromBase64String("MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng"));
@@ -462,6 +476,7 @@ namespace Microsoft.IdentityModel.TestUtils
             Ecdsa256Key = new ECDsaSecurityKey(Ecdsa256) { KeyId = "ECDsa256Key" };
             Ecdsa384Key = new ECDsaSecurityKey(Ecdsa384) { KeyId = "ECDsa384Key" };
             Ecdsa521Key = new ECDsaSecurityKey(Ecdsa521) { KeyId = "ECDsa521Key" };
+
             Ecdsa256Key_Public = new ECDsaSecurityKey(Ecdsa256_Public) { KeyId = "ECDsa256Key_Public" };
             Ecdsa384Key_Public = new ECDsaSecurityKey(Ecdsa384_Public) { KeyId = "ECDsa384Key_Public" };
             Ecdsa521Key_Public = new ECDsaSecurityKey(Ecdsa521_Public) { KeyId = "ECDsa521Key_Public" };
@@ -486,7 +501,7 @@ namespace Microsoft.IdentityModel.TestUtils
             {
                 var rsaCsp = new RSACryptoServiceProvider();
                 rsaCsp.ImportParameters(RsaParameters_2048_Public);
-                return new RsaSecurityKey(rsaCsp) { KeyId = "RsaSecurityKeyWithCspProvider_2048" };
+                return new RsaSecurityKey(rsaCsp) { KeyId = "RsaSecurityKeyWithCspProvider_2048_Public" };
             }
         }
 
@@ -496,7 +511,7 @@ namespace Microsoft.IdentityModel.TestUtils
             {
                 var rsa = new RSACryptoServiceProvider();
                 rsa.ImportParameters(RsaParameters_2048);
-                return new RsaSecurityKey(rsa) { KeyId = "RsaSecurityKey_FromRsa_2048" };
+                return new RsaSecurityKey(rsa) { KeyId = "RsaSecurityKey_2048_FromRsa" };
             }
         }
 
@@ -506,7 +521,7 @@ namespace Microsoft.IdentityModel.TestUtils
             {
                 var rsa = new RSACryptoServiceProvider();
                 rsa.ImportParameters(RsaParameters_2048_Public);
-                return new RsaSecurityKey(rsa) { KeyId = "RsaSecurityKey_FromRsa_2048_Public" };
+                return new RsaSecurityKey(rsa) { KeyId = "RsaSecurityKey_2048_FromRsa_Public" };
             }
         }
 #endif
@@ -765,6 +780,41 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
+        public static JsonWebKey JsonWebKeyRsa_1024
+        {
+            get
+            {
+                return new JsonWebKey
+                {
+                    N = Base64UrlEncoder.Encode(RsaParameters_1024.Modulus),
+                    E = Base64UrlEncoder.Encode(RsaParameters_1024.Exponent),
+                    D = Base64UrlEncoder.Encode(RsaParameters_1024.D),
+                    P = Base64UrlEncoder.Encode(RsaParameters_1024.P),
+                    Q = Base64UrlEncoder.Encode(RsaParameters_1024.Q),
+                    DP = Base64UrlEncoder.Encode(RsaParameters_1024.DP),
+                    DQ = Base64UrlEncoder.Encode(RsaParameters_1024.DQ),
+                    QI = Base64UrlEncoder.Encode(RsaParameters_1024.InverseQ),
+                    Kty = JsonWebAlgorithmsKeyTypes.RSA,
+                    Kid = "JsonWebKeyRsa_1024"
+                };
+            }
+        }
+
+
+        public static JsonWebKey JsonWebKeyRsa_1024_Public
+        {
+            get
+            {
+                return new JsonWebKey
+                {
+                    E = Base64UrlEncoder.Encode(RsaParameters_1024_Public.Exponent),
+                    N = Base64UrlEncoder.Encode(RsaParameters_1024_Public.Modulus),
+                    Kty = JsonWebAlgorithmsKeyTypes.RSA,
+                    Kid = "JsonWebKeyRsa_1024_Public"
+                };
+            }
+        }
+
         //json web key
         public static JsonWebKey JsonWebKeyRsa_2048
         {
@@ -781,7 +831,7 @@ namespace Microsoft.IdentityModel.TestUtils
                     DQ = Base64UrlEncoder.Encode(RsaParameters_2048.DQ),
                     QI = Base64UrlEncoder.Encode(RsaParameters_2048.InverseQ),
                     Kty = JsonWebAlgorithmsKeyTypes.RSA,
-                    Kid = "RsaSecurityKey_2048"
+                    Kid = "JsonWebKeyRsa_2048"
                 };
             }
         }
@@ -800,7 +850,7 @@ namespace Microsoft.IdentityModel.TestUtils
                     E = Base64UrlEncoder.Encode(RsaParameters_2048_Public.Exponent),
                     N = Base64UrlEncoder.Encode(RsaParameters_2048_Public.Modulus),
                     Kty = JsonWebAlgorithmsKeyTypes.RSA,
-                    Kid = "RsaSecurityKey_2048_Public"
+                    Kid = "JsonWebKeyRsa_2048_Public"
                 };
             }
         }
@@ -810,184 +860,38 @@ namespace Microsoft.IdentityModel.TestUtils
             get => new SigningCredentials(JsonWebKeyRsa_2048_Public, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256);
         }
 
-        public static JsonWebKey JsonWebKeyP521WrongX_Public
+        public static JsonWebKey JsonWebKeyP256 => CreateJsonWebKeyEC(JsonWebKeyECTypes.P256, "JsonWebKeyP256", P256_D, P256_X, P256_Y);
+
+        public static JsonWebKey JsonWebKeyP256_Invalid_D => CreateJsonWebKeyEC(JsonWebKeyECTypes.P256, "JsonWebKeyP256_Invalid_D", P256_Invalid_D, P256_X, P256_Y);
+
+        public static JsonWebKey JsonWebKeyP256_Public => CreateJsonWebKeyEC(JsonWebKeyECTypes.P256, "JsonWebKeyP256_Public", null, P256_X, P256_Y);
+
+        public static JsonWebKey JsonWebKeyP384 => CreateJsonWebKeyEC(JsonWebKeyECTypes.P384, "JsonWebKeyP384", P384_D, P384_X, P384_Y);
+
+        public static JsonWebKey JsonWebKeyP384_Public => CreateJsonWebKeyEC(JsonWebKeyECTypes.P384, "JsonWebKeyP384_Public", null, P384_X, P384_Y);
+
+        public static JsonWebKey JsonWebKeyP521 => CreateJsonWebKeyEC(JsonWebKeyECTypes.P521, "JsonWebKeyP521", P521_D, P521_X, P521_Y);
+
+        public static JsonWebKey JsonWebKeyP521_Public => CreateJsonWebKeyEC(JsonWebKeyECTypes.P521, "JsonWebKeyP521_Public", null, P521_X, P521_Y);
+
+        public static JsonWebKey JsonWebKeyP521_Public_Invalid_X => CreateJsonWebKeyEC(JsonWebKeyECTypes.P521, "JsonWebKeyP521_Public_Invalid_X", null, P521_Invalid, P521_Y);
+
+        public static JsonWebKey JsonWebKeyP521_Public_Invalid_Y => CreateJsonWebKeyEC(JsonWebKeyECTypes.P521, "JsonWebKeyP521_Public_Invalid_Y", null, P521_X, P521_Invalid);
+
+        public static JsonWebKey JsonWebKeyP521_Invalid_D => CreateJsonWebKeyEC(JsonWebKeyECTypes.P521, "JsonWebKeyP521_Invalid_D", P521_Invalid, P521_X, P521_Y);
+
+        private static JsonWebKey CreateJsonWebKeyEC(string crv, string kid, string D, string X, string Y)
         {
-            get
+            return new JsonWebKey
             {
-                var curvePointParameterLength = 2 << 20;
-                var curvePointParameter = Base64UrlEncoder.Encode(new byte[curvePointParameterLength]);
-
-                var jsonString = string.Format(
-                    @"{{
-                    ""kty"": ""EC"",
-                    ""kid"": ""bilbo.baggins@hobbiton.example"",
-                    ""use"": ""sig"",
-                    ""crv"": ""P-521"",
-                    ""x"": ""{0}"",
-                    ""y"": ""AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1""
-                    }}", curvePointParameter);
-
-                return new JsonWebKey(jsonString);
-            }
-        }
-
-        public static JsonWebKey JsonWebKeyP521WrongY_Public
-        {
-            get
-            {
-                var curvePointParameterLength = 2 << 20;
-                var curvePointParameter = Base64UrlEncoder.Encode(new byte[curvePointParameterLength]);
-
-                var jsonString = string.Format(@"{{
-                    ""kty"": ""EC"",
-                    ""kid"": ""bilbo.baggins@hobbiton.example"",
-                    ""use"": ""sig"",
-                    ""crv"": ""P-521"",
-                    ""x"": ""AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1"",
-                    ""y"": ""{0}""
-                    }}", curvePointParameter);
-
-                return new JsonWebKey(jsonString);
-            }
-        }
-
-        public static JsonWebKey JsonWebKeyP521WrongD
-        {
-            get
-            {
-                var curvePointParameterLength = 2 << 20;
-                var curvePointParameter = Base64UrlEncoder.Encode(new byte[curvePointParameterLength]);
-
-                var jsonString = string.Format(@"{{
-                    ""kty"": ""EC"",
-                    ""kid"": ""bilbo.baggins@hobbiton.example"",
-                    ""use"": ""sig"",
-                    ""crv"": ""P-521"",
-                    ""x"": ""AHKZLLOsCOzz5cY97ewNUajB957y-C-U88c3v13nmGZx6sYl_oJXu9A5RkTKqjqvjyekWF-7ytDyRXYgCF5cj0Kt"",
-                    ""y"": ""AdymlHvOiLxXkEhayXQnNCvDX4h9htZaCJN34kfmC6pV5OhQHiraVySsUdaQkAgDPrwQrJmbnX9cwlGfP-HqHZR1"",
-                    ""d"": ""{{0}}""
-                    }}", curvePointParameter);
-
-                return new JsonWebKey(jsonString);
-            }
-        }
-
-        public static JsonWebKey JsonWebKeyP256
-        {
-            get
-            {
-                return new JsonWebKey
-                {
-                    Crv = "P-256",
-                    X = "luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA",
-                    Y = "tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ",
-                    D = "OOX7PnYlSTE41BSclDj5Gi_sx_SPgEqStjY3doku4TQ",
-                    KeyId = "JsonWebKeyEcdsa256",
-                    Kid = "JsonWebKeyEcdsa256",
-                    Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
-                };
-            }
-        }
-
-        public static JsonWebKey JsonWebKeyP256_BadPrivateKey
-        {
-            get
-            {
-                var badPrivateKey = "OOX7PnYlSTE41BSclDj5Gi_sx_SPgEqStjY3doku4QA";
-
-                return new JsonWebKey
-                {
-                    Crv = "P-256",
-                    X = "luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA",
-                    Y = "tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ",
-                    D = badPrivateKey,
-                    KeyId = "JsonWebKeyEcdsa256_BadPrivateKey",
-                    Kid = "JsonWebKeyEcdsa256_BadPrivateKey",
-                    Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
-                };
-            }
-        }
-
-        public static JsonWebKey JsonWebKeyP256_Public
-        {
-            get
-            {
-                return new JsonWebKey
-                {
-                    Crv = "P-256",
-                    X = "luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA",
-                    Y = "tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ",
-                    KeyId = "JsonWebKeyEcdsa256_Public",
-                    Kid = "JsonWebKeyEcdsa256_Public",
-                    Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
-                };
-            }
-        }
-
-        public static JsonWebKey JsonWebKeyP384
-        {
-            get
-            {
-                return new JsonWebKey
-                {
-                    Crv = "P-384",
-                    X = "5mn3HaDoUgdNTFCACaWIvrpriQTloEbMbx4eUu_XvB4pyExig45VIozMnj7FedJg",
-                    Y = "Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l",
-                    D = "lJ44FtBCW4DyyGmRwAwFqjrpuet3BiL_VdYqOsywNjvoMDAVvgQ6SGTwIh4Qi7Yl",
-                    KeyId = "JsonWebKeyEcdsa384",
-                    Kid = "JsonWebKeyEcdsa384",
-                    Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
-                };
-            }
-        }
-
-        public static JsonWebKey JsonWebKeyP384_Public
-        {
-            get
-            {
-                return new JsonWebKey
-                {
-                    Crv = "P-384",
-                    X = "5mn3HaDoUgdNTFCACaWIvrpriQTloEbMbx4eUu_XvB4pyExig45VIozMnj7FedJg",
-                    Y = "Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l",
-                    KeyId = "JsonWebKeyEcdsa384_Public",
-                    Kid = "JsonWebKeyEcdsa384_Public",
-                    Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
-                };
-            }
-        }
-
-        public static JsonWebKey JsonWebKeyP521
-        {
-            get
-            {
-                return new JsonWebKey
-                {
-                    Crv = "P-521",
-                    X = "AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr",
-                    Y = "AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW",
-                    D = "AWAduQ9Eu0fw2X_jBfYcSCc3jLfUuQY9Un3pQXHay4BlIhRObnNZAWPWOZccbP0ApfQLPHEAuByMtHv5D6sMVbCz",
-                    KeyId = "JsonWebKeyEcdsa521",
-                    Kid = "JsonWebKeyEcdsa521",
-                    Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
-                };
-            }
-        }
-
-        public static JsonWebKey JsonWebKeyP521_Public
-        {
-            get
-            {
-                return new JsonWebKey
-                {
-                    Crv = "P-521",
-                    X = "AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr",
-                    Y = "AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW",
-                    KeyId = "JsonWebKeyEcdsa521_Public",
-                    Kid = "JsonWebKeyEcdsa521_Public",
-                    Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
-                };
-            }
+                Crv = crv,
+                D = D,
+                X = X,
+                Y = Y,
+                KeyId = kid,
+                Kid = kid,
+                Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
+            };
         }
 
         public static JsonWebKey JsonWebKeySymmetric64

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
@@ -311,6 +311,116 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 return theoryData;
             }
         }
+
+        [Theory, MemberData(nameof(ValidateAsymmetricKeySizeTheoryData))]
+        public void VerifyAsymmetricKeySize(AsymmetricSignatureProviderTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.VerifyAsymmetricKeySize", theoryData);
+
+            try
+            {
+                theoryData.AsymmetricSignatureProvider.ValidateAsymmetricSecurityKeySize(theoryData.SecurityKey, theoryData.Algorithm, theoryData.WillCreateSignatures);
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<AsymmetricSignatureProviderTheoryData> ValidateAsymmetricKeySizeTheoryData
+        {
+            get => new TheoryData<AsymmetricSignatureProviderTheoryData>
+            {
+                new AsymmetricSignatureProviderTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    ExpectedException = ExpectedException.ArgumentOutOfRangeException("IDX10630:"),
+                    SecurityKey = KeyingMaterial.RsaSecurityKey_1024,
+                    TestId = nameof(KeyingMaterial.RsaSecurityKey_1024),
+                    WillCreateSignatures = true
+                },
+                new AsymmetricSignatureProviderTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    SecurityKey = KeyingMaterial.RsaSecurityKey_1024_Public,
+                    TestId = nameof(KeyingMaterial.RsaSecurityKey_1024_Public),
+                    WillCreateSignatures = false
+                },
+                new AsymmetricSignatureProviderTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    ExpectedException = ExpectedException.ArgumentOutOfRangeException("IDX10630:"),
+                    SecurityKey = KeyingMaterial.JsonWebKeyRsa_1024,
+                    TestId = nameof(KeyingMaterial.JsonWebKeyRsa_1024),
+                    WillCreateSignatures = true
+                },
+                new AsymmetricSignatureProviderTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    SecurityKey = KeyingMaterial.JsonWebKeyRsa_1024_Public,
+                    TestId = nameof(KeyingMaterial.JsonWebKeyRsa_1024_Public),
+                    WillCreateSignatures = false
+                },
+                new AsymmetricSignatureProviderTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    SecurityKey = KeyingMaterial.JsonWebKeyRsa_2048,
+                    TestId = nameof(KeyingMaterial.JsonWebKeyRsa_2048),
+                    WillCreateSignatures = true
+                },
+                new AsymmetricSignatureProviderTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    SecurityKey = KeyingMaterial.JsonWebKeyRsa_2048_Public,
+                    TestId = nameof(KeyingMaterial.JsonWebKeyRsa_2048_Public),
+                    WillCreateSignatures = false
+                },
+                new AsymmetricSignatureProviderTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    ExpectedException = ExpectedException.NotSupportedException("IDX10704:"),
+                    SecurityKey = KeyingMaterial.SymmetricSecurityKey2_1024,
+                    TestId = nameof(KeyingMaterial.SymmetricSecurityKey2_1024),
+                    WillCreateSignatures = false
+                },
+                new AsymmetricSignatureProviderTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    ExpectedException = ExpectedException.NotSupportedException("IDX10704:"),
+                    SecurityKey = KeyingMaterial.JsonWebKeySymmetric128,
+                    TestId = nameof(KeyingMaterial.JsonWebKeySymmetric128),
+                    WillCreateSignatures = false
+                },
+                new AsymmetricSignatureProviderTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.EcdsaSha256,
+                    SecurityKey = KeyingMaterial.Ecdsa256Key,
+                    TestId = nameof(KeyingMaterial.Ecdsa256Key),
+                    WillCreateSignatures = true
+                },
+                new AsymmetricSignatureProviderTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.EcdsaSha256,
+                    SecurityKey = KeyingMaterial.Ecdsa256Key_Public,
+                    TestId = nameof(KeyingMaterial.Ecdsa256Key_Public),
+                    WillCreateSignatures = false
+                }
+            };
+        }
+    }
+
+    public class AsymmetricSignatureProviderTheoryData : TheoryDataBase
+    {
+        public string Algorithm { get; set; }
+
+        public AsymmetricSignatureProvider AsymmetricSignatureProvider { get; set; } = new AsymmetricSignatureProvider(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaSha256);
+
+        public SecurityKey SecurityKey { get; set; }
+
+        public bool WillCreateSignatures { get; set; }
     }
 }
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyConverterTest.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyConverterTest.cs
@@ -105,46 +105,57 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             get
             {
-                return new TheoryData<JsonWebKeyConverterTheoryData>()
+                var theoryData = new TheoryData<JsonWebKeyConverterTheoryData>();
+
+                // need to adjust the kid to match as the keys have different id's.
+                var securityKey = KeyingMaterial.RsaSecurityKey_2048;
+                securityKey.KeyId = KeyingMaterial.JsonWebKeyRsa_2048.KeyId;
+                theoryData.Add(new JsonWebKeyConverterTheoryData
                 {
-                    new JsonWebKeyConverterTheoryData
-                    {
-                        First = true,
-                        SecurityKey = KeyingMaterial.RsaSecurityKey_2048,
-                        JsonWebKey = KeyingMaterial.JsonWebKeyRsa_2048,
-                        TestId = nameof(KeyingMaterial.RsaSecurityKey_2048)
-                    },
-                    new JsonWebKeyConverterTheoryData
-                    {
-                        SecurityKey = KeyingMaterial.RsaSecurityKey_2048_Public,
-                        JsonWebKey = KeyingMaterial.JsonWebKeyRsa_2048_Public,
-                        TestId = nameof(KeyingMaterial.RsaSecurityKey_2048_Public)
-                    },
-                    new JsonWebKeyConverterTheoryData
-                    {
-                        SecurityKey = KeyingMaterial.DefaultSymmetricSecurityKey_64,
-                        JsonWebKey = KeyingMaterial.JsonWebKeySymmetric64,
-                        TestId = nameof(KeyingMaterial.DefaultSymmetricSecurityKey_64)
-                    },
-                    new JsonWebKeyConverterTheoryData
-                    {
-                        SecurityKey = KeyingMaterial.DefaultX509Key_2048_With_KeyId,
-                        JsonWebKey = KeyingMaterial.JsonWebKeyX509_2048_With_KeyId,
-                        TestId = nameof(KeyingMaterial.DefaultX509Key_2048_With_KeyId)
-                    },
-                    new JsonWebKeyConverterTheoryData
-                    {
-                        SecurityKey = KeyingMaterial.DefaultX509Key_2048,
-                        JsonWebKey = KeyingMaterial.JsonWebKeyX509_2048,
-                        TestId = nameof(KeyingMaterial.DefaultX509Key_2048)
-                    },
-                    new JsonWebKeyConverterTheoryData
-                    {
-                        SecurityKey = KeyingMaterial.DefaultX509Key_2048_Public,
-                        JsonWebKey = KeyingMaterial.JsonWebKeyX509_2048_Public,
-                        TestId = nameof(KeyingMaterial.DefaultX509Key_2048_Public)
-                    },
-                };
+                    First = true,
+                    SecurityKey = securityKey,
+                    JsonWebKey = KeyingMaterial.JsonWebKeyRsa_2048,
+                    TestId = nameof(KeyingMaterial.RsaSecurityKey_2048)
+                });
+
+                securityKey = KeyingMaterial.RsaSecurityKey_2048_Public;
+                securityKey.KeyId = KeyingMaterial.JsonWebKeyRsa_2048_Public.KeyId;
+                theoryData.Add(new JsonWebKeyConverterTheoryData
+                {
+                    SecurityKey = securityKey,
+                    JsonWebKey = KeyingMaterial.JsonWebKeyRsa_2048_Public,
+                    TestId = nameof(KeyingMaterial.RsaSecurityKey_2048_Public)
+                });
+
+                theoryData.Add(new JsonWebKeyConverterTheoryData
+                {
+                    SecurityKey = KeyingMaterial.DefaultSymmetricSecurityKey_64,
+                    JsonWebKey = KeyingMaterial.JsonWebKeySymmetric64,
+                    TestId = nameof(KeyingMaterial.DefaultSymmetricSecurityKey_64)
+                });
+
+                theoryData.Add(new JsonWebKeyConverterTheoryData
+                {
+                    SecurityKey = KeyingMaterial.DefaultX509Key_2048_With_KeyId,
+                    JsonWebKey = KeyingMaterial.JsonWebKeyX509_2048_With_KeyId,
+                    TestId = nameof(KeyingMaterial.DefaultX509Key_2048_With_KeyId)
+                });
+
+                theoryData.Add(new JsonWebKeyConverterTheoryData
+                {
+                    SecurityKey = KeyingMaterial.DefaultX509Key_2048,
+                    JsonWebKey = KeyingMaterial.JsonWebKeyX509_2048,
+                    TestId = nameof(KeyingMaterial.DefaultX509Key_2048)
+                });
+
+                theoryData.Add(new JsonWebKeyConverterTheoryData
+                {
+                    SecurityKey = KeyingMaterial.DefaultX509Key_2048_Public,
+                    JsonWebKey = KeyingMaterial.JsonWebKeyX509_2048_Public,
+                    TestId = nameof(KeyingMaterial.DefaultX509Key_2048_Public)
+                });
+
+                return theoryData;
             }
         }
     }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -186,7 +186,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 new SignatureProviderTheoryData("JsonWebKeyEcdsa4", ALG.EcdsaSha256, ALG.EcdsaSha256, KEY.JsonWebKeyP256, KEY.JsonWebKeyP256_Public),
                 new SignatureProviderTheoryData("JsonWebKeyEcdsa5", ALG.EcdsaSha384, ALG.EcdsaSha384, KEY.JsonWebKeyP384, KEY.JsonWebKeyP384_Public),
                 new SignatureProviderTheoryData("JsonWebKeyEcdsa6", ALG.EcdsaSha512, ALG.EcdsaSha512, KEY.JsonWebKeyP521, KEY.JsonWebKeyP521_Public),
-                new SignatureProviderTheoryData("JsonWebKeyEcdsa7", ALG.EcdsaSha256, ALG.EcdsaSha256, KEY.JsonWebKeyP256_BadPrivateKey, KEY.JsonWebKeyP256_Public, EE.CryptographicException(ignoreInnerException: true)),
+                new SignatureProviderTheoryData("JsonWebKeyEcdsa7", ALG.EcdsaSha256, ALG.EcdsaSha256, KEY.JsonWebKeyP256_Invalid_D, KEY.JsonWebKeyP256_Public, EE.CryptographicException(ignoreInnerException: true)),
                 new SignatureProviderTheoryData("JsonWebKeyRsa1", ALG.RsaSha256, ALG.RsaSha256, KEY.JsonWebKeyRsa_2048, KEY.JsonWebKeyRsa_2048_Public),
                 new SignatureProviderTheoryData("JsonWebKeyRsa2", ALG.RsaSha256Signature, ALG.RsaSha256Signature, KEY.JsonWebKeyRsa_2048, KEY.JsonWebKeyRsa_2048_Public),
                 new SignatureProviderTheoryData("JsonWebKeyRsa3", ALG.Aes192KeyWrap, ALG.RsaSha256Signature, KEY.JsonWebKeyRsa_2048, KEY.JsonWebKeyRsa_2048_Public, EE.NotSupportedException("IDX10634:")),
@@ -228,9 +228,10 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 // .Net Core throws some funky inner exception that GetType() reports as: Internal.Cryptography.CryptoThrowHelper+WindowsCryptographicException
                 new SignatureProviderTheoryData("PrivateKeyMissing5", ALG.EcdsaSha512, ALG.EcdsaSha512, KEY.Ecdsa521Key_Public, KEY.Ecdsa521Key_Public, new EE(typeof(Exception)){IgnoreExceptionType = true}),
 #endif
-                // BadKeys
-                new SignatureProviderTheoryData("BadKeys1", ALG.EcdsaSha512, ALG.EcdsaSha512, KEY.JsonWebKeyP521WrongX_Public, KEY.JsonWebKeyP521WrongD, EE.InvalidOperationException()),
-                new SignatureProviderTheoryData("BadKeys2", ALG.EcdsaSha512, ALG.EcdsaSha512, KEY.JsonWebKeyP521WrongY_Public, KEY.JsonWebKeyP521WrongD, EE.InvalidOperationException()),
+                // Invalid JsonWebKeyComponents
+                new SignatureProviderTheoryData("JsonWebKeyP521_Public_Invalid_X", ALG.EcdsaSha512, ALG.EcdsaSha512, KEY.JsonWebKeyP521_Public_Invalid_X, KEY.JsonWebKeyP521, EE.InvalidOperationException()),
+                new SignatureProviderTheoryData("JsonWebKeyP521_Public_Invalid_Y", ALG.EcdsaSha512, ALG.EcdsaSha512, KEY.JsonWebKeyP521_Public_Invalid_Y, KEY.JsonWebKeyP521, EE.InvalidOperationException()),
+                new SignatureProviderTheoryData("JsonWebKeyP521_Invalid_D", ALG.EcdsaSha512, ALG.EcdsaSha512, KEY.JsonWebKeyP521_Invalid_D, KEY.JsonWebKeyP521_Public, EE.NotSupportedException()),
             };
         }
 


### PR DESCRIPTION
We want to use JsonWebKeyConveter when converting from a JsonWebKey.
This provides some consistency.
We also noticed that there was some cleanup possible in the JsonWebKeyConverter tests.
We also included #ifdef for Netstandard2.0 for X509SecurityKey when obtaining private and public keys

This address issues: 
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1221
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1222
