### PR TITLE
Work around the RSACryptoServiceProviderProxy crash on mono

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
@@ -83,7 +83,10 @@ namespace Microsoft.IdentityModel.Tokens
             // Level up the provider type only if:
             // 1. it is PROV_RSA_FULL or PROV_RSA_SCHANNEL which denote CSPs that only understand Sha1 algorithms
             // 2. it is not associated with a hardware key
-            if ((rsa.CspKeyContainerInfo.ProviderType == PROV_RSA_FULL || rsa.CspKeyContainerInfo.ProviderType == PROV_RSA_SCHANNEL) && !rsa.CspKeyContainerInfo.HardwareDevice)
+            // 3. we are not running on mono (which reports PROV_RSA_FULL but doesn't need a workaround)
+            var isSha1Provider = rsa.CspKeyContainerInfo.ProviderType == PROV_RSA_FULL || rsa.CspKeyContainerInfo.ProviderType == PROV_RSA_SCHANNEL;
+            var isMono = Type.GetType("Mono.Runtime") != null;
+            if (isSha1Provider && !rsa.CspKeyContainerInfo.HardwareDevice && !isMono)
             {
                 var csp = new CspParameters();
                 csp.ProviderType = PROV_RSA_AES;

--- a/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
@@ -102,6 +102,8 @@ namespace Microsoft.IdentityModel.Tokens
                 try
                 {
                     _rsa = new RSACryptoServiceProvider(csp);
+                    // since we created a new RsaCryptoServiceProvider we need to dispose it
+                    _disposeRsa = true;
                 }
                 catch (CryptographicException) when (isMono)
                 {
@@ -109,9 +111,6 @@ namespace Microsoft.IdentityModel.Tokens
                     // The solution is to simply not level up the provider as this workaround is not needed on mono.
                     _rsa = rsa;
                 }
-
-                // since we created a new RsaCryptoServiceProvider we need to dispose it
-                _disposeRsa = true;
             }
             else
             {


### PR DESCRIPTION
While I understand that #179 was closed as wontfix because mono is not officially supported, this is a really trivial workaround that greatly helps mono users. To put this into perspective, we are currently IL-patching `Microsoft.IdentityModel.Tokens.dll` on every startup of our application because there is no easier way to work around this problem in our case (it's behind other libraries).