### PR TITLE
OpenIdConnectConfiguration.SigningKeys property is no longer used during deserialization

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfiguration.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfiguration.cs
@@ -519,17 +519,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         }
 
         /// <summary>
-        /// Gets a bool that determines if the 'SigningKeys' property should be serialized.
-        /// This is used by Json.NET in order to conditionally serialize properties.
-        /// </summary>
-        /// <return>true if 'SigningKeys' is not empty; otherwise, false.</return>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShouldSerializeSigningKeys()
-        {
-            return SigningKeys.Count > 0;
-        }
-
-        /// <summary>
         /// Gets a bool that determines if the 'scopes_supported' (ScopesSupported) property should be serialized.
         /// This is used by Json.NET in order to conditionally serialize properties.
         /// </summary>

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfiguration.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfiguration.cs
@@ -306,6 +306,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         /// <summary>
         /// Gets the <see cref="ICollection{SecurityKey}"/> that the IdentityProvider indicates are to be used signing tokens.
         /// </summary>
+        [JsonIgnore]
         public ICollection<SecurityKey> SigningKeys { get; } = new Collection<SecurityKey>();
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
@@ -142,6 +142,23 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                                                 ""token_endpoint_auth_methods_supported"":[""client_secret_post"",""private_key_jwt""]
                                             }";
 
+        public static string JsonWithSigningKeys =
+                                            @"{ ""authorization_endpoint"":""https://login.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/oauth2/authorize"",
+                                                ""check_session_iframe"":""https://login.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/oauth2/checksession"",
+                                                ""end_session_endpoint"":""https://login.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/oauth2/logout"",
+                                                ""id_token_signing_alg_values_supported"":[""RS256""],
+                                                ""issuer"":""https://sts.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/"",
+                                                ""jwks_uri"":""JsonWebKeySetSingleX509Data.json"",
+                                                ""microsoft_multi_refresh_token"":true,
+                                                ""response_types_supported"":[""code"",""id_token"",""code id_token""],
+                                                ""response_modes_supported"":[""query"",""fragment"",""form_post""],
+                                                ""scopes_supported"":[""openid""],
+                                                ""subject_types_supported"":[""pairwise""],
+                                                ""token_endpoint"":""https://login.windows.net/d062b2b0-9aca-4ff7-b32a-ba47231a4002/oauth2/token"",
+                                                ""token_endpoint_auth_methods_supported"":[""client_secret_post"",""private_key_jwt""],
+                                                ""SigningKeys"":[""key1"",""key2""]
+                                            }";
+
         public static string OpenIdConnectMetadataBadX509DataString = @"{""jwks_uri"":""JsonWebKeySetBadX509Data.json""}";
         public static string OpenIdConnectMetadataBadBase64DataString = @"{""jwks_uri"":""JsonWebKeySetBadBase64Data.json""}";
         public static string OpenIdConnectMetadataBadUriKeysString = @"{""jwks_uri"":""___NoSuchFile___""}";

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationTests.cs
@@ -107,6 +107,24 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             Assert.NotNull(configuration.UserInfoEndpointSigningAlgValuesSupported);
         }
 
+        // If the OpenIdConnect metadata has a "SigningKeys" claim, it should NOT be deserialized into the corresponding OpenIdConnectConfiguration.SigningKeys property.
+        // This value should only be populated from the 'jwks_uri' claim.
+        [Fact]
+        public void DeserializeOpenIdConnectConfigurationWithSigningKeys()
+        {
+            TestUtilities.WriteHeader($"{this}.DeserializeOpenIdConnectConfigurationWithSigningKeys");
+            var context = new CompareContext();
+
+            var config = OpenIdConnectConfiguration.Create(
+                OpenIdConnectConfiguration.Write(new OpenIdConnectConfiguration(OpenIdConfigData.JsonWithSigningKeys)));
+
+            // "SigningKeys" should be found in AdditionalData.
+            if (!config.AdditionalData.ContainsKey("SigningKeys"))
+                context.AddDiff(@"!config.AdditionalData.ContainsKey(""SigningKeys"")");
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
         [Fact]
         public void GetSets()
         {


### PR DESCRIPTION
Fixes #1242.