### PR TITLE
Fixes for issues relating to Authenticated Encryption and Caching

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,7 +3,7 @@
     <MicrosoftAzureKeyVaultVersion>3.0.5</MicrosoftAzureKeyVaultVersion>
     <MicrosoftAzureServicesAppAuthenticationVersion>1.0.3</MicrosoftAzureServicesAppAuthenticationVersion>
     <MicrosoftCSharpVersion>4.5.0</MicrosoftCSharpVersion>
-    <MicrosoftSourceLinkGitHubVersion>1.0.0-beta2-18618-05</MicrosoftSourceLinkGitHubVersion>
+    <MicrosoftSourceLinkGitHubVersion>1.0.0</MicrosoftSourceLinkGitHubVersion>
     <NetStandardVersion>2.0.3</NetStandardVersion>
     <SystemCollectionsSpecializedVersion>4.3.0</SystemCollectionsSpecializedVersion>
     <SystemComponentModelTypeConverterVersion>4.3.0</SystemComponentModelTypeConverterVersion>

--- a/src/Microsoft.IdentityModel.Tokens/Encryption/AuthenticatedEncryptionProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/AuthenticatedEncryptionProvider.cs
@@ -179,7 +179,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <exception cref="ArgumentNullException"><paramref name="authenticatedData"/> is null or empty.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="iv"/> is null or empty.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="authenticationTag"/> is null or empty.</exception>
-        /// <exception cref="SecurityTokenDecryptionFailedException">Thrown if the signature over authenticationTag fails to verify.</exception>
+        /// <exception cref="SecurityTokenDecryptionFailedException">Thrown if the signature over the authenticationTag fails to verify.</exception>
         /// <exception cref="SecurityTokenDecryptionFailedException">Thrown if the AES crypto operation threw. See inner exception.</exception>
         /// <exception cref="ObjectDisposedException">Thrown if the internal <see cref="SignatureProvider"/> is disposed.</exception>
         public virtual byte[] Decrypt(byte[] ciphertext, byte[] authenticatedData, byte[] iv, byte[] authenticationTag)
@@ -239,12 +239,12 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="disposing">true, if called from Dispose(), false, if invoked inside a finalizer.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (!_disposed)
-            {
-                _disposed = true;
-                if (disposing && _symmetricSignatureProvider != null)
-                    _cryptoProviderFactory.ReleaseSignatureProvider(_symmetricSignatureProvider);
-            }
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            if (disposing && _symmetricSignatureProvider != null)
+                _cryptoProviderFactory.ReleaseSignatureProvider(_symmetricSignatureProvider);
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
@@ -192,7 +192,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (_disposed)
             {
                 CryptoProviderCache?.TryRemove(this);
-                throw LogHelper.LogExceptionMessage(new ObjectDisposedException(typeof(SymmetricSignatureProvider).ToString()));
+                throw LogHelper.LogExceptionMessage(new ObjectDisposedException(GetType().ToString()));
             }
 
             LogHelper.LogInformation(LogMessages.IDX10642, input);
@@ -209,7 +209,6 @@ namespace Microsoft.IdentityModel.Tokens
                 CryptoProviderCache?.TryRemove(this);
                 throw;
             }
-
         }
 
         /// <summary>
@@ -236,7 +235,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (_disposed)
             {
                 CryptoProviderCache?.TryRemove(this);
-                throw LogHelper.LogExceptionMessage(new ObjectDisposedException(typeof(SymmetricSignatureProvider).ToString()));
+                throw LogHelper.LogExceptionMessage(new ObjectDisposedException(GetType().ToString()));
             }
 
 
@@ -283,7 +282,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (_disposed)
             {
                 CryptoProviderCache?.TryRemove(this);
-                throw LogHelper.LogExceptionMessage(new ObjectDisposedException(typeof(SymmetricSignatureProvider).ToString()));
+                throw LogHelper.LogExceptionMessage(new ObjectDisposedException(GetType().ToString()));
             }
 
             LogHelper.LogInformation(LogMessages.IDX10643, input);

--- a/test/Microsoft.IdentityModel.TestUtils/DerivedTypes.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/DerivedTypes.cs
@@ -106,11 +106,15 @@ namespace Microsoft.IdentityModel.TestUtils
     }
 
     /// <summary>
-    /// Helpful for extensibility testing for errors.
+    /// Used by AuthenticationEncryptionProviderTests.
     /// </summary>
-    public class DerivedCryptoProviderFactory : CryptoProviderFactory
+    public class AuthenticatedEncryptionCryptoProviderFactory : CryptoProviderFactory
     {
+        public bool DisposeSignatureProvider { get; set; }
+
         public SymmetricSignatureProvider SymmetricSignatureProviderForSigning { get; set; }
+
+        public SymmetricSignatureProvider SymmetricSignatureProviderForSigningCaching { get; set; }
 
         public SymmetricSignatureProvider SymmetricSignatureProviderForVerifying { get; set; }
 
@@ -119,9 +123,71 @@ namespace Microsoft.IdentityModel.TestUtils
             return SymmetricSignatureProviderForSigning;
         }
 
+        public override SignatureProvider CreateForSigning(SecurityKey key, string algorithm, bool cacheSignatureProvider)
+        {
+            return base.CreateForSigning(key, algorithm, cacheSignatureProvider);
+        }
+
         public override SignatureProvider CreateForVerifying(SecurityKey key, string algorithm)
         {
             return SymmetricSignatureProviderForVerifying;
+        }
+
+        public override SignatureProvider CreateForVerifying(SecurityKey key, string algorithm, bool cacheSignatureProvider)
+        {
+            return SymmetricSignatureProviderForVerifying;
+        }
+
+        public override void ReleaseSignatureProvider(SignatureProvider signatureProvider)
+        {
+            if (DisposeSignatureProvider)
+                base.ReleaseSignatureProvider(signatureProvider);
+        }
+    }
+
+    /// <summary>
+    /// Allows distinguishing where exceptions are thrown
+    /// </summary>
+    public class DecryptAuthenticatedEncryptionCryptoProviderFactory : AuthenticatedEncryptionCryptoProviderFactory
+    {
+    }
+
+    /// <summary>
+    /// Allows distinguishing where exceptions are thrown
+    /// </summary>
+    public class EncryptAuthenticatedEncryptionCryptoProviderFactory : AuthenticatedEncryptionCryptoProviderFactory
+    {
+    }
+
+    public class EncryptSymmetricSignatureProvider : SymmetricSignatureProvider
+    {
+        public EncryptSymmetricSignatureProvider(SecurityKey key, string algorithm) : base(key, algorithm)
+        {
+        }
+        public EncryptSymmetricSignatureProvider(SecurityKey key, string algorithm, bool willCreateSignatures) : base(key, algorithm, willCreateSignatures)
+        {
+        }
+    }
+    public class DecryptSymmetricSignatureProvider : SymmetricSignatureProvider
+    {
+        public DecryptSymmetricSignatureProvider(SecurityKey key, string algorithm) : base(key, algorithm)
+        {
+        }
+        public DecryptSymmetricSignatureProvider(SecurityKey key, string algorithm, bool willCreateSignatures) : base(key, algorithm, willCreateSignatures)
+        {
+        }
+    }
+
+    public class DecryptAuthenticatedEncryptionProvider : AuthenticatedEncryptionProvider
+    {
+        public DecryptAuthenticatedEncryptionProvider(SecurityKey key, string algorithm) : base(key, algorithm)
+        {
+        }
+    }
+    public class EncryptAuthenticatedEncryptionProvider : AuthenticatedEncryptionProvider
+    {
+        public EncryptAuthenticatedEncryptionProvider(SecurityKey key, string algorithm) : base(key, algorithm)
+        {
         }
     }
 


### PR DESCRIPTION
These changes address signature providers adding memory pressure.
We do not cache SignatureProviders by default that are used by the AuthenticationEncryptionProvider.
If this is needed, then users will need to use extensibility from keys.
Tests have been added to show how to do this.
 
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1357
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1292