### PR TITLE
Adds deterministically derived KeyId for Auth Enc subkeys.

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Encryption/AuthenticatedEncryptionProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/AuthenticatedEncryptionProvider.cs
@@ -240,8 +240,16 @@ namespace Microsoft.IdentityModel.Tokens
             Array.Copy(keyBytes, hmacKey, keyLength);
             return new AuthenticatedKeys()
             {
-                AesKey = new SymmetricSecurityKey(aesKey),
+                AesKey = new SymmetricSecurityKey(aesKey)
+                {
+                    KeyId = key.KeyId,
+                    DerivedKeyDesignation = $"AES-{algorithm}"
+                },
                 HmacKey = new SymmetricSecurityKey(hmacKey)
+                {
+                    KeyId = key.KeyId,
+                    DerivedKeyDesignation = $"HMAC-{algorithm}"
+                }
             };
         }
 

--- a/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
+++ b/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
@@ -82,9 +82,8 @@ namespace Microsoft.IdentityModel.Tokens
         private string GetCacheKeyPrivate(SecurityKey securityKey, string algorithm, string typeofProvider)
         {
             return string.Format(CultureInfo.InvariantCulture,
-                                 "{0}-{1}-{2}-{3}",
-                                 securityKey.GetType(),
-                                 string.IsNullOrEmpty(securityKey.KeyId) ? securityKey.InternalId : securityKey.KeyId,
+                                 "{0}-{1}-{2}",
+                                 securityKey.GetCacheKey(),
                                  algorithm,
                                  typeofProvider);
         }

--- a/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
@@ -55,6 +55,8 @@ namespace Microsoft.IdentityModel.Tokens
         [JsonIgnore]
         internal string InternalId { get; } = Guid.NewGuid().ToString();
 
+        internal string DerivedKeyDesignation { get; set; } = null;
+
         /// <summary>
         /// This must be overridden to get the size of this <see cref="SecurityKey"/>.
         /// </summary>
@@ -89,6 +91,14 @@ namespace Microsoft.IdentityModel.Tokens
         public override string ToString()
         {
             return $"{GetType()}, KeyId: '{KeyId}', InternalId: '{InternalId}'.";
+        }
+
+
+        internal string GetCacheKey()
+        {
+            string principalId = string.IsNullOrEmpty(KeyId) ? InternalId : KeyId;
+            //Always include the DerivedKeyDesignation and separator to avoid collisions.
+            return $"{GetType()}-{DerivedKeyDesignation}_{principalId}";
         }
     }
 }


### PR DESCRIPTION
Solves #1292 Using CBC Authenticated encryption modes with HMAC floods InMemoryCryptoProviderCache.

Always includes the separator in the cache key to avoid cache key collisions. We could probably assign a new deterministically generated Id based on the key content (such as a hash of the key content), as it would be more resilient against misuse of the library (Reuse of keyid for distinct keys). But given current conventions and assuming proper use I think this solution should suffice. 
