### PR TITLE
Using TryAllIssuerSigningKeys in saml/saml2 token handlers 

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -909,17 +909,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             }
         }
 
-        private IEnumerable<SecurityKey> GetAllSigningKeys(string token, TokenValidationParameters validationParameters)
-        {
-            LogHelper.LogInformation(TokenLogMessages.IDX10243);
-            if (validationParameters.IssuerSigningKey != null)
-                yield return validationParameters.IssuerSigningKey;
-
-            if (validationParameters.IssuerSigningKeys != null)
-                foreach (SecurityKey key in validationParameters.IssuerSigningKeys)
-                    yield return key;
-        }
-
         private IEnumerable<SecurityKey> GetContentEncryptionKeys(JsonWebToken jwtToken, TokenValidationParameters validationParameters)
         {
             IEnumerable<SecurityKey> keys = null;
@@ -960,11 +949,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <summary>
         /// Returns a <see cref="SecurityKey"/> to use when validating the signature of a token.
         /// </summary>
+        /// <param name="token"></param>
         /// <param name="jwtToken">The <see cref="JsonWebToken"/> that is being validated.</param>
         /// <param name="validationParameters">A <see cref="TokenValidationParameters"/>  required for validation.</param>
+        /// <param name="kidMatched">A <see cref="bool"/> to represent if a issuer signing key matched with token kid or x5t</param>
         /// <returns>Returns a <see cref="SecurityKey"/> to use for signature validation.</returns>
         /// <remarks>If key fails to resolve, then null is returned</remarks>
-        internal virtual SecurityKey ResolveIssuerSigningKey(JsonWebToken jwtToken, TokenValidationParameters validationParameters)
+        internal virtual IEnumerable<SecurityKey> ResolveIssuerSigningKey(string token, JsonWebToken jwtToken, TokenValidationParameters validationParameters, out bool kidMatched)
         {
             if (validationParameters == null)
                 throw LogHelper.LogArgumentNullException(nameof(validationParameters));
@@ -972,7 +963,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (jwtToken == null)
                 throw LogHelper.LogArgumentNullException(nameof(jwtToken));
 
-            return JwtTokenUtilities.ResolveTokenSigningKey(jwtToken.Kid, jwtToken.X5t, jwtToken, validationParameters);
+            return JwtTokenUtilities.GetKeysForTokenSignatureValidation(token, jwtToken.Kid, jwtToken.X5t, jwtToken, validationParameters, out kidMatched);
         }
 
         /// <summary>
@@ -1194,30 +1185,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     return jwtToken;
             }
 
-            var kidMatched = false;
+            bool kidMatched = false;
             IEnumerable<SecurityKey> keys = null;
-            if (validationParameters.IssuerSigningKeyResolver != null)
-            {
-                keys = validationParameters.IssuerSigningKeyResolver(token, jwtToken, jwtToken.Kid, validationParameters);
-            }
-            else
-            {
-                var key = ResolveIssuerSigningKey(jwtToken, validationParameters);
-                if (key != null)
-                {
-                    kidMatched = true;
-                    keys = new List<SecurityKey> { key };
-                }
-            }
-
-            if (keys == null && validationParameters.TryAllIssuerSigningKeys)
-            {
-                // control gets here if:
-                // 1. User specified delegate: IssuerSigningKeyResolver returned null
-                // 2. ResolveIssuerSigningKey returned null
-                // Try all the keys. This is the degenerate case, not concerned about perf.
-                keys = GetAllSigningKeys(token, validationParameters);
-            }
+            keys = ResolveIssuerSigningKey(token, jwtToken, validationParameters, out kidMatched);
 
             // keep track of exceptions thrown, keys that were tried
             var exceptionStrings = new StringBuilder();
@@ -1234,7 +1204,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 throw new SecurityTokenInvalidSignatureException(TokenLogMessages.IDX10508, e);
             }
 
-            if (keys!=null)
+            if (keys != null)
             {
                 foreach (var key in keys)
                 {
@@ -1261,7 +1231,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 }
 
             }
-            
+
             if (kidExists)
             {
                 if (kidMatched)

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -383,14 +383,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <param name="validationParameters">A <see cref="TokenValidationParameters"/> required for validation.</param>
         /// <param name="kidMatched">A <see cref="bool"/> to represent if a a issuer signing key matched with token kid or x5t</param>
         /// <returns>Returns all <see cref="SecurityKey"/> to use for signature validation.</returns>
-        internal static IEnumerable<SecurityKey> GetKeysForTokenSignatureValidation(string token, string kid, string x5t, SecurityToken jwtToken, TokenValidationParameters validationParameters,out bool kidMatched)
+        internal static IEnumerable<SecurityKey> GetKeysForTokenSignatureValidation(string token, string kid, string x5t, SecurityToken jwtToken, TokenValidationParameters validationParameters, out bool kidMatched)
         {
-            IEnumerable<SecurityKey> keys = null;
             kidMatched = false;
 
             if (validationParameters.IssuerSigningKeyResolver != null)
             {
-                keys = validationParameters.IssuerSigningKeyResolver(token, jwtToken, kid, validationParameters);
+                return validationParameters.IssuerSigningKeyResolver(token, jwtToken, kid, validationParameters);
             }
             else
             {
@@ -399,35 +398,18 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 if (key != null)
                 {
                     kidMatched = true;
-                    keys = new List<SecurityKey> { key };
+                    return new List<SecurityKey> { key };
                 }
                 else
                 {
                     kidMatched = false;
                     if (validationParameters.TryAllIssuerSigningKeys)
                     {
-                        keys = GetAllSigningKeys(token, validationParameters);
+                        return TokenUtilities.GetAllSigningKeys(validationParameters);
                     }
                 }
             }
-            return keys;
-        }
-
-        /// <summary>
-        /// Returns all <see cref="SecurityKey"/> provided in validationParameters.
-        /// </summary>
-        /// <param name="token">The <see cref="string"/> representation of the token that is being validated.</param>
-        /// <param name="validationParameters">A <see cref="TokenValidationParameters"/> required for validation.</param>
-        /// <returns>Returns all <see cref="SecurityKey"/> provided in validationParameters.</returns>
-        internal static IEnumerable<SecurityKey> GetAllSigningKeys(string token, TokenValidationParameters validationParameters)
-        {
-            LogHelper.LogInformation(TokenLogMessages.IDX10243);
-            if (validationParameters.IssuerSigningKey != null)
-                yield return validationParameters.IssuerSigningKey;
-
-            if (validationParameters.IssuerSigningKeys != null)
-                foreach (SecurityKey key in validationParameters.IssuerSigningKeys)
-                    yield return key;
+            return null;
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens.Saml/SamlTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/SamlTokenUtilities.cs
@@ -1,0 +1,124 @@
+﻿using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.Xml;
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
+
+namespace Microsoft.IdentityModel.Tokens.Saml
+{
+    /// <summary>
+    /// A class which contains useful methods for processing saml tokens.
+    /// </summary>
+    public class SamlTokenUtilities
+    {
+        /// <summary>
+        /// Returns a <see cref="SecurityKey"/> to use when validating the signature of a token.
+        /// </summary>
+        /// <param name="tokenKeyInfo">The <see cref="KeyInfo"/> field of the token being validated</param>
+        /// <param name="validationParameters">A <see cref="TokenValidationParameters"/> required for validation.</param>
+        /// <returns>Returns a <see cref="SecurityKey"/> to use for signature validation.</returns>
+        /// <remarks>If key fails to resolve, then null is returned</remarks>
+        internal static SecurityKey ResolveTokenSigningKey(KeyInfo tokenKeyInfo, TokenValidationParameters validationParameters)
+        {
+
+            if (validationParameters.IssuerSigningKey != null && tokenKeyInfo.MatchesKey(validationParameters.IssuerSigningKey))
+                return validationParameters.IssuerSigningKey;
+
+            if (validationParameters.IssuerSigningKeys != null)
+            {
+                foreach (var key in validationParameters.IssuerSigningKeys)
+                {
+                    if (tokenKeyInfo.MatchesKey(key))
+                        return key;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns all <see cref="SecurityKey"/> to use when validating the signature of a token.
+        /// </summary>
+        /// <param name="token">The <see cref="string"/> representation of the token that is being validated.</param>
+        /// <param name="samlToken">The <see cref="SecurityToken"/> that is being validated.</param>
+        /// <param name="tokenKeyInfo">The <see cref="KeyInfo"/> field of the token being validated</param>
+        /// <param name="validationParameters">A <see cref="TokenValidationParameters"/> required for validation.</param>
+        /// <param name="keyMatched">A <see cref="bool"/> to represent if a a issuer signing key matched with token kid or x5t</param>
+        /// <returns>Returns all <see cref="SecurityKey"/> to use for signature validation.</returns>
+        internal static IEnumerable<SecurityKey> GetKeysForTokenSignatureValidation(string token,SecurityToken samlToken, KeyInfo tokenKeyInfo, TokenValidationParameters validationParameters, out bool keyMatched)
+        {
+            IEnumerable<SecurityKey> keys = null;
+            keyMatched = false;
+
+            if (validationParameters.IssuerSigningKeyResolver != null)
+            {
+                keys = validationParameters.IssuerSigningKeyResolver(token, samlToken, tokenKeyInfo?.Id, validationParameters);
+            }
+            else
+            {
+                SecurityKey key = ResolveTokenSigningKey(tokenKeyInfo, validationParameters);
+
+                if (key != null)
+                {
+                    keyMatched = true;
+                    keys = new List<SecurityKey> { key };
+                }
+                else
+                {
+                    keyMatched = false;
+                    if (validationParameters.TryAllIssuerSigningKeys)
+                    {
+                        keys = GetAllSigningKeys(validationParameters);
+                    }
+                }
+            }
+            return keys;
+        }
+
+        /// <summary>
+        /// Returns all <see cref="SecurityKey"/> provided in validationParameters.
+        /// </summary>
+        /// <param name="validationParameters">A <see cref="TokenValidationParameters"/> required for validation.</param>
+        /// <returns>Returns all <see cref="SecurityKey"/> provided in validationParameters.</returns>
+        internal static IEnumerable<SecurityKey> GetAllSigningKeys(TokenValidationParameters validationParameters)
+        {
+            LogHelper.LogInformation(TokenLogMessages.IDX10243);
+            if (validationParameters.IssuerSigningKey != null)
+                yield return validationParameters.IssuerSigningKey;
+
+            if (validationParameters.IssuerSigningKeys != null)
+                foreach (SecurityKey key in validationParameters.IssuerSigningKeys)
+                    yield return key;
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens.Saml/SamlTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/SamlTokenUtilities.cs
@@ -50,7 +50,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         /// <remarks>If key fails to resolve, then null is returned</remarks>
         internal static SecurityKey ResolveTokenSigningKey(KeyInfo tokenKeyInfo, TokenValidationParameters validationParameters)
         {
-
             if (validationParameters.IssuerSigningKey != null && tokenKeyInfo.MatchesKey(validationParameters.IssuerSigningKey))
                 return validationParameters.IssuerSigningKey;
 
@@ -75,14 +74,13 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         /// <param name="validationParameters">A <see cref="TokenValidationParameters"/> required for validation.</param>
         /// <param name="keyMatched">A <see cref="bool"/> to represent if a a issuer signing key matched with token kid or x5t</param>
         /// <returns>Returns all <see cref="SecurityKey"/> to use for signature validation.</returns>
-        internal static IEnumerable<SecurityKey> GetKeysForTokenSignatureValidation(string token,SecurityToken samlToken, KeyInfo tokenKeyInfo, TokenValidationParameters validationParameters, out bool keyMatched)
+        internal static IEnumerable<SecurityKey> GetKeysForTokenSignatureValidation(string token, SecurityToken samlToken, KeyInfo tokenKeyInfo, TokenValidationParameters validationParameters, out bool keyMatched)
         {
-            IEnumerable<SecurityKey> keys = null;
             keyMatched = false;
 
             if (validationParameters.IssuerSigningKeyResolver != null)
             {
-                keys = validationParameters.IssuerSigningKeyResolver(token, samlToken, tokenKeyInfo?.Id, validationParameters);
+                return validationParameters.IssuerSigningKeyResolver(token, samlToken, tokenKeyInfo?.Id, validationParameters);
             }
             else
             {
@@ -91,34 +89,18 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 if (key != null)
                 {
                     keyMatched = true;
-                    keys = new List<SecurityKey> { key };
+                    return new List<SecurityKey> { key };
                 }
                 else
                 {
                     keyMatched = false;
                     if (validationParameters.TryAllIssuerSigningKeys)
                     {
-                        keys = GetAllSigningKeys(validationParameters);
+                        return TokenUtilities.GetAllSigningKeys(validationParameters);
                     }
                 }
             }
-            return keys;
-        }
-
-        /// <summary>
-        /// Returns all <see cref="SecurityKey"/> provided in validationParameters.
-        /// </summary>
-        /// <param name="validationParameters">A <see cref="TokenValidationParameters"/> required for validation.</param>
-        /// <returns>Returns all <see cref="SecurityKey"/> provided in validationParameters.</returns>
-        internal static IEnumerable<SecurityKey> GetAllSigningKeys(TokenValidationParameters validationParameters)
-        {
-            LogHelper.LogInformation(TokenLogMessages.IDX10243);
-            if (validationParameters.IssuerSigningKey != null)
-                yield return validationParameters.IssuerSigningKey;
-
-            if (validationParameters.IssuerSigningKeys != null)
-                foreach (SecurityKey key in validationParameters.IssuerSigningKeys)
-                    yield return key;
+            return null;
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/TokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenUtilities.cs
@@ -1,0 +1,59 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Logging;
+using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// A class which contains useful methods for processing tokens.
+    /// </summary>
+    public class TokenUtilities
+    {
+        /// <summary>
+        /// Returns all <see cref="SecurityKey"/> provided in validationParameters.
+        /// </summary>
+        /// <param name="validationParameters">A <see cref="TokenValidationParameters"/> required for validation.</param>
+        /// <returns>Returns all <see cref="SecurityKey"/> provided in validationParameters.</returns>
+        internal static IEnumerable<SecurityKey> GetAllSigningKeys(TokenValidationParameters validationParameters)
+        {
+            LogHelper.LogInformation(TokenLogMessages.IDX10243);
+            if (validationParameters.IssuerSigningKey != null)
+                yield return validationParameters.IssuerSigningKey;
+
+            if (validationParameters.IssuerSigningKeys != null)
+                foreach (SecurityKey key in validationParameters.IssuerSigningKeys)
+                    yield return key;
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Xml/KeyInfo.cs
+++ b/src/Microsoft.IdentityModel.Xml/KeyInfo.cs
@@ -145,6 +145,9 @@ namespace Microsoft.IdentityModel.Xml
         /// </summary>
         internal bool MatchesKey(SecurityKey key)
         {
+            if (key == null)
+                return false;
+
             if (key is X509SecurityKey x509SecurityKey)
             {
                 return Matches(x509SecurityKey);
@@ -163,6 +166,9 @@ namespace Microsoft.IdentityModel.Xml
 
         private bool Matches(X509SecurityKey key)
         {
+            if (key == null)
+                return false;
+
             foreach (var data in X509Data)
             {
                 foreach (var certificate in data.Certificates)
@@ -178,6 +184,9 @@ namespace Microsoft.IdentityModel.Xml
 
         private bool Matches(RsaSecurityKey key)
         {
+            if (key == null)
+                return false;
+
             if (!key.Parameters.Equals(default(RSAParameters)))
             {
                 return (RSAKeyValue.Exponent.Equals(Convert.ToBase64String(key.Parameters.Exponent))
@@ -195,6 +204,9 @@ namespace Microsoft.IdentityModel.Xml
 
         private bool Matches(JsonWebKey key)
         {
+            if (key == null)
+                return false;
+
             if (RSAKeyValue != null)
             {
                 return (RSAKeyValue.Exponent.Equals(Convert.FromBase64String(key.E))

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1187,7 +1187,7 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <param name="kidMatched">A <see cref="bool"/> to represent if a issuer signing key matched with token kid or x5t</param>
         /// <returns>Returns a <see cref="SecurityKey"/> to use for signature validation.</returns>
         /// <remarks>If key fails to resolve, then null is returned</remarks>
-        protected virtual IEnumerable<SecurityKey> ResolveIssuerSigningKey(string token, JwtSecurityToken jwtToken, TokenValidationParameters validationParameters,out bool kidMatched)
+        protected virtual IEnumerable<SecurityKey> ResolveIssuerSigningKey(string token, JwtSecurityToken jwtToken, TokenValidationParameters validationParameters, out bool kidMatched)
         {
             if (validationParameters == null)
                 throw LogHelper.LogArgumentNullException(nameof(validationParameters));
@@ -1195,15 +1195,7 @@ namespace System.IdentityModel.Tokens.Jwt
             if (jwtToken == null)
                 throw LogHelper.LogArgumentNullException(nameof(jwtToken));
 
-            string kid = null;
-            string x5t = null;
-            if (jwtToken.Header != null)
-            {
-                kid = jwtToken.Header.Kid;
-                x5t = jwtToken.Header.X5t;
-            }
-
-            return JwtTokenUtilities.GetKeysForTokenSignatureValidation(token, kid, x5t, jwtToken, validationParameters, out kidMatched);
+            return JwtTokenUtilities.GetKeysForTokenSignatureValidation(token, jwtToken.Header.Kid, jwtToken.Header.X5t, jwtToken, validationParameters, out kidMatched);
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
@@ -1005,7 +1005,19 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidateIssuer = false,
                             RequireSignedTokens = false
                         },
-                    }
+                    },
+                    new Saml2TheoryData
+                    {
+                        ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10500:"),
+                        Handler = new Saml2SecurityTokenHandler(),
+                        TestId = $"{nameof(ReferenceTokens.Saml2Token_AttributeTampered_NoKeyMatch)}NotTryAllIssuerSigningKeys",
+                        Token = ReferenceTokens.Saml2Token_AttributeTampered_NoKeyMatch,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
+                            TryAllIssuerSigningKeys = false
+                        }
+                    },
                 };
             }
         }

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
@@ -665,7 +665,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                         }
                     },
                     new SamlTheoryData
-                    { 
+                    {
                         Audiences = new List<string>(),
                         Token = ReferenceTokens.SamlToken_NoAudienceRestrictions_NoSignature,
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenException), "IDX11401:"),
@@ -740,7 +740,19 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidateIssuer = false,
                             RequireSignedTokens = false
                         },
-                    }
+                    },
+                    new SamlTheoryData
+                    {
+                        ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10500:"),
+                        Handler = new SamlSecurityTokenHandler(),
+                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}NotTryAllIssuerSigningKeys",
+                        Token = ReferenceTokens.SamlToken_Valid,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
+                            TryAllIssuerSigningKeys = false
+                        }
+                    },
                 };
             }
         }


### PR DESCRIPTION
Fixes #1407 

1. Adding usage of _TryAllIssuerSigningKeys_ in saml/saml2 token handlers 
2. Moving the logic of gathering keys to validate signature into jwttoken and samltoken utilities.

All test runs are successful.