### PR TITLE
Added a cgmanifest.json file that specifies the internal Newtonsoft.JSON version that we're using

### DIFF
--- a/build/cgmanifest.json
+++ b/build/cgmanifest.json
@@ -1,0 +1,13 @@
+{"Registrations":[ 
+    {
+      "component": { 
+       "type": "git", 
+       "git": { 
+         "repositoryUrl": "https://github.com/JamesNK/Newtonsoft.Json", 
+         "commitHash": "509643a8952ce731e0207710c429ad6e67dc43db" 
+         }
+       }
+    }
+ ],
+ "Version": 1
+}


### PR DESCRIPTION
Since Wilson 6.x uses Newtonsoft.JSON internally, the Component Governance tool is unable to automatically detect it. Because of this, it must be manually registered as open source in the cgmanifest.json file.