### PR TITLE
Fix exp claim type when using SetDefaultTimesOnTokenCreation

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -495,7 +495,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             {
                 var now = EpochTime.GetIntDate(DateTime.UtcNow);
                 if (!payload.TryGetValue(JwtRegisteredClaimNames.Exp, out _))
-                    payload.Add(JwtRegisteredClaimNames.Exp, now + TimeSpan.FromMinutes(TokenLifetimeInMinutes).TotalSeconds);
+                    payload.Add(JwtRegisteredClaimNames.Exp, now + TokenLifetimeInMinutes * 60);
 
                 if (!payload.TryGetValue(JwtRegisteredClaimNames.Iat, out _))
                     payload.Add(JwtRegisteredClaimNames.Iat, now);


### PR DESCRIPTION
Due to what I think is small programming error, the value used for the exp claim is promoted to a double, and is added as a floating point value in the payload. I saw no real need for using TimeSpan for this calculation, so I simply multiplied by 60 and now the value is an integer as expected.

Please note that [RFC 7519](https://tools.ietf.org/html/rfc7519#section-4.1.4) specifies that the exp claim must be a NumericDate, which CAN be a non-integer value - so the current implementation is still compliant with the RFC. I would still vote for using an integer value consistently for the three claims (since the extra precision is not required). Feel free to reject this request if you don't agree.