### PR TITLE
Allow validation of signed http requests claims if present

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -556,7 +556,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             if (validationParameters.ReplayValidatorAsync != null)
                 await signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.ReplayValidatorAsync(jwtSignedHttpRequest, signedHttpRequestValidationContext, cancellationToken).ConfigureAwait(false);
 
-            if (ShouldValidate(jwtSignedHttpRequest,validationParameters.ValidateTs, ValidateIfPresent(validationParameters, SignedHttpRequestClaimTypes.Ts), SignedHttpRequestClaimTypes.Ts))
+            if (ShouldValidate(jwtSignedHttpRequest, validationParameters.ValidateTs, ValidateIfPresent(validationParameters, SignedHttpRequestClaimTypes.Ts), SignedHttpRequestClaimTypes.Ts))
                 ValidateTsClaim(jwtSignedHttpRequest, signedHttpRequestValidationContext);
 
             if (ShouldValidate(jwtSignedHttpRequest, validationParameters.ValidateM, ValidateIfPresent(validationParameters, SignedHttpRequestClaimTypes.M), SignedHttpRequestClaimTypes.M))

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -551,31 +551,53 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             if (!(signedHttpRequest is JsonWebToken jwtSignedHttpRequest))
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestValidationException(LogHelper.FormatInvariant(LogMessages.IDX23030, signedHttpRequest.GetType(), typeof(JsonWebToken), signedHttpRequest)));
 
-            if (signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.ReplayValidatorAsync != null)
+            var validationParameters = signedHttpRequestValidationContext.SignedHttpRequestValidationParameters;
+
+            if (validationParameters.ReplayValidatorAsync != null)
                 await signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.ReplayValidatorAsync(jwtSignedHttpRequest, signedHttpRequestValidationContext, cancellationToken).ConfigureAwait(false);
 
-            if (signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.ValidateTs)
+            if (ShouldValidate(jwtSignedHttpRequest,validationParameters.ValidateTs, ValidateIfPresent(validationParameters, SignedHttpRequestClaimTypes.Ts), SignedHttpRequestClaimTypes.Ts))
                 ValidateTsClaim(jwtSignedHttpRequest, signedHttpRequestValidationContext);
 
-            if (signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.ValidateM)
+            if (ShouldValidate(jwtSignedHttpRequest, validationParameters.ValidateM, ValidateIfPresent(validationParameters, SignedHttpRequestClaimTypes.M), SignedHttpRequestClaimTypes.M))
                 ValidateMClaim(jwtSignedHttpRequest, signedHttpRequestValidationContext);
 
-            if (signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.ValidateU)
+            if (ShouldValidate(jwtSignedHttpRequest, validationParameters.ValidateU, ValidateIfPresent(validationParameters, SignedHttpRequestClaimTypes.U), SignedHttpRequestClaimTypes.U))
                 ValidateUClaim(jwtSignedHttpRequest, signedHttpRequestValidationContext);
 
-            if (signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.ValidateP)
+            if (ShouldValidate(jwtSignedHttpRequest, validationParameters.ValidateP, ValidateIfPresent(validationParameters, SignedHttpRequestClaimTypes.P), SignedHttpRequestClaimTypes.P))
                 ValidatePClaim(jwtSignedHttpRequest, signedHttpRequestValidationContext);
 
-            if (signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.ValidateQ)
+            if (ShouldValidate(jwtSignedHttpRequest, validationParameters.ValidateQ, ValidateIfPresent(validationParameters, SignedHttpRequestClaimTypes.Q), SignedHttpRequestClaimTypes.Q))
                 ValidateQClaim(jwtSignedHttpRequest, signedHttpRequestValidationContext);
 
-            if (signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.ValidateH)
+            if (ShouldValidate(jwtSignedHttpRequest, validationParameters.ValidateH, ValidateIfPresent(validationParameters, SignedHttpRequestClaimTypes.H), SignedHttpRequestClaimTypes.H))
                 ValidateHClaim(jwtSignedHttpRequest, signedHttpRequestValidationContext);
 
-            if (signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.ValidateB)
+            if (ShouldValidate(jwtSignedHttpRequest, validationParameters.ValidateB, ValidateIfPresent(validationParameters, SignedHttpRequestClaimTypes.B), SignedHttpRequestClaimTypes.B))
                 ValidateBClaim(jwtSignedHttpRequest, signedHttpRequestValidationContext);
 
             return jwtSignedHttpRequest;
+        }
+
+        /// <summary>
+        /// Determine if validation of a claim should happen.
+        /// </summary>
+        /// <param name="jwtSignedHttpRequest">The request being considered to validate the claim on.</param>
+        /// <param name="validateClaim">Force validation to always occur.</param>
+        /// <param name="validateIfPresent">Validate if the claim is present.</param>
+        /// <param name="claimName">The name of the claim to validate.</param>
+        /// <returns>Whether the given claim should be validated.</returns>
+        internal virtual bool ShouldValidate(JsonWebToken jwtSignedHttpRequest, bool validateClaim, bool validateIfPresent, string claimName)
+        {
+            return validateClaim || (validateIfPresent && jwtSignedHttpRequest.TryGetClaim(claimName, out var claimValue) && claimValue != null);
+        }
+
+        private bool ValidateIfPresent(SignedHttpRequestValidationParameters validationParameters, string claim)
+        {
+            return validationParameters.ValidatePresentClaims &&
+                validationParameters.ClaimsToValidateWhenPresent != null &&
+                validationParameters.ClaimsToValidateWhenPresent.Contains(claim);
         }
 
         /// <summary>
@@ -632,8 +654,10 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <param name="signedHttpRequest">A SignedHttpRequest.</param>
         /// <param name="signedHttpRequestValidationContext">A structure that wraps parameters needed for SignedHttpRequest validation.</param>
         /// <remarks>
-        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateTs"/> is set to <c>true</c>.
-        /// </remarks>    
+        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateTs"/> is set to <c>true</c> or a ts claim is present and
+        /// <see cref="SignedHttpRequestValidationParameters.ValidatePresentClaims"/> is set to true and <see cref="SignedHttpRequestClaimTypes.Ts"/> is in
+        /// <see cref="SignedHttpRequestValidationParameters.ClaimsToValidateWhenPresent"/>.
+        /// </remarks>
         internal virtual void ValidateTsClaim(JsonWebToken signedHttpRequest, SignedHttpRequestValidationContext signedHttpRequestValidationContext)
         {
             if (!signedHttpRequest.TryGetPayloadValue(SignedHttpRequestClaimTypes.Ts, out long tsClaimValue))
@@ -653,8 +677,10 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <param name="signedHttpRequest">A SignedHttpRequest.</param>
         /// <param name="signedHttpRequestValidationContext">A structure that wraps parameters needed for SignedHttpRequest validation.</param>
         /// <remarks>
-        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateM"/> is set to <c>true</c>.
-        /// </remarks>     
+        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateM"/> is set to <c>true</c> or a m claim is present and
+        /// <see cref="SignedHttpRequestValidationParameters.ValidatePresentClaims"/> is set to true and <see cref="SignedHttpRequestClaimTypes.M"/> is in
+        /// <see cref="SignedHttpRequestValidationParameters.ClaimsToValidateWhenPresent"/>.
+        /// </remarks>
         internal virtual void ValidateMClaim(JsonWebToken signedHttpRequest, SignedHttpRequestValidationContext signedHttpRequestValidationContext)
         {
             var expectedHttpMethod = signedHttpRequestValidationContext.HttpRequestData.Method;
@@ -679,8 +705,10 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <param name="signedHttpRequest">A SignedHttpRequest.</param>
         /// <param name="signedHttpRequestValidationContext">A structure that wraps parameters needed for SignedHttpRequest validation.</param>
         /// <remarks>
-        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateU"/> is set to <c>true</c>.
-        /// </remarks>     
+        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateU"/> is set to <c>true</c> or a u claim is present and
+        /// <see cref="SignedHttpRequestValidationParameters.ValidatePresentClaims"/> is set to true and <see cref="SignedHttpRequestClaimTypes.U"/> is in
+        /// <see cref="SignedHttpRequestValidationParameters.ClaimsToValidateWhenPresent"/>.
+        /// </remarks>
         internal virtual void ValidateUClaim(JsonWebToken signedHttpRequest, SignedHttpRequestValidationContext signedHttpRequestValidationContext)
         {
             var httpRequestUri = signedHttpRequestValidationContext.HttpRequestData.Uri;
@@ -711,8 +739,10 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <param name="signedHttpRequest">A SignedHttpRequest.</param>
         /// <param name="signedHttpRequestValidationContext">A structure that wraps parameters needed for SignedHttpRequest validation.</param>
         /// <remarks>
-        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateP"/> is set to <c>true</c>.
-        /// </remarks>     
+        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateP"/> is set to <c>true</c> or a p claim is present and
+        /// <see cref="SignedHttpRequestValidationParameters.ValidatePresentClaims"/> is set to true and <see cref="SignedHttpRequestClaimTypes.P"/> is in
+        /// <see cref="SignedHttpRequestValidationParameters.ClaimsToValidateWhenPresent"/>.
+        /// </remarks>
         internal virtual void ValidatePClaim(JsonWebToken signedHttpRequest, SignedHttpRequestValidationContext signedHttpRequestValidationContext)
         {
             var httpRequestUri = signedHttpRequestValidationContext.HttpRequestData.Uri;
@@ -738,8 +768,10 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <param name="signedHttpRequest">A SignedHttpRequest.</param>
         /// <param name="signedHttpRequestValidationContext">A structure that wraps parameters needed for SignedHttpRequest validation.</param>
         /// <remarks>
-        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateQ"/> is set to <c>true</c>.
-        /// </remarks>     
+        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateQ"/> is set to <c>true</c> or a q claim is present and
+        /// <see cref="SignedHttpRequestValidationParameters.ValidatePresentClaims"/> is set to true and <see cref="SignedHttpRequestClaimTypes.Q"/> is in
+        /// <see cref="SignedHttpRequestValidationParameters.ClaimsToValidateWhenPresent"/>.
+        /// </remarks>
         internal virtual void ValidateQClaim(JsonWebToken signedHttpRequest, SignedHttpRequestValidationContext signedHttpRequestValidationContext)
         {
             var httpRequestUri = signedHttpRequestValidationContext.HttpRequestData.Uri;
@@ -810,8 +842,10 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <param name="signedHttpRequest">A SignedHttpRequest.</param>
         /// <param name="signedHttpRequestValidationContext">A structure that wraps parameters needed for SignedHttpRequest validation.</param>
         /// <remarks>
-        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateH"/> is set to <c>true</c>.
-        /// </remarks>     
+        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateH"/> is set to <c>true</c> or a h claim is present and
+        /// <see cref="SignedHttpRequestValidationParameters.ValidatePresentClaims"/> is set to true and <see cref="SignedHttpRequestClaimTypes.H"/> is in
+        /// <see cref="SignedHttpRequestValidationParameters.ClaimsToValidateWhenPresent"/>.
+        /// </remarks>
         internal virtual void ValidateHClaim(JsonWebToken signedHttpRequest, SignedHttpRequestValidationContext signedHttpRequestValidationContext)
         {
             if (!signedHttpRequest.TryGetPayloadValue(SignedHttpRequestClaimTypes.H, out JArray hClaim) || hClaim == null)
@@ -876,8 +910,10 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <param name="signedHttpRequest">A SignedHttpRequest.</param>
         /// <param name="signedHttpRequestValidationContext">A structure that wraps parameters needed for SignedHttpRequest validation.</param>
         /// <remarks>
-        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateB"/> is set to <c>true</c>.
-        /// </remarks>     
+        /// This method will be executed only if <see cref="SignedHttpRequestValidationParameters.ValidateB"/> is set to <c>true</c> or a b claim is present and
+        /// <see cref="SignedHttpRequestValidationParameters.ValidatePresentClaims"/> is set to true and <see cref="SignedHttpRequestClaimTypes.B"/> is in
+        /// <see cref="SignedHttpRequestValidationParameters.ClaimsToValidateWhenPresent"/>.
+        /// </remarks>
         internal virtual void ValidateBClaim(JsonWebToken signedHttpRequest, SignedHttpRequestValidationContext signedHttpRequestValidationContext)
         {
             var httpRequestBody = signedHttpRequestValidationContext.HttpRequestData.Body;

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -593,7 +593,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             return validateClaim || (validateIfPresent && jwtSignedHttpRequest.TryGetClaim(claimName, out var claimValue) && claimValue != null);
         }
 
-        private bool ValidateIfPresent(SignedHttpRequestValidationParameters validationParameters, string claim)
+        private static bool ValidateIfPresent(SignedHttpRequestValidationParameters validationParameters, string claim)
         {
             return validationParameters.ValidatePresentClaims &&
                 validationParameters.ClaimsToValidateWhenPresent != null &&

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestValidationParameters.cs
@@ -110,6 +110,20 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         public bool AcceptUnsignedHeaders { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the claims to validate if present.
+        /// </summary>
+        /// <remarks>
+        /// Validation will only occur if <see cref="ValidatePresentClaims"/> is set to <c>true</c>.
+        /// </remarks>
+        public IEnumerable<string> ClaimsToValidateWhenPresent { get; set; } = new List<string>
+        {
+            SignedHttpRequestClaimTypes.Ts,
+            SignedHttpRequestClaimTypes.M,
+            SignedHttpRequestClaimTypes.U,
+            SignedHttpRequestClaimTypes.P
+        };
+
+        /// <summary>
         /// Gets or sets a collection of <see cref="SecurityKey"/> used for the 'cnf' claim decryption.
         /// </summary>
         public IEnumerable<SecurityKey> CnfDecryptionKeys { get; set; }
@@ -216,5 +230,13 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// </summary>
         /// <remarks>https://tools.ietf.org/html/draft-ietf-oauth-signed-http-request-03#section-3</remarks>  
         public bool ValidateB { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether claims in <see cref="ClaimsToValidateWhenPresent"/> should be validated if present.
+        /// </summary>
+        /// <remarks>
+        /// Allows for validation of a claim if present, even if the validation option for the claim is set to <c>false</c>.
+        /// </remarks>
+        public bool ValidatePresentClaims { get; set; } = false;
     }
 }

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestValidationParameters.cs
@@ -117,9 +117,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// </remarks>
         public IEnumerable<string> ClaimsToValidateWhenPresent { get; set; } = new List<string>
         {
-            SignedHttpRequestClaimTypes.Ts,
             SignedHttpRequestClaimTypes.M,
-            SignedHttpRequestClaimTypes.U,
             SignedHttpRequestClaimTypes.P
         };
 


### PR DESCRIPTION
The truth table is the general idea of my proposed changes. Validate is always respected, if !Validate, then check if the user opted in to check present claims. The claims to check are also configurable which has a sensible default. 

The alternative here would be to add another bool that is used for every claim to control the validate if present behavior

| Claim Valid | Claim present | Validate On | Validate if present | Validate | Fail |
| :---------: | :-----------: | :---------: | :-----------------: | :------: | :--: |
|             | x             | x           |                     |  x       | x    |
|             | x             |             |                     |          |      |
| x           | x             | x           |                     |  x       |      |
| x           | x             |             |                     |          |      |
|             |               | x           |                     | x        | x    |
|             |               |             |                     |          |      |
|             | x             | x           | x                   | x        | x    |
|             | x             |             | x                   | x        | x    |
| x           | x             | x           | x                   | x        |      |
| x           | x             |             | x                   | x        |      |
|             |               | x           | x                   | x        | x    |
|             |               |             | x                   |          |      |

---