### PR TITLE
Fix DateTime claims processing

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.IdentityModel.Logging;
@@ -406,6 +407,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 // Boolean needs item.ToString otherwise 'true' => 'True'
                 if (jvalue.Type is JTokenType.String)
                     claims.Add(new Claim(claimType, jvalue.Value.ToString(), ClaimValueTypes.String, issuer, issuer));
+                // DateTime claims require special processing. jtoken.ToString(Formatting.None) will result in "\"dateTimeValue\"". The quotes will be added.
+                else if (jvalue.Value is DateTime dateTimeValue)
+                    claims.Add(new Claim(claimType, dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), ClaimValueTypes.DateTime, issuer, issuer));
                 else
                     claims.Add(new Claim(claimType, jtoken.ToString(Newtonsoft.Json.Formatting.None), GetClaimValueType(jvalue.Value), issuer, issuer));
             }
@@ -480,6 +484,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 return ClaimValueTypes.Integer64;
             }
 
+            if (objType == typeof(DateTime))
+                return ClaimValueTypes.DateTime;
+
             if (objType == typeof(JObject))
                 return JsonClaimValueTypes.Json;
 
@@ -512,6 +519,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 // Boolean needs item.ToString otherwise 'true' => 'True'
                 if (jvalue.Type is JTokenType.String)
                     return new Claim(key, jvalue.Value.ToString(), ClaimValueTypes.String, issuer, issuer);
+                // DateTime claims require special processing. jTokenValue.ToString(Formatting.None) will result in "\"dateTimeValue\"". The quotes will be added.
+                else if (jvalue.Value is DateTime dateTimeValue)
+                    return new Claim(key, dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), ClaimValueTypes.DateTime, issuer, issuer);
                 else
                     return new Claim(key, jTokenValue.ToString(Formatting.None), GetClaimValueType(jvalue.Value), issuer, issuer);
             }
@@ -573,6 +583,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 // Boolean needs item.ToString otherwise 'true' => 'True'
                 if (jvalue.Type is JTokenType.String)
                     value = new Claim(key, jvalue.Value.ToString(), ClaimValueTypes.String, issuer, issuer);
+                // DateTime claims require special processing. jTokenValue.ToString(Formatting.None) will result in "\"dateTimeValue\"". The quotes will be added.
+                else if (jvalue.Value is DateTime dateTimeValue)
+                    value = new Claim(key, dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), ClaimValueTypes.DateTime, issuer);
                 else
                     value = new Claim(key, jTokenValue.ToString(Formatting.None), GetClaimValueType(jvalue.Value), issuer, issuer);
             }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -267,6 +267,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     return longValue;
             }
 
+            if (claim.ValueType == ClaimValueTypes.DateTime)
+            {
+                if (DateTime.TryParse(claim.Value, out DateTime dateTimeValue))
+                    return dateTimeValue;
+            }
+
             if (claim.ValueType == JsonClaimValueTypes.Json)
                 return JObject.Parse(claim.Value);
 


### PR DESCRIPTION
Currently, claims created from a deserialized JSON string might have 'System.DateTime' (invalid claim type) or ClaimValueTypes.String type, depending on the format of a datetime json string, the way how JSON string was deserialized, and json handler being used.

This PR changes fixes this inconsistency, so claims that hold DateTime values in ISO8061 datetime format will have ClaimValueTypes.DateTime as a claim value type. DateTime strings represented in datetime formats other than ISO8061 will have ClaimValueTypes.String as a claim value type.

Also, by default, Newtonsoft.JSON serializer encloses some DateTime strings with quotes which results in ""dateTimeValue"" (see #1261). This behavior is changed, so that resulting string doesn't contain the
double quotes.

DateTime claim value (string) is now created as an UTC string represented in ISO 8061 date-time format, if a DateTime claim is added directly (via 'JwtPayload.Add()').

Wiki link: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/How-are-DateTime-values-treated%3F

Resolves: #1261