### PR TITLE
Allow users to specify the acceptable algorithms for crypto operations

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -1056,6 +1056,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 {
                     try
                     {
+                        Validators.ValidateAlgorithm(samlToken.Assertion.Signature.SignedInfo.SignatureMethod, key, samlToken, validationParameters);
+
                         samlToken.Assertion.Signature.Verify(key, validationParameters.CryptoProviderFactory ?? key.CryptoProviderFactory);
                         LogHelper.LogInformation(TokenLogMessages.IDX10242, token);
                         samlToken.SigningKey = key;

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -420,6 +420,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                 {
                     try
                     {
+                        Validators.ValidateAlgorithm(samlToken.Assertion.Signature.SignedInfo.SignatureMethod, key, samlToken, validationParameters);
+
                         samlToken.Assertion.Signature.Verify(key, validationParameters.CryptoProviderFactory ?? key.CryptoProviderFactory);
                         LogHelper.LogInformation(TokenLogMessages.IDX10242, token);
                         samlToken.SigningKey = key;

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenInvalidAlgorithmException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenInvalidAlgorithmException.cs
@@ -1,0 +1,110 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// This exception is thrown when a cryptographic algorithm is invalid.
+    /// </summary>
+    [Serializable]
+    public class SecurityTokenInvalidAlgorithmException : SecurityTokenValidationException
+    {
+        [NonSerialized]
+        const string _Prefix = "Microsoft.IdentityModel." + nameof(SecurityTokenInvalidAlgorithmException) + ".";
+
+        [NonSerialized]
+        const string _InvalidAlgorithmKey = _Prefix + nameof(InvalidAlgorithm);
+
+        /// <summary>
+        /// Gets or sets the invalid algorithm that created the validation exception.
+        /// </summary>
+        public string InvalidAlgorithm { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenInvalidAlgorithmException"/> class.
+        /// </summary>
+        public SecurityTokenInvalidAlgorithmException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenInvalidAlgorithmException"/> class.
+        /// </summary>
+        /// <param name="message">Additional information to be included in the exception and displayed to user.</param>
+        public SecurityTokenInvalidAlgorithmException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenInvalidAlgorithmException"/> class.
+        /// </summary>
+        /// <param name="message">Additional information to be included in the exception and displayed to user.</param>
+        /// <param name="innerException">A <see cref="Exception"/> that represents the root cause of the exception.</param>
+        public SecurityTokenInvalidAlgorithmException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenInvalidTypeException"/> class.
+        /// </summary>
+        /// <param name="info">the <see cref="SerializationInfo"/> that holds the serialized object data.</param>
+        /// <param name="context">The contextual information about the source or destination.</param>
+        protected SecurityTokenInvalidAlgorithmException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            SerializationInfoEnumerator enumerator = info.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                switch (enumerator.Name)
+                {
+                    case _InvalidAlgorithmKey:
+                        InvalidAlgorithm = info.GetString(_InvalidAlgorithmKey);
+                        break;
+
+                    default:
+                        // Ignore other fields.
+                        break;
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+
+            if (!string.IsNullOrEmpty(InvalidAlgorithm))
+                info.AddValue(_InvalidAlgorithmKey, InvalidAlgorithm);
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -197,6 +197,8 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10693 = "IDX10693: RSACryptoServiceProvider doesn't support the RSASSA-PSS signature algorithm. The list of supported algorithms is available here: https://aka.ms/IdentityModel/supported-algorithms";
         public const string IDX10694 = "IDX10694: JsonWebKeyConverter threw attempting to convert JsonWebKey: '{0}'. Exception: '{1}'.";
         public const string IDX10695 = "IDX10695: Unable to create a JsonWebKey from an ECDsa object. Required ECParameters structure is not supported by .NET Framework < 4.7.";
+        public const string IDX10696 = "IDX10696: The algorithm '{0}' is not in the user-defined accepted list of algorithms.";
+        public const string IDX10697 = "IDX10697: The user defined 'Delegate' AlgorithmValidator specified on TokenValidationParameters returned false when validating Algorithm: '{0}', SecurityKey: '{1}'.";
 
         // security keys
         public const string IDX10700 = "IDX10700: {0} is unable to use 'rsaParameters'. {1} is null.";

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -34,6 +34,16 @@ using Microsoft.IdentityModel.Logging;
 namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
+    /// Definition for AlgorithmValidator
+    /// </summary>
+    /// <param name="algorithm">The algorithm to validate.</param>
+    /// <param name="securityKey">The <see cref="SecurityKey"/> that signed the <see cref="SecurityToken"/>.</param>
+    /// <param name="securityToken">The <see cref="SecurityToken"/> being validated.</param>
+    /// <param name="validationParameters"><see cref="TokenValidationParameters"/> required for validation.</param>
+    /// <returns><c>true</c> if the algorithm is considered valid</returns>
+    public delegate bool AlgorithmValidator(string algorithm, SecurityKey securityKey, SecurityToken securityToken, TokenValidationParameters validationParameters);
+
+    /// <summary>
     /// Definition for AudienceValidator.
     /// </summary>
     /// <param name="audiences">The audiences found in the <see cref="SecurityToken"/>.</param>
@@ -156,6 +166,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (other == null)
                 throw LogHelper.LogExceptionMessage(new ArgumentNullException(nameof(other)));
 
+            AlgorithmValidator = other.AlgorithmValidator;
             ActorValidationParameters = other.ActorValidationParameters?.Clone();
             AudienceValidator = other.AudienceValidator;
             _authenticationType = other._authenticationType;
@@ -192,6 +203,7 @@ namespace Microsoft.IdentityModel.Tokens
             ValidateIssuerSigningKey = other.ValidateIssuerSigningKey;
             ValidateLifetime = other.ValidateLifetime;
             ValidateTokenReplay = other.ValidateTokenReplay;
+            ValidAlgorithms = other.ValidAlgorithms;
             ValidAudience = other.ValidAudience;
             ValidAudiences = other.ValidAudiences;
             ValidIssuer = other.ValidIssuer;
@@ -221,6 +233,15 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets or sets <see cref="TokenValidationParameters"/>.
         /// </summary>
         public TokenValidationParameters ActorValidationParameters { get; set; }
+
+        /// <summary>
+        /// Gets or sets a delegate used to validate the cryptographic algorithm used.
+        /// </summary>
+        /// <remarks>
+        /// If set, this delegate will validate the cryptographic algorithm used and
+        /// the algorithm will not be checked against <see cref="ValidAlgorithms"/>.
+        /// </remarks>
+        public AlgorithmValidator AlgorithmValidator { get; set; }
 
         /// <summary>
         /// Gets or sets a delegate that will be used to validate the audience.
@@ -604,6 +625,14 @@ namespace Microsoft.IdentityModel.Tokens
         /// </remarks>
         [DefaultValue(false)]
         public bool ValidateTokenReplay { get; set; }
+
+        /// <summary>
+        /// Gets or sets the valid algorithms for cryptographic operations.
+        /// </summary>
+        /// <remarks>
+        /// If set to a non-empty collection, only the algorithms listed will be considered valid.
+        /// </remarks>
+        public IEnumerable<string> ValidAlgorithms { get; set; }
 
         /// <summary>
         /// Gets or sets a string that represents a valid audience that will be used to check against the token's audience.

--- a/src/Microsoft.IdentityModel.Tokens/Validators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validators.cs
@@ -39,6 +39,40 @@ namespace Microsoft.IdentityModel.Tokens
     public static class Validators
     {
         /// <summary>
+        /// Validates if a given algorithm for a <see cref="SecurityKey"/> is valid.
+        /// </summary>
+        /// <param name="algorithm">The algorithm to be validated.</param>
+        /// <param name="securityKey">The <see cref="SecurityKey"/> that signed the <see cref="SecurityToken"/>.</param>
+        /// <param name="securityToken">The <see cref="SecurityToken"/> being validated.</param>
+        /// <param name="validationParameters"><see cref="TokenValidationParameters"/> required for validation.</param>
+        public static void ValidateAlgorithm(string algorithm, SecurityKey securityKey, SecurityToken securityToken, TokenValidationParameters validationParameters)
+        {
+            if (validationParameters == null)
+                throw LogHelper.LogArgumentNullException(nameof(validationParameters));
+
+            if (validationParameters.AlgorithmValidator != null)
+            {
+                if (!validationParameters.AlgorithmValidator(algorithm, securityKey, securityToken, validationParameters))
+                {
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidAlgorithmException(LogHelper.FormatInvariant(LogMessages.IDX10697, algorithm, securityKey))
+                    {
+                        InvalidAlgorithm = algorithm,
+                    });
+                }
+
+                return;
+            }
+
+            if (validationParameters.ValidAlgorithms != null && validationParameters.ValidAlgorithms.Any() && !validationParameters.ValidAlgorithms.Contains(algorithm, StringComparer.Ordinal))
+            {
+                throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidAlgorithmException(LogHelper.FormatInvariant(LogMessages.IDX10696, algorithm))
+                {
+                    InvalidAlgorithm = algorithm,
+                });
+            }
+        }
+
+        /// <summary>
         /// Determines if the audiences found in a <see cref="SecurityToken"/> are valid.
         /// </summary>
         /// <param name="audiences">The audiences found in the <see cref="SecurityToken"/>.</param>

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -1853,7 +1853,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             {
                 return new TheoryData<JwtTheoryData>
                 {
-                     new JwtTheoryData
+                    new JwtTheoryData
                     {
                         TestId = nameof(Default.AsymmetricJws) + "_" + "RequireSignedTokens",
                         Token = Default.AsymmetricJws,
@@ -1867,7 +1867,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             ValidateLifetime = false,
                         }
                     },
-                     new JwtTheoryData
+                    new JwtTheoryData
                     {
                         TestId = nameof(Default.SymmetricJws) + "_" + "RequireSignedTokens",
                         Token = Default.SymmetricJws,
@@ -1939,7 +1939,196 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             ValidateAudience = false,
                             ValidateLifetime = false,
                         }
-                    }
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = nameof(Default.SymmetricJws) + "_" + "SpecifyAcceptedAlgorithms_AlgorithmInList",
+                        Token = Default.SymmetricJws,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = false,
+                            IssuerSigningKey = Default.SymmetricSigningKey,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string> { SecurityAlgorithms.HmacSha256 }
+                        }
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = nameof(Default.SymmetricJws) + "_" + "SpecifyAcceptedAlgorithms_EmptyList",
+                        Token = Default.SymmetricJws,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = false,
+                            IssuerSigningKey = Default.SymmetricSigningKey,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string>()
+                        }
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = nameof(Default.SymmetricJws) + "_" + "SpecifyAcceptedAlgorithms_AlgorithmNotInList",
+                        Token = Default.SymmetricJws,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = false,
+                            IssuerSigningKey = Default.SymmetricSigningKey,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string> { SecurityAlgorithms.RsaSha256 }
+                        },
+                        ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10511")
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = nameof(Default.SymmetricJws) + "_" + "SpecifyAcceptedAlgorithmValidator_Validates",
+                        Token = Default.SymmetricJws,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = false,
+                            IssuerSigningKey = Default.SymmetricSigningKey,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            AlgorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(true)
+                        }
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = nameof(Default.SymmetricJws) + "_" + "SpecifyAcceptedAlgorithmValidator_DoesNotValidate",
+                        Token = Default.SymmetricJws,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = false,
+                            IssuerSigningKey = Default.SymmetricSigningKey,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            AlgorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(false)
+                        },
+                        ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10511")
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = nameof(Default.SymmetricJws) + "_" + "SpecifyAcceptedAlgorithmValidator_Throws",
+                        Token = Default.SymmetricJws,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = false,
+                            IssuerSigningKey = Default.SymmetricSigningKey,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            AlgorithmValidator = (alg, key, token, validationParameters) => throw new TestException("expected error validating algorithm")
+                        },
+                        ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10511")
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = "JWE_NoGivenAcceptedAlgorithms",
+                        Token = new JsonWebTokenHandler().CreateToken(
+                            Default.PayloadString,
+                            KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2,
+                            new EncryptingCredentials(KeyingMaterial.DefaultX509Key_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256)),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = false,
+                            IssuerSigningKey = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            TokenDecryptionKey = KeyingMaterial.DefaultX509Key_2048,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                        },
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = "JWE_AcceptedAlgorithms_AlgorithmsInList",
+                        Token = new JsonWebTokenHandler().CreateToken(
+                            Default.PayloadString,
+                            KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2,
+                            new EncryptingCredentials(KeyingMaterial.DefaultX509Key_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256)),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = false,
+                            IssuerSigningKey = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            TokenDecryptionKey = KeyingMaterial.DefaultX509Key_2048,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string> { SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256, SecurityAlgorithms.HmacSha256Signature }
+                        },
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = "JWE_AcceptedAlgorithms_AlgorithmsNotInList",
+                        Token = new JsonWebTokenHandler().CreateToken(
+                            Default.PayloadString,
+                            KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2,
+                            new EncryptingCredentials(KeyingMaterial.DefaultX509Key_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256)),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = false,
+                            IssuerSigningKey = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            TokenDecryptionKey = KeyingMaterial.DefaultX509Key_2048,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string> { SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256 }
+                        },
+                        ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10511"),
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = "JWE_AcceptedAlgorithmsValidator_Validates",
+                        Token = new JsonWebTokenHandler().CreateToken(
+                            Default.PayloadString,
+                            KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2,
+                            new EncryptingCredentials(KeyingMaterial.DefaultX509Key_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256)),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = false,
+                            IssuerSigningKey = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            TokenDecryptionKey = KeyingMaterial.DefaultX509Key_2048,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            AlgorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(true)
+                        },
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = "JWE_AcceptedAlgorithmsValidator_DoesNotValidate",
+                        Token = new JsonWebTokenHandler().CreateToken(
+                            Default.PayloadString,
+                            KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2,
+                            new EncryptingCredentials(KeyingMaterial.DefaultX509Key_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256)),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = false,
+                            IssuerSigningKey = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            TokenDecryptionKey = KeyingMaterial.DefaultX509Key_2048,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            AlgorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(false)
+                        },
+                        ExpectedException = ExpectedException.SecurityTokenDecryptionFailedException("IDX10697"),
+                    },
                 };
             }
         }

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -1287,6 +1287,153 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                     },
                     new ValidateSignedHttpRequestTheoryData
                     {
+                        SignedHttpRequestToken = signedHttpRequestWithEncryptedAt,
+                        SignedHttpRequestValidationParameters = new SignedHttpRequestValidationParameters()
+                        {
+                            ValidateB = false,
+                            ValidateH = false,
+                            ValidateM = false,
+                            ValidateP = false,
+                            ValidateQ = false,
+                            ValidateTs = false,
+                            ValidateU = false,
+                        },
+                        ValidationParameters =  new TokenValidationParameters()
+                        {
+                            IssuerSigningKey = KeyingMaterial.RsaSigningCreds_2048_Public.Key,
+                            ValidIssuer = Default.Issuer,
+                            ValidAudience = Default.Audience,
+                            TokenDecryptionKey = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes128_Sha2.Key,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string> { SecurityAlgorithms.RsaSha256 },
+                        },
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidAtClaimException), "IDX23013", typeof(SecurityTokenDecryptionFailedException)),
+                        TestId = "ValidEncryptedAcccessToken_DecryptionAlgorithmNotListed",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        SignedHttpRequestToken = signedHttpRequestWithEncryptedAt,
+                        SignedHttpRequestValidationParameters = new SignedHttpRequestValidationParameters()
+                        {
+                            ValidateB = false,
+                            ValidateH = false,
+                            ValidateM = false,
+                            ValidateP = false,
+                            ValidateQ = false,
+                            ValidateTs = false,
+                            ValidateU = false,
+                        },
+                        ValidationParameters =  new TokenValidationParameters()
+                        {
+                            IssuerSigningKey = KeyingMaterial.RsaSigningCreds_2048_Public.Key,
+                            ValidIssuer = Default.Issuer,
+                            ValidAudience = Default.Audience,
+                            TokenDecryptionKey = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes128_Sha2.Key,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string> { SecurityAlgorithms.Aes128CbcHmacSha256 },
+                        },
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidAtClaimException), "IDX23013", typeof(SecurityTokenSignatureKeyNotFoundException)),
+                        TestId = "ValidEncryptedAcccessToken_IssuerAlgorithmNotListed",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        SignedHttpRequestToken = signedHttpRequestWithEncryptedAt,
+                        SignedHttpRequestValidationParameters = new SignedHttpRequestValidationParameters()
+                        {
+                            ValidateB = false,
+                            ValidateH = false,
+                            ValidateM = false,
+                            ValidateP = false,
+                            ValidateQ = false,
+                            ValidateTs = false,
+                            ValidateU = false,
+                        },
+                        ValidationParameters =  new TokenValidationParameters()
+                        {
+                            IssuerSigningKey = KeyingMaterial.RsaSigningCreds_2048_Public.Key,
+                            ValidIssuer = Default.Issuer,
+                            ValidAudience = Default.Audience,
+                            TokenDecryptionKey = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes128_Sha2.Key,
+                            ValidateLifetime = false,
+                            AlgorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(false),
+                        },
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidAtClaimException), "IDX23013", typeof(SecurityTokenDecryptionFailedException)),
+                        TestId = "ValidEncryptedAcccessToken_AcceptedAlgorithmValidatorFails",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        SignedHttpRequestToken = signedHttpRequestWithEncryptedAt,
+                        SignedHttpRequestValidationParameters = new SignedHttpRequestValidationParameters()
+                        {
+                            ValidateB = false,
+                            ValidateH = false,
+                            ValidateM = false,
+                            ValidateP = false,
+                            ValidateQ = false,
+                            ValidateTs = false,
+                            ValidateU = false,
+                        },
+                        ValidationParameters =  new TokenValidationParameters()
+                        {
+                            IssuerSigningKey = KeyingMaterial.RsaSigningCreds_2048_Public.Key,
+                            ValidIssuer = Default.Issuer,
+                            ValidAudience = Default.Audience,
+                            TokenDecryptionKey = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes128_Sha2.Key,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string> { SecurityAlgorithms.Aes128CbcHmacSha256, SecurityAlgorithms.RsaSha256 },
+                        },
+                        TestId = "ValidEncryptedAcccessToken_AcceptedAlgorithmListed",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        SignedHttpRequestToken = signedHttpRequestWithEncryptedAt,
+                        SignedHttpRequestValidationParameters = new SignedHttpRequestValidationParameters()
+                        {
+                            ValidateB = false,
+                            ValidateH = false,
+                            ValidateM = false,
+                            ValidateP = false,
+                            ValidateQ = false,
+                            ValidateTs = false,
+                            ValidateU = false,
+                        },
+                        ValidationParameters =  new TokenValidationParameters()
+                        {
+                            IssuerSigningKey = KeyingMaterial.RsaSigningCreds_2048_Public.Key,
+                            ValidIssuer = Default.Issuer,
+                            ValidAudience = Default.Audience,
+                            TokenDecryptionKey = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes128_Sha2.Key,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string>(),
+                        },
+                        TestId = "ValidEncryptedAcccessToken_EmptyAcceptedAlgorithms",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        SignedHttpRequestToken = signedHttpRequestWithEncryptedAt,
+                        SignedHttpRequestValidationParameters = new SignedHttpRequestValidationParameters()
+                        {
+                            ValidateB = false,
+                            ValidateH = false,
+                            ValidateM = false,
+                            ValidateP = false,
+                            ValidateQ = false,
+                            ValidateTs = false,
+                            ValidateU = false,
+                        },
+                        ValidationParameters =  new TokenValidationParameters()
+                        {
+                            IssuerSigningKey = KeyingMaterial.RsaSigningCreds_2048_Public.Key,
+                            ValidIssuer = Default.Issuer,
+                            ValidAudience = Default.Audience,
+                            TokenDecryptionKey = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes128_Sha2.Key,
+                            ValidateLifetime = false,
+                            AlgorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(true),
+                        },
+                        TestId = "ValidEncryptedAcccessToken_AcceptedAlgorithmValidatorValidates",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
                         SignedHttpRequestToken = signedHttpRequest,
                         SignedHttpRequestValidationParameters = new SignedHttpRequestValidationParameters()
                         {
@@ -1312,6 +1459,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                         },
                         TestId = "ValidTest",
                     }
+
                 };
             }
         }
@@ -1329,7 +1477,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                 Headers = HttpRequestHeaders
             };
 
-            var tokenValidationParameters = SignedHttpRequestTestUtils.DefaultTokenValidationParameters;
+            var tokenValidationParameters = ValidationParameters ?? SignedHttpRequestTestUtils.DefaultTokenValidationParameters;
 
             // add testId for debugging purposes
             var callContext = CallContext;
@@ -1370,6 +1518,8 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         public SecurityKey ExpectedPopKey { get; set; }
 
         internal JsonWebToken SignedHttpRequestToken { get; set; }
+
+        public TokenValidationParameters ValidationParameters { get; set; }
     }
 }
 

--- a/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
@@ -149,6 +149,7 @@ namespace Microsoft.IdentityModel.TestUtils
                 { typeof(SecurityToken).ToString(), CompareAllPublicProperties},
                 { typeof(SecurityTokenHandler).ToString(), CompareAllPublicProperties},
                 { typeof(SecurityTokenExpiredException).ToString(), CompareAllPublicProperties},
+                { typeof(SecurityTokenInvalidAlgorithmException).ToString(), CompareAllPublicProperties},
                 { typeof(SecurityTokenInvalidAudienceException).ToString(), CompareAllPublicProperties},
                 { typeof(SecurityTokenInvalidIssuerException).ToString(), CompareAllPublicProperties},
                 { typeof(SecurityTokenInvalidSigningKeyException).ToString(), CompareAllPublicProperties},

--- a/test/Microsoft.IdentityModel.TestUtils/ValidationDelegates.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ValidationDelegates.cs
@@ -39,6 +39,11 @@ namespace Microsoft.IdentityModel.TestUtils
     /// </summary>
     public static class ValidationDelegates
     {
+        public static AlgorithmValidator AlgorithmValidatorBuilder(bool result)
+        {
+            return (string algorithm, SecurityKey securityKey, SecurityToken securityToken, TokenValidationParameters validationParameters) => result;
+        }
+
         public static bool AudienceValidatorReturnsFalse(IEnumerable<string> audiences, SecurityToken token, TokenValidationParameters validationParameters)
         {
             return false;

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
@@ -1008,6 +1008,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                     },
                     new Saml2TheoryData
                     {
+
                         ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10500:"),
                         Handler = new Saml2SecurityTokenHandler(),
                         TestId = $"{nameof(ReferenceTokens.Saml2Token_AttributeTampered_NoKeyMatch)}NotTryAllIssuerSigningKeys",
@@ -1017,6 +1018,73 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
                             TryAllIssuerSigningKeys = false
                         }
+                    },
+                    new Saml2TheoryData
+                    {
+                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}_SpecifyAlgorithm_AlgorithnInList",
+                        Token = ReferenceTokens.Saml2Token_Valid,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string> { SecurityAlgorithms.RsaSha256Signature }
+                        }
+                    },
+                    new Saml2TheoryData
+                    {
+                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}_SpecifyAlgorithm_EmptyList",
+                        Token = ReferenceTokens.Saml2Token_Valid,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string>()
+                        }
+                    },
+                    new Saml2TheoryData
+                    {
+                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}_SpecifyAlgorithm_AlgorithnNotList",
+                        Token = ReferenceTokens.Saml2Token_Valid,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string> { SecurityAlgorithms.RsaSha512Signature }
+                        },
+                        ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10503")
+                    },
+                    new Saml2TheoryData
+                    {
+                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}_SpecifyAlgorithm_AlgorithmValidationFails",
+                        Token = ReferenceTokens.Saml2Token_Valid,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            AlgorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(false)
+                        },
+                        ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10503")
+                    },
+                    new Saml2TheoryData
+                    {
+                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}_SpecifyAlgorithm_AlgorithmValidationValidates",
+                        Token = ReferenceTokens.Saml2Token_Valid,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            AlgorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(true)
+                        },
                     },
                 };
             }

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
@@ -727,7 +727,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                     },
                     new SamlTheoryData
                     {
-
                         Audiences = new List<string>(),
                         Token = ReferenceTokens.SamlToken_NoConditions_NoSignature,
                         TestId = $"{nameof(ReferenceTokens.SamlToken_NoConditions_NoSignature)}RequireAudienceFalse",
@@ -752,6 +751,78 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
                             TryAllIssuerSigningKeys = false
                         }
+                    },
+                    new SamlTheoryData
+                    {
+                        Handler = new SamlSecurityTokenHandler(),
+                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}_SpecifyAlgorithm_AlgorithnInList",
+                        Token = ReferenceTokens.SamlToken_Valid_WithRsaKeyValue,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.DefaultRsaSecurityKey1,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string> { SecurityAlgorithms.RsaSha256Signature }
+                        }
+                    },
+                    new SamlTheoryData
+                    {
+                        Handler = new SamlSecurityTokenHandler(),
+                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}_SpecifyAlgorithm_EmptyList",
+                        Token = ReferenceTokens.SamlToken_Valid_WithRsaKeyValue,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.DefaultRsaSecurityKey1,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string>(),
+                        }
+                    },
+                    new SamlTheoryData
+                    {
+                        Handler = new SamlSecurityTokenHandler(),
+                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}_SpecifyAlgorithm_AlgorithnNotList",
+                        Token = ReferenceTokens.SamlToken_Valid_WithRsaKeyValue,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.DefaultRsaSecurityKey1,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            ValidAlgorithms = new List<string> { SecurityAlgorithms.RsaSha512Signature }
+                        },
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10501")
+                    },
+                    new SamlTheoryData
+                    {
+                        Handler = new SamlSecurityTokenHandler(),
+                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}_SpecifyAlgorithm_AlgorithmValidationFails",
+                        Token = ReferenceTokens.SamlToken_Valid_WithRsaKeyValue,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.DefaultRsaSecurityKey1,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            AlgorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(false)
+                        },
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10501")
+                    },
+                    new SamlTheoryData
+                    {
+                        Handler = new SamlSecurityTokenHandler(),
+                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}_SpecifyAlgorithm_AlgorithmValidationValidates",
+                        Token = ReferenceTokens.SamlToken_Valid_WithRsaKeyValue,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.DefaultRsaSecurityKey1,
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            AlgorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(true)
+                        },
                     },
                 };
             }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SecurityTokenExceptionTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SecurityTokenExceptionTests.cs
@@ -200,6 +200,23 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         TestId = "SecurityTokenInvalidSigningKeyExceptionSerializesPropertiesDefaultValue",
                         ExceptionType = typeof(SecurityTokenInvalidSigningKeyException),
                     },
+                    new SecurityTokenExceptionTheoryData
+                    {
+                        TestId = "SecurityTokenInvalidAlgorithmSerializesProperties",
+                        ExceptionType = typeof(SecurityTokenInvalidAlgorithmException),
+                        ExceptionSetter = (ex) =>
+                        {
+                            if (!(ex is SecurityTokenInvalidAlgorithmException securityTokenInvalidAlgorithm))
+                                throw new ArgumentException($"expected argument of type {nameof(SecurityTokenInvalidAlgorithmException)} recieved type {ex.GetType()}");
+
+                            securityTokenInvalidAlgorithm.InvalidAlgorithm = Guid.NewGuid().ToString();
+                        },
+                    },
+                    new SecurityTokenExceptionTheoryData
+                    {
+                        TestId = "SecurityTokenInvalidAlgorithmSerializesPropertiesDefaultValue",
+                        ExceptionType = typeof(SecurityTokenInvalidAlgorithmException),
+                    },
                 };
             }
         }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
@@ -42,8 +42,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 41)
-                Assert.True(false, "Number of properties has changed from 41 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 43)
+                Assert.True(false, "Number of properties has changed from 43 to: " + properties.Length + ", adjust tests");
 
             TokenValidationParameters actorValidationParameters = new TokenValidationParameters();
             SecurityKey issuerSigningKey = KeyingMaterial.DefaultX509Key_2048_Public;
@@ -76,10 +76,15 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
             TypeValidator typeValidator = (typ, token, parameters) => "ActualType";
 
+            AlgorithmValidator algorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(false);
+
             var validTypes = new List<string> { "ValidType1", "ValidType2", "ValidType3" };
+
+            var validAlgorithms = new List<string> { "RSA2048", "RSA1024" };
 
             TokenValidationParameters validationParametersInline = new TokenValidationParameters()
             {
+                AlgorithmValidator = algorithmValidator,
                 ActorValidationParameters = actorValidationParameters,
                 AudienceValidator = ValidationDelegates.AudienceValidatorReturnsTrue,
                 IssuerSigningKey = issuerSigningKey,
@@ -91,6 +96,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 SignatureValidator = ValidationDelegates.SignatureValidatorReturnsJwtTokenAsIs,
                 SaveSigninToken = true,
                 TypeValidator = typeValidator,
+                ValidAlgorithms = validAlgorithms,
                 ValidateAudience = false,
                 ValidateIssuer = false,
                 ValidAudience = validAudience,
@@ -106,6 +112,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Assert.True(validationParametersInline.SaveSigninToken);
             Assert.False(validationParametersInline.ValidateAudience);
             Assert.False(validationParametersInline.ValidateIssuer);
+            Assert.True(object.ReferenceEquals(validationParametersInline.ValidAlgorithms, validAlgorithms));
+            Assert.True(object.ReferenceEquals(validationParametersInline.AlgorithmValidator, algorithmValidator));
             Assert.True(object.ReferenceEquals(validationParametersInline.TypeValidator, typeValidator));
             Assert.True(object.ReferenceEquals(validationParametersInline.ValidAudience, validAudience));
             Assert.True(object.ReferenceEquals(validationParametersInline.ValidAudiences, validAudiences));
@@ -113,6 +121,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Assert.True(validationParametersInline.IgnoreTrailingSlashWhenValidatingAudience);
 
             TokenValidationParameters validationParametersSets = new TokenValidationParameters();
+            validationParametersSets.AlgorithmValidator = algorithmValidator;
             validationParametersSets.ActorValidationParameters = actorValidationParameters;
             validationParametersSets.AudienceValidator = ValidationDelegates.AudienceValidatorReturnsTrue;
             validationParametersSets.IssuerSigningKey = KeyingMaterial.DefaultX509Key_2048_Public;
@@ -126,6 +135,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             validationParametersSets.TypeValidator = typeValidator;
             validationParametersSets.ValidateAudience = false;
             validationParametersSets.ValidateIssuer = false;
+            validationParametersSets.ValidAlgorithms = validAlgorithms;
             validationParametersSets.ValidAudience = validAudience;
             validationParametersSets.ValidAudiences = validAudiences;
             validationParametersSets.ValidIssuer = validIssuer;
@@ -151,8 +161,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 41)
-                Assert.True(false, "Number of public fields has changed from 41 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 43)
+                Assert.True(false, "Number of public fields has changed from 43 to: " + properties.Length + ", adjust tests");
 
             GetSetContext context =
                 new GetSetContext


### PR DESCRIPTION
Add a collection and a delegate to token validation parameters to allow
a user to specify which cyrpto algorithms are considered acceptable.

fixes #1224 