### PR TITLE
Internal string formatting cleanup

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -663,7 +663,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (keys == null)
                 keys = JwtTokenUtilities.GetAllDecryptionKeys(validationParameters);
 
-            if (jwtToken.Alg.Equals(JwtConstants.DirectKeyUseAlg))
+            if (jwtToken.Alg.Equals(JwtConstants.DirectKeyUseAlg, StringComparison.Ordinal))
                 return keys;
 
             var unwrappedKeys = new List<SecurityKey>();

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMessage.cs
@@ -181,7 +181,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
             }
 
             // find first <RequestedSecurityToken>
-            var tokenStartIndex = wresult.IndexOf(WsTrustConstants.Elements.RequestedSecurityToken);
+            var tokenStartIndex = wresult.IndexOf(WsTrustConstants.Elements.RequestedSecurityToken, StringComparison.Ordinal);
             if (tokenStartIndex == -1)
             {
                 LogHelper.LogWarning(LogMessages.IDX22904);
@@ -251,16 +251,14 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
             string token = null;
             using (var sr = new StringReader(Wresult))
             {
-                var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit };
-#if NET45 || NET451
-                settings.XmlResolver = null;
-#endif
 
 #if NETSTANDARD1_4
                 var xmlReader = XmlDictionaryReader.CreateTextReader(Encoding.UTF8.GetBytes(Wresult), XmlDictionaryReaderQuotas.Max);
 #else
                 var xmlReader = new XmlTextReader(sr);
 #endif
+                if (xmlReader.Settings != null)
+                    xmlReader.Settings.DtdProcessing = DtdProcessing.Prohibit;
 
                 // Read StartElement <RequestSecurityTokenResponseCollection> this is possible for wstrust 1.3 and 1.4
                 if (XmlUtil.IsStartElement(xmlReader, WsTrustConstants.Elements.RequestSecurityTokenResponseCollection, WsTrustNamespaceNon2005List))

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -28,7 +28,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.IO;
 using System.Security.Claims;
 using System.Text;

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -302,12 +302,12 @@ namespace Microsoft.IdentityModel.Tokens
         {
 
 #if NET461 || NETSTANDARD1_4 || NETSTANDARD2_0
-            if (algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha256) ||
-                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha256Signature) ||
-                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha384) ||
-                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha384Signature) ||
-                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha512) ||
-                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha512Signature))
+            if (algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha256, StringComparison.Ordinal) ||
+                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha256Signature, StringComparison.Ordinal) ||
+                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha384, StringComparison.Ordinal) ||
+                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha384Signature, StringComparison.Ordinal) ||
+                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha512, StringComparison.Ordinal) ||
+                algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha512Signature, StringComparison.Ordinal))
             {
                 RSASignaturePadding = RSASignaturePadding.Pss;
             }
@@ -342,7 +342,7 @@ namespace Microsoft.IdentityModel.Tokens
             // they will use one of these two targets Net45 or Net451, but the type is RSACng.
             // The 'lightup' code will bind to the correct operators.
 #if NET45 || NET451
-            else if (rsa.GetType().ToString().Equals(_rsaCngTypeName, StringComparison.InvariantCulture) && IsRsaCngSupported())
+            else if (rsa.GetType().ToString().Equals(_rsaCngTypeName, StringComparison.Ordinal) && IsRsaCngSupported())
             {
                 _lightUpHashAlgorithmName = GetLightUpHashAlgorithmName();
                 SignatureFunction = Pkcs1SignData;
@@ -358,7 +358,7 @@ namespace Microsoft.IdentityModel.Tokens
 
 #if NET461 || NETSTANDARD1_4 || NETSTANDARD2_0
             // Here we can use RSA straight up.
-            _rsaEncryptionPadding = (algorithm.Equals(SecurityAlgorithms.RsaOAEP, StringComparison.Ordinal) || algorithm.Equals(SecurityAlgorithms.RsaOaepKeyWrap))
+            _rsaEncryptionPadding = (algorithm.Equals(SecurityAlgorithms.RsaOAEP, StringComparison.Ordinal) || algorithm.Equals(SecurityAlgorithms.RsaOaepKeyWrap, StringComparison.Ordinal))
                         ? RSAEncryptionPadding.OaepSHA1
                         : RSAEncryptionPadding.Pkcs1;
             RSA = rsa;

--- a/src/Microsoft.IdentityModel.Tokens/CompressionProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CompressionProviderFactory.cs
@@ -109,7 +109,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (CustomCompressionProvider != null && CustomCompressionProvider.IsSupportedAlgorithm(algorithm))
                 return CustomCompressionProvider;
 
-            if (algorithm.Equals(CompressionAlgorithms.Deflate))
+            if (algorithm.Equals(CompressionAlgorithms.Deflate, StringComparison.Ordinal))
                 return new DeflateCompressionProvider();
 
             throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10652, algorithm)));

--- a/src/Microsoft.IdentityModel.Tokens/DeflateCompressionProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/DeflateCompressionProvider.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using Microsoft.IdentityModel.Logging;
+using System;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
@@ -117,7 +118,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns>true if the compression algorithm is supported, false otherwise.</returns>
         public bool IsSupportedAlgorithm(string algorithm)
         {
-            return Algorithm.Equals(algorithm);
+            return Algorithm.Equals(algorithm, StringComparison.Ordinal);
         }
     }
 }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1439,7 +1439,7 @@ namespace System.IdentityModel.Tokens.Jwt
             if (keys == null)
                 keys = GetAllDecryptionKeys(validationParameters);
 
-            if (jwtToken.Header.Alg.Equals(JwtConstants.DirectKeyUseAlg))
+            if (jwtToken.Header.Alg.Equals(JwtConstants.DirectKeyUseAlg, StringComparison.Ordinal))
                 return keys;
 
             var unwrappedKeys = new List<SecurityKey>();


### PR DESCRIPTION
Use StringComparison settings where applicable.
Set DtdProcessing.Prohibit when creating XmlReaders where possible.