### PR TITLE
RSACryptoServiceProviderProxy should call RSA.Dispose() if a instance was created.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,7 +1,7 @@
 param(
     [string]$buildType="Debug",
     [string]$dotnetDir="c:\Program Files\dotnet",
-    [string]$msbuildDir="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin",
+    [string]$msbuildDir="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin",
     [string]$root=$PSScriptRoot,
     [string]$runTests="YES",
     [string]$failBuildOnTest="YES",

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -200,7 +200,6 @@ namespace Microsoft.IdentityModel.Tokens
                         if (ECDsaSecurityKey != null)
                             ECDsaSecurityKey.ECDsa.Dispose();
 #if DESKTOP
-                        // when investigating issue 1240, should Dispose always be called?
                         if (RsaCryptoServiceProviderProxy != null)
                             RsaCryptoServiceProviderProxy.Dispose();
 #endif
@@ -289,8 +288,9 @@ namespace Microsoft.IdentityModel.Tokens
                 RsaCryptoServiceProviderProxy = new RSACryptoServiceProviderProxy(rsaCryptoServiceProvider);
                 SignatureFunction = SignWithRsaCryptoServiceProviderProxy;
                 VerifyFunction = VerifyWithRsaCryptoServiceProviderProxy;
-                // when investigating issue 1240, should _disposeCryptoOperators be set to true?
-                //_disposeCryptoOperators = true;
+                // RSACryptoServiceProviderProxy will keep track of if it creates a new RSA object.
+                // Only if a new RSA was creaated, RSACryptoServiceProviderProxy will call RSA.Dispose().
+                _disposeCryptoOperators = true;
                 return;
             }
 #endif


### PR DESCRIPTION
When RSACryptoServiceProviderProxy creates a new RSA instance it should be disposed.

https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1240