### PR TITLE
JsonWebTokenHandler implements ISecurityTokenValidator and the M.IM.Protocols.OpenIdConnect assembly makes use of M.IM.JsonWebTokens

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -50,6 +50,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <exception cref="ArgumentException">'jwtEncodedString' is not in JWS or JWE Compact serialization format.</exception>
         /// <remarks>
         /// The contents of the returned <see cref="JsonWebToken"/> have not been validated, the JSON Web Token is simply decoded. Validation can be accomplished using the validation methods in <see cref="JsonWebTokenHandler"/>
+        /// We recommend using the JsonWebToken class over the System.IdentityModel.Tokens.Jwt.JwtSecurityToken class as it is newer, faster, and has more functionality.
         /// </remarks>
         public JsonWebToken(string jwtEncodedString)
         {

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -146,7 +146,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <summary>
         /// Gets a <see cref="IEnumerable{Claim}"/><see cref="Claim"/> for each JSON { name, value }.
         /// </summary>
-        public IEnumerable<Claim> Claims
+        public virtual IEnumerable<Claim> Claims
         {
             get
             {

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -322,7 +322,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// Gets the 'value' of the 'zip' claim { zip, 'value' }.
         /// </summary>
         /// <remarks>If the 'zip' claim is not found, an empty string is returned.</remarks>   
-        public string Zip => Header.Value<string>(JwtHeaderParameterNames.Zip) ?? String.Empty;
+        public string Zip => Header.Value<string>(JwtHeaderParameterNames.Zip) ?? string.Empty;
 
         /// <summary>
         /// Decodes the string into the header, payload and signature.

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -40,7 +40,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
     /// <summary>
     /// A <see cref="SecurityToken"/> designed for representing a JSON Web Token (JWT). 
     /// </summary>
-    public class JsonWebToken : SecurityToken
+    public class JsonWebToken : SecurityToken, IJsonWebToken
     {
         /// <summary>
         /// Initializes a new instance of <see cref="JsonWebToken"/> from a string in JWS or JWE Compact serialized format.
@@ -146,7 +146,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <summary>
         /// Gets a <see cref="IEnumerable{Claim}"/><see cref="Claim"/> for each JSON { name, value }.
         /// </summary>
-        public virtual IEnumerable<Claim> Claims
+        public IEnumerable<Claim> Claims
         {
             get
             {

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -43,6 +43,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
     /// A <see cref="SecurityTokenHandler"/> designed for creating and validating Json Web Tokens. 
     /// See: http://tools.ietf.org/html/rfc7519 and http://www.rfc-editor.org/info/rfc7515.
     /// </summary>
+    /// <remarks>
+    /// We recommend using the JsonWebTokenHandler class over the System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler class as it is newer, faster, and has more functionality.
+    /// </remarks>
     public class JsonWebTokenHandler : TokenHandler, ISecurityTokenValidator
     {
         private List<string> _defaultHeaderParameters = new List<string>()

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
@@ -73,7 +73,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         internal const string IDX21329 = "IDX21329: RequireState is '{0}' but the OpenIdConnectProtocolValidationContext.State is null. State cannot be validated.";
         internal const string IDX21330 = "IDX21330: RequireState is '{0}', the OpenIdConnect Request contained 'state', but the Response does not contain 'state'.";
         internal const string IDX21331 = "IDX21331: The 'state' parameter in the message: '{0}', does not equal the 'state' in the context: '{1}'.";
-        internal const string IDX21332 = "IDX21332: OpenIdConnectProtocolValidationContext.ValidatedIdToken is null. There is no 'id_token' to validate against.";
+        internal const string IDX21332 = "IDX21332: OpenIdConnectProtocolValidationContext.ValidatedJsonWebToken and OpenIdConnectProtocolValidationContext.ValidatedIdToken are both null. There is no 'id_token' to validate against.";
         internal const string IDX21333 = "IDX21333: OpenIdConnectProtocolValidationContext.ProtocolMessage is null, there is no OpenIdConnect Response to validate.";
         internal const string IDX21334 = "IDX21334: Both 'id_token' and 'code' are null in OpenIdConnectProtocolValidationContext.ProtocolMessage received from Authorization Endpoint. Cannot process the message.";
         internal const string IDX21335 = "IDX21335: 'refresh_token' cannot be present in a response message received from Authorization Endpoint.";

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
@@ -47,12 +47,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         internal const string IDX21303 = "IDX21303: Validating hash of OIDC protocol message. Expected: '{0}'.";
         internal const string IDX21304 = "IDX21304: Validating 'c_hash' using id_token and code.";
         internal const string IDX21305 = "IDX21305: OpenIdConnectProtocolValidationContext.ProtocolMessage.Code is null, there is no 'code' in the OpenIdConnect Response to validate.";
-        internal const string IDX21306 = "IDX21306: The 'c_hash' claim was not a string in the 'id_token', but a 'code' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
+        // internal const string IDX21306 = "";
         internal const string IDX21307 = "IDX21307: The 'c_hash' claim was not found in the id_token, but a 'code' was in the OpenIdConnectMessage, id_token: '{0}'";
         internal const string IDX21308 = "IDX21308: 'Azp' claim exists in the 'id_token' but 'ciient_id' is null. Cannot validate the 'azp' claim.";
         internal const string IDX21309 = "IDX21309: Validating 'at_hash' using id_token and access_token.";
         internal const string IDX21310 = "IDX21310: OpenIdConnectProtocolValidationContext.ProtocolMessage.AccessToken is null, there is no 'token' in the OpenIdConnect Response to validate.";
-        internal const string IDX21311 = "IDX21311: The 'at_hash' claim was not a string in the 'id_token', but an 'access_token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
+        // internal const string IDX21311 = "";
         internal const string IDX21312 = "IDX21312: The 'at_hash' claim was not found in the 'id_token', but a 'access_token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
         internal const string IDX21313 = "IDX21313: The id_token: '{0}' is not valid. Delegate threw exception, see inner exception for more details.";
         internal const string IDX21314 = "IDX21314: OpenIdConnectProtocol requires the jwt token to have an '{0}' claim. The jwt did not contain an '{0}' claim, jwt: '{1}'.";

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
@@ -47,12 +47,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         internal const string IDX21303 = "IDX21303: Validating hash of OIDC protocol message. Expected: '{0}'.";
         internal const string IDX21304 = "IDX21304: Validating 'c_hash' using id_token and code.";
         internal const string IDX21305 = "IDX21305: OpenIdConnectProtocolValidationContext.ProtocolMessage.Code is null, there is no 'code' in the OpenIdConnect Response to validate.";
-        // internal const string IDX21306 = "";
+        internal const string IDX21306 = "IDX21306: The 'c_hash' claim was not a string in the 'id_token', but a 'code' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
         internal const string IDX21307 = "IDX21307: The 'c_hash' claim was not found in the id_token, but a 'code' was in the OpenIdConnectMessage, id_token: '{0}'";
         internal const string IDX21308 = "IDX21308: 'Azp' claim exists in the 'id_token' but 'ciient_id' is null. Cannot validate the 'azp' claim.";
         internal const string IDX21309 = "IDX21309: Validating 'at_hash' using id_token and access_token.";
         internal const string IDX21310 = "IDX21310: OpenIdConnectProtocolValidationContext.ProtocolMessage.AccessToken is null, there is no 'token' in the OpenIdConnect Response to validate.";
-        // internal const string IDX21311 = "";
+        internal const string IDX21311 = "IDX21311: The 'at_hash' claim was not a string in the 'id_token', but an 'access_token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
         internal const string IDX21312 = "IDX21312: The 'at_hash' claim was not found in the 'id_token', but a 'access_token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
         internal const string IDX21313 = "IDX21313: The id_token: '{0}' is not valid. Delegate threw exception, see inner exception for more details.";
         internal const string IDX21314 = "IDX21314: OpenIdConnectProtocol requires the jwt token to have an '{0}' claim. The jwt did not contain an '{0}' claim, jwt: '{1}'.";

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Microsoft.IdentityModel.Protocols.OpenIdConnect.csproj
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Microsoft.IdentityModel.Protocols.OpenIdConnect.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.IdentityModel.Protocols\Microsoft.IdentityModel.Protocols.csproj" />
+    <ProjectReference Include="..\Microsoft.IdentityModel.JsonWebTokens\Microsoft.IdentityModel.JsonWebTokens.csproj" />
     <ProjectReference Include="..\System.IdentityModel.Tokens.Jwt\System.IdentityModel.Tokens.Jwt.csproj" />
   </ItemGroup>
 

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidationContext.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidationContext.cs
@@ -27,7 +27,6 @@
 
 using System;
 using System.IdentityModel.Tokens.Jwt;
-using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
@@ -71,7 +70,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         /// <summary>
         /// This id_token is assumed to have audience, issuer, lifetime and signature validated.
         /// </summary>
-        [Obsolete("The 'ValidatedIdToken' property is obsolete. Please use 'ValidatedJwtToken' instead.")]
+        [Obsolete("The 'ValidatedIdToken' property is obsolete. Please use 'ValidatedJsonWebToken' instead.")]
         public JwtSecurityToken ValidatedIdToken { get; set; }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidationContext.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidationContext.cs
@@ -27,6 +27,8 @@
 
 using System;
 using System.IdentityModel.Tokens.Jwt;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 {
@@ -69,6 +71,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         /// <summary>
         /// This id_token is assumed to have audience, issuer, lifetime and signature validated.
         /// </summary>
+        [Obsolete("The 'ValidatedIdToken' property is obsolete. Please use 'ValidatedJwtToken' instead.")]
         public JwtSecurityToken ValidatedIdToken { get; set; }
+
+        /// <summary>
+        /// This JWT security token is assumed to have audience, issuer, lifetime and signature validated.
+        /// </summary>
+        public IJsonWebToken ValidatedJsonWebToken { get; set; }
     }
 }

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -591,11 +591,15 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 return;
             }
 
-            string chash;
             var validatedToken = validationContext.ValidatedJsonWebToken ?? validationContext.ValidatedIdToken;
-            if (!validatedToken.TryGetPayloadValue(JwtRegisteredClaimNames.CHash, out  chash))
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogHelper.FormatInvariant(LogMessages.IDX21307, validationContext.ValidatedJsonWebToken ?? validationContext.ValidatedIdToken)));
 #pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (!validatedToken.TryGetPayloadValue(JwtRegisteredClaimNames.CHash, out object cHashClaim))
+                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogHelper.FormatInvariant(LogMessages.IDX21307, validatedToken)));
+
+            var chash = cHashClaim as string;
+            if (chash == null)
+                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogHelper.FormatInvariant(LogMessages.IDX21306, validatedToken)));
+            
             try
             {
                 ValidateHash(chash, validationContext.ProtocolMessage.Code, validatedToken.Alg);
@@ -635,11 +639,15 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 return;
             }
 
-            string atHash;
             var validatedToken = validationContext.ValidatedJsonWebToken ?? validationContext.ValidatedIdToken;
-            if (!validatedToken.TryGetPayloadValue(JwtRegisteredClaimNames.AtHash, out atHash))
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidAtHashException(LogHelper.FormatInvariant(LogMessages.IDX21312, validationContext.ValidatedJsonWebToken ?? validationContext.ValidatedIdToken)));
 #pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (!validatedToken.TryGetPayloadValue(JwtRegisteredClaimNames.AtHash, out object atHashClaim))
+                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidAtHashException(LogHelper.FormatInvariant(LogMessages.IDX21312, validatedToken)));
+            
+            var atHash = atHashClaim as string;
+            if (atHash == null)
+                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidAtHashException(LogHelper.FormatInvariant(LogMessages.IDX21311, validatedToken)));
+            
             try
             {
                 ValidateHash(atHash, validationContext.ProtocolMessage.AccessToken, validatedToken.Alg);

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -451,7 +451,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Iss.ToLowerInvariant(), idToken)));
 
             // sub is required in OpenID spec; but we don't want to block valid idTokens provided by some identity providers
-            if (RequireSub && (string.IsNullOrWhiteSpace(idToken.Subject)))
+            if (RequireSub && string.IsNullOrWhiteSpace(idToken.Subject))
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Sub.ToLowerInvariant(), idToken)));
 
             // optional claims

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -30,18 +30,31 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.IdentityModel.Json.Linq;
+using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
+using JwtRegisteredClaimNames = Microsoft.IdentityModel.JsonWebTokens.JwtRegisteredClaimNames;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 {
     /// <summary>
-    /// Delegate for validating additional claims in 'id_token' 
+    /// Delegate for validating additional claims in 'id_token' (of type <see cref="IJsonWebToken"/>).
+    /// </summary>
+    /// <param name="idToken"><see cref="IJsonWebToken"/> to validate</param>
+    /// <param name="context"><see cref="OpenIdConnectProtocolValidationContext"/> used for validation</param>
+    public delegate void JsonWebTokenValidator(IJsonWebToken idToken, OpenIdConnectProtocolValidationContext context);
+
+    /// <summary>
+    /// Delegate for validating additional claims in 'id_token' (of type <see cref="JwtSecurityToken"/>).
     /// </summary>
     /// <param name="idToken"><see cref="JwtSecurityToken"/> to validate</param>
     /// <param name="context"><see cref="OpenIdConnectProtocolValidationContext"/> used for validation</param>
+    [Obsolete("The 'IdTokenValidator' is used for validating 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' which is now obsolete. " +
+        "Please use the 'OpenIdConnectProtocolValidationContext.ValidatedJsonWebToken' and the corresponding 'JsonWebTokenValidator'.")]
     public delegate void IdTokenValidator(JwtSecurityToken idToken, OpenIdConnectProtocolValidationContext context);
 
     /// <summary>
@@ -217,9 +230,16 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         public bool RequireTimeStampInNonce { get; set; }
 
         /// <summary>
-        /// Gets or sets the delegate for validating 'id_token'
+        /// Gets or sets the delegate for validating 'id_token' (of type <see cref="JwtSecurityToken"/>).
         /// </summary>
+#pragma warning disable 0618 // 'IdTokenValidator' is obsolete.
         public IdTokenValidator IdTokenValidator { get; set; }
+#pragma warning restore 0618 // 'IdTokenValidator' is obsolete.
+
+        /// <summary>
+        /// Gets or sets the delegate for validating 'id_token' (of type <see cref="JsonWebToken"/>).
+        /// </summary>
+        public JsonWebTokenValidator JsonWebTokenValidator { get; set; }
 
         /// <summary>
         /// Validates that an OpenIdConnect Response from 'authorization_endpoint" is valid as per http://openid.net/specs/openid-connect-core-1_0.html
@@ -251,8 +271,10 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 return;
             }
 
-            if (validationContext.ValidatedIdToken == null)
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
 
             // 'refresh_token' should not be returned from 'authorization_endpoint'. http://tools.ietf.org/html/rfc6749#section-4.2.2.
             if (!string.IsNullOrEmpty(validationContext.ProtocolMessage.RefreshToken))
@@ -284,8 +306,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             // both 'id_token' and 'access_token' are required
             if (string.IsNullOrEmpty(validationContext.ProtocolMessage.IdToken) || string.IsNullOrEmpty(validationContext.ProtocolMessage.AccessToken))
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21336));
-
-            if (validationContext.ValidatedIdToken == null)
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
 
             ValidateIdToken(validationContext);
@@ -293,11 +315,16 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 
             // only if 'at_hash' claim exist. 'at_hash' is not required in token response.
             object atHashClaim;
-            if (validationContext.ValidatedIdToken.Payload.TryGetValue(JwtRegisteredClaimNames.AtHash, out atHashClaim))
+            if (validationContext.ValidatedJsonWebToken != null)
             {
-                ValidateAtHash(validationContext);
+                if (validationContext.ValidatedJsonWebToken.TryGetPayloadValue(JwtRegisteredClaimNames.AtHash, out atHashClaim))
+                    ValidateAtHash(validationContext);
+            } else // validationContext.ValidatedIdToken != null
+            {
+                if (validationContext.ValidatedIdToken.Payload.TryGetValue(JwtRegisteredClaimNames.AtHash, out atHashClaim))
+                    ValidateAtHash(validationContext);
             }
-
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
         }
 
         /// <summary>
@@ -314,24 +341,27 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             if (string.IsNullOrEmpty(validationContext.UserInfoEndpointResponse))
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21337));
 
-            if (validationContext.ValidatedIdToken == null)
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
 
             string sub = string.Empty;
             try
             {
                 // if user info response is a jwt token
-                var handler = new JwtSecurityTokenHandler();
+                var handler = new JsonWebTokenHandler();
                 if (handler.CanReadToken(validationContext.UserInfoEndpointResponse))
                 {
-                    var token = handler.ReadToken(validationContext.UserInfoEndpointResponse) as JwtSecurityToken;
-                    sub = token.Payload.Sub;
+                    var token = handler.ReadToken(validationContext.UserInfoEndpointResponse) as JsonWebToken;
+                    sub = token.Subject;
                 }
                 else
                 {
                     // if the response is not a jwt, it should be json
-                    var payload = JwtPayload.Deserialize(validationContext.UserInfoEndpointResponse);
-                    sub = payload.Sub;
+                    var payload = JObject.Parse(validationContext.UserInfoEndpointResponse);
+                    if (payload.TryGetValue(JwtRegisteredClaimNames.Sub, out var subJToken))
+                        sub = subJToken.ToObject<string>();
                 }
             }
             catch (Exception ex)
@@ -342,11 +372,24 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             if (string.IsNullOrEmpty(sub))
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21345));
 
-            if (string.IsNullOrEmpty(validationContext.ValidatedIdToken.Payload.Sub))
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21346));
+            if (validationContext.ValidatedJsonWebToken != null)
+            {
+                if (string.IsNullOrEmpty(validationContext.ValidatedJsonWebToken.Subject))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21346));
 
-            if (!string.Equals(validationContext.ValidatedIdToken.Payload.Sub, sub, StringComparison.Ordinal))
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21338, validationContext.ValidatedIdToken.Payload.Sub, sub)));
+                if (!string.Equals(validationContext.ValidatedJsonWebToken.Subject, sub, StringComparison.Ordinal))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21338, validationContext.ValidatedJsonWebToken.Subject, sub)));
+            }
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            else // validationContext.ValidatedIdToken != null
+            {
+                if (string.IsNullOrEmpty(validationContext.ValidatedIdToken.Payload.Sub))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21346));
+
+                if (!string.Equals(validationContext.ValidatedIdToken.Payload.Sub, sub, StringComparison.Ordinal))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21338, validationContext.ValidatedIdToken.Payload.Sub, sub)));
+            }
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
         }
 
         /// <summary>
@@ -358,9 +401,91 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             if (validationContext == null)
                 throw LogHelper.LogArgumentNullException("validationContext");
 
-            if (validationContext.ValidatedIdToken == null)
-                throw LogHelper.LogArgumentNullException("validationContext.ValidatedIdToken");
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
+                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
 
+            if (validationContext.ValidatedJsonWebToken != null)
+                ValidateIdJsonWebToken(validationContext);
+            else // validationContext.ValidatedIdToken != null
+                ValidateIdJwtSecurityToken(validationContext);
+        }
+
+        private void ValidateIdJsonWebToken(OpenIdConnectProtocolValidationContext validationContext)
+        {
+            // if user sets the custom validator, we call the delegate. The default checks for multiple audiences and azp are not executed.
+            if (JsonWebTokenValidator != null)
+            {
+                try
+                {
+                    JsonWebTokenValidator(validationContext.ValidatedJsonWebToken, validationContext);
+                }
+                catch (Exception ex)
+                {
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21313, validationContext.ValidatedJsonWebToken), ex));
+                }
+                return;
+            }
+            else
+            {
+                var idToken = validationContext.ValidatedJsonWebToken;
+
+                // required claims
+                if (!idToken.Audiences.Any())
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Aud.ToLowerInvariant(), idToken)));
+
+                if (idToken.ValidTo.Equals(DateTime.MinValue))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Exp.ToLowerInvariant(), idToken)));
+
+                if (idToken.IssuedAt.Equals(DateTime.MinValue))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Iat.ToLowerInvariant(), idToken)));
+
+                if (idToken.Issuer.Equals(string.Empty))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Iss.ToLowerInvariant(), idToken)));
+
+                // sub is required in OpenID spec; but we don't want to block valid idTokens provided by some identity providers
+                if (RequireSub && (string.IsNullOrWhiteSpace(idToken.Subject)))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Sub.ToLowerInvariant(), idToken)));
+
+                // optional claims
+                if (RequireAcr && !idToken.TryGetPayloadValue(JwtRegisteredClaimNames.Acr, out string _))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21315, idToken)));
+
+                if (RequireAmr && !idToken.TryGetPayloadValue(JwtRegisteredClaimNames.Amr, out string _))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21316, idToken)));
+
+                if (RequireAuthTime && !idToken.TryGetPayloadValue(JwtRegisteredClaimNames.AuthTime, out string _))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21317, idToken)));
+
+                string azp = null;
+                if (RequireAzp && !idToken.TryGetPayloadValue(JwtRegisteredClaimNames.Azp, out azp))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21318, idToken)));
+
+                // if multiple audiences are present in the id_token, 'azp' claim should be present
+                if (Enumerable.Count(idToken.Audiences) > 1 && string.IsNullOrEmpty(azp))
+                {
+                    LogHelper.LogWarning(LogMessages.IDX21339);
+                }
+
+                // if 'azp' claim exist, it should be equal to 'client_id' of the application
+                if (!string.IsNullOrEmpty(azp))
+                {
+                    if (string.IsNullOrEmpty(validationContext.ClientId))
+                    {
+                        throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21308));
+                    }
+                    else if (!string.Equals(azp, validationContext.ClientId, StringComparison.Ordinal))
+                    {
+                        throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21340, azp, validationContext.ClientId)));
+                    }
+                }
+            }
+        }
+
+        private void ValidateIdJwtSecurityToken(OpenIdConnectProtocolValidationContext validationContext)
+        {
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
             // if user sets the custom validator, we call the delegate. The default checks for multiple audiences and azp are not executed.
             if (this.IdTokenValidator != null)
             {
@@ -377,7 +502,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             else
             {
                 JwtSecurityToken idToken = validationContext.ValidatedIdToken;
-
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
                 // required claims
                 if (idToken.Payload.Aud.Count == 0)
                     throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogHelper.FormatInvariant(LogMessages.IDX21314, JwtRegisteredClaimNames.Aud.ToLowerInvariant(), idToken)));
@@ -519,9 +644,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 
             if (validationContext == null)
                 throw LogHelper.LogArgumentNullException(nameof(validationContext));
-
-            if (validationContext.ValidatedIdToken == null)
-                throw LogHelper.LogArgumentNullException(nameof(validationContext.ValidatedIdToken));
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
+                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
 
             if (validationContext.ProtocolMessage == null)
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21333));
@@ -532,23 +657,30 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 return;
             }
 
-            object cHashClaim;
-            if (!validationContext.ValidatedIdToken.Payload.TryGetValue(JwtRegisteredClaimNames.CHash, out cHashClaim))
+            string chash;
+            if (validationContext.ValidatedJsonWebToken != null)
             {
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogHelper.FormatInvariant(LogMessages.IDX21307, validationContext.ValidatedIdToken)));
+                if (!validationContext.ValidatedJsonWebToken.TryGetPayloadValue(JwtRegisteredClaimNames.CHash, out  chash))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogHelper.FormatInvariant(LogMessages.IDX21307, validationContext.ValidatedJsonWebToken)));
             }
-
-            var chash = cHashClaim as string;
-            if (chash == null)
+            else // validationContext.ValidatedIdToken != null
             {
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogHelper.FormatInvariant(LogMessages.IDX21306, validationContext.ValidatedIdToken)));
+                if (!validationContext.ValidatedIdToken.Payload.TryGetValue(JwtRegisteredClaimNames.CHash, out var cHashClaim))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogHelper.FormatInvariant(LogMessages.IDX21307, validationContext.ValidatedIdToken)));
+                chash = cHashClaim as string;
+                if (chash == null)
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogHelper.FormatInvariant(LogMessages.IDX21306, validationContext.ValidatedIdToken)));
             }
 
             try
             {
-                ValidateHash(chash, validationContext.ProtocolMessage.Code, validationContext.ValidatedIdToken.Header.Alg);
+                if (validationContext.ValidatedJsonWebToken != null)
+                    ValidateHash(chash, validationContext.ProtocolMessage.Code, validationContext.ValidatedJsonWebToken.Alg);
+                else // validationContext.ValidatedIdToken != null
+                    ValidateHash(chash, validationContext.ProtocolMessage.Code, validationContext.ValidatedIdToken.Header.Alg);
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
             }
-            catch(OpenIdConnectProtocolException ex)
+            catch (OpenIdConnectProtocolException ex)
             {
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidCHashException(LogMessages.IDX21347, ex));
             }
@@ -570,8 +702,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             if (validationContext == null)
                 throw LogHelper.LogArgumentNullException("validationContext");
 
-            if (validationContext.ValidatedIdToken == null)
-                throw LogHelper.LogArgumentNullException("validationContext.ValidatedIdToken");
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
+                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
 
             if (validationContext.ProtocolMessage == null)
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21333));
@@ -582,17 +715,30 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 return;
             }
 
-            object atHashClaim;
-            if (!validationContext.ValidatedIdToken.Payload.TryGetValue(JwtRegisteredClaimNames.AtHash, out atHashClaim))
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidAtHashException(LogHelper.FormatInvariant(LogMessages.IDX21312, validationContext.ValidatedIdToken)));
+            string atHash;
+            if (validationContext.ValidatedJsonWebToken != null)
+            {
+                if (!validationContext.ValidatedJsonWebToken.TryGetPayloadValue(JwtRegisteredClaimNames.AtHash, out atHash))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidAtHashException(LogHelper.FormatInvariant(LogMessages.IDX21312, validationContext.ValidatedJsonWebToken)));
 
-            var atHash = atHashClaim as string;
-            if (atHash == null)
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidAtHashException(LogHelper.FormatInvariant(LogMessages.IDX21311, validationContext.ValidatedIdToken)));
+            }
+            else // validationContext.ValidatedIdToken != null
+            {
+                if (!validationContext.ValidatedIdToken.Payload.TryGetValue(JwtRegisteredClaimNames.AtHash, out var atHashClaim))
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidAtHashException(LogHelper.FormatInvariant(LogMessages.IDX21312, validationContext.ValidatedIdToken)));
 
+                atHash = atHashClaim as string;
+                if (atHash == null)
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidAtHashException(LogHelper.FormatInvariant(LogMessages.IDX21311, validationContext.ValidatedIdToken)));
+            }
+           
             try
             {
-                ValidateHash(atHash, validationContext.ProtocolMessage.AccessToken, validationContext.ValidatedIdToken.Header.Alg);
+                if (validationContext.ValidatedJsonWebToken != null)
+                    ValidateHash(atHash, validationContext.ProtocolMessage.AccessToken, validationContext.ValidatedJsonWebToken.Alg);
+                else if (validationContext.ValidatedIdToken != null)
+                    ValidateHash(atHash, validationContext.ProtocolMessage.AccessToken, validationContext.ValidatedIdToken.Header.Alg);
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
             }
             catch (OpenIdConnectProtocolException ex)
             {
@@ -601,7 +747,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         }
 
         /// <summary>
-        /// Validates that the <see cref="JwtSecurityToken"/> contains the nonce.
+        /// Validates that the <see cref="SecurityToken"/> contains the nonce.
         /// </summary>
         /// <param name="validationContext">A <see cref="OpenIdConnectProtocolValidationContext"/> that contains the 'nonce' to validate.</param>
         /// <exception cref="ArgumentNullException">If 'validationContext' is null.</exception>
@@ -618,10 +764,16 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             if (validationContext == null)
                 throw LogHelper.LogArgumentNullException(nameof(validationContext));
 
-            if (validationContext.ValidatedIdToken == null)
-                throw LogHelper.LogArgumentNullException(nameof(validationContext.ValidatedIdToken));
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            if (validationContext.ValidatedJsonWebToken == null && validationContext.ValidatedIdToken == null)
+                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
 
-            string nonceFoundInJwt = validationContext.ValidatedIdToken.Payload.Nonce;
+            string nonceFoundInJwt;
+            if (validationContext.ValidatedJsonWebToken != null)
+                validationContext.ValidatedJsonWebToken.TryGetPayloadValue(JwtRegisteredClaimNames.Nonce, out nonceFoundInJwt);
+            else // validationContext.ValidatedIdToken != null
+               nonceFoundInJwt = validationContext.ValidatedIdToken.Payload.Nonce;
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
 
             // if a nonce is not required AND there is no nonce in the context (which represents what was returned from the IDP) and the token log and return
             if (!RequireNonce && string.IsNullOrEmpty(validationContext.Nonce) && string.IsNullOrEmpty(nonceFoundInJwt))
@@ -639,7 +791,14 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidNonceException(LogHelper.FormatInvariant(LogMessages.IDX21349, RequireNonce)));
 
             if (!string.Equals(nonceFoundInJwt, validationContext.Nonce, StringComparison.Ordinal))
-                throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidNonceException(LogHelper.FormatInvariant(LogMessages.IDX21321, validationContext.Nonce, nonceFoundInJwt, validationContext.ValidatedIdToken)));
+            {
+                if (validationContext.ValidatedJsonWebToken != null)
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidNonceException(LogHelper.FormatInvariant(LogMessages.IDX21321, validationContext.Nonce, nonceFoundInJwt, validationContext.ValidatedJsonWebToken)));
+                else // validationContext.ValidatedIdToken != null
+#pragma warning disable 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+                    throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolInvalidNonceException(LogHelper.FormatInvariant(LogMessages.IDX21321, validationContext.Nonce, nonceFoundInJwt, validationContext.ValidatedIdToken)));
+#pragma warning restore 0618 // 'OpenIdConnectProtocolValidationContext.ValidatedIdToken' is obsolete.
+            }
 
             if (RequireTimeStampInNonce)
             {

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlAttributeKeyComparer.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlAttributeKeyComparer.cs
@@ -54,12 +54,12 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                     throw LogArgumentNullException(nameof(attribute));
                 }
 
-                FriendlyName = String.Empty;
+                FriendlyName = string.Empty;
                 Name = attribute.Name;
-                NameFormat = String.Empty;
-                Namespace = attribute.Namespace ?? String.Empty;
-                ValueType = attribute.AttributeValueXsiType ?? String.Empty;
-                OriginalIssuer = attribute.OriginalIssuer ?? String.Empty;
+                NameFormat = string.Empty;
+                Namespace = attribute.Namespace ?? string.Empty;
+                ValueType = attribute.AttributeValueXsiType ?? string.Empty;
+                OriginalIssuer = attribute.OriginalIssuer ?? string.Empty;
 
                 ComputeHashCode();
             }

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2AttributeKeyComparer.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2AttributeKeyComparer.cs
@@ -56,11 +56,11 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                 if (attribute == null)
                     throw LogArgumentNullException(nameof(attribute));
 
-                _friendlyName = attribute.FriendlyName ?? String.Empty;
+                _friendlyName = attribute.FriendlyName ?? string.Empty;
                 _name = attribute.Name;
-                _nameFormat = attribute.NameFormat == null ? String.Empty : attribute.NameFormat.OriginalString;
-                _valueType = attribute.AttributeValueXsiType ?? String.Empty;
-                _originalIssuer = attribute.OriginalIssuer ?? String.Empty;
+                _nameFormat = attribute.NameFormat == null ? string.Empty : attribute.NameFormat.OriginalString;
+                _valueType = attribute.AttributeValueXsiType ?? string.Empty;
+                _originalIssuer = attribute.OriginalIssuer ?? string.Empty;
 
                 ComputeHashCode();
             }

--- a/src/Microsoft.IdentityModel.Tokens/IJsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.Tokens/IJsonWebToken.cs
@@ -1,0 +1,117 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Interface for a json web token (JWT).
+    /// </summary>
+    public interface IJsonWebToken : ISecurityToken
+    {
+        /// <summary>
+        /// This must be implemented to get the Actor of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Actor { get; }
+
+        /// <summary>
+        /// This must be implemented to get the Algorithm used when signing this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Alg { get; }
+
+        /// <summary>
+        /// This must be implemented to get the Audiences of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        IEnumerable<string> Audiences { get; }
+
+        /// <summary>
+        /// This must be implemented to get the <see cref="Claim"/>s for each value in the JWT payload.
+        /// </summary>
+        IEnumerable<Claim> Claims { get; }
+
+        /// <summary>
+        /// This must be implemented to get the Content Type of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Cty { get; }
+
+        /// <summary>
+        /// This must be implemented to get the Encryption Algorithm of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Enc { get; }
+
+        /// <summary>
+        /// This must be implemented to get the time this <see cref="IJsonWebToken"/> was issued at.
+        /// </summary>
+        DateTime IssuedAt { get; }
+
+        /// <summary>
+        /// This must be implemented to get the key ID of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Kid { get; }
+
+        /// <summary>
+        /// This must be implemented to get the Subject of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Subject { get; }
+
+        /// <summary>
+        /// This must be implemented to get the Type of this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string Typ { get; }
+
+        /// <summary>
+        /// This must be implemented to get the X509 Certificate Thumbprint associated with this <see cref="IJsonWebToken"/>.
+        /// </summary>
+        string X5t { get; }
+
+        /// <summary>
+        /// This must be implemented to obtain a 'value' corresponding to the provided key from the JWT payload { key, 'value' }.
+        /// </summary>
+        T GetPayloadValue<T>(string key);
+
+        /// <summary>
+        /// This must be implemented to get the 'value' corresponding to the provided key from the JWT payload { key, 'value' }.
+        /// </summary>
+        /// <remarks>This should return 'true' if 'value' is found, and 'false' otherwise.</remarks>
+
+        bool TryGetPayloadValue<T>(string key, out T value);
+
+        /// <summary>
+        /// This must be implemented to get the 'value' corresponding to the provided key from the JWT header { key, 'value' }.
+        /// </summary>
+        T GetHeaderValue<T>(string key);
+
+        /// <summary>
+        /// This must be implemented to get the 'value' corresponding to the provided key from the JWT header { key, 'value' }.
+        /// </summary>
+        /// <remarks>This should return 'true' if 'value' is found, and 'false' otherwise.</remarks>
+        bool TryGetHeaderValue<T>(string key, out T value);
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/IJsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.Tokens/IJsonWebToken.cs
@@ -32,7 +32,7 @@ using System.Security.Claims;
 namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
-    /// Interface for a json web token (JWT).
+    /// Interface for a JSON Web Token (JWT).
     /// </summary>
     public interface IJsonWebToken : ISecurityToken
     {

--- a/src/Microsoft.IdentityModel.Tokens/ISecurityToken.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ISecurityToken.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------------------------
+﻿//------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -30,39 +30,39 @@ using System;
 namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
-    /// Base class for security token.
+    /// Interface for a security token.
     /// </summary>
-    public abstract class SecurityToken : ISecurityToken
+    public interface ISecurityToken
     {
         /// <summary>
-        /// This must be overridden to get the Id of this <see cref="SecurityToken"/>.
+        /// This must be implemented to get the Id of this <see cref="SecurityToken"/>.
         /// </summary>
-        public abstract string Id { get; }
+        string Id { get; }
 
         /// <summary>
-        /// This must be overridden to get the issuer of this <see cref="SecurityToken"/>.
+        /// This must be implemented to get the issuer of this <see cref="SecurityToken"/>.
         /// </summary>
-        public abstract string Issuer { get; }
+        string Issuer { get; }
 
         /// <summary>
-        /// This must be overridden to get the <see cref="SecurityKey"/>.
+        /// This must be implemented to get the <see cref="SecurityKey"/>.
         /// </summary>
-        public abstract SecurityKey SecurityKey { get; }
+        SecurityKey SecurityKey { get; }
 
         /// <summary>
-        /// This must be overridden to get or set the <see cref="SecurityKey"/> that signed this instance.
+        /// This must be implemented to get or set the <see cref="SecurityKey"/> that signed this instance.
         /// </summary>
         /// <remarks><see cref="ISecurityTokenValidator"/>.ValidateToken(...) can this value when a <see cref="SecurityKey"/> is used to successfully validate a signature.</remarks>
-        public abstract SecurityKey SigningKey { get; set; }
+        SecurityKey SigningKey { get; set; }
 
         /// <summary>
-        /// This must be overridden to get the time when this <see cref="SecurityToken"/> was Valid.
+        /// This must be implemented to get the time when this <see cref="SecurityToken"/> was Valid.
         /// </summary>
-        public abstract DateTime ValidFrom { get; }
+        DateTime ValidFrom { get; }
 
         /// <summary>
-        /// This must be overridden to get the time when this <see cref="SecurityToken"/> is no longer Valid.
+        /// This must be implemented to get the time when this <see cref="SecurityToken"/> is no longer Valid.
         /// </summary>
-        public abstract DateTime ValidTo { get; }
+        DateTime ValidTo { get; }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/ISecurityToken.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ISecurityToken.cs
@@ -35,12 +35,12 @@ namespace Microsoft.IdentityModel.Tokens
     public interface ISecurityToken
     {
         /// <summary>
-        /// This must be implemented to get the Id of this <see cref="SecurityToken"/>.
+        /// This must be implemented to get the Id of this <see cref="ISecurityToken"/>.
         /// </summary>
         string Id { get; }
 
         /// <summary>
-        /// This must be implemented to get the issuer of this <see cref="SecurityToken"/>.
+        /// This must be implemented to get the issuer of this <see cref="ISecurityToken"/>.
         /// </summary>
         string Issuer { get; }
 
@@ -52,16 +52,16 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// This must be implemented to get or set the <see cref="SecurityKey"/> that signed this instance.
         /// </summary>
-        /// <remarks><see cref="ISecurityTokenValidator"/>.ValidateToken(...) can this value when a <see cref="SecurityKey"/> is used to successfully validate a signature.</remarks>
+        /// <remarks><see cref="ISecurityTokenValidator"/>.ValidateToken(...) can set this value when a <see cref="SecurityKey"/> is used to successfully validate a signature.</remarks>
         SecurityKey SigningKey { get; set; }
 
         /// <summary>
-        /// This must be implemented to get the time when this <see cref="SecurityToken"/> was Valid.
+        /// This must be implemented to get the time when this <see cref="ISecurityToken"/> starts to be valid.
         /// </summary>
         DateTime ValidFrom { get; }
 
         /// <summary>
-        /// This must be implemented to get the time when this <see cref="SecurityToken"/> is no longer Valid.
+        /// This must be implemented to get the time when this <see cref="ISecurityToken"/> is no longer valid.
         /// </summary>
         DateTime ValidTo { get; }
     }

--- a/src/Microsoft.IdentityModel.Xml/DelegatingXmlDictionaryWriter.cs
+++ b/src/Microsoft.IdentityModel.Xml/DelegatingXmlDictionaryWriter.cs
@@ -373,8 +373,8 @@ namespace Microsoft.IdentityModel.Xml
         public override void WriteXmlnsAttribute(string prefix, string @namespace)
         {
             UseInnerWriter.WriteXmlnsAttribute(prefix, @namespace);
-            TracingWriter?.WriteAttributeString(prefix, String.Empty, @namespace, String.Empty);
-            InternalWriter?.WriteAttributeString(prefix, String.Empty, @namespace, String.Empty);
+            TracingWriter?.WriteAttributeString(prefix, string.Empty, @namespace, string.Empty);
+            InternalWriter?.WriteAttributeString(prefix, string.Empty, @namespace, string.Empty);
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Xml/XmlUtil.cs
+++ b/src/Microsoft.IdentityModel.Xml/XmlUtil.cs
@@ -250,7 +250,7 @@ namespace Microsoft.IdentityModel.Xml
                 throw LogArgumentNullException(nameof(qualifiedString));
 
             string name = qualifiedString;
-            string prefix = String.Empty;
+            string prefix = string.Empty;
 
             int colon = qualifiedString.IndexOf(':');
             if (colon > -1)

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
@@ -338,21 +338,6 @@ namespace System.IdentityModel.Tokens.Jwt
         }
 
         /// <summary>
-        /// Gets the 'value' of the 'iat' claim { iat, 'value' } from the <see cref="JwtPayload"/>.
-        /// This value is converted to a <see cref="DateTime"/> assuming 'value' is seconds since UnixEpoch (UTC 1970-01-01T0:0:0Z).
-        /// </summary>
-        /// <remarks>If the 'iat' claim is not found, then <see cref="DateTime.MinValue"/> is returned.</remarks>
-        public DateTime IssuedAt
-        {
-            get
-            {
-                if (Payload != null)
-                    return EpochTime.DateTime(Convert.ToInt64(Math.Truncate(Convert.ToDouble(Payload.Iat)), CultureInfo.InvariantCulture));
-                return DateTime.MinValue;
-            }
-        }
-
-        /// <summary>
         /// Gets the 'value' of the 'issuer' claim { iss, 'value' }.
         /// </summary>
         /// <remarks>If the 'issuer' claim is not found, an empty string is returned.</remarks>

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
@@ -49,6 +49,7 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <exception cref="ArgumentException">'jwtEncodedString' is not in JWS Compact serialized format.</exception>
         /// <remarks>
         /// The contents of this <see cref="JwtSecurityToken"/> have not been validated, the JSON Web Token is simply decoded. Validation can be accomplished using <see cref="JwtSecurityTokenHandler.ValidateToken(String, TokenValidationParameters, out SecurityToken)"/>
+        /// We recommend using the <see cref="JsonWebToken"/> class over the JwtSecurityToken class as it is newer, faster, and has more functionality.
         /// </remarks>
         public JwtSecurityToken(string jwtEncodedString)
         {

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
@@ -25,12 +25,11 @@
 //
 //------------------------------------------------------------------------------
 
+using System.Collections.Generic;
+using System.Security.Claims;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Security.Claims;
 
 namespace System.IdentityModel.Tokens.Jwt
 {

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
@@ -219,7 +219,8 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Payload != null)
                     return Payload.Actort;
-                return String.Empty;
+
+                return string.Empty;
             }
         }
 
@@ -234,7 +235,8 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Header != null)
                     return Header.Alg;
-                return String.Empty;
+
+                return string.Empty;
             }
         }
 
@@ -248,6 +250,7 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Payload != null)
                     return Payload.Aud;
+
                 return new List<string>();
             }
         }
@@ -264,6 +267,7 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Payload != null)
                     return Payload.Claims;
+
                 return new List<Claim>();
             }
         }
@@ -278,7 +282,8 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Header != null)
                     return Header.Cty;
-                return String.Empty;
+
+                return string.Empty;
             }
         }
 
@@ -292,7 +297,8 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Header != null)
                     return Header.Enc;
-                return String.Empty;
+
+                return string.Empty;
             }
         }
         /// <summary>
@@ -312,7 +318,8 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Payload != null)
                     return Payload.Base64UrlEncode();
-                return String.Empty;
+
+                return string.Empty;
             }
         }
 
@@ -331,7 +338,8 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Payload != null)
                     return Payload.Jti;
-                return String.Empty;
+
+                return string.Empty;
 
             }
         }
@@ -346,7 +354,8 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Payload != null)
                     return Payload.Iss;
-                return String.Empty;
+
+                return string.Empty;
             }
         }
 
@@ -362,6 +371,7 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (InnerToken != null)
                     return InnerToken.Payload;
+
                 return _payload;
             }
             internal set
@@ -385,7 +395,8 @@ namespace System.IdentityModel.Tokens.Jwt
             { 
                 if (Header != null)
                     return Header.Kid;
-                return String.Empty;
+
+                return string.Empty;
             }
         }
 
@@ -480,7 +491,8 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Header != null)
                     return Header.Typ;
-                return String.Empty;
+
+                return string.Empty;
             }
         }
 
@@ -508,7 +520,8 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Payload != null)
                     return Payload.Sub;
-                return String.Empty;
+
+                return string.Empty;
             }
         }
 
@@ -522,6 +535,7 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Payload != null)
                     return Payload.ValidFrom;
+
                 return DateTime.MinValue;
             }
         }
@@ -536,6 +550,7 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Payload != null)
                     return Payload.ValidTo;
+
                 return DateTime.MinValue;
             }
         }
@@ -550,6 +565,7 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Payload != null)
                     return Payload.IssuedAt;
+
                 return DateTime.MinValue;
             }
         }
@@ -564,7 +580,8 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (Header != null)
                     return Header.X5t;
-                return String.Empty;
+
+                return string.Empty;
             }
         }
 

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -41,6 +41,9 @@ namespace System.IdentityModel.Tokens.Jwt
     /// <summary>
     /// A <see cref="SecurityTokenHandler"/> designed for creating and validating Json Web Tokens. See: http://tools.ietf.org/html/rfc7519 and http://www.rfc-editor.org/info/rfc7515
     /// </summary>
+    /// <remarks>
+    /// We recommend using the <see cref="JsonWebTokenHandler"/> class over the JwtSecurityTokenHandler class as it is newer, faster, and has more functionality.
+    /// </remarks>
     public class JwtSecurityTokenHandler : SecurityTokenHandler
     {
 

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -673,7 +673,6 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <exception cref="ArgumentException"><paramref name="token"/> does not have 3 or 5 parts.</exception>
         /// <exception cref="ArgumentException"><see cref="CanReadToken(string)"/> returns false.</exception>
         /// <exception cref="SecurityTokenDecryptionFailedException"><paramref name="token"/> was a JWE was not able to be decrypted.</exception>
-        /// <exception cref="SecurityTokenEncryptionKeyNotFoundException"><paramref name="token"/> 'kid' header claim is not null AND decryption fails.</exception>
         /// <exception cref="SecurityTokenException"><paramref name="token"/> 'enc' header claim is null or empty.</exception>
         /// <exception cref="SecurityTokenExpiredException"><paramref name="token"/> 'exp' claim is &lt; DateTime.UtcNow.</exception>
         /// <exception cref="SecurityTokenInvalidAudienceException"><see cref="TokenValidationParameters.ValidAudience"/> is null or whitespace and <see cref="TokenValidationParameters.ValidAudiences"/> is null. Audience is not validated if <see cref="TokenValidationParameters.ValidateAudience"/> is set to false.</exception>
@@ -1349,7 +1348,6 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <exception cref="ArgumentNullException">if 'jwtToken' is null.</exception>
         /// <exception cref="ArgumentNullException">if 'validationParameters' is null.</exception>
         /// <exception cref="SecurityTokenException">if 'jwtToken.Header.enc' is null or empty.</exception>
-        /// <exception cref="SecurityTokenEncryptionKeyNotFoundException">if 'jwtToken.Header.kid' is not null AND decryption fails.</exception>
         /// <exception cref="SecurityTokenDecryptionFailedException">if the JWE was not able to be decrypted.</exception>
         protected string DecryptToken(JwtSecurityToken jwtToken, TokenValidationParameters validationParameters)
         {

--- a/src/System.IdentityModel.Tokens.Jwt/LogMessages.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/LogMessages.cs
@@ -65,6 +65,11 @@ namespace System.IdentityModel.Tokens.Jwt
         internal const string IDX12739 = "IDX12739: JWT: '{0}' has three segments but is not in proper JWS format.";
         internal const string IDX12740 = "IDX12740: JWT: '{0}' has five segments but is not in proper JWE format.";
         internal const string IDX12741 = "IDX12741: JWT: '{0}' must have three segments (JWS) or five segments (JWE).";
+
+        //parsing
+        internal const string IDX12800 = "IDX12800: Claim with name '{0}' does not exist in the header.";
+        internal const string IDX12801 = "IDX12801: Claim with name '{0}' does not exist in the payload.";
+        internal const string IDX12802 = "IDX12802: Unable to convert the '{0}' claim to the following type: '{1}'. Claim type was: '{2}'.";
 #pragma warning restore 1591
     }
 }

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -1913,6 +1913,100 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
+
+        [Theory, MemberData(nameof(ValidateTokenAndCreateClaimsPrincipalTheoryData))]
+        public void ValidateTokenAndCreateClaimsPrincipal(JwtTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.ValidateTokenAndCreateClaimsPrincipal", theoryData);
+            var jsonWebTokenHandler = new JsonWebTokenHandler();
+            try
+            {
+                var claimsPrincipal = jsonWebTokenHandler.ValidateToken(theoryData.Token, theoryData.ValidationParameters, out SecurityToken token);
+                var tokenValidationResult = jsonWebTokenHandler.ValidateToken(theoryData.Token, theoryData.ValidationParameters);
+
+                 if (claimsPrincipal == null)
+                    context.AddDiff("claimsPrincipal == null");
+
+                 if (token == null)
+                    context.AddDiff("token == null");
+
+                IdentityComparer.AreEqual(token, tokenValidationResult.SecurityToken, context);
+
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+        }
+
+        public static TheoryData<JwtTheoryData> ValidateTokenAndCreateClaimsPrincipalTheoryData
+        {
+            get
+            {
+                return new TheoryData<JwtTheoryData>
+                {
+                    new JwtTheoryData
+                    {
+                        TestId = nameof(Default.SymmetricJws) + "RequireSignedTokens",
+                        Token = Default.SymmetricJws,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = true,
+                            IssuerSigningKey = Default.SymmetricSigningKey,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                        }
+                    },
+                    new JwtTheoryData
+                    {
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10501:"),
+                        TestId = nameof(Default.SymmetricJws) + "RequireSignedTokensNullSigningKey",
+                        Token = Default.SymmetricJws,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = true,
+                            IssuerSigningKey = null,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                        }
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = nameof(Default.SymmetricJws) + "DontRequireSignedTokens",
+                        Token = Default.SymmetricJws,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = false,
+                            IssuerSigningKey = Default.SymmetricSigningKey,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                        }
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = nameof(Default.UnsignedJwt) + "DontRequireSignedTokensNullSigningKey",
+                        Token = Default.UnsignedJwt,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = false,
+                            IssuerSigningKey = null,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                        }
+                    }
+                };
+            }
+        }
+
         [Theory, MemberData(nameof(JWECompressionTheoryData))]
         public void EncryptExistingJWSWithCompressionTest(CreateTokenTheoryData theoryData)
         {

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorJsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorJsonWebTokenTests.cs
@@ -1057,7 +1057,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     },
                     new OidcProtocolValidatorJsonWebTokenTheoryData
                     {
-                        ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidCHashException), "IDX21307:"),
+                        ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidCHashException), "IDX21306:"),
                         TestId = "ValidatedIdToken.chash is not a string, but array",
                         ValidationContext = new OpenIdConnectProtocolValidationContext
                         {

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorJsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorJsonWebTokenTests.cs
@@ -951,7 +951,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     new OidcProtocolValidatorJsonWebTokenTheoryData
                     {
                         ExpectedException = new ExpectedException(typeof(ArgumentNullException), "IDX10000:"),
-                        TestId = "ValidatedIdToken.Header.alg == string.empty",
+                        TestId = "ValidatedIdToken.Header.alg == string.Empty",
                         ValidationContext = new OpenIdConnectProtocolValidationContext
                         {
                             ProtocolMessage = new OpenIdConnectMessage { Code = code },

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
@@ -1039,7 +1039,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     },
                     new OidcProtocolValidatorTheoryData
                     {
-                        ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidCHashException), "IDX21306:"),
+                        ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidCHashException), "IDX21307:"),
                         TestId = "ValidatedIdToken.chash is not a string, but array",
                         ValidationContext = new OpenIdConnectProtocolValidationContext
                         {
@@ -1051,7 +1051,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     },
                     new OidcProtocolValidatorTheoryData
                     {
-                        ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidCHashException), "IDX21306:"),
+                        ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidCHashException), "IDX21307:"),
                         TestId = "Multiple chashes",
                         ValidationContext = new OpenIdConnectProtocolValidationContext
                         {
@@ -1417,7 +1417,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new OidcProtocolValidatorTheoryData
                 {
-                    ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidAtHashException), "IDX21311:"),
+                    ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidAtHashException), "IDX21312:"),
                     ProtocolValidator = new PublicOpenIdConnectProtocolValidator(),
                     TestId = "multiple at_hash claims",
                     ValidationContext = new OpenIdConnectProtocolValidationContext()

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
@@ -911,7 +911,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     new OidcProtocolValidatorTheoryData
                     {
                         ExpectedException = new ExpectedException(typeof(ArgumentNullException), "IDX10000:"),
-                        TestId = "ValidatedIdToken.Header.alg == string.empty",
+                        TestId = "ValidatedIdToken.Header.alg == string.Empty",
                         ValidationContext = new OpenIdConnectProtocolValidationContext
                         {
                             ProtocolMessage = new OpenIdConnectMessage { Code = code },

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
@@ -1039,7 +1039,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     },
                     new OidcProtocolValidatorTheoryData
                     {
-                        ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidCHashException), "IDX21307:"),
+                        ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidCHashException), "IDX21306:"),
                         TestId = "ValidatedIdToken.chash is not a string, but array",
                         ValidationContext = new OpenIdConnectProtocolValidationContext
                         {
@@ -1051,7 +1051,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     },
                     new OidcProtocolValidatorTheoryData
                     {
-                        ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidCHashException), "IDX21307:"),
+                        ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidCHashException), "IDX21306:"),
                         TestId = "Multiple chashes",
                         ValidationContext = new OpenIdConnectProtocolValidationContext
                         {
@@ -1417,7 +1417,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new OidcProtocolValidatorTheoryData
                 {
-                    ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidAtHashException), "IDX21312:"),
+                    ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolInvalidAtHashException), "IDX21311:"),
                     ProtocolValidator = new PublicOpenIdConnectProtocolValidator(),
                     TestId = "multiple at_hash claims",
                     ValidationContext = new OpenIdConnectProtocolValidationContext()

--- a/test/Microsoft.IdentityModel.TestUtils/ReferenceSaml.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ReferenceSaml.cs
@@ -144,7 +144,7 @@ namespace Microsoft.IdentityModel.TestUtils
             {
                 return new SamlActionTestSet
                 {
-                    Xml = XmlGenerator.SamlActionXml(SamlConstants.Namespace, Default.SamlAction.Namespace.ToString(), String.Empty)
+                    Xml = XmlGenerator.SamlActionXml(SamlConstants.Namespace, Default.SamlAction.Namespace.ToString(), string.Empty)
                 };
             }
         }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/EncryptingCredentialsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/EncryptingCredentialsTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 new EncryptingCredentialsTheoryData
                 {
                     Key = Default.AsymmetricEncryptionKeyPublic,
-                    Alg = String.Empty,
+                    Alg = string.Empty,
                     Enc = SecurityAlgorithms.Aes128CbcHmacSha256,
                     ExpectedException = ExpectedException.ArgumentNullException("IDX10000: The parameter 'alg'"),
                     TestId = "EmptyAlgString"
@@ -98,7 +98,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     Key = Default.AsymmetricEncryptionKeyPublic,
                     Alg = SecurityAlgorithms.RsaOaepKeyWrap,
-                    Enc = String.Empty,
+                    Enc = string.Empty,
                     ExpectedException = ExpectedException.ArgumentNullException("IDX10000: The parameter 'enc'"),
                     TestId = "EmptyEncString"
                 },
@@ -142,7 +142,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 new EncryptingCredentialsTheoryData
                 {
                     Key = Default.SymmetricEncryptionKey128,
-                    Enc = String.Empty,
+                    Enc = string.Empty,
                     ExpectedException = ExpectedException.ArgumentNullException("IDX10000: The parameter 'enc'"),
                     TestId = "EmptyEncString"
                 },

--- a/test/Microsoft.IdentityModel.Tokens.Tests/X509EncryptingCredentialsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/X509EncryptingCredentialsTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 new X509EncryptingCredentialsTheoryData
                 {
                     Certificate = Default.Certificate,
-                    Alg = String.Empty,
+                    Alg = string.Empty,
                     Enc = SecurityAlgorithms.Aes128CbcHmacSha256,
                     ExpectedException = ExpectedException.ArgumentNullException("IDX10000: The parameter 'alg'"),
                     TestId = "EmptyAlgString"
@@ -83,7 +83,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 {
                     Certificate = Default.Certificate,
                     Alg = SecurityAlgorithms.RsaOaepKeyWrap,
-                    Enc = String.Empty,
+                    Enc = string.Empty,
                     ExpectedException = ExpectedException.ArgumentNullException("IDX10000: The parameter 'enc'"),
                     TestId = "EmptyEncString"
                 },

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -949,14 +949,14 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     new JwtTheoryData
                     {
                         ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidAudienceException), substringExpected: "IDX10208: Unable to validate audience. validationParameters.ValidAudience is null or whitespace ", propertiesExpected: new Dictionary<string, object>{ { "InvalidAudience", Default.Audience } }),
-                        TestId = "'ValidAudiences == string.empty'",
+                        TestId = "'ValidAudiences == string.Empty'",
                         SecurityToken = tokenHandler.CreateJwtSecurityToken(issuer: Default.Issuer, audience: Default.Audience),
                         ValidationParameters = ValidateAudienceValidationParameters(null, new List<string>{ string.Empty }, null, true),
                     },
                     new JwtTheoryData
                     {
                         ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidAudienceException), substringExpected: "IDX10208: Unable to validate audience. ", propertiesExpected: new Dictionary<string, object>{ { "InvalidAudience", Default.Audience } }),
-                        TestId = "'ValidAudience string.empty, validAudiences whitespace'",
+                        TestId = "'ValidAudience string.Empty, validAudiences whitespace'",
                         SecurityToken = tokenHandler.CreateJwtSecurityToken(issuer: Default.Issuer, audience: Default.Audience),
                         ValidationParameters = ValidateAudienceValidationParameters(string.Empty, new List<string>{ "    " }, null, true),
                     },

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
@@ -253,7 +253,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     Claims = null,
                     SigningCredentials = null,
                 },
-                String.Empty,
+                string.Empty,
                 ExpectedException.ArgumentNullException()
             );
 
@@ -264,19 +264,19 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             };
 
             JwtSecurityTokenTestVariation outerValidJweDirect = CreateVariationOnToken(EncodedJwts.ValidJweDirect);
-            dataSet.Add("ValidJweDirect- Construct by parts", outerValidJweDirect, innerToken, String.Empty, ExpectedException.NoExceptionExpected);
+            dataSet.Add("ValidJweDirect- Construct by parts", outerValidJweDirect, innerToken, string.Empty, ExpectedException.NoExceptionExpected);
             dataSet.Add("ValidJweDirect- Construct by string", outerValidJweDirect, null, EncodedJwts.ValidJweDirect, ExpectedException.NoExceptionExpected);
 
             JwtSecurityTokenTestVariation outerValidJweDirect2 = CreateVariationOnToken(EncodedJwts.ValidJweDirect2);
-            dataSet.Add("ValidJweDirect2- Construct by parts", outerValidJweDirect2, innerToken, String.Empty, ExpectedException.NoExceptionExpected);
+            dataSet.Add("ValidJweDirect2- Construct by parts", outerValidJweDirect2, innerToken, string.Empty, ExpectedException.NoExceptionExpected);
             dataSet.Add("ValidJweDirect2- Construct by string", outerValidJweDirect2, null, EncodedJwts.ValidJweDirect2, ExpectedException.NoExceptionExpected);
 
             JwtSecurityTokenTestVariation outerValidJwe = CreateVariationOnToken(EncodedJwts.ValidJwe);
-            dataSet.Add("ValidJwe- Construct by parts", outerValidJwe, innerToken, String.Empty, ExpectedException.NoExceptionExpected);
+            dataSet.Add("ValidJwe- Construct by parts", outerValidJwe, innerToken, string.Empty, ExpectedException.NoExceptionExpected);
             dataSet.Add("ValidJwe- Construct by string", outerValidJwe, null, EncodedJwts.ValidJwe, ExpectedException.NoExceptionExpected);
 
             JwtSecurityTokenTestVariation outerValidJwe2 = CreateVariationOnToken(EncodedJwts.ValidJwe2);
-            dataSet.Add("ValidJwe2- Construct by parts", outerValidJwe2, innerToken, String.Empty, ExpectedException.NoExceptionExpected);
+            dataSet.Add("ValidJwe2- Construct by parts", outerValidJwe2, innerToken, string.Empty, ExpectedException.NoExceptionExpected);
             dataSet.Add("ValidJwe2- Construct by string", outerValidJwe2, null, EncodedJwts.ValidJwe2, ExpectedException.NoExceptionExpected);
 
             // Hand in a valid variation. We should fail before the variation is used.


### PR DESCRIPTION
This PR combines the following two PRs: #1243 and #1127.

Tests still need to be added to make sure that the TryGetPayloadValue() (and other similar methods on the IJsonWebToken interface) are implemented properly by JwtSecurityToken.

It may also be a good idea to include a RawData property on either the IJsonWebToken or ISecurityToken interface, as otherwise a user of the library will need to cast to a specific token type in order to obtain the original encoded token. 

(Fixes #1160)
(Fixes #1227)