### PR TITLE
Change SecurityKey.InternalId and SignatureProvider caching logic

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/ECDsaSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ECDsaSecurityKey.cs
@@ -110,6 +110,20 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
+        /// Determines whether the <see cref="ECDsaSecurityKey"/> can compute a JWK thumbprint.
+        /// </summary>
+        /// <returns><c>true</c> if JWK thumbprint can be computed; otherwise, <c>false</c>.</returns>
+        /// <remarks>https://tools.ietf.org/html/rfc7638</remarks>
+        public override bool CanComputeJwkThumbprint()
+        {
+#if NETSTANDARD2_0
+            if (ECDsaAdapter.Instance.SupportsECParameters())
+                return true;
+#endif
+            return false;
+        }
+
+        /// <summary>
         /// Computes a sha256 hash over the <see cref="ECDsaSecurityKey"/>.
         /// </summary>
         /// <returns>A JWK thumbprint.</returns>
@@ -119,9 +133,6 @@ namespace Microsoft.IdentityModel.Tokens
 #if NETSTANDARD2_0
             if (ECDsaAdapter.Instance.SupportsECParameters())
             {
-                if (ECDsa == null)
-                    throw LogHelper.LogArgumentNullException(nameof(ECDsa));
-
                 ECParameters parameters = ECDsa.ExportParameters(false);
                 var canonicalJwk = $@"{{""{JsonWebKeyParameterNames.Crv}"":""{ECDsaAdapter.Instance.GetCrvParameterValue(parameters.Curve)}"",""{JsonWebKeyParameterNames.Kty}"":""{JsonWebAlgorithmsKeyTypes.EllipticCurve}"",""{JsonWebKeyParameterNames.X}"":""{Base64UrlEncoder.Encode(parameters.Q.X)}"",""{JsonWebKeyParameterNames.Y}"":""{Base64UrlEncoder.Encode(parameters.Q.Y)}""}}";
                 return Utility.GenerateSha256Hash(canonicalJwk);

--- a/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
+++ b/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
@@ -97,10 +97,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns><c>True</c> if <paramref name="signatureProvider"/> should be cached, <c>false</c> otherwise.</returns>
         private bool ShouldCacheSignatureProvider(SignatureProvider signatureProvider)
         {
-            if (signatureProvider.Key.InternalId.Length == 0)
-                return false;
-            else
-                return true;
+            return signatureProvider.Key.InternalId.Length != 0;
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
+++ b/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
@@ -90,14 +90,14 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
-        /// For some security key types, in some runtimes, it's not possible to extract public key material and create <see cref="SecurityKey.InternalId"/>.
+        /// For some security key types, in some runtimes, it's not possible to extract public key material and create an <see cref="SecurityKey.InternalId"/>.
         /// In these cases, <see cref="SecurityKey.InternalId"/> will be an empty string, and these keys should not be cached.
         /// </summary>
         /// <param name="signatureProvider"><see cref="SignatureProvider"/> to be examined.</param>
         /// <returns><c>True</c> if <paramref name="signatureProvider"/> should be cached, <c>false</c> otherwise.</returns>
         private bool ShouldCacheSignatureProvider(SignatureProvider signatureProvider)
         {
-            if (string.IsNullOrEmpty(signatureProvider?.Key?.InternalId))
+            if (signatureProvider.Key.InternalId.Length == 0)
                 return false;
             else
                 return true;

--- a/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
+++ b/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
@@ -84,9 +84,23 @@ namespace Microsoft.IdentityModel.Tokens
             return string.Format(CultureInfo.InvariantCulture,
                                  "{0}-{1}-{2}-{3}",
                                  securityKey.GetType(),
-                                 string.IsNullOrEmpty(securityKey.KeyId) ? securityKey.InternalId : securityKey.KeyId,
+                                 securityKey.InternalId,
                                  algorithm,
                                  typeofProvider);
+        }
+
+        /// <summary>
+        /// For some security key types, in some runtimes, it's not possible to extract public key material and create <see cref="SecurityKey.InternalId"/>.
+        /// In these cases, <see cref="SecurityKey.InternalId"/> will be an empty string, and these keys should not be cached.
+        /// </summary>
+        /// <param name="signatureProvider"><see cref="SignatureProvider"/> to be examined.</param>
+        /// <returns><c>True</c> if <paramref name="signatureProvider"/> should be cached, <c>false</c> otherwise.</returns>
+        private bool ShouldCacheSignatureProvider(SignatureProvider signatureProvider)
+        {
+            if (string.IsNullOrEmpty(signatureProvider?.Key?.InternalId))
+                return false;
+            else
+                return true;
         }
 
         /// <summary>
@@ -94,12 +108,17 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         /// <param name="signatureProvider"><see cref="SignatureProvider"/> to cache.</param>
         /// <exception cref="ArgumentNullException">if signatureProvider is null.</exception>
-        /// <returns>true if the <see cref="SignatureProvider"/> was added, false if the cache already contained the <see cref="SignatureProvider"/></returns>
+        /// <returns>
+        /// <c>true</c> if the <see cref="SignatureProvider"/> was added, <c>false</c> if the cache already contained the <see cref="SignatureProvider"/> or if <see cref="SignatureProvider"/> should not be cached.
+        /// </returns>
         /// <remarks>if the <see cref="SignatureProvider"/> is added <see cref="SignatureProvider.CryptoProviderCache"/> will be set to 'this'.</remarks>
         public override bool TryAdd(SignatureProvider signatureProvider)
         {
             if (signatureProvider == null)
                 throw LogHelper.LogArgumentNullException(nameof(signatureProvider));
+
+            if (!ShouldCacheSignatureProvider(signatureProvider))
+                return false;
 
             var cacheKey = GetCacheKey(signatureProvider);
             if (signatureProvider.WillCreateSignatures)

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
@@ -374,10 +374,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         private bool CanComputeOctThumbprint()
         {
-            if (string.IsNullOrEmpty(K))
-                return false;
-            else
-                return true;
+            return !string.IsNullOrEmpty(K);
         }
 
         private byte[] ComputeOctThumbprint()
@@ -391,10 +388,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         private bool CanComputeRsaThumbprint()
         {
-            if (string.IsNullOrEmpty(E) || string.IsNullOrEmpty(N))
-                return false;
-            else
-                return true;
+            return !(string.IsNullOrEmpty(E) || string.IsNullOrEmpty(N));
         }
 
         private byte[] ComputeRsaThumbprint()
@@ -411,10 +405,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         private bool CanComputeECThumbprint()
         {
-            if (string.IsNullOrEmpty(Crv) || string.IsNullOrEmpty(X) || string.IsNullOrEmpty(Y))
-                return false;
-            else
-                return true;
+            return !(string.IsNullOrEmpty(Crv) || string.IsNullOrEmpty(X) || string.IsNullOrEmpty(Y));
         }
 
         private byte[] ComputeECThumbprint()

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
@@ -333,6 +333,26 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
+        /// Determines whether the <see cref="JsonWebKey"/> can compute a JWK thumbprint.
+        /// </summary>
+        /// <returns><c>true</c> if JWK thumbprint can be computed; otherwise, <c>false</c>.</returns>
+        /// <remarks>https://tools.ietf.org/html/rfc7638</remarks>
+        public override bool CanComputeJwkThumbprint()
+        {
+            if (string.IsNullOrEmpty(Kty))
+                return false;
+
+            if (string.Equals(Kty, JsonWebAlgorithmsKeyTypes.EllipticCurve, StringComparison.Ordinal))
+                return CanComputeECThumbprint();
+            else if (string.Equals(Kty, JsonWebAlgorithmsKeyTypes.RSA, StringComparison.Ordinal))
+                return CanComputeRsaThumbprint();
+            else if (string.Equals(Kty, JsonWebAlgorithmsKeyTypes.Octet, StringComparison.Ordinal))
+                return CanComputeOctThumbprint();
+            else
+                return false;
+        }
+
+        /// <summary>
         /// Computes a sha256 hash over the <see cref="JsonWebKey"/>.
         /// </summary>
         /// <returns>A JWK thumbprint.</returns>
@@ -352,6 +372,14 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10706, nameof(Kty), string.Join(", ", JsonWebAlgorithmsKeyTypes.EllipticCurve, JsonWebAlgorithmsKeyTypes.RSA, JsonWebAlgorithmsKeyTypes.Octet), nameof(Kty))));
         }
 
+        private bool CanComputeOctThumbprint()
+        {
+            if (string.IsNullOrEmpty(K))
+                return false;
+            else
+                return true;
+        }
+
         private byte[] ComputeOctThumbprint()
         {
             if (string.IsNullOrEmpty(K))
@@ -359,6 +387,14 @@ namespace Microsoft.IdentityModel.Tokens
 
             var canonicalJwk = $@"{{""{JsonWebKeyParameterNames.K}"":""{K}"",""{JsonWebKeyParameterNames.Kty}"":""{Kty}""}}";
             return Utility.GenerateSha256Hash(canonicalJwk);
+        }
+
+        private bool CanComputeRsaThumbprint()
+        {
+            if (string.IsNullOrEmpty(E) || string.IsNullOrEmpty(N))
+                return false;
+            else
+                return true;
         }
 
         private byte[] ComputeRsaThumbprint()
@@ -371,6 +407,14 @@ namespace Microsoft.IdentityModel.Tokens
 
             var canonicalJwk = $@"{{""{JsonWebKeyParameterNames.E}"":""{E}"",""{JsonWebKeyParameterNames.Kty}"":""{Kty}"",""{JsonWebKeyParameterNames.N}"":""{N}""}}";
             return Utility.GenerateSha256Hash(canonicalJwk);
+        }
+
+        private bool CanComputeECThumbprint()
+        {
+            if (string.IsNullOrEmpty(Crv) || string.IsNullOrEmpty(X) || string.IsNullOrEmpty(Y))
+                return false;
+            else
+                return true;
         }
 
         private byte[] ComputeECThumbprint()

--- a/src/Microsoft.IdentityModel.Tokens/RsaSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaSecurityKey.cs
@@ -193,10 +193,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <remarks>https://tools.ietf.org/html/rfc7638</remarks>
         public override bool CanComputeJwkThumbprint()
         {
-            if (Rsa != null || (Parameters.Exponent != null && Parameters.Modulus != null))
-                return true;
-            else
-                return false;
+            return (Rsa != null || (Parameters.Exponent != null && Parameters.Modulus != null));
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/RsaSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaSecurityKey.cs
@@ -187,21 +187,31 @@ namespace Microsoft.IdentityModel.Tokens
         public RSA Rsa { get; private set; }
 
         /// <summary>
+        /// Determines whether the <see cref="RsaSecurityKey"/> can compute a JWK thumbprint.
+        /// </summary>
+        /// <returns><c>true</c> if JWK thumbprint can be computed; otherwise, <c>false</c>.</returns>
+        /// <remarks>https://tools.ietf.org/html/rfc7638</remarks>
+        public override bool CanComputeJwkThumbprint()
+        {
+            if (Rsa != null || (Parameters.Exponent != null && Parameters.Modulus != null))
+                return true;
+            else
+                return false;
+        }
+
+        /// <summary>
         /// Computes a sha256 hash over the <see cref="RsaSecurityKey"/>.
         /// </summary>
         /// <returns>A JWK thumbprint.</returns>
         /// <remarks>https://tools.ietf.org/html/rfc7638</remarks>
         public override byte[] ComputeJwkThumbprint()
         {
-            if (Parameters.Exponent == null)
-            {
-                if (Rsa == null)
-                    throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10705, nameof(Rsa)), nameof(Rsa)));
+            var rsaParameters = Parameters;
 
-                Parameters = Rsa.ExportParameters(false);
-            }
+            if (rsaParameters.Exponent == null || rsaParameters.Modulus == null)
+                rsaParameters = Rsa.ExportParameters(false);
 
-            var canonicalJwk = $@"{{""{JsonWebKeyParameterNames.E}"":""{Base64UrlEncoder.Encode(Parameters.Exponent)}"",""{JsonWebKeyParameterNames.Kty}"":""{JsonWebAlgorithmsKeyTypes.RSA}"",""{JsonWebKeyParameterNames.N}"":""{Base64UrlEncoder.Encode(Parameters.Modulus)}""}}";
+            var canonicalJwk = $@"{{""{JsonWebKeyParameterNames.E}"":""{Base64UrlEncoder.Encode(rsaParameters.Exponent)}"",""{JsonWebKeyParameterNames.Kty}"":""{JsonWebAlgorithmsKeyTypes.RSA}"",""{JsonWebKeyParameterNames.N}"":""{Base64UrlEncoder.Encode(rsaParameters.Modulus)}""}}";
             return Utility.GenerateSha256Hash(canonicalJwk);
         }
     }

--- a/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
@@ -37,11 +37,23 @@ namespace Microsoft.IdentityModel.Tokens
     public abstract class SecurityKey
     {
         private CryptoProviderFactory _cryptoProviderFactory;
+        private readonly Lazy<string> _internalId;
 
         internal SecurityKey(SecurityKey key)
         {
             _cryptoProviderFactory = key._cryptoProviderFactory;
             KeyId = key.KeyId;
+            _internalId = new Lazy<string>(() =>
+            {
+                try
+                {
+                    return Base64UrlEncoder.Encode(ComputeJwkThumbprint());
+                }
+                catch
+                {
+                    return string.Empty;
+                }
+            });
         }
 
         /// <summary>
@@ -50,10 +62,21 @@ namespace Microsoft.IdentityModel.Tokens
         public SecurityKey()
         {
             _cryptoProviderFactory = CryptoProviderFactory.Default;
+            _internalId = new Lazy<string>(() =>
+            {
+                try
+                {
+                    return Base64UrlEncoder.Encode(ComputeJwkThumbprint());
+                }
+                catch
+                {
+                    return string.Empty;
+                }
+            });
         }
 
         [JsonIgnore]
-        internal string InternalId { get; } = Guid.NewGuid().ToString();
+        internal virtual string InternalId { get => _internalId.Value; }
 
         /// <summary>
         /// This must be overridden to get the size of this <see cref="SecurityKey"/>.

--- a/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
@@ -37,23 +37,13 @@ namespace Microsoft.IdentityModel.Tokens
     public abstract class SecurityKey
     {
         private CryptoProviderFactory _cryptoProviderFactory;
-        private readonly Lazy<string> _internalId;
+        private Lazy<string> _internalId;
 
         internal SecurityKey(SecurityKey key)
         {
             _cryptoProviderFactory = key._cryptoProviderFactory;
             KeyId = key.KeyId;
-            _internalId = new Lazy<string>(() =>
-            {
-                try
-                {
-                    return Base64UrlEncoder.Encode(ComputeJwkThumbprint());
-                }
-                catch
-                {
-                    return string.Empty;
-                }
-            });
+            SetInternalId();
         }
 
         /// <summary>
@@ -62,17 +52,7 @@ namespace Microsoft.IdentityModel.Tokens
         public SecurityKey()
         {
             _cryptoProviderFactory = CryptoProviderFactory.Default;
-            _internalId = new Lazy<string>(() =>
-            {
-                try
-                {
-                    return Base64UrlEncoder.Encode(ComputeJwkThumbprint());
-                }
-                catch
-                {
-                    return string.Empty;
-                }
-            });
+            SetInternalId();
         }
 
         [JsonIgnore]
@@ -115,6 +95,16 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
+        /// Determines whether the <see cref="SecurityKey"/> can compute a JWK thumbprint.
+        /// </summary>
+        /// <returns><c>true</c> if JWK thumbprint can be computed; otherwise, <c>false</c>.</returns>
+        /// <remarks>https://tools.ietf.org/html/rfc7638</remarks>
+        public virtual bool CanComputeJwkThumbprint()
+        {
+            return false;
+        }
+
+        /// <summary>
         /// Computes a sha256 hash over the <see cref="SecurityKey"/>.
         /// </summary>
         /// <returns>A JWK thumbprint.</returns>
@@ -122,6 +112,20 @@ namespace Microsoft.IdentityModel.Tokens
         public virtual byte[] ComputeJwkThumbprint()
         {
             throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10710)));
+        }
+
+        /// <summary>
+        /// Sets the <see cref="InternalId"/> to value of <see cref="SecurityKey"/>'s JWK thumbprint if it can be computed, otherwise sets the <see cref="InternalId"/> to <see cref="string.Empty"/>.
+        /// </summary>
+        private void SetInternalId()
+        {
+            _internalId = new Lazy<string>(() =>
+            {
+                if (CanComputeJwkThumbprint())
+                    return Base64UrlEncoder.Encode(ComputeJwkThumbprint());
+                else
+                    return string.Empty;
+            });
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/SymmetricSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SymmetricSecurityKey.cs
@@ -82,15 +82,22 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
+        /// Determines whether the <see cref="SymmetricSecurityKey"/> can compute a JWK thumbprint.
+        /// </summary>
+        /// <returns><c>true</c> if JWK thumbprint can be computed; otherwise, <c>false</c>.</returns>
+        /// <remarks>https://tools.ietf.org/html/rfc7638</remarks>
+        public override bool CanComputeJwkThumbprint()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Computes a sha256 hash over the <see cref="SymmetricSecurityKey"/>.
         /// </summary>
         /// <returns>A JWK thumbprint.</returns>
         /// <remarks>https://tools.ietf.org/html/rfc7638</remarks>
         public override byte[] ComputeJwkThumbprint()
         {
-            if (Key == null)
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10705, nameof(Key)), nameof(Key)));
-
             var canonicalJwk = $@"{{""{JsonWebKeyParameterNames.K}"":""{Base64UrlEncoder.Encode(Key)}"",""{JsonWebKeyParameterNames.Kty}"":""{JsonWebAlgorithmsKeyTypes.Octet}""}}";
             return Utility.GenerateSha256Hash(canonicalJwk);
         }

--- a/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
@@ -179,6 +179,17 @@ namespace Microsoft.IdentityModel.Tokens
 
         internal override string InternalId => X5t;
 
+
+        /// <summary>
+        /// Determines whether the <see cref="X509SecurityKey"/> can compute a JWK thumbprint.
+        /// </summary>
+        /// <returns><c>true</c> if JWK thumbprint can be computed; otherwise, <c>false</c>.</returns>
+        /// <remarks>https://tools.ietf.org/html/rfc7638</remarks>
+        public override bool CanComputeJwkThumbprint()
+        {
+            return (PublicKey as RSA) != null ? true : false;
+        }
+
         /// <summary>
         /// Computes a sha256 hash over the <see cref="X509SecurityKey"/>.
         /// </summary>

--- a/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
@@ -177,6 +177,8 @@ namespace Microsoft.IdentityModel.Tokens
             get; private set;
         }
 
+        internal override string InternalId => X5t;
+
         /// <summary>
         /// Computes a sha256 hash over the <see cref="X509SecurityKey"/>.
         /// </summary>

--- a/test/Microsoft.IdentityModel.TestUtils/DerivedTypes.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/DerivedTypes.cs
@@ -329,19 +329,18 @@ namespace Microsoft.IdentityModel.TestUtils
             _agorithm = algorithm;
             _keyBytes = keyBytes;
         }
+        public override byte[] Key => _keyBytes;
 
-        public override byte[] Key
+        public override int KeySize
         {
             get
             {
                 if (_throwOnKeyProperty != null)
                     throw _throwOnKeyProperty;
 
-                return _keyBytes;
+                return _key.KeySize;
             }
         }
-
-        public override int KeySize { get { return _key.KeySize; } }
     }
 
     public class NotAsymmetricOrSymmetricSecurityKey : SecurityKey

--- a/test/Microsoft.IdentityModel.TestUtils/DerivedTypes.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/DerivedTypes.cs
@@ -255,6 +255,8 @@ namespace Microsoft.IdentityModel.TestUtils
             _keySize = keySize;
         }
 
+        internal override string InternalId { get =>_keyId; }
+
         public Exception ThrowOnGetKeyId { get; set; }
 
         public Exception ThrowOnSetKeyId { get; set; }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderCacheTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderCacheTests.cs
@@ -233,7 +233,63 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         CryptoProviderCache = sharedCache,
                         SignatureProvider = new AsymmetricSignatureProvider(Default.AsymmetricSigningKey, Default.AsymmetricSigningAlgorithm),
                         TestId = "AsymmetricSignatureProviderAddedSecondTime"
-                    }
+                    },
+                    new CryptoProviderCacheTheoryData
+                    {
+                        Added = true,
+                        CryptoProviderCache = sharedCache,
+                        SignatureProvider = new AsymmetricSignatureProvider(KeyingMaterial.RsaSecurityKey1, ALG.RsaSha256, false),
+                        TestId = nameof(KeyingMaterial.RsaSecurityKey_2048)
+                    },
+                    // test signing signature provider
+                    new CryptoProviderCacheTheoryData
+                    {
+                        Added = true,
+                        CryptoProviderCache = sharedCache,
+                        SignatureProvider = new AsymmetricSignatureProvider(KeyingMaterial.RsaSecurityKey_2048, ALG.RsaSha256, true),
+                        TestId = nameof(KeyingMaterial.RsaSecurityKey_2048)
+                    },
+                    new CryptoProviderCacheTheoryData
+                    {
+                        Added = true,
+                        CryptoProviderCache = sharedCache,
+                        SignatureProvider = new AsymmetricSignatureProvider(KeyingMaterial.DefaultX509Key_2048_Public, ALG.RsaSha256, false),
+                        TestId = nameof(KeyingMaterial.DefaultX509Key_2048_Public)
+                    },
+                    new CryptoProviderCacheTheoryData
+                    {
+                        Added = true,
+                        CryptoProviderCache = sharedCache,
+                        SignatureProvider = new AsymmetricSignatureProvider(KeyingMaterial.JsonWebKeyRsa_2048_Public, ALG.RsaSha256, false),
+                        TestId = nameof(KeyingMaterial.JsonWebKeyRsa_2048_Public)
+                    },
+                    // test symmetric signature provider
+                    new CryptoProviderCacheTheoryData
+                    {
+                        Added = true,
+                        CryptoProviderCache = sharedCache,
+                        SignatureProvider = new SymmetricSignatureProvider(KeyingMaterial.DefaultSymmetricSecurityKey_384, ALG.HmacSha384, true),
+                        TestId = nameof(KeyingMaterial.DefaultSymmetricSecurityKey_256)
+                    },
+#if NET_CORE
+                    // ecdsa signature provider should be added to the cache on core
+                    new CryptoProviderCacheTheoryData
+                    {
+                        Added = true,
+                        CryptoProviderCache = sharedCache,
+                        SignatureProvider = new AsymmetricSignatureProvider(KeyingMaterial.Ecdsa256Key_Public, ALG.EcdsaSha256, false),
+                        TestId = nameof(KeyingMaterial.Ecdsa256Key_Public)
+                    },
+#else
+                    // ecdsa signature provider should NOT be added to the cache on desktop
+                    new CryptoProviderCacheTheoryData
+                    {
+                        Added = false,
+                        CryptoProviderCache = sharedCache,
+                        SignatureProvider = new AsymmetricSignatureProvider(KeyingMaterial.Ecdsa256Key_Public, ALG.EcdsaSha256, false),
+                        TestId = nameof(KeyingMaterial.Ecdsa256Key_Public)
+                    },
+#endif
                 };
 
                 return theoryData;

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ECDsaSecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ECDsaSecurityKeyTests.cs
@@ -94,6 +94,16 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
             }
         }
+
+        [Fact]
+        public void CanComputeJwkThumbprint()
+        {
+#if NET_CORE
+            Assert.True(KeyingMaterial.Ecdsa256Key.CanComputeJwkThumbprint(), "Couldn't compute JWK thumbprint on an ECDsaSecurityKey on .NET Core.");
+#else
+            Assert.False(KeyingMaterial.Ecdsa256Key.CanComputeJwkThumbprint(), "ECDsaSecurityKey shouldn't be able to compute JWK thumbprint on Deskop (non-netstandard2.0 target).");
+#endif
+        }
     }
 }
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyTests.cs
@@ -257,6 +257,16 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
+        [Theory, MemberData(nameof(ComputeJwkThumbprintTheoryData))]
+        public void CanComputeJwkThumbprint(JwkThumbprintTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.CanComputeJwkThumbprint", theoryData);
+            if (theoryData.CanComputeJwkThumbprint != theoryData.JWK.CanComputeJwkThumbprint())
+                context.AddDiff($"theoryData.CanComputeJwkThumbprint ({theoryData.CanComputeJwkThumbprint}) != theoryData.JWK.CanComputeJwkThumbprint ({theoryData.JWK.CanComputeJwkThumbprint()})");
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
         public static TheoryData<JwkThumbprintTheoryData> ComputeJwkThumbprintTheoryData
         {
             get
@@ -267,6 +277,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     {
                         First = true,
                         JWK = new JsonWebKey() { },
+                        CanComputeJwkThumbprint = false,
                         ExpectedException = ExpectedException.ArgumentException("IDX10705: Cannot create a JWK thumbprint, 'Kty' is null or empty."),
                         TestId = "InvalidKtyIsNull",
                     },
@@ -276,6 +287,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         {
                             Kty = string.Empty
                         },
+                        CanComputeJwkThumbprint = false,
                         ExpectedException = ExpectedException.ArgumentException("IDX10705: Cannot create a JWK thumbprint, 'Kty' is null or empty."),
                         TestId = "InvalidKtyIsEmpty",
                     },
@@ -285,6 +297,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         {
                             Kty = "INVALID_DATA"
                         },
+                        CanComputeJwkThumbprint = false,
                         ExpectedException = ExpectedException.ArgumentException("IDX10706: Cannot create a JWK thumbprint, 'Kty'"),
                         TestId = "InvalidKtyNotAsExpected",
                     },
@@ -294,6 +307,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         {
                             Kty = JsonWebAlgorithmsKeyTypes.RSA
                         },
+                        CanComputeJwkThumbprint = false,
                         ExpectedException = ExpectedException.ArgumentException("IDX10705: Cannot create a JWK thumbprint, 'E'"),
                         TestId = "InvalidEIsNullOrEmpty"
                     },
@@ -304,6 +318,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                             Kty = JsonWebAlgorithmsKeyTypes.RSA,
                             E = "AQAB"
                         },
+                        CanComputeJwkThumbprint = false,
                         ExpectedException = ExpectedException.ArgumentException("IDX10705: Cannot create a JWK thumbprint, 'N'"),
                         TestId = "InvalidNIsNullOrEmpty"
                     },
@@ -313,6 +328,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         {
                             Kty = JsonWebAlgorithmsKeyTypes.Octet
                         },
+                        CanComputeJwkThumbprint = false,
                         ExpectedException = ExpectedException.ArgumentException("IDX10705: Cannot create a JWK thumbprint, 'K'"),
                         TestId = "InvalidKIsNullOrEmpty"
                     },
@@ -322,6 +338,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         {
                             Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve
                         },
+                        CanComputeJwkThumbprint = false,
                         ExpectedException = ExpectedException.ArgumentException("IDX10705: Cannot create a JWK thumbprint, 'Crv'"),
                         TestId = "InvalidCrvIsNullOrEmpty"
                     },
@@ -332,6 +349,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                             Kty = JsonWebAlgorithmsKeyTypes.EllipticCurve,
                             Crv = "P-256"
                         },
+                        CanComputeJwkThumbprint = false,
                         ExpectedException = ExpectedException.ArgumentException("IDX10705: Cannot create a JWK thumbprint, 'X'"),
                         TestId = "InvalidCrvIsNullOrEmpty"
                     },
@@ -343,6 +361,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                             Crv = "P-256",
                             X = "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
                         },
+                        CanComputeJwkThumbprint = false,
                         ExpectedException = ExpectedException.ArgumentException("IDX10705: Cannot create a JWK thumbprint, 'Y'"),
                         TestId = "InvalidCrvIsNullOrEmpty"
                     },
@@ -354,6 +373,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                             E = "AQAB",
                             N = "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
                         },
+                        CanComputeJwkThumbprint = true,
                         ExpectedBase64UrlEncodedJwkThumbprint = "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",
                         TestId = "ValidRsa"
                     },
@@ -366,6 +386,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                             X = "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
                             Y = "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
                         },
+                        CanComputeJwkThumbprint = true,
                         ExpectedBase64UrlEncodedJwkThumbprint = "oKIywvGUpTVTyxMQ3bwIIeQUudfr_CkLMjCE19ECD-U",
                         TestId = "ValidEc"
                     },
@@ -376,6 +397,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                             Kty = JsonWebAlgorithmsKeyTypes.Octet,
                             K = "Vbxq2mlbGJw8XH+ZoYBnUHmHga8/o/IduvU/Tht70iE=" // KeyingMaterial.DefaultSymmetricKeyEncoded_256
                         },
+                        CanComputeJwkThumbprint = true,
                         ExpectedBase64UrlEncodedJwkThumbprint = "uQcNOQPV2rRRS-R_VQnj7gRR_19AaHlGbU0f9F5hkUs",
                         TestId = "ValidOctet"
                     },
@@ -388,6 +410,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             public JsonWebKey JWK { get; set; }
 
             public string ExpectedBase64UrlEncodedJwkThumbprint { get; set; }
+
+            public bool CanComputeJwkThumbprint { get; set; }
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaSecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaSecurityKeyTests.cs
@@ -189,6 +189,12 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 return dataset;
             }
         }
+
+        [Fact]
+        public void CanComputeJwkThumbprint()
+        {
+            Assert.True(KeyingMaterial.DefaultRsaSecurityKey1.CanComputeJwkThumbprint(), "Couldn't compute JWK thumbprint on an RSASecurityKey.");
+        }
     }
 }
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
@@ -134,5 +134,114 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 return theoryData;
             }
         }
+
+        [Theory, MemberData(nameof(CreateInternalIdsTheoryData))]
+        public void CreateInternalIds(SecurityKeyTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.CreateInternalIds", theoryData);
+            try
+            {
+                if (theoryData.ExpectedInternalId != theoryData.SecurityKey.InternalId)
+                    context.AddDiff($"ExpectedInternalId: '{theoryData.ExpectedInternalId}'; actual InternalId: '{theoryData.SecurityKey.InternalId}'");
+
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<SecurityKeyTheoryData> CreateInternalIdsTheoryData
+        {
+            get
+            {
+                return new TheoryData<SecurityKeyTheoryData>
+                {
+                    new SecurityKeyTheoryData
+                    {
+                        First = true,
+                        SecurityKey = KeyingMaterial.RsaSecurityKey_2048,
+                        ExpectedInternalId = Base64UrlEncoder.Encode(KeyingMaterial.RsaSecurityKey_2048.ComputeJwkThumbprint()),
+                        TestId = nameof(KeyingMaterial.RsaSecurityKey_2048)
+                    },
+                    new SecurityKeyTheoryData
+                    {
+                        SecurityKey = KeyingMaterial.RsaSecurityKey_2048_Public,
+                        ExpectedInternalId = Base64UrlEncoder.Encode(KeyingMaterial.RsaSecurityKey_2048_Public.ComputeJwkThumbprint()),
+                        TestId = nameof(KeyingMaterial.RsaSecurityKey_2048_Public)
+                    },
+                    new SecurityKeyTheoryData
+                    {
+                        SecurityKey = KeyingMaterial.DefaultSymmetricSecurityKey_64,
+                        ExpectedInternalId = Base64UrlEncoder.Encode(KeyingMaterial.DefaultSymmetricSecurityKey_64.ComputeJwkThumbprint()),
+                        TestId = nameof(KeyingMaterial.DefaultSymmetricSecurityKey_64)
+                    },
+                     // X509SecurityKey should have InternalId set to its x5t.
+                    new SecurityKeyTheoryData
+                    {
+                        SecurityKey = KeyingMaterial.DefaultX509Key_2048,
+                        ExpectedInternalId = KeyingMaterial.DefaultX509Key_2048.X5t,
+                        TestId = nameof(KeyingMaterial.DefaultX509Key_2048)
+                    },
+                    // custom derived SecurityKey should have InternalId set to an empty string.
+                    new SecurityKeyTheoryData
+                    {
+                        SecurityKey = new CustomSecurityKey(),
+                        ExpectedInternalId = string.Empty,
+                        TestId = nameof(CustomSecurityKey)
+                    },
+                    new SecurityKeyTheoryData
+                    {
+                        SecurityKey = KeyingMaterial.JsonWebKeyRsa_2048_Public,
+                        ExpectedInternalId = Base64UrlEncoder.Encode(KeyingMaterial.JsonWebKeyRsa_2048_Public.ComputeJwkThumbprint()),
+                        TestId = nameof(KeyingMaterial.JsonWebKeyRsa_2048_Public)
+                    },
+#if NET_CORE
+                    // EcdsaSecurityKey should have InternalId set to its jwk thumbprint on core.
+                    new SecurityKeyTheoryData
+                    {
+                        SecurityKey = KeyingMaterial.Ecdsa256Key_Public,
+                        ExpectedInternalId = Base64UrlEncoder.Encode(KeyingMaterial.Ecdsa256Key_Public.ComputeJwkThumbprint()),
+                        TestId = nameof(KeyingMaterial.Ecdsa256Key_Public)
+                    },
+                    new SecurityKeyTheoryData
+                    {
+                        SecurityKey = KeyingMaterial.Ecdsa256Key,
+                        ExpectedInternalId = Base64UrlEncoder.Encode(KeyingMaterial.Ecdsa256Key.ComputeJwkThumbprint()),
+                        TestId = nameof(KeyingMaterial.Ecdsa256Key)
+                    },
+#else
+                    // EcdsaSecurityKey should have InternalId set to an empty string on desktop.
+                    new SecurityKeyTheoryData
+                    {
+                        SecurityKey = KeyingMaterial.Ecdsa256Key_Public,
+                        ExpectedInternalId = string.Empty,
+                        TestId = nameof(KeyingMaterial.Ecdsa256Key_Public) + "_emptyInternalId"
+                    },
+                    new SecurityKeyTheoryData
+                    {
+                        SecurityKey = KeyingMaterial.Ecdsa256Key,
+                        ExpectedInternalId = string.Empty,
+                        TestId = nameof(KeyingMaterial.Ecdsa256Key) + "_emptyInternalId"
+                    },
+#endif
+                };
+            }
+        }
+
+        public class SecurityKeyTheoryData : TheoryDataBase
+        {
+            public SecurityKey SecurityKey { get; set; }
+
+            public string ExpectedInternalId { get; set; }
+        }
+
+        class CustomSecurityKey : SecurityKey
+        {
+            public override int KeySize => 1;
+        }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
@@ -154,6 +154,13 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
+        [Fact]
+        public void CanComputeJwkThumbprint()
+        {
+            Assert.False(new CustomSecurityKey().CanComputeJwkThumbprint(), "CustomSecurityKey shouldn't be able to compute JWK thumbprint if CanComputeJwkThumbprint() is not overriden.");
+        }
+
+
         public static TheoryData<SecurityKeyTheoryData> CreateInternalIdsTheoryData
         {
             get

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -292,13 +292,14 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                                                 ALG.HmacSha256Signature,
                                                 new FaultingSymmetricSecurityKey(Default.SymmetricSigningKey256, new CryptographicException("Inner CryptographicException"), null, null, Default.SymmetricSigningKey256.Key),
                                                 KEY.SymmetricSecurityKey2_256,
-                                                EE.InvalidOperationException("IDX10677:", typeof(CryptographicException))),
+                                                EE.CryptographicException("Inner CryptographicException")),
+
                 new SignatureProviderTheoryData("SymmetricSecurityKey13",
                                                 ALG.HmacSha256Signature,
                                                 ALG.HmacSha256Signature,
                                                 KEY.SymmetricSecurityKey2_256,
                                                 new FaultingSymmetricSecurityKey(Default.SymmetricSigningKey256, new CryptographicException("Inner CryptographicException"), null, null, Default.SymmetricSigningKey256.Key),
-                                                EE.InvalidOperationException("IDX10677:", typeof(CryptographicException))),
+                                                EE.CryptographicException("Inner CryptographicException")),
 
                 new SignatureProviderTheoryData("UnknownKeyType1", ALG.HmacSha256Signature, ALG.HmacSha256Signature, NotAsymmetricOrSymmetricSecurityKey.New, KEY.SymmetricSecurityKey2_256, EE.NotSupportedException("IDX10621:")),
                 new SignatureProviderTheoryData("UnknownKeyType2", ALG.HmacSha256Signature, ALG.HmacSha256Signature, KEY.SymmetricSecurityKey2_256, NotAsymmetricOrSymmetricSecurityKey.New, EE.NotSupportedException("IDX10621:")),

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SymmetricSecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SymmetricSecurityKeyTests.cs
@@ -88,6 +88,12 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 return dataset;
             }
         }
+
+        [Fact]
+        public void CanComputeJwkThumbprint()
+        {
+            Assert.True(KEY.DefaultSymmetricSecurityKey_256.CanComputeJwkThumbprint(), "Couldn't compute JWK thumbprint on a SymmetricSecurityKey.");
+        }
     }
 }
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/X509SecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/X509SecurityKeyTests.cs
@@ -141,6 +141,13 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     "CustomProvider:" + SecurityAlgorithms.RsaSsaPssSha256Signature),
             };
         }
+
+        [Fact]
+        public void CanComputeJwkThumbprint()
+        {
+            Assert.True(KeyingMaterial.DefaultX509Key_2048.CanComputeJwkThumbprint(), "Couldn't compute JWK thumbprint on an X509SecurityKey.");
+        }
+
     }
 
     public class X509SecurityKeyTheoryData : TheoryDataBase


### PR DESCRIPTION
Cache key in InMemoryCryptoProviderCache is now based on SecurityKey's InternalId.
A SecurityKey with empty InternalId will not be cached.

InternalId is now lazy-initialized, so that there is no extra cost when caching is disabled.

Rules for creating InternalId for different key types:
* X509SecurityKey: x5t.
* RsaSecurityKey, SymmetricSecurityKey, JsonWebSecurityKey: base64url
encoded jwk thumbprint.
* EcdsaSecurityKey: base64url encoded jwk thumbprint in runtimes where
it's possible to compute it, otherwise empty string.
* Custom derived keys: base64url encoded jwk thumbprint (if
implemented), otherwise empty string.

fixes: #1219 