### PR TITLE
Added TokenContext back and a new OpenIdConnectMessage(object json) constructor

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs
@@ -128,6 +128,20 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenIdConnectMessage"/> class.
+        /// </summary>
+        /// <param name="json">The JSON object from which the instance is created.</param>
+        [Obsolete("The 'OpenIdConnectMessage(object json)' constructor is obsolete. Please use 'OpenIdConnectMessage(string json)' instead.")]
+        public OpenIdConnectMessage(object json)
+        {
+            if (json == null)
+                throw LogHelper.LogArgumentNullException(nameof(json));
+
+            var jObject = JObject.Parse(json.ToString());
+            SetJsonParameters(jObject);
+        }
+
         private void SetJsonParameters(JObject json)
         {
             if (json == null)

--- a/src/Microsoft.IdentityModel.Tokens/TokenContext.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenContext.cs
@@ -34,45 +34,21 @@ namespace Microsoft.IdentityModel.Tokens
     /// <summary>
     /// An opaque context used to store work when working with authentication artifacts.
     /// </summary>
-    public class CallContext
+    [Obsolete("The 'TokenContext' property is obsolete. Please use 'CallContext' instead.")]
+    public class TokenContext : CallContext
     {
         /// <summary>
-        /// Instantiates a new <see cref="CallContext"/> with a default activityId.
+        /// Instantiates a new <see cref="TokenContext"/> with a default activity ID.
         /// </summary>
-        public CallContext()
+        public TokenContext() : base()
         {
         }
 
         /// <summary>
-        /// Instantiates a new <see cref="CallContext"/> with an activityId.
+        /// Instantiates a new <see cref="TokenContext"/> with an activity ID.
         /// </summary>
-        public CallContext(Guid activityId)
+        public TokenContext(Guid activityId) : base (activityId)
         {
-            if (activityId == null)
-                throw new ArgumentNullException(nameof(activityId));
-
-            ActivityId = activityId;
         }
-
-        /// <summary>
-        /// Gets or set a <see cref="Guid"/> that will be used in the call to EventSource.SetCurrentThreadActivityId before logging.
-        /// </summary>
-        public Guid ActivityId { get; set; } = Guid.Empty;
-
-        /// <summary>
-        /// Gets or sets a boolean controlling if logs are written into the context.
-        /// Useful when debugging.
-        /// </summary>
-        public bool CaptureLogs { get; set; } = false;
-
-        /// <summary>
-        /// The collection of logs associated with a request. Use <see cref="CaptureLogs"/> to control capture.
-        /// </summary>
-        public ICollection<string> Logs { get; private set; } = new Collection<string>();
-
-        /// <summary>
-        /// Gets or sets an <see cref="IDictionary{String, Object}"/> that enables custom extensibility scenarios.
-        /// </summary>
-        public IDictionary<string, object> PropertyBag { get; set; }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
@@ -61,7 +61,7 @@ namespace Microsoft.IdentityModel.Tokens
         public SecurityToken SecurityToken { get; set; }
 
         /// <summary>
-        /// Gets or sets the <see cref="TokenContext"/> that contains call information.
+        /// Gets or sets the <see cref="CallContext"/> that contains call information.
         /// </summary>
         public CallContext TokenContext { get; set; }
 

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
@@ -29,7 +29,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
-using Microsoft.IdentityModel.Json.Linq;
+using Newtonsoft.Json.Linq;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -53,7 +53,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             try
             {
                 messageFromJson = new OpenIdConnectMessage(theoryData.Json);
-                messageFromJsonObj = new OpenIdConnectMessage(theoryData.JObject?.ToString());
+                messageFromJsonObj = new OpenIdConnectMessage(theoryData.JObject);
                 IdentityComparer.AreEqual(messageFromJson, messageFromJsonObj, context);
                 IdentityComparer.AreEqual(messageFromJson, theoryData.Message, context);
                 theoryData.ExpectedException.ProcessNoException();


### PR DESCRIPTION
- Added `TokenContext` back in from 5x (as it was renamed to `CallContext` in 6x).
- Added an `OpenIdConnectMessage(object json)` constructor to avoid having compile time breaking changes (as `OpenIdConnectMessage(JObject json)` was removed in 6x).
