### PR TITLE
JsonWebToken now retrieves claim values in a case sensitive manner.

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -497,7 +497,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             string issuer = Issuer ?? ClaimsIdentity.DefaultIssuer;
 
-            if (!Payload.TryGetValue(key, out var jTokenValue))
+            if (!Payload.TryGetValue(key, StringComparison.Ordinal, out var jTokenValue))
                 throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14304, key)));
 
             if (jTokenValue.Type == JTokenType.Null)
@@ -531,7 +531,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (typeof(T).Equals(typeof(Claim)))
                 return (T)(object)GetClaim(key);
 
-            if (!Payload.TryGetValue(key, out var jTokenValue))
+            if (!Payload.TryGetValue(key, StringComparison.Ordinal, out var jTokenValue))
                 throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14304, key)));
 
             T value;
@@ -555,7 +555,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             string issuer = Issuer ?? ClaimsIdentity.DefaultIssuer;
 
-            if (!Payload.TryGetValue(key, out var jTokenValue))
+            if (!Payload.TryGetValue(key, StringComparison.Ordinal, out var jTokenValue))
             {
                 value = null;
                 return false;
@@ -601,7 +601,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 return foundClaim;
             }
 
-            if (!Payload.TryGetValue(key, out var jTokenValue))
+            if (!Payload.TryGetValue(key, StringComparison.Ordinal, out var jTokenValue))
             {
                 value = default(T);
                 return false;
@@ -629,7 +629,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (string.IsNullOrEmpty(key))
                 throw LogHelper.LogArgumentNullException(nameof(key));
 
-            if (!Header.TryGetValue(key, out var jTokenValue))
+            if (!Header.TryGetValue(key, StringComparison.Ordinal, out var jTokenValue))
                 throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14303, key)));
 
             T value;
@@ -657,7 +657,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 return false;
             }
 
-            if (!Header.TryGetValue(key, out var jTokenValue))
+            if (!Header.TryGetValue(key, StringComparison.Ordinal, out var jTokenValue))
             {
                 value = default(T);
                 return false;

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -308,13 +308,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (SetDefaultTimesOnTokenCreation)
             {
                 var now = EpochTime.GetIntDate(DateTime.UtcNow);
-                if (!payload.TryGetValue(JwtRegisteredClaimNames.Exp, out _))
+                if (!payload.TryGetValue(JwtRegisteredClaimNames.Exp, StringComparison.Ordinal, out _))
                     payload.Add(JwtRegisteredClaimNames.Exp, now + TimeSpan.FromMinutes(TokenLifetimeInMinutes).TotalSeconds);
 
-                if (!payload.TryGetValue(JwtRegisteredClaimNames.Iat, out _))
+                if (!payload.TryGetValue(JwtRegisteredClaimNames.Iat, StringComparison.Ordinal, out _))
                     payload.Add(JwtRegisteredClaimNames.Iat, now);
 
-                if (!payload.TryGetValue(JwtRegisteredClaimNames.Nbf, out _))
+                if (!payload.TryGetValue(JwtRegisteredClaimNames.Nbf, StringComparison.Ordinal, out _))
                     payload.Add(JwtRegisteredClaimNames.Nbf, now);
             }
 

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -162,7 +162,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <returns>The DateTime representation of a claim.</returns>
         internal static DateTime GetDateTime(string key, JObject payload)
         {
-            if (!payload.TryGetValue(key, out var jToken))
+            if (!payload.TryGetValue(key, StringComparison.Ordinal, out var jToken))
                 return DateTime.MinValue;
 
             return EpochTime.DateTime(Convert.ToInt64(Math.Truncate(Convert.ToDouble(ParseTimeValue(jToken, key), CultureInfo.InvariantCulture))));

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
@@ -144,6 +144,16 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 ExpectedException.ArgumentException("IDX14304:").ProcessException(ex, context);
             }
 
+            try // Try to retrieve a claim value using an uppercase version of an existing key.
+            {
+                jsonWebToken.GetClaim("STRING");
+                context.AddDiff("jsonWebToken.GetClaim(\"STRING\") was successful, but claim types are case sensitive.");
+            }
+            catch (Exception ex)
+            {
+                ExpectedException.ArgumentException("IDX14304:").ProcessException(ex, context);
+            }
+
             TestUtilities.AssertFailIfErrors(context);
         }
 
@@ -157,6 +167,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
             // Tries to retrieve a value that does not exist in the payload.
             var success = jsonWebToken.TryGetClaim("doesnotexist", out Claim doesNotExist);
+            IdentityComparer.AreEqual(null, doesNotExist, context);
+            IdentityComparer.AreEqual(false, success, context);
+
+            // Tries to retrieve a claim value using an uppercase version of an existing key.
+            success = jsonWebToken.TryGetClaim("STRING", out doesNotExist);
             IdentityComparer.AreEqual(null, doesNotExist, context);
             IdentityComparer.AreEqual(false, success, context);
 
@@ -250,6 +265,16 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 ExpectedException.ArgumentException("IDX14305:", typeof(System.FormatException)).ProcessException(ex, context);
             }
 
+            try // Try to retrieve a claim value using an uppercase version of an existing key.
+            {
+                token.GetHeaderValue<string>("STRING");
+                context.AddDiff("token.GetHeaderValue<string>(\"STRING\") was successful, but claim types are case sensitive.");
+            }
+            catch (Exception ex)
+            {
+                ExpectedException.ArgumentException("IDX14304:").ProcessException(ex, context);
+            }
+
             TestUtilities.AssertFailIfErrors(context);
         }
 
@@ -279,6 +304,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             IdentityComparer.AreEqual("bob", name, context);
             IdentityComparer.AreEqual(true, success, context);
 
+            // Tries to retrieve a claim value using an uppercase version of an existing key.
+            success = token.TryGetHeaderValue("STRING", out string doesNotExist);
+            IdentityComparer.AreEqual(null, doesNotExist, context);
+            IdentityComparer.AreEqual(false, success, context);
+
             success = token.TryGetHeaderValue("float", out float floatingPoint);
             IdentityComparer.AreEqual(42.0, floatingPoint, context);
             IdentityComparer.AreEqual(true, success, context);
@@ -295,8 +325,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             IdentityComparer.AreEqual(boolean, true, context);
             IdentityComparer.AreEqual(true, success, context);
 
-            success = token.TryGetHeaderValue("doesnotexist", out int doesNotExist);
-            IdentityComparer.AreEqual(0, doesNotExist, context);
+            success = token.TryGetHeaderValue("doesnotexist", out doesNotExist);
+            IdentityComparer.AreEqual(null, doesNotExist, context);
             IdentityComparer.AreEqual(false, success, context);
 
             success = token.TryGetHeaderValue("string", out int cannotConvert);
@@ -358,6 +388,16 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 ExpectedException.ArgumentException("IDX14305:", typeof(System.FormatException)).ProcessException(ex, context);
             }
 
+            try // Try to retrieve a claim value using an uppercase version of an existing key.
+            {
+                token.GetPayloadValue<string>("STRING");
+                context.AddDiff("token.GetPayloadValue<string>(\"STRING\") was successful, but claim types are case sensitive.");
+            }
+            catch (Exception ex)
+            {
+                ExpectedException.ArgumentException("IDX14304:").ProcessException(ex, context);
+            }
+
             TestUtilities.AssertFailIfErrors(context);
         }
 
@@ -387,6 +427,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             IdentityComparer.AreEqual("bob", name, context);
             IdentityComparer.AreEqual(true, success, context);
 
+            // Tries to retrieve a claim value using an uppercase version of an existing key.
+            success = token.TryGetPayloadValue("STRING", out string doesNotExist);
+            IdentityComparer.AreEqual(null, doesNotExist, context);
+            IdentityComparer.AreEqual(false, success, context);
+
             success = token.TryGetPayloadValue("float", out float floatingPoint);
             IdentityComparer.AreEqual(42.0, floatingPoint, context);
             IdentityComparer.AreEqual(true, success, context);
@@ -403,8 +448,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             IdentityComparer.AreEqual(boolean, true, context);
             IdentityComparer.AreEqual(true, success, context);
 
-            success = token.TryGetPayloadValue("doesnotexist", out int doesNotExist);
-            IdentityComparer.AreEqual(0, doesNotExist, context);
+            success = token.TryGetPayloadValue("doesnotexist", out doesNotExist);
+            IdentityComparer.AreEqual(null, doesNotExist, context);
             IdentityComparer.AreEqual(false, success, context);
 
             success = token.TryGetPayloadValue("string", out int cannotConvert);

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
@@ -272,7 +272,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
             catch (Exception ex)
             {
-                ExpectedException.ArgumentException("IDX14304:").ProcessException(ex, context);
+                ExpectedException.ArgumentException("IDX14303:").ProcessException(ex, context);
             }
 
             TestUtilities.AssertFailIfErrors(context);


### PR DESCRIPTION
Claim names are case sensitive according to the JWT RFC:
https://tools.ietf.org/html/rfc7519#section-10.1.1