### PR TITLE
Validators call delegates before checking if validation should occur

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -214,8 +214,8 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets or sets a delegate that will be used to validate the audience.
         /// </summary>
         /// <remarks>
-        /// If set, this delegate will be called to validate the 'audience' instead of normal processing.
-        /// If <see cref="ValidateAudience"/> is false, this delegate will not be called.
+        /// If set, this delegate will be called to validate the 'audience', instead of normal processing. This means that no default 'audience' validation will occur.
+        /// Even if <see cref="ValidateAudience"/> is false, this delegate will still be called.
         /// </remarks>
         public AudienceValidator AudienceValidator { get; set; }
 
@@ -329,7 +329,8 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets or sets a delegate for validating the <see cref="SecurityKey"/> that signed the token.
         /// </summary>
         /// <remarks>
-        /// If set, this delegate will be called to validate the <see cref="SecurityKey"/> that signed the token, instead of normal processing.
+        /// If set, this delegate will be called to validate the <see cref="SecurityKey"/> that signed the token, instead of normal processing. This means that no default <see cref="SecurityKey"/> validation will occur.
+        /// Even if <see cref="ValidateIssuerSigningKey"/> is false, this delegate will still be called.
         /// </remarks>
         public IssuerSigningKeyValidator IssuerSigningKeyValidator { get; set; }
 
@@ -355,8 +356,8 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets or sets a delegate that will be used to validate the issuer of the token.
         /// </summary>
         /// <remarks>
-        /// If set, this delegate will be called to validate the 'issuer' of the token, instead of normal processing.
-        /// If <see cref="ValidateIssuer"/> is false, this delegate will not be called.
+        /// If set, this delegate will be called to validate the 'issuer' of the token, instead of normal processing. This means that no default 'issuer' validation will occur.
+        /// Even if <see cref="ValidateIssuer"/> is false, this delegate will still be called.
         /// </remarks>
         public IssuerValidator IssuerValidator { get; set; }
 
@@ -364,8 +365,8 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets or sets a delegate that will be used to validate the lifetime of the token
         /// </summary>
         /// <remarks>
-        /// If set, this delegate will be called to validate the lifetime of the token, instead of normal processing.
-        /// If <see cref="ValidateLifetime"/> is false, this delegate will not be called.
+        /// If set, this delegate will be called to validate the lifetime of the token, instead of normal processing. This means that no default lifetime validation will occur.
+        /// Even if <see cref="ValidateLifetime"/> is false, this delegate will still be called.
         /// </remarks>
         public LifetimeValidator LifetimeValidator { get; set; }
 
@@ -500,8 +501,8 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets or sets a delegate that will be used to validate the token replay of the token
         /// </summary>
         /// <remarks>
-        /// If set, this delegate will be called to validate the token replay of the token, instead of normal processing.
-        /// If <see cref="ValidateTokenReplay"/> is false, this delegate will not be called.
+        /// If set, this delegate will be called to validate the token replay of the token, instead of normal processing. This means no default token replay validation will occur.
+        /// Even if <see cref="ValidateTokenReplay"/> is false, this delegate will still be called.
         /// </remarks>
         public TokenReplayValidator TokenReplayValidator { get; set; }
 
@@ -515,7 +516,9 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets or sets a boolean to control if the audience will be validated during token validation.
         /// </summary>
         /// <remarks>Validation of the audience, mitigates forwarding attacks. For example, a site that receives a token, could not replay it to another side.
-        /// A forwarded token would contain the audience of the original site.</remarks>
+        /// A forwarded token would contain the audience of the original site.
+        /// This boolean only applies to default audience validation. If <see cref="AudienceValidator"/> is set, it will be called regardless of whether this
+        /// property is true or false.</remarks>
         [DefaultValue(true)]
         public bool ValidateAudience { get; set; }
 
@@ -528,13 +531,19 @@ namespace Microsoft.IdentityModel.Tokens
         /// It is possible that a token issued for the same audience could be from a different tenant. For example an application could accept users from
         /// contoso.onmicrosoft.com but not fabrikam.onmicrosoft.com, both valid tenants. A application that accepts tokens from fabrikam could forward them
         /// to the application that accepts tokens for contoso.
+        /// This boolean only applies to default issuer validation. If <see cref= "IssuerValidator" /> is set, it will be called regardless of whether this
+        /// property is true or false.
         /// </remarks>
         [DefaultValue(true)]
         public bool ValidateIssuer { get; set; }
 
         /// <summary>
         /// Gets or sets a boolean to control if the lifetime will be validated during token validation.
-        /// </summary>                
+        /// </summary> 
+        /// <remarks>
+        /// This boolean only applies to default lifetime validation. If <see cref= "LifetimeValidator" /> is set, it will be called regardless of whether this
+        /// property is true or false.
+        /// </remarks>
         [DefaultValue(true)]
         public bool ValidateLifetime { get; set; }
 
@@ -542,13 +551,20 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets or sets a boolean that controls if validation of the <see cref="SecurityKey"/> that signed the securityToken is called.
         /// </summary>
         /// <remarks>It is possible for tokens to contain the public key needed to check the signature. For example, X509Data can be hydrated into an X509Certificate,
-        /// which can be used to validate the signature. In these cases it is important to validate the SigningKey that was used to validate the signature. </remarks>
+        /// which can be used to validate the signature. In these cases it is important to validate the SigningKey that was used to validate the signature. 
+        /// This boolean only applies to default signing key validation. If <see cref= "IssuerSigningKeyValidator" /> is set, it will be called regardless of whether this
+        /// property is true or false.
+        /// </remarks>
         [DefaultValue(false)]
         public bool ValidateIssuerSigningKey { get; set; }
 
         /// <summary>
         /// Gets or sets a boolean to control if the token replay will be validated during token validation.
-        /// </summary>                
+        /// </summary> 
+        /// <remarks>
+        /// This boolean only applies to default token replay validation. If <see cref= "TokenReplayValidator" /> is set, it will be called regardless of whether this
+        /// property is true or false.
+        /// </remarks>
         [DefaultValue(false)]
         public bool ValidateTokenReplay { get; set; }
 

--- a/src/Microsoft.IdentityModel.Tokens/Validators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validators.cs
@@ -53,12 +53,6 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters == null)
                 throw LogHelper.LogArgumentNullException(nameof(validationParameters));
 
-            if (!validationParameters.ValidateAudience)
-            {
-                LogHelper.LogWarning(LogMessages.IDX10233);
-                return;
-            }
-
             if (validationParameters.AudienceValidator != null)
             {
                 if (!validationParameters.AudienceValidator(audiences, securityToken, validationParameters))
@@ -67,6 +61,12 @@ namespace Microsoft.IdentityModel.Tokens
                         InvalidAudience = Utility.SerializeAsSingleCommaDelimitedString(audiences)
                     });
 
+                return;
+            }
+
+            if (!validationParameters.ValidateAudience)
+            {
+                LogHelper.LogWarning(LogMessages.IDX10233);
                 return;
             }
 
@@ -127,14 +127,14 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters == null)
                 throw LogHelper.LogArgumentNullException(nameof(validationParameters));
 
+            if (validationParameters.IssuerValidator != null)
+                return validationParameters.IssuerValidator(issuer, securityToken, validationParameters);
+
             if (!validationParameters.ValidateIssuer)
             {
                 LogHelper.LogInformation(LogMessages.IDX10235);
                 return issuer;
             }
-
-            if (validationParameters.IssuerValidator != null)
-                return validationParameters.IssuerValidator(issuer, securityToken, validationParameters);
 
             if (string.IsNullOrWhiteSpace(issuer))
                 throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidIssuerException(LogMessages.IDX10211)
@@ -188,16 +188,16 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters == null)
                 throw LogHelper.LogArgumentNullException(nameof(validationParameters));
 
+            if (validationParameters.IssuerSigningKeyValidator != null)
+            {
+                if (!validationParameters.IssuerSigningKeyValidator(securityKey, securityToken, validationParameters))
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, securityKey)) { SigningKey = securityKey });
+            }
+
             if (!validationParameters.ValidateIssuerSigningKey)
             {
                 LogHelper.LogInformation(LogMessages.IDX10237);
                 return;
-            }
-
-            if (validationParameters.IssuerSigningKeyValidator != null)
-            {
-                if (!validationParameters.IssuerSigningKeyValidator(securityKey, securityToken, validationParameters))
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, securityKey)){ SigningKey = securityKey });
             }
 
             if (!validationParameters.RequireSignedTokens && securityKey == null)
@@ -250,18 +250,18 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters == null)
                 throw LogHelper.LogArgumentNullException(nameof(validationParameters));
 
-            if (!validationParameters.ValidateLifetime)
-            {
-                LogHelper.LogInformation(LogMessages.IDX10238);
-                return;
-            }
-
             if (validationParameters.LifetimeValidator != null)
             {
                 if (!validationParameters.LifetimeValidator(notBefore, expires, securityToken, validationParameters))
                     throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidLifetimeException(LogHelper.FormatInvariant(LogMessages.IDX10230, securityToken))
                         { NotBefore = notBefore, Expires = expires });
 
+                return;
+            }
+
+            if (!validationParameters.ValidateLifetime)
+            {
+                LogHelper.LogInformation(LogMessages.IDX10238);
                 return;
             }
 
@@ -304,16 +304,16 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters == null)
                 throw LogHelper.LogArgumentNullException(nameof(validationParameters));
 
-            if (!validationParameters.ValidateTokenReplay)
-            {
-                LogHelper.LogInformation(LogMessages.IDX10246);
-                return;
-            }
-
             if (validationParameters.TokenReplayValidator != null)
             {
                 if (!validationParameters.TokenReplayValidator(expirationTime, securityToken, validationParameters))
                     throw LogHelper.LogExceptionMessage(new SecurityTokenReplayDetectedException(LogHelper.FormatInvariant(LogMessages.IDX10228, securityToken)));
+                return;
+            }
+
+            if (!validationParameters.ValidateTokenReplay)
+            {
+                LogHelper.LogInformation(LogMessages.IDX10246);
                 return;
             }
 

--- a/test/Microsoft.IdentityModel.TestUtils/ReferenceTheoryData.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ReferenceTheoryData.cs
@@ -26,12 +26,14 @@ namespace Microsoft.IdentityModel.TestUtils
                     new TokenReplayTheoryData
                     {
                         TestId = $"ValidateTokenReplay: false, {nameof(ValidationDelegates.TokenReplayValidatorReturnsFalse)}",
-                        TokenReplayValidator = ValidationDelegates.TokenReplayValidatorReturnsFalse
+                        TokenReplayValidator = ValidationDelegates.TokenReplayValidatorReturnsFalse,
+                        ExpectedException = ExpectedException.SecurityTokenReplayDetected("IDX10228:")
                     },
                     new TokenReplayTheoryData
                     {
                         TestId = $"ValidateTokenReplay: false, {nameof(ValidationDelegates.TokenReplayValidatorThrows)}",
-                        TokenReplayValidator = ValidationDelegates.TokenReplayValidatorThrows
+                        TokenReplayValidator = ValidationDelegates.TokenReplayValidatorThrows,
+                        ExpectedException = ExpectedException.SecurityTokenReplayDetected("TokenReplayValidatorThrows")
                     },
                     new TokenReplayTheoryData
                     {

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
@@ -431,6 +431,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
 
                 theoryData.Add(new Saml2TheoryData
                 {
+                    ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidSigningKeyException)),
                     SecurityToken = tokenHandler.CreateToken(tokenDescriptor),
                     TestId = nameof(ValidationDelegates.IssuerSecurityKeyValidatorThrows) + "-false",
                     ValidationParameters = validationParameters
@@ -468,6 +469,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
 
                 theoryData.Add(new Saml2TheoryData
                 {
+                    ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidAudienceException)),
                     SecurityToken = tokenHandler.CreateToken(tokenDescriptor),
                     TestId = nameof(ValidationDelegates.AudienceValidatorThrows) + "-false",
                     ValidationParameters = validationParameters

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
@@ -873,6 +873,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
 
                 theoryData.Add(new SamlTheoryData
                 {
+                    ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidSigningKeyException)),
                     SecurityToken = tokenHandler.CreateToken(tokenDescriptor),
                     TestId = nameof(ValidationDelegates.IssuerSecurityKeyValidatorThrows) + "-false",
                     ValidationParameters = validationParameters
@@ -910,6 +911,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
 
                 theoryData.Add(new SamlTheoryData
                 {
+                    ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidAudienceException)),
                     SecurityToken = tokenHandler.CreateToken(tokenDescriptor),
                     TestId = nameof(ValidationDelegates.AudienceValidatorThrows) + "-false",
                     ValidationParameters = validationParameters

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/ValidateTheoryData.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/ValidateTheoryData.cs
@@ -106,6 +106,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             theoryData.Add(new TokenTheoryData
             {
                 Audiences = new List<string> { "John" },
+                ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException(),
                 TestId = "AudienceValidator throws, validateAudience false",
                 ValidationParameters = new TokenValidationParameters
                 {

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -982,12 +982,14 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     },
                     new JwtTheoryData
                     {
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidAudienceException), substringExpected: $"{typeof(ValidationDelegates)}.AudienceValidatorThrows"),
                         TestId = "'validateAudience == false, AudienceValidator throws'",
                         SecurityToken = tokenHandler.CreateJwtSecurityToken(issuer: Default.Issuer, audience: Default.Audience),
                         ValidationParameters = ValidateAudienceValidationParameters(null, null, ValidationDelegates.AudienceValidatorThrows, false),
                     },
                     new JwtTheoryData
                     {
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidAudienceException), substringExpected: "IDX10231", propertiesExpected: new Dictionary<string, object>{ { "InvalidAudience", Default.Audience } }),
                         TestId = "'validateAudience == false, AudienceValidator return false'",
                         SecurityToken = tokenHandler.CreateJwtSecurityToken(issuer: Default.Issuer, audience: Default.Audience),
                         ValidationParameters = ValidateAudienceValidationParameters(null, null, ValidationDelegates.AudienceValidatorReturnsFalse, false),
@@ -1077,7 +1079,8 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                         ValidationParameters = ValidateIssuerValidationParameters(null, Default.Issuers, null, true)
                     },
                     new JwtTheoryData
-                    {
+                    {                        
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidIssuerException), "IssuerValidatorThrows"),
                         TestId = "ValidationDelegates.IssuerValidatorThrows, ValidateIssuer: false",
                         Token = jwt,
                         ValidationParameters = ValidateIssuerValidationParameters(
@@ -1181,19 +1184,21 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     },
                     new JwtTheoryData
                     {
+                        ExpectedException = ExpectedException.SecurityTokenInvalidLifetimeException("IDX10230:"),
                         TestId = $"{nameof(ValidationDelegates.LifetimeValidatorReturnsFalse)}, ValidateLifetime: false",
                         Token = Default.UnsignedJwt,
                         ValidationParameters = ValidateLifetimeValidationParameters(ValidationDelegates.LifetimeValidatorReturnsFalse, false)
                     },
                     new JwtTheoryData
                     {
-                        ExpectedException = ExpectedException.SecurityTokenInvalidLifetimeException("IDX10230:"),
+                        ExpectedException = ExpectedException.SecurityTokenInvalidLifetimeException("LifetimeValidatorThrows"),
                         TestId = nameof(ValidationDelegates.LifetimeValidatorThrows),
                         Token = Default.UnsignedJwt,
-                        ValidationParameters = ValidateLifetimeValidationParameters(ValidationDelegates.LifetimeValidatorReturnsFalse, true)
+                        ValidationParameters = ValidateLifetimeValidationParameters(ValidationDelegates.LifetimeValidatorThrows, true)
                     },
                     new JwtTheoryData
-                    {
+                    {                        
+                        ExpectedException = ExpectedException.SecurityTokenInvalidLifetimeException("LifetimeValidatorThrows"),
                         TestId = $"'{nameof(ValidationDelegates.LifetimeValidatorThrows)}, ValidateLifetime: false'",
                         Token = Default.UnsignedJwt,
                         ValidationParameters = ValidateLifetimeValidationParameters(ValidationDelegates.LifetimeValidatorThrows, false)


### PR DESCRIPTION
Fixes #1100.

Ex. `TokenValidationParameters.AudienceValidator` is called before the value of `TokenValidationParameters.ValidateAudience` is checked.