### PR TITLE
All DateTime properties are clearly marked as UTC

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/AuthenticationInformation.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/AuthenticationInformation.cs
@@ -61,7 +61,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         }
 
         /// <summary>
-        /// Gets or sets the AuthenticationInstant
+        /// Gets or sets the AuthenticationInstant. This value should be in UTC.
         /// </summary>
         public DateTime AuthenticationInstant { get; set; }
 
@@ -76,7 +76,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         public string DnsName { get; set; }
 
         /// <summary>
-        /// Gets or sets the time that the session referred to in the session index MUST be considered ended.
+        /// Gets or sets the time that the session referred to in the session index MUST be considered ended. This value should be in UTC.
         /// </summary>
         public DateTime? NotOnOrAfter { get; set; }
 

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlAuthenticationStatement.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlAuthenticationStatement.cs
@@ -74,7 +74,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         }
 
         /// <summary>
-        /// Gets or sets the instant of authentication.
+        /// Gets or sets the instant of authentication. This value should be in UTC.
         /// </summary>
         public DateTime AuthenticationInstant
         {

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlConditions.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlConditions.cs
@@ -72,12 +72,12 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         public ICollection<SamlCondition> Conditions { get; }
 
         /// <summary>
-        /// Gets or sets the earliest time instant at which the assertion is valid.
+        /// Gets or sets the earliest time instant at which the assertion is valid. This value should be in UTC.
         /// </summary>
         public DateTime NotBefore { get; set; } = DateTimeUtil.GetMinValue(DateTimeKind.Utc);
 
         /// <summary>
-        /// Gets or sets the time instant at which the assertion has expired.
+        /// Gets or sets the time instant at which the assertion has expired. This value should be in UTC.
         /// </summary>
         public DateTime NotOnOrAfter { get; set; } = DateTimeUtil.GetMaxValue(DateTimeKind.Utc);
     }

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityToken.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityToken.cs
@@ -96,7 +96,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         }
 
         /// <summary>
-        /// Gets the time the token is valid from.
+        /// Gets the time the token is valid from. This value is always in UTC.
         /// </summary>
         public override DateTime ValidFrom
         {
@@ -112,7 +112,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         }
 
         /// <summary>
-        /// Gets the time the token is valid to.
+        /// Gets the time the token is valid to. This value is always in UTC.
         /// </summary>
         public override DateTime ValidTo
         {

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/AuthenticationInformation.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/AuthenticationInformation.cs
@@ -59,7 +59,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         }
 
         /// <summary>
-        /// Gets or sets the AuthenticationInstant
+        /// Gets or sets the AuthenticationInstant. This value should be in UTC.
         /// </summary>
         public DateTime AuthenticationInstant { get; set; }
 
@@ -69,7 +69,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         public string DnsName { get; set; }
 
         /// <summary>
-        /// Gets or sets the time that the session referred to in the session index MUST be considered ended.
+        /// Gets or sets the time that the session referred to in the session index MUST be considered ended. This value should be in UTC.
         /// </summary>
         public DateTime? NotOnOrAfter { get; set; }
 

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2AuthenticationStatement.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2AuthenticationStatement.cs
@@ -73,7 +73,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         }
 
         /// <summary>
-        /// Gets or sets the time at which the authentication took place. [Saml2Core, 2.7.2]
+        /// Gets or sets the time at which the authentication took place. If the provided DateTime is not in UTC, it will
+        /// be converted to UTC. [Saml2Core, 2.7.2]
         /// </summary>
         /// <exception cref="ArgumentNullException">if 'value' is null.</exception>
         public DateTime AuthenticationInstant
@@ -95,7 +96,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         /// <summary>
         /// Gets or sets the time instant at which the session between the principal 
         /// identified by the subject and the SAML authority issuing this statement
-        /// must be considered ended. [Saml2Core, 2.7.2]
+        /// must be considered ended. If the provided DateTime is not in UTC, it will
+        /// be converted to UTC. [Saml2Core, 2.7.2]
         /// </summary>
         public DateTime? SessionNotOnOrAfter
         {

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Conditions.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Conditions.cs
@@ -70,7 +70,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         }
 
         /// <summary>
-        /// Gets or sets the earliest time instant at which the assertion is valid.
+        /// Gets or sets the earliest time instant at which the assertion is valid. If the provided DateTime is not in UTC, it will
+        /// be converted to UTC.
         /// [Saml2Core, 2.5.1]
         /// </summary>
         /// <exception cref="ArgumentException">if 'value' is greater or equal to <see cref="NotOnOrAfter"/>.</exception>
@@ -93,7 +94,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         }
 
         /// <summary>
-        /// Gets or sets the time instant at which the assertion has expired.
+        /// Gets or sets the time instant at which the assertion has expired. If the provided DateTime is not in UTC, it will
+        /// be converted to UTC.
         /// [Saml2Core, 2.5.1]
         /// </summary>
         /// <exception cref="ArgumentException">if 'value' is less than or equal to <see cref="NotBefore"/>.</exception>

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityToken.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityToken.cs
@@ -87,7 +87,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         }
 
         /// <summary>
-        /// Gets the time the token is valid from.
+        /// Gets the time the token is valid from. This value is always in UTC.
         /// </summary>
         public override DateTime ValidFrom
         {
@@ -101,7 +101,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         }
 
         /// <summary>
-        /// Gets the time the token is valid to.
+        /// Gets the time the token is valid to. This value is always in UTC.
         /// </summary>
         public override DateTime ValidTo
         {

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SubjectConfirmationData.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SubjectConfirmationData.cs
@@ -77,7 +77,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         }
 
         /// <summary>
-        /// Gets or sets a time instant before which the subject cannot be confirmed. [Saml2Core, 2.4.1.2]
+        /// Gets or sets a time instant before which the subject cannot be confirmed. If the provided DateTime is not in UTC, it will
+        /// be converted to UTC.[Saml2Core, 2.4.1.2]
         /// </summary>
         public DateTime? NotBefore
         {
@@ -86,7 +87,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         }
 
         /// <summary>
-        /// Gets or sets a time instant at which the subject can no longer be confirmed. [Saml2Core, 2.4.1.2]
+        /// Gets or sets a time instant at which the subject can no longer be confirmed. If the provided DateTime is not in UTC, it will
+        /// be converted to UTC. [Saml2Core, 2.4.1.2]
         /// </summary>
         public DateTime? NotOnOrAfter
         {

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenExpiredException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenExpiredException.cs
@@ -38,7 +38,7 @@ namespace Microsoft.IdentityModel.Tokens
     public class SecurityTokenExpiredException : SecurityTokenValidationException
     {
         /// <summary>
-        /// Gets or sets the Expires value that created the validation exception.
+        /// Gets or sets the Expires value that created the validation exception. This value is always in UTC.
         /// </summary>
         public DateTime Expires { get; set; }
 

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenInvalidLifetimeException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenInvalidLifetimeException.cs
@@ -38,12 +38,12 @@ namespace Microsoft.IdentityModel.Tokens
     public class SecurityTokenInvalidLifetimeException : SecurityTokenValidationException
     {
         /// <summary>
-        /// Gets or sets the NotBefore value that created the validation exception.
+        /// Gets or sets the NotBefore value that created the validation exception. This value is always in UTC.
         /// </summary>
         public DateTime? NotBefore { get; set; }
 
         /// <summary>
-        /// Gets or sets the Expires value that created the validation exception.
+        /// Gets or sets the Expires value that created the validation exception. This value is always in UTC.
         /// </summary>
         public DateTime? Expires { get; set; }
 

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenNotYetValidException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenNotYetValidException.cs
@@ -39,7 +39,7 @@ namespace Microsoft.IdentityModel.Tokens
     public class SecurityTokenNotYetValidException : SecurityTokenValidationException
     {
         /// <summary>
-        /// Gets or sets the NotBefore value that created the validation exception.
+        /// Gets or sets the NotBefore value that created the validation exception. This value is always in UTC.
         /// </summary>
         public DateTime NotBefore { get; set; }
 

--- a/src/Microsoft.IdentityModel.Tokens/SecurityTokenDescriptor.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityTokenDescriptor.cs
@@ -52,7 +52,7 @@ namespace Microsoft.IdentityModel.Tokens
         public EncryptingCredentials EncryptingCredentials { get; set; }
 
         /// <summary>
-        /// Gets or sets the value of the 'expiration' claim.
+        /// Gets or sets the value of the 'expiration' claim. This value should be in UTC.
         /// </summary>
         public DateTime? Expires { get; set; }
 
@@ -62,12 +62,12 @@ namespace Microsoft.IdentityModel.Tokens
         public string Issuer { get; set; }
 
         /// <summary>
-        /// Gets or sets the time the security token was issued.
+        /// Gets or sets the time the security token was issued. This value should be in UTC.
         /// </summary>
         public DateTime? IssuedAt { get; set; }
 
         /// <summary>
-        /// Gets or sets the notbefore time for the security token.
+        /// Gets or sets the notbefore time for the security token. This value should be in UTC.
         /// </summary>
         public DateTime? NotBefore { get; set; }
 


### PR DESCRIPTION
Addresses #1262.

I went through all our public DateTime properties and made sure that the documentation comments clearly state that the properties are in UTC.

In the case where a property can be set by a user, the comment states that it "should" be UTC, whereas if it's set by our library the comment states that it's "always" in UTC. 

Some of the properties have setters that convert DateTimes to UTC, so I added a different comment for these that explains this behavior.


