### PR TITLE
JWT tokens can now be created from both SecurityTokenDescriptor.Subject and SecurityTokenDescriptor.Claims

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
@@ -52,7 +52,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         internal const string IDX14111 = "IDX14111: JWT: '{0}' must have three segments (JWS) or five segments (JWE).";
         internal const string IDX14112 = "IDX14112: Only a single 'Actor' is supported. Found second claim of type: '{0}', value: '{1}'";
         internal const string IDX14113 = "IDX14113: A duplicate value for 'SecurityTokenDescriptor.{0}' exists in 'SecurityTokenDescriptor.Claims'. \nThe value of 'SecurityTokenDescriptor.{0}' is used.";
-        internal const string IDX14114 = "IDX14114: No claims were added to the SecurityTokenDescriptor.";
+        internal const string IDX14114 = "IDX14114: Both '{0}.{1}' and '{0}.{2}' are null or empty.";
         internal const string IDX14115 = "IDX14115: A JWT cannot be created with an empty payload.";
 
         // logging

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -270,7 +270,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml
             if (tokenDescriptor == null)
                 throw LogArgumentNullException(nameof(tokenDescriptor));
 
-#pragma warning disable 0618 // 'SecurityTokenDescriptor.Subject' is obsolete.
             if (tokenDescriptor.Subject != null)
             {
                 var attributes = new List<SamlAttribute>();
@@ -295,7 +294,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 }
 
                 AddActorToAttributes(attributes, tokenDescriptor.Subject.Actor);
-#pragma warning restore 0618 // 'SecurityTokenDescriptor.Subject' is obsolete.
 
                 var consolidatedAttributes = ConsolidateAttributes(attributes);
                 if (consolidatedAttributes.Count > 0)
@@ -452,13 +450,10 @@ namespace Microsoft.IdentityModel.Tokens.Saml
 
             var samlSubject = new SamlSubject();
             Claim identityClaim = null;
-
-#pragma warning disable 0618 // 'SecurityTokenDescriptor.Subject' is obsolete.
             if (tokenDescriptor.Subject != null && tokenDescriptor.Subject.Claims != null)
             {
                 foreach (var claim in tokenDescriptor.Subject.Claims)
                 {
-#pragma warning restore 0618 // 'SecurityTokenDescriptor.Subject' is obsolete.
                     if (claim.Type == ClaimTypes.NameIdentifier)
                     {
                         // Do not allow multiple name identifier claim.

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -694,7 +694,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
             if (tokenDescriptor == null)
                 throw LogArgumentNullException(nameof(tokenDescriptor));
 
-#pragma warning disable 0618 // 'SecurityTokenDescriptor.Subject' is obsolete.
             if (tokenDescriptor.Subject == null)
                 throw LogArgumentNullException(nameof(tokenDescriptor.Subject));
 
@@ -719,7 +718,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
 
             if (tokenDescriptor.Subject.Actor != null)
                 attributes.Add(CreateAttribute(new Claim(ClaimTypes.Actor, CreateActorString(tokenDescriptor.Subject.Actor), ClaimValueTypes.String)));
-#pragma warning restore 0618 // 'SecurityTokenDescriptor.Subject' is obsolete.
 
             return new Saml2AttributeStatement(ConsolidateAttributes(attributes));
         }
@@ -914,12 +912,10 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
             string nameIdentifierSpProviderId = null;
             string nameIdentifierSpNameQualifier = null;
 
-#pragma warning disable 0618 // 'SecurityTokenDescriptor.Subject' is obsolete.
             if (tokenDescriptor.Subject != null && tokenDescriptor.Subject.Claims != null)
             {
                 foreach (var claim in tokenDescriptor.Subject.Claims)
                 {
-#pragma warning restore 0618 // 'SecurityTokenDescriptor.Subject' is obsolete.
                     if (claim.Type == ClaimTypes.NameIdentifier)
                     {
                         // Do not allow multiple name identifier claim.

--- a/src/Microsoft.IdentityModel.Tokens/SecurityTokenDescriptor.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityTokenDescriptor.cs
@@ -73,6 +73,9 @@ namespace Microsoft.IdentityModel.Tokens
 
         /// <summary>
         /// Gets or sets the <see cref="Dictionary{TKey, TValue}"/> which represents the claims that will be used when creating a security token.
+        /// If both <cref see="Claims"/> and <see cref="Subject"/> are set, the claim values in Subject will be combined with the values
+        /// in Claims. The values found in Claims take precedence over those found in Subject, so any duplicate
+        /// values will be overridden.
         /// </summary>
         public IDictionary<string, object> Claims { get; set; }
 
@@ -83,8 +86,10 @@ namespace Microsoft.IdentityModel.Tokens
 
         /// <summary>
         /// Gets or sets the <see cref="ClaimsIdentity"/>.
+        /// If both <cref see="Claims"/> and <see cref="Subject"/> are set, the claim values in Subject will be combined with the values
+        /// in Claims. The values found in Claims take precedence over those found in Subject, so any duplicate
+        /// values will be overridden.
         /// </summary>
-        [Obsolete("SecurityTokenDescriptor.Subject is obsolete, please use SecurityTokenDescriptor.Payload instead.")]
         public ClaimsIdentity Subject { get; set; }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/json/JsonConvert.cs
+++ b/src/Microsoft.IdentityModel.Tokens/json/JsonConvert.cs
@@ -301,7 +301,7 @@ namespace Microsoft.IdentityModel.Json
 
         private static string EnsureDecimalPlace(double value, string text)
         {
-            if (double.IsNaN(value) || double.IsInfinity(value) || text.IndexOf(".", StringComparison.OrdinalIgnoreCase) != -1 || text.IndexOf("E", StringComparison.OrdinalIgnoreCase) != -1 || text.IndexOf("e", StringComparison.OrdinalIgnoreCase) != -1)
+            if (double.IsNaN(value) || double.IsInfinity(value) || text.IndexOf('.') != -1 || text.IndexOf('E') != -1 || text.IndexOf('e') != -1)
             {
                 return text;
             }

--- a/src/Microsoft.IdentityModel.Tokens/json/JsonPosition.cs
+++ b/src/Microsoft.IdentityModel.Tokens/json/JsonPosition.cs
@@ -83,7 +83,7 @@ namespace Microsoft.IdentityModel.Json
 
                         if (writer == null)
                         {
-                            writer = new StringWriter(sb, CultureInfo.InvariantCulture);
+                            writer = new StringWriter(sb);
                         }
 
                         JavaScriptUtils.WriteEscapedJavaScriptString(writer, propertyName, '\'', false, JavaScriptUtils.SingleQuoteCharEscapeFlags, StringEscapeHandling.Default, null, ref buffer);

--- a/src/Microsoft.IdentityModel.Tokens/json/Linq/JContainer.Async.cs
+++ b/src/Microsoft.IdentityModel.Tokens/json/Linq/JContainer.Async.cs
@@ -153,7 +153,7 @@ namespace Microsoft.IdentityModel.Json.Linq
                         property.SetLineInfo(lineInfo, settings);
                         JObject parentObject = (JObject)parent;
                         // handle multiple properties with the same name in JSON
-                        JProperty existingPropertyWithName = parentObject.Property(propertyName, StringComparison.OrdinalIgnoreCase);
+                        JProperty existingPropertyWithName = parentObject.Property(propertyName);
                         if (existingPropertyWithName == null)
                         {
                             parent.Add(property);

--- a/src/Microsoft.IdentityModel.Tokens/json/Linq/JContainer.cs
+++ b/src/Microsoft.IdentityModel.Tokens/json/Linq/JContainer.cs
@@ -842,7 +842,7 @@ namespace Microsoft.IdentityModel.Json.Linq
                         property.SetLineInfo(lineInfo, settings);
                         JObject parentObject = (JObject)parent;
                         // handle multiple properties with the same name in JSON
-                        JProperty existingPropertyWithName = parentObject.Property(propertyName, StringComparison.OrdinalIgnoreCase);
+                        JProperty existingPropertyWithName = parentObject.Property(propertyName);
                         if (existingPropertyWithName == null)
                         {
                             parent.Add(property);

--- a/src/Microsoft.IdentityModel.Tokens/json/Linq/JObject.cs
+++ b/src/Microsoft.IdentityModel.Tokens/json/Linq/JObject.cs
@@ -352,13 +352,13 @@ namespace Microsoft.IdentityModel.Json.Linq
             {
                 ValidationUtils.ArgumentNotNull(propertyName, nameof(propertyName));
 
-                JProperty property = Property(propertyName, StringComparison.OrdinalIgnoreCase);
+                JProperty property = Property(propertyName);
 
                 return property?.Value;
             }
             set
             {
-                JProperty property = Property(propertyName, StringComparison.OrdinalIgnoreCase);
+                JProperty property = Property(propertyName);
                 if (property != null)
                 {
                     property.Value = value;
@@ -591,7 +591,7 @@ namespace Microsoft.IdentityModel.Json.Linq
         /// <returns><c>true</c> if item was successfully removed; otherwise, <c>false</c>.</returns>
         public bool Remove(string propertyName)
         {
-            JProperty property = Property(propertyName, StringComparison.OrdinalIgnoreCase);
+            JProperty property = Property(propertyName);
             if (property == null)
             {
                 return false;
@@ -609,7 +609,7 @@ namespace Microsoft.IdentityModel.Json.Linq
         /// <returns><c>true</c> if a value was successfully retrieved; otherwise, <c>false</c>.</returns>
         public bool TryGetValue(string propertyName, out JToken value)
         {
-            JProperty property = Property(propertyName, StringComparison.OrdinalIgnoreCase);
+            JProperty property = Property(propertyName);
             if (property == null)
             {
                 value = null;
@@ -637,7 +637,7 @@ namespace Microsoft.IdentityModel.Json.Linq
 
         bool ICollection<KeyValuePair<string, JToken>>.Contains(KeyValuePair<string, JToken> item)
         {
-            JProperty property = Property(item.Key, StringComparison.OrdinalIgnoreCase);
+            JProperty property = Property(item.Key);
             if (property == null)
             {
                 return false;

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -395,7 +395,6 @@ namespace System.IdentityModel.Tokens.Jwt
             if (tokenDescriptor == null)
                 throw LogHelper.LogArgumentNullException(nameof(tokenDescriptor));
 
-#pragma warning disable 0618 // 'SecurityTokenDescriptor.Subject' is obsolete.
             return CreateJwtSecurityTokenPrivate(
                 tokenDescriptor.Issuer,
                 tokenDescriptor.Audience,
@@ -405,7 +404,6 @@ namespace System.IdentityModel.Tokens.Jwt
                 tokenDescriptor.IssuedAt,
                 tokenDescriptor.SigningCredentials,
                 tokenDescriptor.EncryptingCredentials);
-#pragma warning restore 0618 // 'SecurityTokenDescriptor.Subject' is obsolete.
         }
 
         /// <summary>
@@ -468,7 +466,6 @@ namespace System.IdentityModel.Tokens.Jwt
             if (tokenDescriptor == null)
                 throw LogHelper.LogArgumentNullException(nameof(tokenDescriptor));
 
-#pragma warning disable 0618 // 'SecurityTokenDescriptor.Subject' is obsolete.
             return CreateJwtSecurityTokenPrivate(
                 tokenDescriptor.Issuer,
                 tokenDescriptor.Audience,
@@ -478,7 +475,6 @@ namespace System.IdentityModel.Tokens.Jwt
                 tokenDescriptor.IssuedAt,
                 tokenDescriptor.SigningCredentials,
                 tokenDescriptor.EncryptingCredentials);
-#pragma warning restore 0618 // 'SecurityTokenDescriptor.Subject' is obsolete.
         }
 
         private JwtSecurityToken CreateJwtSecurityTokenPrivate(string issuer, string audience, ClaimsIdentity subject, DateTime? notBefore, DateTime? expires, DateTime? issuedAt, SigningCredentials signingCredentials, EncryptingCredentials encryptingCredentials)

--- a/test/Microsoft.IdentityModel.TestUtils/Default.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/Default.cs
@@ -413,8 +413,8 @@ namespace Microsoft.IdentityModel.TestUtils
             {
                 { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
                 { JwtRegisteredClaimNames.GivenName, "Bob" },
-                { JwtRegisteredClaimNames.Iss, Default.Issuer },
-                { JwtRegisteredClaimNames.Aud, Default.Audience },
+                { JwtRegisteredClaimNames.Iss, Issuer },
+                { JwtRegisteredClaimNames.Aud, Audience },
                 { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(Default.IssueInstant).ToString() },
                 { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(Default.NotBefore).ToString()},
                 { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Default.Expires).ToString() }


### PR DESCRIPTION
Fixes #1193.

If both SecurityTokenDescriptor.Subject and SecurityTokenDescriptor.Claims are set, both are used when creating a JWT token. However, if duplicate values are present, the ones found in SecurityTokenDescriptor.Claims will override those found in SecurityTokenDescriptor.Subject.