### PR TITLE
Added 'typ' header claim validation to JwtSecurityTokenHandler and JsonWebTokenHandler

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -157,6 +157,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// Creates an unsigned JWS (Json Web Signature).
         /// </summary>
         /// <param name="payload">A string containing JSON which represents the JWT token payload.</param>
+        /// <exception cref="ArgumentNullException">if <paramref name="payload"/> is null.</exception>
         /// <returns>A JWS in Compact Serialization Format.</returns>
         public virtual string CreateToken(string payload)
         {
@@ -164,6 +165,25 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 throw LogHelper.LogArgumentNullException(nameof(payload));
 
             return CreateTokenPrivate(JObject.Parse(payload), null, null, null, null);
+        }
+
+        /// <summary>
+        /// Creates an unsigned JWS (Json Web Signature).
+        /// </summary>
+        /// <param name="payload">A string containing JSON which represents the JWT token payload.</param>
+        /// <param name="additionalHeaderClaims">Defines the dictionary containing any custom header claims that need to be added to the JWT token header.</param>
+        /// <exception cref="ArgumentNullException">if <paramref name="payload"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">if <paramref name="additionalHeaderClaims"/> is null.</exception>
+        /// <returns>A JWS in Compact Serialization Format.</returns>
+        public virtual string CreateToken(string payload, IDictionary<string, object> additionalHeaderClaims)
+        {
+            if (string.IsNullOrEmpty(payload))
+                throw LogHelper.LogArgumentNullException(nameof(payload));
+
+            if (additionalHeaderClaims == null)
+                throw LogHelper.LogArgumentNullException(nameof(additionalHeaderClaims));
+
+            return CreateTokenPrivate(JObject.Parse(payload), null, null, null, additionalHeaderClaims);
         }
 
         /// <summary>
@@ -222,10 +242,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (tokenDescriptor == null)
                 throw LogHelper.LogArgumentNullException(nameof(tokenDescriptor));
 
-            if ((tokenDescriptor.Subject == null || !tokenDescriptor.Subject.Claims.Any()) 
+            if ((tokenDescriptor.Subject == null || !tokenDescriptor.Subject.Claims.Any())
                 && (tokenDescriptor.Claims == null || !tokenDescriptor.Claims.Any()))
                 LogHelper.LogWarning(LogMessages.IDX14114, nameof(SecurityTokenDescriptor), nameof(SecurityTokenDescriptor.Subject), nameof(SecurityTokenDescriptor.Claims));
-            
+
             JObject payload;
             if (tokenDescriptor.Subject != null)
                 payload = JObject.FromObject(JwtTokenUtilities.CreateDictionaryFromClaims(tokenDescriptor.Subject.Claims));
@@ -1120,6 +1140,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 ValidateToken(jsonWebToken.Actor, validationParameters.ActorValidationParameters ?? validationParameters);
             }
             Validators.ValidateIssuerSecurityKey(jsonWebToken.SigningKey, jsonWebToken, validationParameters);
+           
+            JwtTokenUtilities.ValidateTokenType(jsonWebToken.Typ, validationParameters);
 
             return new TokenValidationResult
             {

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -32,6 +32,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.Linq;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
@@ -321,6 +322,40 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             }
 
             throw LogHelper.LogExceptionMessage(new FormatException(LogHelper.FormatInvariant(LogMessages.IDX14300, claimName, jToken.ToString(), typeof(long))));
+        }
+
+        /// <summary>
+        /// Validates the 'typ' claim of the JWT token header.
+        /// </summary>
+        /// <param name="type">The value of the 'typ' header claim."/></param>
+        /// <param name="validationParameters"><see cref="TokenValidationParameters"/> required for validation.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="validationParameters"/> is null or whitespace.</exception>
+        /// <exception cref="SecurityTokenInvalidTypeException">If <paramref name="type"/> is null or whitespace and <see cref="TokenValidationParameters.ValidTypes"/> is not null.</exception>
+        /// <exception cref="SecurityTokenInvalidTypeException">If <paramref name="type"/> failed to match <see cref="TokenValidationParameters.ValidTypes"/>.</exception>
+        /// <remarks>An EXACT match is required. <see cref="StringComparison.Ordinal"/> (case sensitive) is used for comparing <paramref name="type"/> against <see cref="TokenValidationParameters.ValidTypes"/>.</remarks>
+        internal static void ValidateTokenType(string type, TokenValidationParameters validationParameters)
+        {
+            if (validationParameters == null)
+                throw LogHelper.LogArgumentNullException(nameof(validationParameters));
+
+            if (validationParameters.ValidTypes == null || validationParameters.ValidTypes.Count() == 0)
+            {
+                LogHelper.LogInformation(TokenLogMessages.IDX10254);
+                return;
+            }
+
+            if (string.IsNullOrEmpty(type))
+                throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidTypeException(TokenLogMessages.IDX10256) { InvalidType = null });
+
+            if (!validationParameters.ValidTypes.Contains(type, StringComparer.Ordinal))
+            {
+                throw LogHelper.LogExceptionMessage(
+                                new SecurityTokenInvalidTypeException(LogHelper.FormatInvariant(TokenLogMessages.IDX10257, type, Utility.SerializeAsSingleCommaDelimitedString(validationParameters.ValidTypes)))
+                                { InvalidType = type }); ;
+            }
+
+            // if it reaches here, token type was succcessfully validated.
+            LogHelper.LogInformation(TokenLogMessages.IDX10258, type);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
@@ -55,7 +55,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         internal const string IDX14114 = "IDX14114: Both '{0}.{1}' and '{0}.{2}' are null or empty.";
         // internal const string IDX14115 = "IDX14115:";
         internal const string IDX14116 = "IDX14116: ''{0}' cannot contain the following claims: '{1}'. These values are added by default (if necessary) during security token creation.";
-        
+
         // logging
         internal const string IDX14200 = "IDX14200: Creating raw signature using the signature credentials.";
         

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenInvalidTypeException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenInvalidTypeException.cs
@@ -1,0 +1,85 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+#if DESKTOPNET45
+        [Serializable]
+#endif
+    /// <summary>
+    /// This exception is thrown when the token type ('typ' header claim) of a JWT token is invalid.
+    /// </summary>
+    public class SecurityTokenInvalidTypeException : SecurityTokenValidationException
+    {
+        /// <summary>
+        /// Gets or sets the invalid type that created the validation exception.
+        /// </summary>
+        public string InvalidType { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenInvalidTypeException"/> class.
+        /// </summary>
+        public SecurityTokenInvalidTypeException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenInvalidTypeException"/> class.
+        /// </summary>
+        /// <param name="message">Additional information to be included in the exception and displayed to user.</param>
+        public SecurityTokenInvalidTypeException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenInvalidTypeException"/> class.
+        /// </summary>
+        /// <param name="message">Additional information to be included in the exception and displayed to user.</param>
+        /// <param name="innerException">A <see cref="Exception"/> that represents the root cause of the exception.</param>
+        public SecurityTokenInvalidTypeException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+#if DESKTOPNET45
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenInvalidTypeException"/> class.
+        /// </summary>
+        /// <param name="info">the <see cref="SerializationInfo"/> that holds the serialized object data.</param>
+        /// <param name="context">The contextual information about the source or destination.</param>
+        protected SecurityTokenInvalidTypeException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+#endif
+
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -86,6 +86,10 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10252 = "IDX10252: RequireSignedTokens property on ValidationParameters is set to false and the issuer signing key is null. Exiting without validating the issuer signing key.";
         public const string IDX10253 = "IDX10253: RequireSignedTokens property on ValidationParameters is set to true, but the issuer signing key is null.";
         public const string IDX10254 = "IDX10254: '{0}.{1}' failed. The virtual method '{2}.{3}' returned null. If this method was overridden, ensure a valid '{4}' is returned.";
+        public const string IDX10255 = "IDX10255: ValidTypes property on ValidationParameters is either null or empty. Exiting without validating the token type.";
+        public const string IDX10256 = "IDX10256: Unable to validate the token type. TokenValidationParameters.ValidTypes is set, but the 'typ' header claim is null or empty.";
+        public const string IDX10257 = "IDX10257: Token type validation failed. Type: '{0}'. Did not match: validationParameters.TokenTypes: '{1}'.";
+        public const string IDX10258 = "IDX10258: Token type validated. Type: '{0}'.";
 
         // 10500 - SignatureValidation
         public const string IDX10500 = "IDX10500: Signature validation failed. No security keys were provided to validate the signature.";

--- a/src/Microsoft.IdentityModel.Tokens/SecurityTokenDescriptor.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityTokenDescriptor.cs
@@ -81,7 +81,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         /// <summary>
         /// Gets or sets the <see cref="Dictionary{TKey, TValue}"/> which contains any custom header claims that need to be added to the JWT token header.
-        /// The 'alg', 'kid', 'typ', 'x5t', 'enc', and 'zip' claims are added by default based on the <see cref="SigningCredentials"/>,
+        /// The 'alg', 'kid', 'x5t', 'enc', and 'zip' claims are added by default based on the <see cref="SigningCredentials"/>,
         /// <see cref="EncryptingCredentials"/>, and/or <see cref="CompressionAlgorithm"/> provided and SHOULD NOT be included in this dictionary as this
         /// will result in an exception being thrown. 
         /// <remarks> These claims are only added to the outer header (in case of a JWE).</remarks>

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -571,5 +571,12 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets or sets the <see cref="IEnumerable{String}"/> that contains valid issuers that will be used to check against the token's issuer.
         /// </summary>
         public IEnumerable<string> ValidIssuers { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IEnumerable{String}"/> that contains valid types that will be used to check against the JWT header's 'typ' claim.
+        /// If this property is not set, the 'typ' header claim will not be validated and all types will be accepted.
+        /// In the case of a JWE, this property will ONLY apply to the inner token header.
+        /// </summary>
+        public IEnumerable<string> ValidTypes { get; set; }
     }
 }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -741,6 +741,9 @@ namespace System.IdentityModel.Tokens.Jwt
                 ValidateToken(jwtToken.Actor, validationParameters.ActorValidationParameters ?? validationParameters, out _);
             }
             ValidateIssuerSecurityKey(jwtToken.SigningKey, jwtToken, validationParameters);
+            
+            JwtTokenUtilities.ValidateTokenType(jwtToken.Header.Typ, validationParameters);
+
             var identity = CreateClaimsIdentity(jwtToken, issuer, validationParameters);
             if (validationParameters.SaveSigninToken)
                 identity.BootstrapContext = jwtToken.RawData;

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -1809,6 +1809,22 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 throw new SecurityTokenException("Token does not contain the correct value for the 'email' claim.");
         }
 
+
+        [Theory, MemberData(nameof(ValidateTypeTheoryData))]
+        public void ValidateType(JwtTheoryData theoryData)
+        {
+            TestUtilities.WriteHeader($"{this}.ValidateType", theoryData);
+
+            var tokenValidationResult = new JsonWebTokenHandler().ValidateToken(theoryData.Token, theoryData.ValidationParameters);
+            if (tokenValidationResult.Exception != null)
+                theoryData.ExpectedException.ProcessException(tokenValidationResult.Exception);
+            else
+                theoryData.ExpectedException.ProcessNoException();
+
+        }
+
+        public static TheoryData<JwtTheoryData> ValidateTypeTheoryData = JwtSecurityTokenHandlerTests.ValidateTypeTheoryData;
+
         [Theory, MemberData(nameof(ValidateJwsTheoryData))]
         public void ValidateJWS(JwtTheoryData theoryData)
         {

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
@@ -42,8 +42,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 37)
-                Assert.True(false, "Number of properties has changed from 37 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 38)
+                Assert.True(false, "Number of properties has changed from 38 to: " + properties.Length + ", adjust tests");
 
             TokenValidationParameters actorValidationParameters = new TokenValidationParameters();
             SecurityKey issuerSigningKey = KeyingMaterial.DefaultX509Key_2048_Public;
@@ -144,8 +144,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 37)
-                Assert.True(false, "Number of public fields has changed from 37 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 38)
+                Assert.True(false, "Number of public fields has changed from 38 to: " + properties.Length + ", adjust tests");
 
             GetSetContext context =
                 new GetSetContext


### PR DESCRIPTION
Fixes #1220.

Changes include:

- Added 'typ' header claim validation for both `JwtSecurityTokenHandler` and `JsonWebTokenHandler`.
- Added a `SecurityTokenInvalidTypeException`.
- Added a `ValidTypes` property to the TokenValidationParameters.
- Added an overloaded method for creating an unsigned JWS (using `JsonWebTokenHandler`) that also allows for additional header parameters.
- Fixed comment on `SecurityTokenDescriptor.AdditionalHeaderClaims` to clarify that the 'typ' header claim can be overridden. 