### PR TITLE
Removed caching json headers

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -332,20 +332,14 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         private void Decode(string[] tokenParts, string rawData)
         {
             LogHelper.LogInformation(LogMessages.IDX14106, rawData);
-            if (!JsonWebTokenManager.RawHeaderToJObjectCache.TryGetValue(tokenParts[0], out var header))
+            try
             {
-                try
-                {
-                    Header = JObject.Parse(Base64UrlEncoder.Decode(tokenParts[0]));
-                    JsonWebTokenManager.RawHeaderToJObjectCache.TryAdd(tokenParts[0], Header);
-                }
-                catch (Exception ex)
-                {
-                    throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14102, tokenParts[0], rawData), ex));
-                }
+                Header = JObject.Parse(Base64UrlEncoder.Decode(tokenParts[0]));
             }
-            else
-                Header = header;
+            catch (Exception ex)
+            {
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14102, tokenParts[0], rawData), ex));
+            }
 
             if (tokenParts.Length == JwtConstants.JweSegmentCount)
                 DecodeJwe(tokenParts);

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -458,11 +458,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
             var rawHeader = Base64UrlEncodedUnsignedJWSHeader;
             // If there's no additional header claims to be added to the header and the token will be signed, try to retrieve a header value from the cache.
-            if ((additionalHeaderClaims == null || additionalHeaderClaims.Count == 0) && signingCredentials != null && !JsonWebTokenManager.KeyToHeaderCache.TryGetValue(JsonWebTokenManager.GetHeaderCacheKey(signingCredentials), out rawHeader))
+            if ((additionalHeaderClaims == null || additionalHeaderClaims.Count == 0) && signingCredentials != null)
             {
                 var header = CreateDefaultJWSHeader(signingCredentials);
                 rawHeader = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(header.ToString(Formatting.None)));
-                JsonWebTokenManager.KeyToHeaderCache.TryAdd(JsonWebTokenManager.GetHeaderCacheKey(signingCredentials), rawHeader);
             } // Otherwise, if there is no outer JWT header, add additional header claims to this header.
             else if (additionalHeaderClaims != null && additionalHeaderClaims.Count != 0)
             {

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenManager.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenManager.cs
@@ -33,6 +33,8 @@ using System.Globalization;
 
 namespace Microsoft.IdentityModel.JsonWebTokens
 {
+    // Feature is off pending additional memory tests.
+    /*
     internal static class JsonWebTokenManager
     {
         internal static ConcurrentDictionary<string, string> KeyToHeaderCache = new ConcurrentDictionary<string, string>();
@@ -51,4 +53,5 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             return GetHeaderCacheKey(signingCredentials.Key, signingCredentials.Algorithm);
         }
     }
+    */
 }

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -159,7 +159,6 @@ namespace Microsoft.IdentityModel.Tokens
             IssuerSigningKeyValidator = other.IssuerSigningKeyValidator;
             IssuerValidator = other.IssuerValidator;
             LifetimeValidator = other.LifetimeValidator;
-            TokenReplayValidator = other.TokenReplayValidator;
             NameClaimType = other.NameClaimType;
             NameClaimTypeRetriever = other.NameClaimTypeRetriever;
             PropertyBag = other.PropertyBag;
@@ -175,6 +174,7 @@ namespace Microsoft.IdentityModel.Tokens
             TokenDecryptionKeys = other.TokenDecryptionKeys;
             TokenReader = other.TokenReader;
             TokenReplayCache = other.TokenReplayCache;
+            TokenReplayValidator = other.TokenReplayValidator;
             ValidateActor = other.ValidateActor;
             ValidateAudience = other.ValidateAudience;
             ValidateIssuer = other.ValidateIssuer;
@@ -185,6 +185,7 @@ namespace Microsoft.IdentityModel.Tokens
             ValidAudiences = other.ValidAudiences;
             ValidIssuer = other.ValidIssuer;
             ValidIssuers = other.ValidIssuers;
+            ValidTypes = other.ValidTypes;
         }
 
         /// <summary>
@@ -203,12 +204,6 @@ namespace Microsoft.IdentityModel.Tokens
             ValidateLifetime = true;
             ValidateTokenReplay = false;
         }
-
-        /// <summary>
-        /// Gets or sets a boolean that controls if a '/' is significant at the end of the audience.
-        /// </summary>
-        [DefaultValue(true)]
-        public bool IgnoreTrailingSlashWhenValidatingAudience { get; set; } = true;
 
         /// <summary>
         /// Gets or sets <see cref="TokenValidationParameters"/>.
@@ -331,6 +326,13 @@ namespace Microsoft.IdentityModel.Tokens
         public CryptoProviderFactory CryptoProviderFactory { get; set; }
 
         /// <summary>
+        /// Gets or sets a boolean that controls if a '/' is significant at the end of the audience.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool IgnoreTrailingSlashWhenValidatingAudience { get; set; } = true;
+
+
+        /// <summary>
         /// Gets or sets a delegate for validating the <see cref="SecurityKey"/> that signed the token.
         /// </summary>
         /// <remarks>
@@ -398,29 +400,6 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="string"/> that defines the <see cref="ClaimsIdentity.RoleClaimType"/>.
-        /// </summary>
-        /// <remarks>
-        /// <para>Controls the results of <see cref="ClaimsPrincipal.IsInRole( string )"/>.</para>
-        /// <para>Each <see cref="Claim"/> where <see cref="Claim.Type"/> == <see cref="RoleClaimType"/> will be checked for a match against the 'string' passed to <see cref="ClaimsPrincipal.IsInRole(string)"/>.</para>
-        /// </remarks>
-        public string RoleClaimType
-        {
-            get
-            {
-                return _roleClaimType;
-            }
-
-            set
-            {
-                if (string.IsNullOrWhiteSpace(value))
-                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException("value", LogMessages.IDX10103));
-
-                _roleClaimType = value;
-            }
-        }
-
-        /// <summary>
         /// Gets or sets a delegate that will be called to obtain the NameClaimType to use when creating a ClaimsIdentity
         /// after validating a token.
         /// </summary>
@@ -448,6 +427,29 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         [DefaultValue(true)]
         public bool RequireSignedTokens { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="string"/> that defines the <see cref="ClaimsIdentity.RoleClaimType"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>Controls the results of <see cref="ClaimsPrincipal.IsInRole( string )"/>.</para>
+        /// <para>Each <see cref="Claim"/> where <see cref="Claim.Type"/> == <see cref="RoleClaimType"/> will be checked for a match against the 'string' passed to <see cref="ClaimsPrincipal.IsInRole(string)"/>.</para>
+        /// </remarks>
+        public string RoleClaimType
+        {
+            get
+            {
+                return _roleClaimType;
+            }
+
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException("value", LogMessages.IDX10103));
+
+                _roleClaimType = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets a delegate that will be called to obtain the RoleClaimType to use when creating a ClaimsIdentity
@@ -543,16 +545,6 @@ namespace Microsoft.IdentityModel.Tokens
         public bool ValidateIssuer { get; set; }
 
         /// <summary>
-        /// Gets or sets a boolean to control if the lifetime will be validated during token validation.
-        /// </summary> 
-        /// <remarks>
-        /// This boolean only applies to default lifetime validation. If <see cref= "LifetimeValidator" /> is set, it will be called regardless of whether this
-        /// property is true or false.
-        /// </remarks>
-        [DefaultValue(true)]
-        public bool ValidateLifetime { get; set; }
-
-        /// <summary>
         /// Gets or sets a boolean that controls if validation of the <see cref="SecurityKey"/> that signed the securityToken is called.
         /// </summary>
         /// <remarks>It is possible for tokens to contain the public key needed to check the signature. For example, X509Data can be hydrated into an X509Certificate,
@@ -562,6 +554,16 @@ namespace Microsoft.IdentityModel.Tokens
         /// </remarks>
         [DefaultValue(false)]
         public bool ValidateIssuerSigningKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean to control if the lifetime will be validated during token validation.
+        /// </summary>
+        /// <remarks>
+        /// This boolean only applies to default lifetime validation. If <see cref= "LifetimeValidator" /> is set, it will be called regardless of whether this
+        /// property is true or false.
+        /// </remarks>
+        [DefaultValue(true)]
+        public bool ValidateLifetime { get; set; }
 
         /// <summary>
         /// Gets or sets a boolean to control if the token replay will be validated during token validation.

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -1945,6 +1945,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
+        // Feature is off pending additional memory tests.
+        /*
         // Test checks that headers created with additional claims are not added to JsonWebTokenManager.KeyToHeaderCache.
         [Fact]
         public void HeaderCacheTest()
@@ -1970,6 +1972,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
             TestUtilities.AssertFailIfErrors(context);
         }
+        */
 
         [Theory, MemberData(nameof(JWECompressionTheoryData))]
         public void JWECompressionTest(CreateTokenTheoryData theoryData)

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
@@ -74,6 +74,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     { "CustomKey", "CustomValue" }
                 };
 
+            var validTypes = new List<string> { "ValidType1", "ValidType2", "ValidType3" };
+
             TokenValidationParameters validationParametersInline = new TokenValidationParameters()
             {
                 ActorValidationParameters = actorValidationParameters,
@@ -92,6 +94,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 ValidAudiences = validAudiences,
                 ValidIssuer = validIssuer,
                 ValidIssuers = validIssuers,
+                ValidTypes = validTypes
             };
 
             Assert.True(object.ReferenceEquals(actorValidationParameters, validationParametersInline.ActorValidationParameters));
@@ -122,13 +125,11 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             validationParametersSets.ValidAudiences = validAudiences;
             validationParametersSets.ValidIssuer = validIssuer;
             validationParametersSets.ValidIssuers = validIssuers;
+            validationParametersSets.ValidTypes = validTypes;
 
             var compareContext = new CompareContext();
             IdentityComparer.AreEqual(validationParametersInline, validationParametersSets, compareContext);
-
-            TokenValidationParameters tokenValidationParametersCloned = validationParametersInline.Clone() as TokenValidationParameters;
-            IdentityComparer.AreEqual(tokenValidationParametersCloned, validationParametersInline, compareContext);
-            //tokenValidationParametersCloned.AudienceValidator(new string[]{"bob"}, JwtTestTokens.Simple();
+            IdentityComparer.AreEqual(validationParametersInline.Clone() as TokenValidationParameters, validationParametersInline, compareContext);
 
             string id = Guid.NewGuid().ToString();
             DerivedTokenValidationParameters derivedValidationParameters = new DerivedTokenValidationParameters(id, validationParametersInline);
@@ -136,7 +137,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             IdentityComparer.AreEqual(derivedValidationParameters, derivedValidationParametersCloned, compareContext);
             IdentityComparer.AreEqual(derivedValidationParameters.InternalString, derivedValidationParametersCloned.InternalString, compareContext);
 
-            TestUtilities.AssertFailIfErrors("TokenValidationParameters", compareContext.Diffs);
+            TestUtilities.AssertFailIfErrors(compareContext);
         }
 
         [Fact]


### PR DESCRIPTION
Removed caching of JsonHeaders.
This was reported to some users as causing memory presure.

Fixed https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1379.
TokenValidationParmaters.Clone() was not setting the inbound ValidTypes

Rearranged properties in TokenValidationParameters to in lex-order