### PR TITLE
Remove System.Net.Http package reference for .NET Framework (4.5/4.6)

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/Microsoft.IdentityModel.Protocols.SignedHttpRequest.csproj
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/Microsoft.IdentityModel.Protocols.SignedHttpRequest.csproj
@@ -22,9 +22,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' ">
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   
-   <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' And '$(TargetFramework)' != 'net461' ">
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttpVersion)" />
   </ItemGroup>
 

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests.csproj
@@ -21,6 +21,7 @@
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' ">
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
The out-of-band [System.Net.Http nuget](https://www.nuget.org/packages/System.Net.Http/) package is known for causing issues with .NET 4.5/4.6 deployments, and the general guidance is to [avoid using it when targeting the .NET Framework](https://github.com/dotnet/runtime/issues/26131#issuecomment-388199236). 

The proposed change replaces the nuget reference with a framework reference for .NET 4.5 and .NET 4.6.