### PR TITLE
check for VSINSTALLDIR and adjust path for msbuild.exe

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
   </packageSources>

--- a/build.ps1
+++ b/build.ps1
@@ -64,6 +64,11 @@ function ClearBaselineFiles($root)
 
 ################################################# Functions ############################################################
 
+if ($env:VSINSTALLDIR)
+{
+    $msbuildDir = $env:VSINSTALLDIR+"\MSBuild\Current\Bin\amd64";
+}
+
 WriteSectionHeader("build.ps1 - parameters");
 Write-Host "buildType:                  " $buildType;
 Write-Host "dotnetDir:                  " $dotnetDir

--- a/build.ps1
+++ b/build.ps1
@@ -66,7 +66,10 @@ function ClearBaselineFiles($root)
 
 if ($env:VSINSTALLDIR)
 {
-    $msbuildDir = $env:VSINSTALLDIR+"\MSBuild\Current\Bin\amd64";
+    if (Test-Path($env:VSINSTALLDIR+"\MSBuild\Current\Bin"))
+    {
+        $msbuildDir = $env:VSINSTALLDIR+"\MSBuild\Current\Bin";
+    }
 }
 
 WriteSectionHeader("build.ps1 - parameters");


### PR DESCRIPTION
This PR has two small items.
1. Checking the environment variable for the installation path to Visual Studio and setting the msbuildDir variable from that.
2. Adding '< / clear>' in nuget.config. This ensures that our build will use a controlled set of packages.