### PR TITLE
Fixes for issues:

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -45,15 +45,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
     /// </summary>
     public class JsonWebTokenHandler : TokenHandler
     {
-        private List<string> _defaultHeaderParameters = new List<string>()
-        {
-            JwtHeaderParameterNames.Alg,
-            JwtHeaderParameterNames.Kid,
-            JwtHeaderParameterNames.X5t,
-            JwtHeaderParameterNames.Enc,
-            JwtHeaderParameterNames.Zip
-        };
-
         /// <summary>
         /// Gets the Base64Url encoded string representation of the following JWT header: 
         /// { <see cref="JwtHeaderParameterNames.Alg"/>, <see cref="SecurityAlgorithms.None"/> }.
@@ -138,9 +129,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         private JObject CreateDefaultJWSHeader(SigningCredentials signingCredentials)
         {
             var header = new JObject()
-                {
-                    { JwtHeaderParameterNames.Alg, signingCredentials.Algorithm }
-                };
+            {
+                { JwtHeaderParameterNames.Alg, signingCredentials.Algorithm }
+            };
 
             if (signingCredentials.Key.KeyId != null)
                 header.Add(JwtHeaderParameterNames.Kid, signingCredentials.Key.KeyId);
@@ -462,9 +453,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
         private string CreateTokenPrivate(JObject payload, SigningCredentials signingCredentials, EncryptingCredentials encryptingCredentials, string compressionAlgorithm, IDictionary<string, object> additionalHeaderClaims)
         {
-
-            if (additionalHeaderClaims != null && additionalHeaderClaims.Count > 0 && additionalHeaderClaims.Keys.Intersect(_defaultHeaderParameters, StringComparer.OrdinalIgnoreCase).Any())
-                throw LogHelper.LogExceptionMessage(new SecurityTokenException(LogHelper.FormatInvariant(LogMessages.IDX14116, nameof(additionalHeaderClaims), string.Join(", ", _defaultHeaderParameters))));
+            if (additionalHeaderClaims != null && additionalHeaderClaims.Count > 0 && additionalHeaderClaims.Keys.Intersect(JwtTokenUtilities.DefaultHeaderParameters, StringComparer.OrdinalIgnoreCase).Any())
+                throw LogHelper.LogExceptionMessage(new SecurityTokenException(LogHelper.FormatInvariant(LogMessages.IDX14116, nameof(additionalHeaderClaims), string.Join(", ", JwtTokenUtilities.DefaultHeaderParameters))));
 
             var rawHeader = Base64UrlEncodedUnsignedJWSHeader;
             // If there's no additional header claims to be added to the header and the token will be signed, try to retrieve a header value from the cache.
@@ -1343,7 +1333,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
             var signatureProvider = cryptoProviderFactory.CreateForVerifying(key, algorithm);
             if (signatureProvider == null)
-                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(TokenLogMessages.IDX10647, (key == null ? "Null" : key.ToString()), (algorithm == null ? "Null" : algorithm))));
+                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(TokenLogMessages.IDX10636, key == null ? "Null" : key.ToString(), algorithm ?? "Null")));
 
             try
             {

--- a/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
@@ -58,7 +58,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
         // logging
         internal const string IDX14200 = "IDX14200: Creating raw signature using the signature credentials.";
-        
+        internal const string IDX14201 = "IDX14201: Creating raw signature using the signature credentials. Caching SignatureProvider: '{0}'.";
+
         // parsing
         internal const string IDX14300 = "IDX14300: Could not parse '{0}' : '{1}' as a '{2}'.";
         internal const string IDX14301 = "IDX14301: Unable to parse the header into a JSON object. \nHeader: '{0}'.";

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -139,6 +139,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10634 = "IDX10634: Unable to create the SignatureProvider.\nAlgorithm: '{0}', SecurityKey: '{1}'\n is not supported. The list of supported algorithms is available here: https://aka.ms/IdentityModel/supported-algorithms";
         // public const string IDX10635 = "IDX10635:";
         public const string IDX10636 = "IDX10636: CryptoProviderFactory.CreateForVerifying returned null for key: '{0}', signatureAlgorithm: '{1}'.";
+        public const string IDX10637 = "IDX10637: CryptoProviderFactory.CreateForSigning returned null for key: '{0}', signatureAlgorithm: '{1}'.";
         public const string IDX10638 = "IDX10638: Cannot create the SignatureProvider, 'key.HasPrivateKey' is false, cannot create signatures. Key: {0}.";
         public const string IDX10640 = "IDX10640: Algorithm is not supported: '{0}'.";
         // public const string IDX10641 = "IDX10641:";

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -824,7 +824,7 @@ namespace System.IdentityModel.Tokens.Jwt
             var cryptoProviderFactory = validationParameters.CryptoProviderFactory ?? key.CryptoProviderFactory;
             var signatureProvider = cryptoProviderFactory.CreateForVerifying(key, algorithm);
             if (signatureProvider == null)
-                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(TokenLogMessages.IDX10647, (key == null ? "Null" : key.ToString()), (algorithm == null ? "Null" : algorithm))));
+                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(TokenLogMessages.IDX10636, key == null ? "Null" : key.ToString(), algorithm ?? "Null")));
 
             try
             {

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestTestUtils.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestTestUtils.cs
@@ -44,15 +44,10 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
 {
     public static class SignedHttpRequestTestUtils
     {
-        // Default access token. Created using AcessTokenPayload (with DefaultCnfJwk) and SignedHttpRequestTestUtils.DefaultSigningCredentials
-        // new JsonWebToken(SignedHttpRequestTestUtils.CreateAt(SignedHttpRequestTestUtils.DefaultCnfJwk, false)); 
-        internal static string DefaultEncodedAccessToken = "eyJhbGciOiJSUzI1NiIsImtpZCI6IlJzYVNlY3VyaXR5S2V5XzIwNDgiLCJ0eXAiOiJwb3AifQ.eyJlbWFpbCI6IkJvYkBjb250b3NvLmNvbSIsImdpdmVuX25hbWUiOiJCb2IiLCJpc3MiOiJodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tIiwiYXVkIjoiaHR0cDovL0RlZmF1bHQuQXVkaWVuY2UuY29tIiwiaWF0IjoiMTQ4OTc3NTYxNyIsIm5iZiI6IjE0ODk3NzU2MTciLCJleHAiOiIxNjE2MDA2MDE3IiwiY25mIjp7Imp3ayI6eyJrdHkiOiJSU0EiLCJuIjoiNi1GckZrdF9UQnlRX0w1ZDdvci05UFZBb3dwc3d4VWUzZEplWUZUWTBMZ3E3ektJNU9RNVJuU3JJMFQ5eXJmblJ6RTlvT2RkNHptVmo5dHhWTEkteXlTdmluQXUzeVFEUW91MkdhNDJNTF8tSzRKcmQ1Y2xNVVBSR01iWGRWNVJsOXp6QjBzMkpvWkplZHVhNWR3b1F3MEdrUzVaOFlBWEJFelVMcnVwMDZmbkI1bjZ4NXIyeTFDXzhFYnA1Y3lFNEJqczdXNjhyVWx5SWx4MWx6WXZha3hTbmhVeFNzang3dV9tSWR5d3lHZmdpVDN0dzBGc1d2a2lfS1l1ckFQUjFCU01YaEN6elpUa01XS0U4SWFMa2hhdXc1TWR4b2p4eUJWdU5ZLUpfZWxxLUhnSl9kWks2Zzd2TU52WHoyX3ZULVN5a0lrendpRDllU0k5VVdmc2p3IiwiZSI6IkFRQUIiLCJhbGciOiJSUzI1NiIsImtpZCI6IlJzYVNlY3VyaXR5S2V5XzIwNDgifX19.aPR__XV6yb6soNrTMDi9VoxQgGZTCuojBGy49S-qvzQyaAYuPtl52htegtjqozQUrIuTBLDq-YUZRa2xPs5Y1dL1SWjGUu0wJadyDQzA6BUGL-67TQB-Mnwi2JIEHXYS1NWu3k09aOWhqQE-ovGgZGz7BjX4yRRAu70C09r0YG3ahaGkWHSfFJLeKG59BOmDuBlUUxe5Q8gJQR09iFY7knTPJLL3LWfM87W3chresTwNZV9eBFCRFAwAUMmPom4jee4TD7FmUuKLmTdKNdkw-Cmgj2Vf7McSK3aZtBgpu3va5O0vfD7_IBKA0SQJL3iBH4UT2Bmr5tzvyP7tix5W1A";
+        internal static string DefaultEncodedAccessToken => CreateAt(DefaultCnfJwk, false);
+        internal static string DefaultEncodedAccessTokenWithCnfThumprint = CreateAt(DefaultCnfJwkThumprint, false);
 
-        // Default access token. Created using AcessTokenPayload (with DefaultCnfJwkThumprint) and SignedHttpRequestTestUtils.DefaultSigningCredentials
-        // new JsonWebToken(SignedHttpRequestTestUtils.CreateAt(SignedHttpRequestTestUtils.DefaultCnfJwkThumprint, false)); 
-        internal static string DefaultEncodedAccessTokenWithCnfThumprint = "eyJhbGciOiJSUzI1NiIsImtpZCI6IlJzYVNlY3VyaXR5S2V5XzIwNDgiLCJ0eXAiOiJwb3AifQ.eyJlbWFpbCI6IkJvYkBjb250b3NvLmNvbSIsImdpdmVuX25hbWUiOiJCb2IiLCJpc3MiOiJodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tIiwiYXVkIjoiaHR0cDovL0RlZmF1bHQuQXVkaWVuY2UuY29tIiwiaWF0IjoiMTQ4OTc3NTYxNyIsIm5iZiI6IjE0ODk3NzU2MTciLCJleHAiOiIxNjE2MDA2MDE3IiwiY25mIjp7ImtpZCI6Il9PM3pCTG4yaXVJV1gwNmdOUnBQNWNEc3psRFAyZlp6YklaN1dMTi1WV00ifX0.nZ0SsD6rIO3agzCT9KKBhgyb9d3tOABu6J-TzaLZ32UmJT53SbjGi_njXgjyWH1BsRPrqGaAUPIXOvRQh446tSgCDmAXhKJqp_yD-7-u6xHCco1bHSF_wXJOLA81ksKi2yXetjRibGRU-9j-lfM0UuEBN2TBRmxKzBqCImMaICCDOlm3egSaKpbowszA3z09cLyKbQiAXzCf7d00FW54eaJQJsNeowVMLi4J9YM9iF3dpoUVaF29BqAYVGrxynvlJ1j2sbtYWvwRn7PRMoS4TEtorLloTu7ihBSe8cV1NaO9H2pGQJaURbf1hu6pbP7PQ4v6lYyfrkuDC0GvzSEEEA";
-
-        internal static SigningCredentials DefaultSigningCredentials => KeyingMaterial.RsaSigningCreds_2048;
+        internal static SigningCredentials DefaultSigningCredentials => new SigningCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256){ CryptoProviderFactory = new CryptoProviderFactory()};
 
         internal static EncryptingCredentials DefaultEncryptingCredentials => KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes128_Sha2;
 
@@ -82,7 +77,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             { "n",   Base64UrlEncoder.Encode(KeyingMaterial.RsaParameters_2048.Modulus)},
             { "e",  Base64UrlEncoder.Encode(KeyingMaterial.RsaParameters_2048.Exponent) },
             { JwtHeaderParameterNames.Alg, SecurityAlgorithms.RsaSha256 },
-            { JwtHeaderParameterNames.Kid, KeyingMaterial.RsaSecurityKey_2048.KeyId }
+            { JwtHeaderParameterNames.Kid, KeyingMaterial.RsaSecurityKey_2048.InternalId }
         };
 
         internal static JObject InvalidJwk => new JObject
@@ -90,7 +85,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             { "kty", "RSA" },
             { "e", "bad_data" },
             { JwtHeaderParameterNames.Alg, SecurityAlgorithms.RsaSha256 },
-            { JwtHeaderParameterNames.Kid, KeyingMaterial.RsaSecurityKey_2048.KeyId }
+            { JwtHeaderParameterNames.Kid, KeyingMaterial.RsaSecurityKey_2048.InternalId }
         };
 
         internal static JObject DefaultCnfJwk => new JObject


### PR DESCRIPTION
Fixes the issues below.
We do not want to cache SignatureProviders for SignedHttpRequests as the belief is these will be used, particularly when verifying, infrequently.
We do not need or want to put a kid into the SignedHttpRequest as we should be relying on the cnf claim or extensibility.

https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1352
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1351

Some formatting and error messages were modified.