### PR TITLE
Added a setter for the AuthenticationProtocolMessage.Script property

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/AuthenticationProtocolMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols/AuthenticationProtocolMessage.cs
@@ -40,6 +40,7 @@ namespace Microsoft.IdentityModel.Protocols
     public abstract class AuthenticationProtocolMessage
     {
         private string _postTitle = "Working...";
+        private string _script = "<script language=\"javascript\">window.setTimeout('document.forms[0].submit()', 0);</script>"; 
         private string _scriptButtonText = "Submit";
         private string _scriptDisabledText = "Script is disabled. Click Submit to continue.";
 
@@ -148,7 +149,7 @@ namespace Microsoft.IdentityModel.Protocols
             set
             {
                 if (value == null)
-                    throw LogHelper.LogArgumentNullException("value");
+                    throw LogHelper.LogArgumentNullException(nameof(IssuerAddress));
 
                 _issuerAddress = value;
             }
@@ -179,7 +180,7 @@ namespace Microsoft.IdentityModel.Protocols
             set
             {
                 if (value == null)
-                    throw LogHelper.LogArgumentNullException("value");
+                    throw LogHelper.LogArgumentNullException(nameof(PostTitle));
 
                 _postTitle = value;
             }
@@ -239,7 +240,22 @@ namespace Microsoft.IdentityModel.Protocols
         /// <summary>
         /// Gets the script used when constructing the post string.
         /// </summary>
-        public string Script { get; } = "<script language=\"javascript\">window.setTimeout('document.forms[0].submit()', 0);</script>";
+        /// <exception cref="ArgumentNullException">If the 'value' is null.</exception>
+        public string Script
+        {
+            get
+            {
+                return _script;
+            }
+
+            set
+            {
+                if (value == null)
+                    throw LogHelper.LogArgumentNullException(nameof(Script));
+
+                _script = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the script button text used when constructing the post string.
@@ -255,7 +271,7 @@ namespace Microsoft.IdentityModel.Protocols
             set
             {
                 if (value == null)
-                    throw LogHelper.LogArgumentNullException("value");
+                    throw LogHelper.LogArgumentNullException(nameof(ScriptButtonText));
 
                 _scriptButtonText = value;
             }
@@ -275,7 +291,7 @@ namespace Microsoft.IdentityModel.Protocols
             set
             {
                 if (value == null)
-                    throw LogHelper.LogArgumentNullException("value");
+                    throw LogHelper.LogArgumentNullException(nameof(ScriptDisabledText));
 
                 _scriptDisabledText = value;
             }

--- a/test/Microsoft.IdentityModel.Protocols.Tests/AuthenticationProtocolMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/AuthenticationProtocolMessageTests.cs
@@ -71,6 +71,7 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             {
                 "IssuerAddress",
                 "PostTitle",
+                "Script",
                 "ScriptButtonText",
                 "ScriptDisabledText",
             };
@@ -78,7 +79,8 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             var context = new GetSetContext();
             foreach(string property in properties)
             {
-                TestUtilities.SetGet(authenticationProtocolMessage, property, null, ExpectedException.ArgumentNullException(substringExpected: "value"), context);
+                TestUtilities.SetGet(authenticationProtocolMessage, property, null, ExpectedException.ArgumentNullException(substringExpected: property), context);
+                TestUtilities.SetGet(authenticationProtocolMessage, property, "", ExpectedException.NoExceptionExpected, context);
                 TestUtilities.SetGet(authenticationProtocolMessage, property, property, ExpectedException.NoExceptionExpected, context);
                 TestUtilities.SetGet(authenticationProtocolMessage, property, "    ", ExpectedException.NoExceptionExpected, context);
                 TestUtilities.SetGet(authenticationProtocolMessage, property, "\t\n\r", ExpectedException.NoExceptionExpected, context);


### PR DESCRIPTION
Fixes #1263.

Also modified the setters for the other public properties on `AuthenticationProtocolMessage` so that if an `ArgumentNullException` is thrown it includes the name of the property (not just "value").

NOTE: `LogHelper.LogArgumentNullException()` uses the following message:
`"IDX10000: The parameter '{0}' cannot be a 'null' or an empty object."`
This doesn't really make sense for the properties on this class since they can be empty strings. 
Should another log message be added that's just "the parameter cannot be null"?