### PR TITLE
Consider WsTrust version when issuing tokens

### DIFF
--- a/src/System.ServiceModel.Federation/WSTrustChannelSecurityTokenProvider.cs
+++ b/src/System.ServiceModel.Federation/WSTrustChannelSecurityTokenProvider.cs
@@ -374,7 +374,7 @@ namespace System.ServiceModel.Federation
                 // with an unspecified expiration. Similarly, a response lifetime without an expiration
                 // time represents an unspecified expiration. In any of these cases, err on the side of
                 // retrieving a new response instead of possibly using an invalid or expired one.
-                return false;
+                return true;
             }
 
             // If a response's lifetime doesn't specify a created time, conservatively assume the response was just created.

--- a/src/System.ServiceModel.Federation/WSTrustChannelSecurityTokenProvider.cs
+++ b/src/System.ServiceModel.Federation/WSTrustChannelSecurityTokenProvider.cs
@@ -168,7 +168,8 @@ namespace System.ServiceModel.Federation
                 KeySizeInBits = keySize,
                 KeyType = keyType,
                 RequestType = WsTrustActions.Issue,
-                TokenType = SecurityTokenRequirement.TokenType
+                TokenType = SecurityTokenRequirement.TokenType,
+                WsTrustVersion = WsTrustVersion
             };
 
             if (entropy != null)
@@ -273,7 +274,7 @@ namespace System.ServiceModel.Federation
         {
             get
             {
-                var trustVersion = MessageSecurityVersion.TrustVersion;
+                TrustVersion trustVersion = MessageSecurityVersion.TrustVersion;
 
                 if (trustVersion == TrustVersion.WSTrust13)
                 {
@@ -296,7 +297,7 @@ namespace System.ServiceModel.Federation
         {
             get
             {
-                var version = WsTrustVersion;
+                WsTrustVersion version = WsTrustVersion;
                 if (version is WsTrust14Version)
                 {
                     return WsTrustKeyTypes.Trust14;
@@ -321,7 +322,7 @@ namespace System.ServiceModel.Federation
         {
             get
             {
-                var version = WsTrustVersion;
+                WsTrustVersion version = WsTrustVersion;
                 if (version is WsTrust14Version)
                 {
                     return WsTrustActions.Trust14;
@@ -365,7 +366,7 @@ namespace System.ServiceModel.Federation
 
         private bool IsWsTrustResponseExpired(WsTrustResponse response)
         {
-            var responseLifetime = response?.RequestSecurityTokenResponseCollection?[0]?.Lifetime;
+            Lifetime responseLifetime = response?.RequestSecurityTokenResponseCollection?[0]?.Lifetime;
 
             if (responseLifetime == null || responseLifetime.Expires == null)
             {
@@ -403,7 +404,7 @@ namespace System.ServiceModel.Federation
         /// </summary>
         protected override IdentityModel.Tokens.SecurityToken GetTokenCore(TimeSpan timeout)
         {
-            var request = CreateWsTrustRequest();
+            WsTrustRequest request = CreateWsTrustRequest();
             WsTrustResponse trustResponse = GetCachedResponse(request);
             if (trustResponse is null)
             {
@@ -427,7 +428,7 @@ namespace System.ServiceModel.Federation
             // Assumes that token is first and Saml2SecurityToken.
             using (var stream = new MemoryStream())
             {
-                var response = trustResponse.RequestSecurityTokenResponseCollection[0];
+                RequestSecurityTokenResponse response = trustResponse.RequestSecurityTokenResponseCollection[0];
 
                 // Get security token
                 var writer = XmlDictionaryWriter.CreateTextWriter(stream, Encoding.UTF8, false);
@@ -455,8 +456,8 @@ namespace System.ServiceModel.Federation
                 IdentityModel.Tokens.SecurityToken proofToken = GetProofToken(request, response);
 
                 // Get lifetime
-                var created = response.Lifetime?.Created ?? DateTime.UtcNow;
-                var expires = response.Lifetime?.Expires ?? created.AddDays(1);
+                DateTime created = response.Lifetime?.Created ?? DateTime.UtcNow;
+                DateTime expires = response.Lifetime?.Expires ?? created.AddDays(1);
 
                 return new GenericXmlSecurityToken(dom.DocumentElement,
                                                    proofToken,

--- a/src/System.ServiceModel.Federation/WSTrustChannelSecurityTokenProvider.cs
+++ b/src/System.ServiceModel.Federation/WSTrustChannelSecurityTokenProvider.cs
@@ -31,7 +31,6 @@ namespace System.ServiceModel.Federation
         private const int DefaultPublicKeySize = 1024;
         private const string Namespace = "http://schemas.microsoft.com/ws/2006/05/servicemodel/securitytokenrequirement";
         private const string IssuedSecurityTokenParametersProperty = Namespace + "/IssuedSecurityTokenParameters";
-        private const string IssuerBindingProperty = Namespace + "/IssuerBinding";
         private const string SecurityAlgorithmSuiteProperty = Namespace + "/SecurityAlgorithmSuite";
         private const string SecurityBindingElementProperty = Namespace + "/SecurityBindingElement";
         private const string TargetAddressProperty = Namespace + "/TargetAddress";
@@ -45,7 +44,6 @@ namespace System.ServiceModel.Federation
         private int _issuedTokenRenewalThresholdPercentage = DefaultIssuedTokenRenewalThresholdPercentage;
         private SecurityKeyEntropyMode _keyEntropyMode;
         private MessageSecurityVersion _messageSecurityVersion;
-        private Binding _issuerBinding;
         private readonly ChannelFactory<IRequestChannel> _channelFactory;
         private readonly SecurityAlgorithmSuite _securityAlgorithmSuite;
 
@@ -56,7 +54,6 @@ namespace System.ServiceModel.Federation
         {
             SecurityTokenRequirement = tokenRequirement ?? throw new ArgumentNullException(nameof(tokenRequirement));
             SecurityTokenRequirement.TryGetProperty(SecurityAlgorithmSuiteProperty, out _securityAlgorithmSuite);
-            SecurityTokenRequirement.TryGetProperty(IssuerBindingProperty, out _issuerBinding);
             _issuedTokenParameters = SecurityTokenRequirement.GetProperty<IssuedSecurityTokenParameters>(IssuedSecurityTokenParametersProperty);
             InitializeKeyEntropyMode();
             InitializeMessageSecurityVersion();
@@ -116,7 +113,7 @@ namespace System.ServiceModel.Federation
 
         protected virtual ChannelFactory<IRequestChannel> CreateChannelFactory()
         {
-            var factory = new ChannelFactory<IRequestChannel>(_issuedTokenParameters.IssuerBinding, _issuedTokenParameters.IssuerAddress);
+            var factory = new ChannelFactory<IRequestChannel>(IssuerBinding, _issuedTokenParameters.IssuerAddress);
 
             // Temporary as test STS is not trusted.
             // This code should be removed.
@@ -233,12 +230,11 @@ namespace System.ServiceModel.Federation
         }
 
         /// <summary>
-        /// Gets or sets the issuer binding.
+        /// Gets the issuer binding from the issued token parameters.
         /// </summary>
         public Binding IssuerBinding
         {
-            get => _issuerBinding;
-            set => _issuerBinding = value ?? throw new ArgumentNullException(nameof(value));
+            get => _issuedTokenParameters?.IssuerBinding;
         }
 
         /// <summary>

--- a/test/System.ServiceModel.Federation.Tests/MessageSecurityVersionTheoryData.cs
+++ b/test/System.ServiceModel.Federation.Tests/MessageSecurityVersionTheoryData.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.IdentityModel.TestUtils;
+
+namespace System.ServiceModel.Federation.Tests
+{
+    public class MessageSecurityVersionTheoryData : TheoryDataBase
+    {
+        public MessageSecurityVersion IssuerBindingSecurityVersion { get; set; }
+
+        public MessageSecurityVersion DefaultMessageSecurityVersion { get; set; }
+
+        public MessageSecurityVersion OuterBindingSecurityVersion { get; set; }
+
+        public MessageSecurityVersion ExpectedMessageSecurityVersion { get; set; }
+    }
+}

--- a/test/System.ServiceModel.Federation.Tests/Mocks/MockRequestChannel.cs
+++ b/test/System.ServiceModel.Federation.Tests/Mocks/MockRequestChannel.cs
@@ -14,6 +14,7 @@ namespace System.ServiceModel.Federation.Tests.Mocks
     class MockRequestChannel : IRequestChannel
     {
         public TimeSpan TokenLifetime { get; set; } = TimeSpan.FromMinutes(10);
+        public string LastActionSent { get; private set; }
 
         public MockResponseSettings ResponseSettings { get; }
 
@@ -24,6 +25,8 @@ namespace System.ServiceModel.Federation.Tests.Mocks
 
         public Message Request(Message message)
         {
+            LastActionSent = message.Headers.Action;
+
             // Create mock WsTrustResponse containing the SAML2 token and the specified lifetime
             DateTime issuedAt = DateTime.UtcNow;
             var response = new WsTrustResponse(new RequestSecurityTokenResponse

--- a/test/System.ServiceModel.Federation.Tests/Mocks/MockRequestChannelFactory.cs
+++ b/test/System.ServiceModel.Federation.Tests/Mocks/MockRequestChannelFactory.cs
@@ -9,14 +9,23 @@ namespace System.ServiceModel.Federation.Tests.Mocks
 {
     class MockRequestChannelFactory: ChannelFactory<IRequestChannel>
     {
-        public MockResponseSettings ResponseSettings { get; set; }
+        private MockResponseSettings _responseSettings;
+
+        public MockResponseSettings ResponseSettings
+        {
+            get => _responseSettings;
+            set
+            {
+                _responseSettings = value;
+                Channel = new MockRequestChannel(_responseSettings);
+            }
+        }
+
+        public MockRequestChannel Channel { get; private set; } = new MockRequestChannel(null);
 
         public MockRequestChannelFactory() : base(new ServiceEndpoint(new ContractDescription("Name")) { Address = new EndpointAddress("http://localhost") })
         { }
 
-        public override IRequestChannel CreateChannel(EndpointAddress address, Uri via)
-        {
-            return new MockRequestChannel(ResponseSettings);
-        }
+        public override IRequestChannel CreateChannel(EndpointAddress address, Uri via) => Channel;
     }
 }

--- a/test/System.ServiceModel.Federation.Tests/Mocks/WSTrustChannelSecurityTokenProviderWithMockChannelFactory.cs
+++ b/test/System.ServiceModel.Federation.Tests/Mocks/WSTrustChannelSecurityTokenProviderWithMockChannelFactory.cs
@@ -18,6 +18,7 @@ namespace System.ServiceModel.Federation.Tests.Mocks
         public Entropy RequestEntropy { get; set; }
 
         public int? RequestKeySizeInBits { get; set; }
+        public MockRequestChannelFactory ChannelFactory { get; } = new MockRequestChannelFactory();
 
         public WSTrustChannelSecurityTokenProviderWithMockChannelFactory(SecurityTokenRequirement tokenRequirement, string requestContext) :
             base(tokenRequirement, requestContext)
@@ -29,7 +30,7 @@ namespace System.ServiceModel.Federation.Tests.Mocks
 
         // Override channel factory creation with a mock channel factory so that it's possible to test WSTrustChannelSecurityTokenProvider
         // without actually making requests to an STS for tokens.
-        protected override ChannelFactory<IRequestChannel> CreateChannelFactory() => new MockRequestChannelFactory();
+        protected override ChannelFactory<IRequestChannel> CreateChannelFactory() => ChannelFactory;
 
         protected override WsTrustRequest CreateWsTrustRequest()
         {
@@ -43,6 +44,8 @@ namespace System.ServiceModel.Federation.Tests.Mocks
 
             return request;
         }
+
+        public WsTrustRequest GetWsTrustRequest() => CreateWsTrustRequest();
 
         public void SetResponseSettings(MockResponseSettings responseSettings)
         {

--- a/test/System.ServiceModel.Federation.Tests/ProviderCachingTheoryData.cs
+++ b/test/System.ServiceModel.Federation.Tests/ProviderCachingTheoryData.cs
@@ -15,5 +15,6 @@ namespace System.ServiceModel.Federation.Tests
         public int WaitBetweenGetTokenCallsMS { get; set; }
 
         public bool ShouldShareToken { get; set; }
+        public Action JustInTimePrep { get; set; }
     }
 }

--- a/test/System.ServiceModel.Federation.Tests/WSTrustChannelSecurityTokenProviderTests.cs
+++ b/test/System.ServiceModel.Federation.Tests/WSTrustChannelSecurityTokenProviderTests.cs
@@ -202,7 +202,8 @@ namespace System.ServiceModel.Federation.Tests
                 SecurityTokenRequirement tokenRequirement = WSTrustTestHelpers.CreateSecurityRequirement(
                     new BasicHttpBinding(),
                     keyType: theoryData.RequestKeyType,
-                    securityAlgorithmSuite: theoryData.RequestSecurityAlgorithmSuite);
+                    securityAlgorithmSuite: theoryData.RequestSecurityAlgorithmSuite,
+                    defauiltMessageSecurityVersion: MessageSecurityVersion.WSSecurity11WSTrust13WSSecureConversation13WSSecurityPolicy12BasicSecurityProfile10);
                 var provider = new WSTrustChannelSecurityTokenProviderWithMockChannelFactory(tokenRequirement)
                 {
                     CacheIssuedTokens = false,

--- a/test/System.ServiceModel.Federation.Tests/WSTrustChannelSecurityTokenProviderTests.cs
+++ b/test/System.ServiceModel.Federation.Tests/WSTrustChannelSecurityTokenProviderTests.cs
@@ -791,27 +791,21 @@ namespace System.ServiceModel.Federation.Tests
                 },
                 new ErrorConditionTheoryData
                 {
-                    Action = (WSTrustChannelSecurityTokenProvider p) => p.IssuerBinding = null,
-                    ExpectedException = ExpectedException.ArgumentNullException("value"),
-                    TestId = "Test6 (set IssuerBinding to null)"
-                },
-                new ErrorConditionTheoryData
-                {
                     Action = (WSTrustChannelSecurityTokenProvider p) => p.MessageSecurityVersion = null,
                     ExpectedException = ExpectedException.ArgumentNullException("value"),
-                    TestId = "Test7 (set MessageSecurityVersion to null)"
+                    TestId = "Test6 (set MessageSecurityVersion to null)"
                 },
                 new ErrorConditionTheoryData
                 {
                     Action = (WSTrustChannelSecurityTokenProvider p) => p.KeyEntropyMode = (SecurityKeyEntropyMode)6,
                     ExpectedException = new ExpectedException(typeof(InvalidEnumArgumentException)),
-                    TestId = "Test8 (set KeyEntropyMode to invalid enum value)"
+                    TestId = "Test7 (set KeyEntropyMode to invalid enum value)"
                 },
                 new ErrorConditionTheoryData
                 {
                     Action = (WSTrustChannelSecurityTokenProvider p) => p = new WSTrustChannelSecurityTokenProvider(null),
                     ExpectedException = ExpectedException.ArgumentNullException("tokenRequirement"),
-                    TestId = "Test9 (create WSTrustChannelSecurityTokenProvider with null requirements)"
+                    TestId = "Test8 (create WSTrustChannelSecurityTokenProvider with null requirements)"
                 }
             };
         }

--- a/test/System.ServiceModel.Federation.Tests/WSTrustTestHelpers.cs
+++ b/test/System.ServiceModel.Federation.Tests/WSTrustTestHelpers.cs
@@ -15,6 +15,7 @@ namespace System.ServiceModel.Federation.Tests
     static class WSTrustTestHelpers
     {
         const string TargetAddressUri = "http://schemas.microsoft.com/ws/2006/05/servicemodel/securitytokenrequirement/TargetAddress";
+        const string IssuerBindingUri = "http://schemas.microsoft.com/ws/2006/05/servicemodel/securitytokenrequirement/IssuerBinding";
         const string IssuedTokenParametersUri = "http://schemas.microsoft.com/ws/2006/05/servicemodel/securitytokenrequirement/IssuedSecurityTokenParameters";
         const string SecurityAlgorithmSuiteUri = "http://schemas.microsoft.com/ws/2006/05/servicemodel/securitytokenrequirement/SecurityAlgorithmSuite";
 
@@ -31,7 +32,8 @@ namespace System.ServiceModel.Federation.Tests
             string tokenType = Saml2Constants.OasisWssSaml2TokenProfile11,
             string targetAddress = "http://localhost",
             SecurityKeyType keyType = SecurityKeyType.BearerKey,
-            SecurityAlgorithmSuite securityAlgorithmSuite = null)
+            SecurityAlgorithmSuite securityAlgorithmSuite = null,
+            MessageSecurityVersion defauiltMessageSecurityVersion = null)
         {
             var requirements = new SecurityTokenRequirement
             {
@@ -42,9 +44,10 @@ namespace System.ServiceModel.Federation.Tests
             {
                 IssuerAddress = new EndpointAddress(issuerAddress),
                 KeyType = keyType,
-                IssuerBinding = issuerBinding
+                IssuerBinding = issuerBinding,
+                DefaultMessageSecurityVersion = defauiltMessageSecurityVersion
             };
-
+            requirements.Properties.Add(IssuerBindingUri, issuerBinding);
             requirements.Properties.Add(TargetAddressUri, new EndpointAddress(targetAddress));
             requirements.Properties.Add(IssuedTokenParametersUri, issuedTokenParameters);
             requirements.Properties.Add(SecurityAlgorithmSuiteUri, securityAlgorithmSuite ?? DefaultSecurityAlgorithmSuite);

--- a/test/System.ServiceModel.Federation.Tests/WSTrustTestHelpers.cs
+++ b/test/System.ServiceModel.Federation.Tests/WSTrustTestHelpers.cs
@@ -18,6 +18,7 @@ namespace System.ServiceModel.Federation.Tests
         const string IssuerBindingUri = "http://schemas.microsoft.com/ws/2006/05/servicemodel/securitytokenrequirement/IssuerBinding";
         const string IssuedTokenParametersUri = "http://schemas.microsoft.com/ws/2006/05/servicemodel/securitytokenrequirement/IssuedSecurityTokenParameters";
         const string SecurityAlgorithmSuiteUri = "http://schemas.microsoft.com/ws/2006/05/servicemodel/securitytokenrequirement/SecurityAlgorithmSuite";
+        const string SecurityBindingElementUri = "http://schemas.microsoft.com/ws/2006/05/servicemodel/securitytokenrequirement/SecurityBindingElement";
 
         // SecurityAlgorithmSuite.Default isn't exposed publicly because customers aren't expected to need to specify it explicitly.
         // Getting the default algorithm suite here as a testing convenience.
@@ -33,7 +34,8 @@ namespace System.ServiceModel.Federation.Tests
             string targetAddress = "http://localhost",
             SecurityKeyType keyType = SecurityKeyType.BearerKey,
             SecurityAlgorithmSuite securityAlgorithmSuite = null,
-            MessageSecurityVersion defauiltMessageSecurityVersion = null)
+            MessageSecurityVersion defauiltMessageSecurityVersion = null,
+            SecurityBindingElement securityBindingElement = null)
         {
             var requirements = new SecurityTokenRequirement
             {
@@ -51,6 +53,10 @@ namespace System.ServiceModel.Federation.Tests
             requirements.Properties.Add(TargetAddressUri, new EndpointAddress(targetAddress));
             requirements.Properties.Add(IssuedTokenParametersUri, issuedTokenParameters);
             requirements.Properties.Add(SecurityAlgorithmSuiteUri, securityAlgorithmSuite ?? DefaultSecurityAlgorithmSuite);
+            if (securityBindingElement != null)
+            {
+                requirements.Properties.Add(SecurityBindingElementUri, securityBindingElement);
+            }
 
             return requirements;
         }


### PR DESCRIPTION
This updates `WSTrustChannelSecurityTokenProvider` to get message security version from the issuer binding's security binding element or from the issued token parameter's default message security version. One question is where the issuer binding should be retrieved from. This change gets the issuer binding from the incoming security token requirement (which is where it came from in NetFx). Other code paths in WSTrustChannelSecurityTokenProvider (such as `CreateChannelFactory`) get the issuer binding from issued token parameters, though. We should review whether there's a reason to get the binding from these different sources and, if not, standardize on one input.

This PR also fixes a small bug that was introduced when the token provider's "is unexpired" method was changed to "is expired".

Fixes #1371 
