### PR TITLE
Get RequestContext from WsFederationHttpBinding

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.WsTrust/WsTrustMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsTrust/WsTrustMessage.cs
@@ -169,7 +169,8 @@ namespace Microsoft.IdentityModel.Protocols.WsTrust
         public string Context
         {
             get => _context;
-            set => _context = (string.IsNullOrEmpty(value)) ? throw LogHelper.LogArgumentNullException(nameof(value)) : value;
+            // Permit this to be null since the Context attribute is optional.
+            set => _context = value;
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Protocols.WsTrust/WsTrustMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsTrust/WsTrustMessage.cs
@@ -169,8 +169,7 @@ namespace Microsoft.IdentityModel.Protocols.WsTrust
         public string Context
         {
             get => _context;
-            // Permit this to be null since the Context attribute is optional.
-            set => _context = value;
+            set => _context = (string.IsNullOrEmpty(value)) ? throw LogHelper.LogArgumentNullException(nameof(value)) : value;
         }
 
         /// <summary>

--- a/src/System.ServiceModel.Federation/WSTrustChannelSecurityTokenProvider.cs
+++ b/src/System.ServiceModel.Federation/WSTrustChannelSecurityTokenProvider.cs
@@ -49,7 +49,7 @@ namespace System.ServiceModel.Federation
 
             IssuedSecurityTokenParameters issuedTokenParameters = SecurityTokenRequirement.GetProperty<IssuedSecurityTokenParameters>("http://schemas.microsoft.com/ws/2006/05/servicemodel/securitytokenrequirement/IssuedSecurityTokenParameters");
 
-            RequestContext = requestContext ?? Guid.NewGuid().ToString();
+            RequestContext = string.IsNullOrEmpty(requestContext) ? Guid.NewGuid().ToString() : requestContext;
             _wsTrustRequest = CreateWsTrustRequest(issuedTokenParameters);
             _channelFactory = CreateChannelFactory(issuedTokenParameters);
         }

--- a/src/System.ServiceModel.Federation/WsFederationBindingElement.cs
+++ b/src/System.ServiceModel.Federation/WsFederationBindingElement.cs
@@ -14,14 +14,35 @@ namespace System.ServiceModel.Federation
 
         public SecurityBindingElement SecurityBindingElement { get; }
 
+        public string WSTrustContext
+        {
+            get;
+            set;
+        }
+
         public override BindingElement Clone()
         {
-            return new WsFederationBindingElement(IssuedTokenParameters, SecurityBindingElement);
+            return new WsFederationBindingElement(IssuedTokenParameters, SecurityBindingElement)
+            {
+                WSTrustContext = WSTrustContext
+            };
         }
 
         public override T GetProperty<T>(BindingContext context)
         {
             return SecurityBindingElement.GetProperty<T>(context);
+        }
+
+        public override IChannelFactory<TChannel> BuildChannelFactory<TChannel>(BindingContext context)
+        {
+            if (context.BindingParameters.Contains(typeof(WsTrustChannelClientCredentials)))
+            {
+                var credentials = context.BindingParameters[typeof(WsTrustChannelClientCredentials)] as WsTrustChannelClientCredentials;
+                credentials.RequestContext = WSTrustContext;
+            }
+
+            var channelFactory = base.BuildChannelFactory<TChannel>(context);
+            return channelFactory;
         }
     }
 }

--- a/src/System.ServiceModel.Federation/WsFederationBindingElement.cs
+++ b/src/System.ServiceModel.Federation/WsFederationBindingElement.cs
@@ -14,6 +14,9 @@ namespace System.ServiceModel.Federation
 
         public SecurityBindingElement SecurityBindingElement { get; }
 
+        /// <summary>
+        /// Gets or sets a context string used in outgoing WsTrust requests that may be useful for correlating requests.
+        /// </summary>
         public string WSTrustContext
         {
             get;

--- a/src/System.ServiceModel.Federation/WsFederationHttpBinding.cs
+++ b/src/System.ServiceModel.Federation/WsFederationHttpBinding.cs
@@ -23,6 +23,9 @@ namespace System.ServiceModel.Federation
             get;
         }
 
+        /// <summary>
+        /// Gets or sets a context string used in outgoing WsTrust requests that may be useful for correlating requests.
+        /// </summary>
         public string WSTrustContext
         {
             get;

--- a/src/System.ServiceModel.Federation/WsFederationHttpBinding.cs
+++ b/src/System.ServiceModel.Federation/WsFederationHttpBinding.cs
@@ -23,6 +23,12 @@ namespace System.ServiceModel.Federation
             get;
         }
 
+        public string WSTrustContext
+        {
+            get;
+            set;
+        }
+
         private SecurityBindingElement SecurityBindingElement { get; set; }
 
         protected override SecurityBindingElement CreateMessageSecurity()
@@ -54,14 +60,8 @@ namespace System.ServiceModel.Federation
         public override BindingElementCollection CreateBindingElements()
         {
             var bindingElementCollection = base.CreateBindingElements();
-            bindingElementCollection.Insert(0, new WsFederationBindingElement(IssuedTokenParameters, SecurityBindingElement));
+            bindingElementCollection.Insert(0, new WsFederationBindingElement(IssuedTokenParameters, SecurityBindingElement) { WSTrustContext = WSTrustContext });
             return bindingElementCollection;
-        }
-
-        public override IChannelFactory<TChannel> BuildChannelFactory<TChannel>(BindingParameterCollection parameters)
-        {
-            var channelFactory = base.BuildChannelFactory<TChannel>(parameters);
-            return channelFactory;
         }
 
         protected override TransportBindingElement GetTransport()

--- a/src/System.ServiceModel.Federation/WsTrustChannelClientCredentials.cs
+++ b/src/System.ServiceModel.Federation/WsTrustChannelClientCredentials.cs
@@ -37,6 +37,11 @@ namespace System.ServiceModel.Federation
         }
 
         /// <summary>
+        /// The context to use in outgoing WsTrustRequests. Useful for correlation WSTrust actions.
+        /// </summary>
+        internal string RequestContext { get; set; }
+
+        /// <summary>
         /// Gets or sets whether issued tokens should be cached and reused within their expiry periods.
         /// </summary>
         public bool CacheIssuedTokens { get; set; } = WSTrustChannelSecurityTokenProvider.DefaultCacheIssuedTokens;

--- a/src/System.ServiceModel.Federation/WsTrustChannelSecurityTokenManager.cs
+++ b/src/System.ServiceModel.Federation/WsTrustChannelSecurityTokenManager.cs
@@ -26,14 +26,14 @@ namespace System.ServiceModel.Federation
         {
             // If token requirement matches SAML token return the custom SAML token provider
             // that performs custom work to serve up the token
-            var tokenProvider = new WSTrustChannelSecurityTokenProvider(tokenRequirement);
-
-            if (ClientCredentials is WsTrustChannelClientCredentials wsTrustChannelClientCredentials)
-            {
-                tokenProvider.CacheIssuedTokens = wsTrustChannelClientCredentials.CacheIssuedTokens;
-                tokenProvider.MaxIssuedTokenCachingTime = wsTrustChannelClientCredentials.MaxIssuedTokenCachingTime;
-                tokenProvider.IssuedTokenRenewalThresholdPercentage = wsTrustChannelClientCredentials.IssuedTokenRenewalThresholdPercentage;
-            }
+            var tokenProvider = (ClientCredentials is WsTrustChannelClientCredentials wsTrustChannelClientCredentials) ?
+                new WSTrustChannelSecurityTokenProvider(tokenRequirement, wsTrustChannelClientCredentials.RequestContext)
+                {
+                    CacheIssuedTokens = wsTrustChannelClientCredentials.CacheIssuedTokens,
+                    MaxIssuedTokenCachingTime = wsTrustChannelClientCredentials.MaxIssuedTokenCachingTime,
+                    IssuedTokenRenewalThresholdPercentage = wsTrustChannelClientCredentials.IssuedTokenRenewalThresholdPercentage
+                }
+                : new WSTrustChannelSecurityTokenProvider(tokenRequirement);
 
             return tokenProvider;
         }

--- a/test/System.ServiceModel.Federation.Tests/Mocks/WSTrustChannelSecurityTokenProviderWithMockChannelFactory.cs
+++ b/test/System.ServiceModel.Federation.Tests/Mocks/WSTrustChannelSecurityTokenProviderWithMockChannelFactory.cs
@@ -11,6 +11,10 @@ namespace System.ServiceModel.Federation.Tests.Mocks
     /// </summary>
     class WSTrustChannelSecurityTokenProviderWithMockChannelFactory : WSTrustChannelSecurityTokenProvider
     {
+        public WSTrustChannelSecurityTokenProviderWithMockChannelFactory(SecurityTokenRequirement tokenRequirement, string requestContext) :
+            base(tokenRequirement, requestContext)
+        { }
+
         public WSTrustChannelSecurityTokenProviderWithMockChannelFactory(SecurityTokenRequirement tokenRequirement) :
             base(tokenRequirement)
         { }

--- a/test/System.ServiceModel.Federation.Tests/ReflectionHelpers.cs
+++ b/test/System.ServiceModel.Federation.Tests/ReflectionHelpers.cs
@@ -1,0 +1,17 @@
+﻿using System.Reflection;
+
+namespace System.ServiceModel.Federation.Tests
+{
+    public static class ReflectionHelpers
+    {
+        public static object GetInternalProperty(object obj, string propertyName) =>
+            obj.GetType()
+            .GetProperty(propertyName, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)?
+            .GetValue(obj);
+
+        public static object CallInternalMethod(object obj, string methodName, params object[] args) =>
+            obj.GetType()
+            .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)?
+            .Invoke(obj, args);
+    }
+}

--- a/test/System.ServiceModel.Federation.Tests/WSTrustChannelSecurityTokenProviderTests.cs
+++ b/test/System.ServiceModel.Federation.Tests/WSTrustChannelSecurityTokenProviderTests.cs
@@ -130,11 +130,10 @@ namespace System.ServiceModel.Federation.Tests
                 });
 
                 // Confirm that caches can be shared if contexts are the same
-                var provider3 = new WSTrustChannelSecurityTokenProviderWithMockChannelFactory(tokenRequirement)
+                var provider3 = new WSTrustChannelSecurityTokenProviderWithMockChannelFactory(tokenRequirement, provider1.RequestContext)
                 {
                     // Share cache and context
-                    TestIssuedTokensCache = provider1.TestIssuedTokensCache,
-                    TokenContext = provider1.TokenContext
+                    TestIssuedTokensCache = provider1.TestIssuedTokensCache
                 };
                 data.Add(new ProviderCachingTheoryData
                 {

--- a/test/System.ServiceModel.Federation.Tests/WSTrustChannelSecurityTokenProviderTests.cs
+++ b/test/System.ServiceModel.Federation.Tests/WSTrustChannelSecurityTokenProviderTests.cs
@@ -28,9 +28,18 @@ namespace System.ServiceModel.Federation.Tests
                 var tokenProvider = credentials.CreateSecurityTokenManager().CreateSecurityTokenProvider(tokenRequirements) as WSTrustChannelSecurityTokenProvider;
 
                 theoryData.ExpectedException.ProcessNoException(context);
-                IdentityComparer.AreEqual(tokenProvider.CacheIssuedTokens, theoryData.CacheIssuedTokens, context);
-                IdentityComparer.AreEqual(tokenProvider.MaxIssuedTokenCachingTime, theoryData.MaxIssuedTokenCachingTime, context);
-                IdentityComparer.AreEqual(tokenProvider.IssuedTokenRenewalThresholdPercentage, theoryData.IssuedTokenRenewalThresholdPercentage, context);
+                if (tokenProvider.CacheIssuedTokens != theoryData.CacheIssuedTokens)
+                {
+                    context.AddDiff($"Expected CacheIssuedTokens: {theoryData.CacheIssuedTokens}; actual CacheIssuedTokens: {tokenProvider.CacheIssuedTokens}");
+                }
+                if (tokenProvider.MaxIssuedTokenCachingTime != theoryData.MaxIssuedTokenCachingTime)
+                {
+                    context.AddDiff($"Expected MaxIssuedTokenCachingTime: {theoryData.MaxIssuedTokenCachingTime}; actual MaxIssuedTokenCachingTime: {tokenProvider.MaxIssuedTokenCachingTime}");
+                }
+                if (tokenProvider.IssuedTokenRenewalThresholdPercentage != theoryData.IssuedTokenRenewalThresholdPercentage)
+                {
+                    context.AddDiff($"Expected IssuedTokenRenewalThresholdPercentage: {theoryData.IssuedTokenRenewalThresholdPercentage}; actual IssuedTokenRenewalThresholdPercentage: {tokenProvider.IssuedTokenRenewalThresholdPercentage}");
+                }
             }
             catch (Exception ex)
             {

--- a/test/System.ServiceModel.Federation.Tests/WsFederationHttpBindingTests.cs
+++ b/test/System.ServiceModel.Federation.Tests/WsFederationHttpBindingTests.cs
@@ -40,7 +40,16 @@ namespace System.ServiceModel.Federation.Tests
                     context.AddDiff($"Expected KeyType: {theoryData.IssuedSecurityTokenParametersKeyType}; actual KeyType: {issuedSecurityTokenParameters.KeyType}");
                 }
 
-                if (theoryData.RequestContext != null)
+                // Confirm that if a request context was specified, it was used. Otherwise, a random GUID is used
+                // as the context.
+                if (string.IsNullOrEmpty(theoryData.RequestContext))
+                {
+                    if (!Guid.TryParse(provider.RequestContext, out _))
+                    {
+                        context.AddDiff($"Expected a random guid Context; actual Context: {provider.RequestContext}");
+                    }
+                }
+                else
                 {
                     if (!string.Equals(provider.RequestContext, theoryData.RequestContext))
                     {

--- a/test/System.ServiceModel.Federation.Tests/WsFederationHttpBindingTests.cs
+++ b/test/System.ServiceModel.Federation.Tests/WsFederationHttpBindingTests.cs
@@ -1,0 +1,122 @@
+﻿using System.IdentityModel.Selectors;
+using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
+using System.ServiceModel.Security.Tokens;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens.Saml2;
+using Xunit;
+
+namespace System.ServiceModel.Federation.Tests
+{
+    public class WsFederationHttpBindingTests
+    {
+        [Theory, MemberData(nameof(SecurityKeyTheoryData))]
+        public void BindingPropertiesPropagated(WsFederationHttpBindingTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.SecurityKeyTypePropagated", theoryData);
+
+            try
+            {
+                var issuedTokenParameters = new IssuedTokenParameters
+                {
+                    IssuerAddress = new EndpointAddress(new Uri("https://localhost")),
+                    IssuerBinding = new WSHttpBinding(SecurityMode.Transport),
+                    SecurityKey = theoryData.IssuedTokenParametersSecurityKey,
+                    Target = "https://localhost",
+                    TokenType = Saml2Constants.OasisWssSaml2TokenProfile11
+                };
+
+                var binding = new WsFederationHttpBinding(issuedTokenParameters)
+                {
+                    WSTrustContext = theoryData.RequestContext
+                };
+                var provider = GetProviderForBinding(binding) as WSTrustChannelSecurityTokenProvider;
+
+                IssuedSecurityTokenParameters issuedSecurityTokenParameters = provider?.SecurityTokenRequirement.GetProperty<IssuedSecurityTokenParameters>("http://schemas.microsoft.com/ws/2006/05/servicemodel/securitytokenrequirement/IssuedSecurityTokenParameters");
+
+                theoryData.ExpectedException.ProcessNoException(context);
+                if (issuedSecurityTokenParameters.KeyType != theoryData.IssuedSecurityTokenParametersKeyType)
+                {
+                    context.AddDiff($"Expected KeyType: {theoryData.IssuedSecurityTokenParametersKeyType}; actual KeyType: {issuedSecurityTokenParameters.KeyType}");
+                }
+
+                if (theoryData.RequestContext != null)
+                {
+                    if (!string.Equals(provider.RequestContext, theoryData.RequestContext))
+                    {
+                        context.AddDiff($"Expected Context: {theoryData.RequestContext}; actual Context: {provider.RequestContext}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<WsFederationHttpBindingTheoryData> SecurityKeyTheoryData
+        {
+            get => new TheoryData<WsFederationHttpBindingTheoryData>
+            {
+                                new WsFederationHttpBindingTheoryData
+                {
+                    IssuedTokenParametersSecurityKey = KeyingMaterial.RsaSecurityKey_1024,
+                    IssuedSecurityTokenParametersKeyType = System.IdentityModel.Tokens.SecurityKeyType.AsymmetricKey,
+                    RequestContext = "DummyContext"
+                },
+                new WsFederationHttpBindingTheoryData
+                {
+                    First = true,
+                    IssuedTokenParametersSecurityKey = KeyingMaterial.RsaSecurityKey_1024,
+                    IssuedSecurityTokenParametersKeyType = System.IdentityModel.Tokens.SecurityKeyType.AsymmetricKey,
+                    RequestContext = null
+                },
+                new WsFederationHttpBindingTheoryData
+                {
+                    IssuedTokenParametersSecurityKey = KeyingMaterial.DefaultSymmetricSecurityKey_56,
+                    IssuedSecurityTokenParametersKeyType = System.IdentityModel.Tokens.SecurityKeyType.SymmetricKey,
+                    RequestContext = null
+                },
+                new WsFederationHttpBindingTheoryData
+                {
+                    IssuedTokenParametersSecurityKey = null,
+                    IssuedSecurityTokenParametersKeyType = System.IdentityModel.Tokens.SecurityKeyType.BearerKey,
+                    RequestContext = null
+                },
+
+                new WsFederationHttpBindingTheoryData
+                {
+                    IssuedTokenParametersSecurityKey = KeyingMaterial.RsaSecurityKey_1024,
+                    IssuedSecurityTokenParametersKeyType = System.IdentityModel.Tokens.SecurityKeyType.AsymmetricKey,
+                    RequestContext = string.Empty
+                },
+            };
+        }
+
+        public static SecurityTokenProvider GetProviderForBinding(Binding binding)
+        {
+            var factory = new ChannelFactory<IRequestChannel>(binding, new EndpointAddress(new Uri("https://localhost")));
+
+            // TODO: This substitution shouldn't be necessary in the future.
+            factory.Endpoint.EndpointBehaviors.Remove(typeof(ClientCredentials));
+            factory.Endpoint.EndpointBehaviors.Add(new WsTrustChannelClientCredentials());
+
+            IRequestChannel channel = factory.CreateChannel();
+            channel.Open();
+
+            // TODO: This is not a great way to test since private reflection is fragile.
+            // This allows for quick initial testing but should be replaced with a more robust testing approach
+            // in the future (perhaps overriding the WsFederationHttpBinding's transport element to intercept requests)
+            var serviceChannel = ReflectionHelpers.CallInternalMethod(channel, "GetServiceChannel");
+            var innerChannel = ReflectionHelpers.GetInternalProperty(serviceChannel, "InnerChannel");
+            var securityProtocol = ReflectionHelpers.GetInternalProperty(innerChannel, "SecurityProtocol");
+            var providerSpecifications = ReflectionHelpers.GetInternalProperty(securityProtocol, "ChannelSupportingTokenProviderSpecification");
+            var specification = ReflectionHelpers.CallInternalMethod(providerSpecifications, "get_Item", 0);
+            var provider = ReflectionHelpers.GetInternalProperty(specification, "TokenProvider");
+
+            return provider as SecurityTokenProvider;
+        }
+    }
+}

--- a/test/System.ServiceModel.Federation.Tests/WsFederationHttpBindingTheoryData.cs
+++ b/test/System.ServiceModel.Federation.Tests/WsFederationHttpBindingTheoryData.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.IdentityModel.TestUtils;
+
+namespace System.ServiceModel.Federation.Tests
+{
+    public class WsFederationHttpBindingTheoryData: TheoryDataBase
+    {
+        public string RequestContext { get; set; }
+        public Microsoft.IdentityModel.Tokens.SecurityKey IssuedTokenParametersSecurityKey { get; set; }
+        public System.IdentityModel.Tokens.SecurityKeyType IssuedSecurityTokenParametersKeyType { get; set; }
+    }
+}


### PR DESCRIPTION
This adds a `WSTrustContext` property to both `WsFederationHttpBinding` and `WsFederationHttpBindingElement` and pipes those values through to `WsTrustChannelClientCredentials`, so that it will be used as the `RequestContext` in `WSTrustChannelSecurityTokenProvider`.