### PR TITLE
Fix DateTime claims processing

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.IdentityModel.Logging;
@@ -406,6 +407,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 // Boolean needs item.ToString otherwise 'true' => 'True'
                 if (jvalue.Type is JTokenType.String)
                     claims.Add(new Claim(claimType, jvalue.Value.ToString(), ClaimValueTypes.String, issuer, issuer));
+                // DateTime claims require special processing. jtoken.ToString(Formatting.None) will result in "\"dateTimeValue\"". The quotes will be added.
+                else if (jvalue.Value is DateTime dateTimeValue)
+                    claims.Add(new Claim(claimType, dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), ClaimValueTypes.DateTime, issuer, issuer));
                 else
                     claims.Add(new Claim(claimType, jtoken.ToString(Newtonsoft.Json.Formatting.None), GetClaimValueType(jvalue.Value), issuer, issuer));
             }
@@ -480,6 +484,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 return ClaimValueTypes.Integer64;
             }
 
+            if (objType == typeof(DateTime))
+                return ClaimValueTypes.DateTime;
+
             if (objType == typeof(JObject))
                 return JsonClaimValueTypes.Json;
 
@@ -512,6 +519,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 // Boolean needs item.ToString otherwise 'true' => 'True'
                 if (jvalue.Type is JTokenType.String)
                     return new Claim(key, jvalue.Value.ToString(), ClaimValueTypes.String, issuer, issuer);
+                // DateTime claims require special processing. jTokenValue.ToString(Formatting.None) will result in "\"dateTimeValue\"". The quotes will be added.
+                else if (jvalue.Value is DateTime dateTimeValue)
+                    return new Claim(key, dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), ClaimValueTypes.DateTime, issuer, issuer);
                 else
                     return new Claim(key, jTokenValue.ToString(Formatting.None), GetClaimValueType(jvalue.Value), issuer, issuer);
             }
@@ -573,6 +583,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 // Boolean needs item.ToString otherwise 'true' => 'True'
                 if (jvalue.Type is JTokenType.String)
                     value = new Claim(key, jvalue.Value.ToString(), ClaimValueTypes.String, issuer, issuer);
+                // DateTime claims require special processing. jTokenValue.ToString(Formatting.None) will result in "\"dateTimeValue\"". The quotes will be added.
+                else if (jvalue.Value is DateTime dateTimeValue)
+                    value =  new Claim(key, dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), ClaimValueTypes.DateTime, issuer);
                 else
                     value = new Claim(key, jTokenValue.ToString(Formatting.None), GetClaimValueType(jvalue.Value), issuer, issuer);
             }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -267,6 +267,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     return longValue;
             }
 
+            if (claim.ValueType == ClaimValueTypes.DateTime)
+            {
+                if (DateTime.TryParse(claim.Value, out DateTime dateTimeValue))
+                    return dateTimeValue;
+            }
+
             if (claim.ValueType == JsonClaimValueTypes.Json)
                 return JObject.Parse(claim.Value);
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using Microsoft.IdentityModel.Logging;
@@ -42,7 +43,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 {
     public class JsonWebTokenTests
     {
-        private string jObject = @"{""intarray"":[1,2,3], ""array"":[1,""2"",3], ""jobject"": { ""string1"":""string1value"", ""string2"":""string2value"" },""string"":""bob"", ""float"":42.0, ""integer"":42, ""nill"": null, ""bool"" : true }";
+        private static DateTime dateTime = new DateTime(2000, 01, 01, 0, 0, 0, DateTimeKind.Local);
+        private string jObject = $@"{{""intarray"":[1,2,3], ""array"":[1,""2"",3], ""jobject"": {{ ""string1"":""string1value"", ""string2"":""string2value"" }},""string"":""bob"", ""float"":42.0, ""integer"":42, ""nill"": null, ""bool"" : true, ""dateTime"": ""{dateTime.ToString("o", CultureInfo.InvariantCulture)}"" }}";
         private List<Claim> payloadClaims = new List<Claim>()
         {
             new Claim("intarray", @"[1,2,3]", JsonClaimValueTypes.JsonArray, "LOCAL AUTHORITY", "LOCAL AUTHORITY"),
@@ -52,7 +54,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             new Claim("float", "42.0", ClaimValueTypes.Double, "LOCAL AUTHORITY", "LOCAL AUTHORITY"),
             new Claim("integer", "42", ClaimValueTypes.Integer, "LOCAL AUTHORITY", "LOCAL AUTHORITY"),
             new Claim("nill", "", JsonClaimValueTypes.JsonNull, "LOCAL AUTHORITY", "LOCAL AUTHORITY"),
-            new Claim("bool", "true", ClaimValueTypes.Boolean, "LOCAL AUTHORITY", "LOCAL AUTHORITY")
+            new Claim("bool", "true", ClaimValueTypes.Boolean, "LOCAL AUTHORITY", "LOCAL AUTHORITY"),
+            new Claim("dateTime", dateTime.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), ClaimValueTypes.DateTime, "LOCAL AUTHORITY", "LOCAL AUTHORITY"),
         };
 
         // Test checks to make sure that the JsonWebToken.GetClaim() method is able to retrieve every Claim returned by the Claims property (with the exception 
@@ -231,6 +234,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             var boolean = token.GetHeaderValue<bool>("bool");
             IdentityComparer.AreEqual(boolean, true, context);
 
+            var dateTimeValue = token.GetHeaderValue<DateTime>("dateTime");
+            IdentityComparer.AreEqual(dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), dateTime.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), context);
+
             try // Try to retrieve a value that doesn't exist in the header.
             {
                 token.GetHeaderValue<int>("doesnotexist");
@@ -293,6 +299,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             IdentityComparer.AreEqual(boolean, true, context);
             IdentityComparer.AreEqual(true, success, context);
 
+            success = token.TryGetHeaderValue("dateTime", out DateTime dateTimeValue);
+            IdentityComparer.AreEqual(dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), dateTime.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), context);
+            IdentityComparer.AreEqual(true, success, context);
+
             success = token.TryGetHeaderValue("doesnotexist", out int doesNotExist);
             IdentityComparer.AreEqual(0, doesNotExist, context);
             IdentityComparer.AreEqual(false, success, context);
@@ -336,6 +346,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
             var boolean = token.GetPayloadValue<bool>("bool");
             IdentityComparer.AreEqual(boolean, true, context);
+
+            var dateTimeValue = token.GetPayloadValue<DateTime>("dateTime");
+            IdentityComparer.AreEqual(dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), dateTime.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), context);
 
             try // Try to retrieve a value that doesn't exist in the header.
             {
@@ -397,6 +410,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
             success = token.TryGetPayloadValue("bool", out bool boolean);
             IdentityComparer.AreEqual(boolean, true, context);
+            IdentityComparer.AreEqual(true, success, context);
+
+            var dateTimeValue = token.GetPayloadValue<DateTime>("dateTime");
+            IdentityComparer.AreEqual(dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), dateTime.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), context);
             IdentityComparer.AreEqual(true, success, context);
 
             success = token.TryGetPayloadValue("doesnotexist", out int doesNotExist);

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
@@ -27,6 +27,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using System.Security.Claims;
 using Microsoft.IdentityModel.TestUtils;
@@ -186,6 +187,18 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         [Fact]
+        public void TestDateTimeClaims()
+        {
+            JwtPayload jwtPayload = new JwtPayload();
+            var dateTime = new DateTime(2020, 1, 1, 1, 1, 1, 1);
+            jwtPayload.Add("dateTime", dateTime);
+            var dateTimeClaim = jwtPayload.Claims.First();
+
+            Assert.True(string.Equals(dateTimeClaim.ValueType, ClaimValueTypes.DateTime, StringComparison.Ordinal), "dateTimeClaim.Type != ClaimValueTypes.DateTime");
+            Assert.True(string.Equals(dateTimeClaim.Value, dateTime.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), StringComparison.Ordinal), "dateTimeClaim.Type != ClaimValueTypes.DateTime");
+        }
+
+        [Fact]
         public void TestClaimWithLargeExpValue()
         {
             JwtPayload jwtPayload = new JwtPayload();
@@ -257,6 +270,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                         new Claim("ClaimValueTypes.int.MinValue", intMinValue, ClaimValueTypes.Integer),
                         new Claim("ClaimValueTypes.long.MaxValue", longMaxValue, ClaimValueTypes.Integer64),
                         new Claim("ClaimValueTypes.long.MinValue", longMinValue, ClaimValueTypes.Integer64),
+                        new Claim("ClaimValueTypes.DateTime.IS8061", "2019-11-15T14:31:21.6101326Z", ClaimValueTypes.DateTime),
                         new Claim("ClaimValueTypes.JsonClaimValueTypes.Json1", @"{""jsonProperty1"":""jsonvalue1""}", JsonClaimValueTypes.Json),
                         new Claim("ClaimValueTypes.JsonClaimValueTypes.Json2", @"{""jsonProperty2"":""jsonvalue2""}", JsonClaimValueTypes.Json),
                         new Claim("ClaimValueTypes.JsonClaimValueTypes.JsonArray", "1", ClaimValueTypes.Integer),
@@ -272,6 +286,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                         new Claim("emailaddress", "user1@contoso.com", ClaimValueTypes.String, "http://test.local/api/"),
                         new Claim("emailaddress", "user2@contoso.com", ClaimValueTypes.String, "http://test.local/api/"),
                         new Claim("name", "user", ClaimValueTypes.String, "http://test.local/api/"),
+                        new Claim("dateTime", "2019-11-15T14:31:21.6101326Z", ClaimValueTypes.DateTime, "http://test.local/api/"),
                         new Claim("iss", "http://test.local/api/", ClaimValueTypes.String, "http://test.local/api/")
                     },
                     dataset);
@@ -291,6 +306,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                         new Claim("ClaimValueTypes", "-132.64", ClaimValueTypes.Double),
                         new Claim("ClaimValueTypes", "true", ClaimValueTypes.Boolean),
                         new Claim("ClaimValueTypes", "false", ClaimValueTypes.Boolean),
+                        new Claim("ClaimValueTypes", "2019-11-15T14:31:21.6101326Z", ClaimValueTypes.DateTime),
                         new Claim("ClaimValueTypes", @"{""name3.1"":""value3.1""}", JsonClaimValueTypes.Json),
                         new Claim("ClaimValueTypes", @"[""status"",""feed""]", JsonClaimValueTypes.JsonArray),
                     },
@@ -301,6 +317,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     {
                         new Claim("json3", @"{""name3.1"":""value3.1""}", JsonClaimValueTypes.Json),
                         new Claim("json3", @"{""name3.2"":""value3.2""}", JsonClaimValueTypes.Json),
+                        new Claim("json3", @"{""dateTime"":""2019-11-15T14:31:21.6101326Z""}", JsonClaimValueTypes.Json),
                         new Claim("json3", @"{""name3.3"":[1,2,3]}", JsonClaimValueTypes.Json),
                         new Claim("json3", "name3.4"),
                         new Claim("may_act",  @"{""sub"":""admin@example.net"",""name"":""Admin""}", JsonClaimValueTypes.Json),
@@ -342,6 +359,10 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
                     case ClaimValueTypes.Integer64:
                         jsonValue = long.Parse(claim.Value);
+                        break;
+
+                    case ClaimValueTypes.DateTime:
+                        jsonValue = DateTime.Parse(claim.Value);
                         break;
 
                     case JsonClaimValueTypes.Json:
@@ -436,6 +457,13 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                         long long64;
                         if (!long.TryParse(claim.Value, out long64))
                             context.Diffs.Add(string.Format(CultureInfo.InvariantCulture, "long.TryParse(claim.Value, out long64), value: '{0}'", claim.Value));
+
+                        break;
+
+                    case ClaimValueTypes.DateTime:
+                        DateTime datetime;
+                        if (!DateTime.TryParse(claim.Value, out datetime))
+                            context.Diffs.Add(string.Format(CultureInfo.InvariantCulture, "DateTime.TryParse(claim.Value, out datetime), value: '{0}'", claim.Value));
 
                         break;
 


### PR DESCRIPTION
Currently, claims created from a deserialized JSON string have a `System.DateTime` type.
This PR changes that behavior, so claims that hold DateTime values have `ClaimValueTypes.DateTime` as a type.

Also, by default, Newtonsoft.JSON serializer encloses a DateTime string with quotes which results in "\"dateTimeValue\"" (see #1261).
This behavior is changed, so that resulting string doesn't contain the double quotes.

DateTime claim value (string) is now created as an UTC string represented in ISO 8061 date-time format.

Resolves: #1261 