### PR TITLE
Ignore single ending slash when validating audience

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -172,8 +172,8 @@ if ($runTests -eq "YES")
             Write-Host ">>> Set-Location $root\test\$name"
             pushd
             Set-Location $root\test\$name
-            Write-Host ">>> Start-Process -Wait -PassThru -NoNewWindow $dotnetexe 'test $name.csproj' --filter category!=nonwindowstests --no-build --no-restore -nodereuse:false -v q -c $buildType"
-            $p = Start-Process -Wait -PassThru -NoNewWindow $dotnetexe "test $name.csproj --filter category!=nonwindowstests --no-build --no-restore -nodereuse:false -v q -c $buildType"
+            Write-Host ">>> Start-Process -Wait -PassThru -NoNewWindow $dotnetexe 'test $name.csproj' --filter category!=nonwindowstests --no-build --no-restore -nodereuse:false -v n -c $buildType"
+            $p = Start-Process -Wait -PassThru -NoNewWindow $dotnetexe "test $name.csproj --filter category!=nonwindowstests --no-build --no-restore -nodereuse:false -v n -c $buildType"
 
             if($p.ExitCode -ne 0)
             {

--- a/src/Microsoft.IdentityModel.Logging/LogHelper.cs
+++ b/src/Microsoft.IdentityModel.Logging/LogHelper.cs
@@ -38,14 +38,6 @@ namespace Microsoft.IdentityModel.Logging
     /// </summary>
     public class LogHelper
     {
-        private static readonly List<string> CustomExceptionTypePrefixes = new List<string>()
-        {
-            "Microsoft.IdentityModel.Protocols",
-            "Microsoft.IdentityModel.Tokens.SecurityToken",
-            "Microsoft.IdentityModel.Tokens.Saml",
-            "Microsoft.IdentityModel.Xml"
-        };
-
         /// <summary>
         /// Logs an exception using the event source logger and returns new <see cref="ArgumentNullException"/> exception.
         /// </summary>
@@ -344,27 +336,15 @@ namespace Microsoft.IdentityModel.Logging
 
         private static string RemovePII(object arg)
         {
-            if (arg is Exception)
-            {
-                Exception e = arg as Exception;
-                if (IsCustomException(e))
-                    return e.ToString();
-                else
-                    return e.GetType().ToString();
-            }
-            else
-            {
-                return IdentityModelEventSource.HiddenPIIString;
-            }
+            if (arg is Exception ex && ex.GetType().FullName.StartsWith("Microsoft.IdentityModel.", StringComparison.Ordinal))
+                return ex.ToString();
+
+            return arg.GetType().ToString();
         }
 
         internal static bool IsCustomException(Exception ex)
         {
-            // check if the exception type has a custom exception prefix
-            if (CustomExceptionTypePrefixes.Exists(e => ex.GetType().FullName.Contains(e)))
-                return true;
-            else
-                return false;
+            return ex.GetType().FullName.StartsWith("Microsoft.IdentityModel.", StringComparison.Ordinal);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -145,15 +145,14 @@ namespace Microsoft.IdentityModel.Tokens
         protected TokenValidationParameters(TokenValidationParameters other)
         {
             if (other == null)
-            {
-                throw LogHelper.LogExceptionMessage(new ArgumentNullException("other"));
-            }
+                throw LogHelper.LogExceptionMessage(new ArgumentNullException(nameof(other)));
 
             ActorValidationParameters = other.ActorValidationParameters?.Clone();
             AudienceValidator = other.AudienceValidator;
             _authenticationType = other._authenticationType;
             ClockSkew = other.ClockSkew;
             CryptoProviderFactory = other.CryptoProviderFactory;
+            IgnoreTrailingSlashWhenValidatingAudience = other.IgnoreTrailingSlashWhenValidatingAudience;
             IssuerSigningKey = other.IssuerSigningKey;
             IssuerSigningKeyResolver = other.IssuerSigningKeyResolver;
             IssuerSigningKeys = other.IssuerSigningKeys;
@@ -204,6 +203,12 @@ namespace Microsoft.IdentityModel.Tokens
             ValidateLifetime = true;
             ValidateTokenReplay = false;
         }
+
+        /// <summary>
+        /// Gets or sets a boolean that controls if a '/' is significant at the end of the audience.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool IgnoreTrailingSlashWhenValidatingAudience { get; set; } = true;
 
         /// <summary>
         /// Gets or sets <see cref="TokenValidationParameters"/>.

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
@@ -42,8 +42,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 38)
-                Assert.True(false, "Number of properties has changed from 38 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 39)
+                Assert.True(false, "Number of properties has changed from 39 to: " + properties.Length + ", adjust tests");
 
             TokenValidationParameters actorValidationParameters = new TokenValidationParameters();
             SecurityKey issuerSigningKey = KeyingMaterial.DefaultX509Key_2048_Public;
@@ -103,6 +103,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Assert.True(object.ReferenceEquals(validationParametersInline.ValidAudience, validAudience));
             Assert.True(object.ReferenceEquals(validationParametersInline.ValidAudiences, validAudiences));
             Assert.True(object.ReferenceEquals(validationParametersInline.ValidIssuer, validIssuer));
+            Assert.True(validationParametersInline.IgnoreTrailingSlashWhenValidatingAudience);
 
             TokenValidationParameters validationParametersSets = new TokenValidationParameters();
             validationParametersSets.ActorValidationParameters = actorValidationParameters;
@@ -144,8 +145,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 38)
-                Assert.True(false, "Number of public fields has changed from 38 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 39)
+                Assert.True(false, "Number of public fields has changed from 39 to: " + properties.Length + ", adjust tests");
 
             GetSetContext context =
                 new GetSetContext
@@ -156,6 +157,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         new KeyValuePair<string, List<object>>("AuthenticationType", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
                         //new KeyValuePair<string, List<object>>("CertificateValidator", new List<object>{(string)null, X509CertificateValidator.None, X509CertificateValidatorEx.None}),
                         new KeyValuePair<string, List<object>>("ClockSkew", new List<object>{TokenValidationParameters.DefaultClockSkew, TimeSpan.FromHours(2), TimeSpan.FromMinutes(1)}),
+                        new KeyValuePair<string, List<object>>("IgnoreTrailingSlashWhenValidatingAudience",  new List<object>{true, false, true}),
                         new KeyValuePair<string, List<object>>("IssuerSigningKey", new List<object>{(SecurityKey)null, KeyingMaterial.DefaultX509Key_2048, KeyingMaterial.RsaSecurityKey_2048}),
                         new KeyValuePair<string, List<object>>("IssuerSigningKeys", new List<object>{(IEnumerable<SecurityKey>)null, new List<SecurityKey>{KeyingMaterial.DefaultX509Key_2048, KeyingMaterial.RsaSecurityKey_1024}, new List<SecurityKey>()}),
                         new KeyValuePair<string, List<object>>("NameClaimType", new List<object>{ClaimsIdentity.DefaultNameClaimType, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
@@ -173,6 +175,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     },
                     Object = validationParameters,
                 };
+
             TestUtilities.GetSet(context);
             TestUtilities.AssertFailIfErrors("TokenValidationParametersTests: GetSets", context.Errors);
             Assert.Null(validationParameters.AudienceValidator);


### PR DESCRIPTION
It is common for '/' to show up at the end of the audience.
From a security standpoint, this is not meaningful, we added support for ignoring such slash's.

Issue: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1273