### PR TITLE
Simplify caching since a token provider will always use the same RST

### DIFF
--- a/src/System.ServiceModel.Federation/System.ServiceModel.Federation.csproj
+++ b/src/System.ServiceModel.Federation/System.ServiceModel.Federation.csproj
@@ -19,7 +19,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsVersion)" />
     <PackageReference Include="System.Private.ServiceModel" Version="$(WCFVersion)" />
     <PackageReference Include="System.ServiceModel.Http" Version="$(WCFVersion)" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="$(WCFVersion)" />

--- a/test/System.ServiceModel.Federation.Tests/Mocks/WSTrustChannelSecurityTokenProviderWithMockChannelFactory.cs
+++ b/test/System.ServiceModel.Federation.Tests/Mocks/WSTrustChannelSecurityTokenProviderWithMockChannelFactory.cs
@@ -1,7 +1,6 @@
 ﻿using System.IdentityModel.Selectors;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Security.Tokens;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace System.ServiceModel.Federation.Tests.Mocks
 {
@@ -23,14 +22,5 @@ namespace System.ServiceModel.Federation.Tests.Mocks
         // without actually making requests to an STS for tokens.
         protected override ChannelFactory<IRequestChannel> CreateChannelFactory(IssuedSecurityTokenParameters issuedTokenParameters) =>
             new MockRequestChannelFactory();
-
-        // Provide access to the (non-public) token cache so that it's possible to test sharing a cache between provider instances.
-        // That scenario isn't supported by the current public API, but is intended to work in the future, so it's good to make
-        // sure the scenario remains functional.
-        public IDistributedCache TestIssuedTokensCache
-        {
-            get => IssuedTokensCache;
-            set => IssuedTokensCache = value;
-        }
     }
 }

--- a/test/System.ServiceModel.Federation.Tests/WSTrustChannelSecurityTokenProviderTests.cs
+++ b/test/System.ServiceModel.Federation.Tests/WSTrustChannelSecurityTokenProviderTests.cs
@@ -129,32 +129,6 @@ namespace System.ServiceModel.Federation.Tests
                     ShouldShareToken = false
                 });
 
-                // Confirm that caches can be shared if contexts are the same
-                var provider3 = new WSTrustChannelSecurityTokenProviderWithMockChannelFactory(tokenRequirement, provider1.RequestContext)
-                {
-                    // Share cache and context
-                    TestIssuedTokensCache = provider1.TestIssuedTokensCache
-                };
-                data.Add(new ProviderCachingTheoryData
-                {
-                    Provider1 = provider1,
-                    Provider2 = provider3,
-                    ShouldShareToken = true
-                });
-
-                // Confirm that different contexts will result in not re-using tokens
-                var provider4 = new WSTrustChannelSecurityTokenProviderWithMockChannelFactory(tokenRequirement)
-                {
-                    // Share cache but not context
-                    TestIssuedTokensCache = provider1.TestIssuedTokensCache
-                };
-                data.Add(new ProviderCachingTheoryData
-                {
-                    Provider1 = provider1,
-                    Provider2 = provider4,
-                    ShouldShareToken = false
-                });
-
                 // Confirm that no caching occurs when caching is disabled
                 var provider5 = new WSTrustChannelSecurityTokenProviderWithMockChannelFactory(tokenRequirement);
                 provider5.CacheIssuedTokens = false;
@@ -165,7 +139,7 @@ namespace System.ServiceModel.Federation.Tests
                     ShouldShareToken = false
                 });
 
-                // Confirm that tokens are cached longer than MaxIssuedTokenCachingTime
+                // Confirm that tokens are not cached longer than MaxIssuedTokenCachingTime
                 var provider6 = new WSTrustChannelSecurityTokenProviderWithMockChannelFactory(tokenRequirement)
                 {
                     MaxIssuedTokenCachingTime = TimeSpan.FromSeconds(2)
@@ -239,11 +213,6 @@ namespace System.ServiceModel.Federation.Tests
                 {
                     Action = (WSTrustChannelSecurityTokenProvider p) => p.IssuedTokenRenewalThresholdPercentage = 101,
                     ExpectedException = ExpectedException.ArgumentOutOfRangeException("value")
-                },
-                new ErrorConditionTheoryData
-                {
-                    Action = (WSTrustChannelSecurityTokenProvider p) => (p as WSTrustChannelSecurityTokenProviderWithMockChannelFactory).TestIssuedTokensCache = null,
-                    ExpectedException = ExpectedException.ArgumentNullException("value")
                 }
             };
         }


### PR DESCRIPTION
We should add back fuller cache support (including using `IDistributedCache`) in the future
if/when caches can be shared between providers. With the current API surface area, though,
there's no way for a given `WSTrustChannelSecurityTokenProvider` to use more than one RST,
so it will only ever have to cache a single response. Given that, the design that we had here
was more complicated and slower than it needed to be.