### PR TITLE
Support for SecurityTokenDescriptor.Claims in JwtSecurity/Saml/Saml2 Tokens

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -65,7 +65,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             JwtHeaderParameterNames.Zip
         };
 
-        internal static Dictionary<string, object> CreateDictionaryFromClaims(IEnumerable<Claim> claims)
+        /// <summary>
+        /// Creates a dictionary from a list of Claim's.
+        /// </summary>
+        /// <param name="claims"> A list of claims.</param>
+        /// <returns> A Dictionary representing claims.</returns>
+        internal static IDictionary<string, object> CreateDictionaryFromClaims(IEnumerable<Claim> claims)
         {
             var payload = new Dictionary<string, object>();
 

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/LogMessages.cs
@@ -43,6 +43,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         // signature creation / validation
         internal const string IDX11312 = "IDX11312: Unable to validate token. A SamlSamlAttributeStatement can only have one SamlAttribute of type 'Actor'. This special SamlAttribute is used in delegation scenarios.";
         internal const string IDX11313 = "IDX11313: Unable to process Saml attribute. A SamlSubject must contain either or both of Name and ConfirmationMethod.";
+        internal const string IDX11314 = "IDX11314: The AttributeValueXsiType of a SAML Attribute must be a string of the form 'prefix#suffix', where prefix and suffix are non-empty strings. Found: '{0}'";
 
         // SamlSerializer reading
         internal const string IDX11100 = "IDX11100: Saml Only one element of type '{0}' is supported.";

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlAttribute.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlAttribute.cs
@@ -91,16 +91,16 @@ namespace Microsoft.IdentityModel.Tokens.Saml
 
                 int indexOfHash = value.IndexOf('#');
                 if (indexOfHash == -1)
-                    throw LogExceptionMessage(new SecurityTokenInvalidAudienceException("value, SR.GetString(SR.ID4254)")); ;
+                    throw LogExceptionMessage(new SecurityTokenInvalidAudienceException(FormatInvariant(LogMessages.IDX11314, value)));
 
                 string prefix = value.Substring(0, indexOfHash);
                 if (prefix.Length == 0)
-                    throw LogExceptionMessage(new ArgumentException("value SR.GetString(SR.ID4254)"));
+                    throw LogExceptionMessage(new ArgumentException(FormatInvariant(LogMessages.IDX11314, value)));
 
                 string suffix = value.Substring(indexOfHash + 1);
                 if (suffix.Length == 0)
                 {
-                    throw LogExceptionMessage(new ArgumentException("value, SR.GetString(SR.ID4254)"));
+                    throw LogExceptionMessage(new ArgumentException(FormatInvariant(LogMessages.IDX11314, value)));
                 }
 
                 _attributeValueXsiType = value;

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -270,10 +270,12 @@ namespace Microsoft.IdentityModel.Tokens.Saml
             if (tokenDescriptor == null)
                 throw LogArgumentNullException(nameof(tokenDescriptor));
 
-            if (tokenDescriptor.Subject != null)
+            IEnumerable<Claim> claims = SamlTokenUtilities.GetAllClaims(tokenDescriptor.Claims, tokenDescriptor.Subject != null ? tokenDescriptor.Subject.Claims : null);
+
+            if (claims != null && claims.Any())
             {
                 var attributes = new List<SamlAttribute>();
-                foreach (var claim in tokenDescriptor.Subject.Claims)
+                foreach (var claim in claims)
                 {
                     if (claim != null && claim.Type != ClaimTypes.NameIdentifier)
                     {
@@ -293,7 +295,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                     }
                 }
 
-                AddActorToAttributes(attributes, tokenDescriptor.Subject.Actor);
+                AddActorToAttributes(attributes, tokenDescriptor.Subject?.Actor);
 
                 var consolidatedAttributes = ConsolidateAttributes(attributes);
                 if (consolidatedAttributes.Count > 0)
@@ -450,9 +452,12 @@ namespace Microsoft.IdentityModel.Tokens.Saml
 
             var samlSubject = new SamlSubject();
             Claim identityClaim = null;
-            if (tokenDescriptor.Subject != null && tokenDescriptor.Subject.Claims != null)
+
+            IEnumerable<Claim> claims = SamlTokenUtilities.GetAllClaims(tokenDescriptor.Claims, tokenDescriptor.Subject != null ? tokenDescriptor.Subject.Claims : null);
+
+            if (claims != null && claims.Any())
             {
-                foreach (var claim in tokenDescriptor.Subject.Claims)
+                foreach (var claim in claims)
                 {
                     if (claim.Type == ClaimTypes.NameIdentifier)
                     {

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlTokenUtilities.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.IdentityModel.Logging;
-using Microsoft.IdentityModel.Xml;
+﻿
 //------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
@@ -27,11 +26,12 @@ using Microsoft.IdentityModel.Xml;
 //
 //------------------------------------------------------------------------------
 
-using System;
+using System.Security.Claims;
+using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.IdentityModel.Xml;
+using System;
+using Microsoft.IdentityModel.Logging;
 using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
 
 namespace Microsoft.IdentityModel.Tokens.Saml
@@ -39,7 +39,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
     /// <summary>
     /// A class which contains useful methods for processing saml tokens.
     /// </summary>
-    public class SamlTokenUtilities
+    internal class SamlTokenUtilities
     {
         /// <summary>
         /// Returns a <see cref="SecurityKey"/> to use when validating the signature of a token.
@@ -100,6 +100,90 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                     }
                 }
             }
+            return null;
+        }
+
+        /// <summary>
+        /// Creates <see cref="Claim"/>'s from <paramref name="claimsCollection"/>.
+        /// </summary>
+        /// <param name="claimsCollection"> A dictionary that represents a set of claims.</param>
+        /// <returns> A collection of <see cref="Claim"/>'s created from the <paramref name="claimsCollection"/>.</returns>
+        internal static IEnumerable<Claim> CreateClaimsFromDictionary(IDictionary<string, object> claimsCollection)
+        {
+            if (claimsCollection == null)
+                return null;
+
+            var claims = new List<Claim>();
+            foreach (var claim in claimsCollection)
+            {
+                string claimType = claim.Key;
+                object claimValue = claim.Value;
+                if (claimValue != null)
+                {
+                    var valueType = GetXsiTypeForValue(claimValue);
+                    if (valueType == null && claimValue is IEnumerable claimList)
+                    {
+                        foreach (var item in claimList)
+                        {
+                            valueType = GetXsiTypeForValue(item);
+                            if (valueType == null && item is IEnumerable)
+                                throw new NotSupportedException(LogHelper.FormatInvariant(TokenLogMessages.IDX10105, claimType));
+
+                            claims.Add(new Claim(claimType, item.ToString(), valueType));
+                        }
+                    }
+                    else
+                    {
+                        claims.Add(new Claim(claimType, claimValue.ToString(), valueType));
+                    }
+                }
+            }
+
+            return claims;
+        }
+
+        /// <summary>
+        /// Merges <paramref name="claims"/> and <paramref name="subjectClaims"/>
+        /// </summary>
+        /// <param name="claims"> A dictionary of claims.</param>
+        /// <param name="subjectClaims"> A collection of <see cref="Claim"/>'s</param>
+        /// <returns> A merged list of <see cref="Claim"/>'s.</returns>
+        internal static IEnumerable<Claim> GetAllClaims(IDictionary<string, object> claims, IEnumerable<Claim> subjectClaims)
+        {
+            if (claims == null)
+                return subjectClaims;
+            else
+                return TokenUtilities.MergeClaims(CreateClaimsFromDictionary(claims), subjectClaims);
+        }
+
+        /// <summary>
+        /// Gets the value type of the <see cref="Claim"/> from its value <paramref name="value"/>
+        /// </summary>
+        /// <param name="value"> The <see cref="Claim"/> value.</param>
+        /// <returns> The value type of the <see cref="Claim"/>.</returns>
+        internal static string GetXsiTypeForValue(object value)
+        {
+            if (value != null)
+            {
+                if (value is string)
+                    return ClaimValueTypes.String;
+
+                if (value is bool)
+                    return ClaimValueTypes.Boolean;
+
+                if (value is int)
+                    return ClaimValueTypes.Integer32;
+
+                if (value is long)
+                    return ClaimValueTypes.Integer64;
+
+                if (value is double)
+                    return ClaimValueTypes.Double;
+
+                if (value is DateTime)
+                    return ClaimValueTypes.DateTime;
+            }
+
             return null;
         }
     }

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -29,6 +29,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Security.Claims;
 using System.Text;
 using System.Xml;
@@ -681,20 +682,26 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                 throw LogArgumentNullException(nameof(tokenDescriptor.Subject));
 
             var attributes = new List<Saml2Attribute>();
-            foreach (Claim claim in tokenDescriptor.Subject.Claims)
+
+            IEnumerable<Claim> claims = SamlTokenUtilities.GetAllClaims(tokenDescriptor.Claims, tokenDescriptor.Subject != null ? tokenDescriptor.Subject.Claims : null);
+
+            if (claims != null && claims.Any())
             {
-                if (claim != null)
+                foreach (Claim claim in claims)
                 {
-                    switch (claim.Type)
+                    if (claim != null)
                     {
-                        // TODO - should these really be filtered?
-                        case ClaimTypes.AuthenticationInstant:
-                        case ClaimTypes.AuthenticationMethod:
-                        case ClaimTypes.NameIdentifier:
-                            break;
-                        default:
-                            attributes.Add(CreateAttribute(claim));
-                            break;
+                        switch (claim.Type)
+                        {
+                            // TODO - should these really be filtered?
+                            case ClaimTypes.AuthenticationInstant:
+                            case ClaimTypes.AuthenticationMethod:
+                            case ClaimTypes.NameIdentifier:
+                                break;
+                            default:
+                                attributes.Add(CreateAttribute(claim));
+                                break;
+                        }
                     }
                 }
             }
@@ -895,9 +902,11 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
             string nameIdentifierSpProviderId = null;
             string nameIdentifierSpNameQualifier = null;
 
-            if (tokenDescriptor.Subject != null && tokenDescriptor.Subject.Claims != null)
+            IEnumerable<Claim> claims = SamlTokenUtilities.GetAllClaims(tokenDescriptor.Claims, tokenDescriptor.Subject != null ? tokenDescriptor.Subject.Claims : null);
+
+            if (claims != null && claims.Any())
             {
-                foreach (var claim in tokenDescriptor.Subject.Claims)
+                foreach (var claim in claims)
                 {
                     if (claim.Type == ClaimTypes.NameIdentifier)
                     {

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -45,6 +45,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10102 = "IDX10102: NameClaimType cannot be null or whitespace.";
         public const string IDX10103 = "IDX10103: RoleClaimType cannot be null or whitespace.";
         public const string IDX10104 = "IDX10104: TokenLifetimeInMinutes must be greater than zero. value: '{0}'";
+        public const string IDX10105 = "IDX10105: ClaimValue that is a collection of collections is not supported. Such ClaimValue is found for ClaimType : '{0}'";
 
         // token validation
         public const string IDX10204 = "IDX10204: Unable to validate issuer. validationParameters.ValidIssuer is null or whitespace AND validationParameters.ValidIssuers is null.";
@@ -226,6 +227,7 @@ namespace Microsoft.IdentityModel.Tokens
         //public const string IDX10811 = "IDX10811:"
         public const string IDX10812 = "IDX10812: Unable to create a {0} from the properties found in the JsonWebKey: '{1}'.";
         public const string IDX10813 = "IDX10813: Unable to create a {0} from the properties found in the JsonWebKey: '{1}', Exception '{2}'.";
+
 
 #pragma warning restore 1591
     }

--- a/src/Microsoft.IdentityModel.Tokens/TokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenUtilities.cs
@@ -28,8 +28,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Security.Claims;
 using Microsoft.IdentityModel.Logging;
 using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
 
@@ -38,7 +37,7 @@ namespace Microsoft.IdentityModel.Tokens
     /// <summary>
     /// A class which contains useful methods for processing tokens.
     /// </summary>
-    public class TokenUtilities
+    internal class TokenUtilities
     {
         /// <summary>
         /// Returns all <see cref="SecurityKey"/> provided in validationParameters.
@@ -54,6 +53,31 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters.IssuerSigningKeys != null)
                 foreach (SecurityKey key in validationParameters.IssuerSigningKeys)
                     yield return key;
+        }
+
+        /// <summary>
+        /// Merges claims. If a claim with same type exists in both <paramref name="claims"/> and <paramref name="subjectClaims"/>, the one in claims will be kept.
+        /// </summary>
+        /// <param name="claims"> Collection of <see cref="Claim"/>'s.</param>
+        /// <param name="subjectClaims"> Collection of <see cref="Claim"/>'s.</param>
+        /// <returns> A Merged list of <see cref="Claim"/>'s.</returns>
+        internal static IEnumerable<Claim> MergeClaims(IEnumerable<Claim> claims, IEnumerable<Claim> subjectClaims)
+        {
+            if (claims == null)
+                return subjectClaims;
+
+            if (subjectClaims == null)
+                return claims;
+
+            List<Claim> result = claims.ToList();
+
+            foreach (Claim claim in subjectClaims)
+            {
+                if (!claims.Any(i => i.Type == claim.Type))
+                    result.Add(claim);
+            }
+
+            return result;
         }
     }
 }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -359,7 +359,7 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <returns>A Base64UrlEncoded string in 'Compact Serialization Format'.</returns>
         public virtual string CreateEncodedJwt(string issuer, string audience, ClaimsIdentity subject, DateTime? notBefore, DateTime? expires, DateTime? issuedAt, SigningCredentials signingCredentials)
         {
-            return CreateJwtSecurityTokenPrivate(issuer, audience, subject, notBefore, expires, issuedAt, signingCredentials, null).RawData;
+            return CreateJwtSecurityTokenPrivate(issuer, audience, subject, notBefore, expires, issuedAt, signingCredentials, null, null).RawData;
         }
 
         /// <summary>
@@ -382,7 +382,31 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <exception cref="ArgumentException">If 'expires' &lt;= 'notBefore'.</exception>
         public virtual string CreateEncodedJwt(string issuer, string audience, ClaimsIdentity subject, DateTime? notBefore, DateTime? expires, DateTime? issuedAt, SigningCredentials signingCredentials, EncryptingCredentials encryptingCredentials)
         {
-            return CreateJwtSecurityTokenPrivate(issuer, audience, subject, notBefore, expires, issuedAt, signingCredentials, encryptingCredentials).RawData;
+            return CreateJwtSecurityTokenPrivate(issuer, audience, subject, notBefore, expires, issuedAt, signingCredentials, encryptingCredentials, null).RawData;
+        }
+
+        /// <summary>
+        /// Creates a JWT in 'Compact Serialization Format'.
+        /// </summary>
+        /// <param name="issuer">The issuer of the token.</param>
+        /// <param name="audience">The audience for this token.</param>
+        /// <param name="subject">The source of the <see cref="Claim"/>(s) for this token.</param>
+        /// <param name="notBefore">Translated into 'epoch time' and assigned to 'nbf'.</param>
+        /// <param name="expires">Translated into 'epoch time' and assigned to 'exp'.</param>
+        /// <param name="issuedAt">Translated into 'epoch time' and assigned to 'iat'.</param>
+        /// <param name="signingCredentials">Contains cryptographic material for signing.</param>
+        /// <param name="encryptingCredentials">Contains cryptographic material for encrypting.</param>
+        /// <param name="claimCollection">A collection of (key,value) pairs representing <see cref="Claim"/>(s) for this token.</param>
+        /// <remarks>If <see cref="ClaimsIdentity.Actor"/> is not null, then a claim { actort, 'value' } will be added to the payload. <see cref="CreateActorValue"/> for details on how the value is created.
+        /// <para>See <seealso cref="JwtHeader"/> for details on how the HeaderParameters are added to the header.</para>
+        /// <para>See <seealso cref="JwtPayload"/> for details on how the values are added to the payload.</para>
+        /// <para>Each <see cref="Claim"/> in the <paramref name="subject"/> will map <see cref="Claim.Type"/> by applying <see cref="OutboundClaimTypeMap"/>. Modifying <see cref="OutboundClaimTypeMap"/> could change the outbound JWT.</para>
+        /// </remarks>
+        /// <returns>A Base64UrlEncoded string in 'Compact Serialization Format'.</returns>
+        /// <exception cref="ArgumentException">If 'expires' &lt;= 'notBefore'.</exception>
+        public virtual string CreateEncodedJwt(string issuer, string audience, ClaimsIdentity subject, DateTime? notBefore, DateTime? expires, DateTime? issuedAt, SigningCredentials signingCredentials, EncryptingCredentials encryptingCredentials, IDictionary<string, object> claimCollection)
+        {
+            return CreateJwtSecurityTokenPrivate(issuer, audience, subject, notBefore, expires, issuedAt, signingCredentials, encryptingCredentials, claimCollection).RawData;
         }
 
         /// <summary>
@@ -403,7 +427,8 @@ namespace System.IdentityModel.Tokens.Jwt
                 tokenDescriptor.Expires,
                 tokenDescriptor.IssuedAt,
                 tokenDescriptor.SigningCredentials,
-                tokenDescriptor.EncryptingCredentials);
+                tokenDescriptor.EncryptingCredentials,
+                tokenDescriptor.Claims);
         }
 
         /// <summary>
@@ -429,7 +454,34 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <exception cref="ArgumentException">If 'expires' &lt;= 'notBefore'.</exception>
         public virtual JwtSecurityToken CreateJwtSecurityToken(string issuer, string audience, ClaimsIdentity subject, DateTime? notBefore, DateTime? expires, DateTime? issuedAt, SigningCredentials signingCredentials, EncryptingCredentials encryptingCredentials)
         {
-            return CreateJwtSecurityTokenPrivate(issuer, audience, subject, notBefore, expires, issuedAt, signingCredentials, encryptingCredentials);
+            return CreateJwtSecurityTokenPrivate(issuer, audience, subject, notBefore, expires, issuedAt, signingCredentials, encryptingCredentials, null);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="JwtSecurityToken"/>
+        /// </summary>
+        /// <param name="issuer">The issuer of the token.</param>
+        /// <param name="audience">The audience for this token.</param>
+        /// <param name="subject">The source of the <see cref="Claim"/>(s) for this token.</param>
+        /// <param name="notBefore">The notbefore time for this token.</param>
+        /// <param name="expires">The expiration time for this token.</param>
+        /// <param name="issuedAt">The issue time for this token.</param>
+        /// <param name="signingCredentials">Contains cryptographic material for generating a signature.</param>
+        /// <param name="encryptingCredentials">Contains cryptographic material for encrypting the token.</param>
+        /// <param name="claimCollection">A collection of (key,value) pairs representing <see cref="Claim"/>(s) for this token.</param>
+        /// <remarks>If <see cref="ClaimsIdentity.Actor"/> is not null, then a claim { actort, 'value' } will be added to the payload. <see cref="CreateActorValue"/> for details on how the value is created.
+        /// <para>See <seealso cref="JwtHeader"/> for details on how the HeaderParameters are added to the header.</para>
+        /// <para>See <seealso cref="JwtPayload"/> for details on how the values are added to the payload.</para>
+        /// <para>Each <see cref="Claim"/> on the <paramref name="subject"/> added will have <see cref="Claim.Type"/> translated according to the mapping found in
+        /// <see cref="OutboundClaimTypeMap"/>. Adding and removing to <see cref="OutboundClaimTypeMap"/> will affect the name component of the Json claim.</para>
+        /// <para><see cref="SigningCredentials.SigningCredentials(SecurityKey, string)"/> is used to sign <see cref="JwtSecurityToken.RawData"/>.</para>
+        /// <para><see cref="EncryptingCredentials.EncryptingCredentials(SecurityKey, string, string)"/> is used to encrypt <see cref="JwtSecurityToken.RawData"/> or <see cref="JwtSecurityToken.RawPayload"/> .</para>
+        /// </remarks>
+        /// <returns>A <see cref="JwtSecurityToken"/>.</returns>
+        /// <exception cref="ArgumentException">If 'expires' &lt;= 'notBefore'.</exception>
+        public virtual JwtSecurityToken CreateJwtSecurityToken(string issuer, string audience, ClaimsIdentity subject, DateTime? notBefore, DateTime? expires, DateTime? issuedAt, SigningCredentials signingCredentials, EncryptingCredentials encryptingCredentials, IDictionary<string, object> claimCollection)
+        {
+            return CreateJwtSecurityTokenPrivate(issuer, audience, subject, notBefore, expires, issuedAt, signingCredentials, encryptingCredentials, claimCollection);
         }
 
         /// <summary>
@@ -453,7 +505,7 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <exception cref="ArgumentException">If 'expires' &lt;= 'notBefore'.</exception>
         public virtual JwtSecurityToken CreateJwtSecurityToken(string issuer = null, string audience = null, ClaimsIdentity subject = null, DateTime? notBefore = null, DateTime? expires = null, DateTime? issuedAt = null, SigningCredentials signingCredentials = null)
         {
-            return CreateJwtSecurityTokenPrivate(issuer, audience, subject, notBefore, expires, issuedAt, signingCredentials, null);
+            return CreateJwtSecurityTokenPrivate(issuer, audience, subject, notBefore, expires, issuedAt, signingCredentials, null, null);
         }
 
         /// <summary>
@@ -474,10 +526,11 @@ namespace System.IdentityModel.Tokens.Jwt
                 tokenDescriptor.Expires,
                 tokenDescriptor.IssuedAt,
                 tokenDescriptor.SigningCredentials,
-                tokenDescriptor.EncryptingCredentials);
+                tokenDescriptor.EncryptingCredentials,
+                tokenDescriptor.Claims);
         }
 
-        private JwtSecurityToken CreateJwtSecurityTokenPrivate(string issuer, string audience, ClaimsIdentity subject, DateTime? notBefore, DateTime? expires, DateTime? issuedAt, SigningCredentials signingCredentials, EncryptingCredentials encryptingCredentials)
+        private JwtSecurityToken CreateJwtSecurityTokenPrivate(string issuer, string audience, ClaimsIdentity subject, DateTime? notBefore, DateTime? expires, DateTime? issuedAt, SigningCredentials signingCredentials, EncryptingCredentials encryptingCredentials, IDictionary<string, object> claimCollection)
         {
             if (SetDefaultTimesOnTokenCreation && (!expires.HasValue || !issuedAt.HasValue || !notBefore.HasValue))
             {
@@ -493,7 +546,7 @@ namespace System.IdentityModel.Tokens.Jwt
             }
 
             LogHelper.LogVerbose(LogMessages.IDX12721, (audience ?? "null"), (issuer ?? "null"));
-            JwtPayload payload = new JwtPayload(issuer, audience, (subject == null ? null : OutboundClaimTypeTransform(subject.Claims)), notBefore, expires, issuedAt);
+            JwtPayload payload = new JwtPayload(issuer, audience, (subject == null ? null : OutboundClaimTypeTransform(subject.Claims)), (claimCollection == null ? null : OutboundClaimTypeTransform(claimCollection)), notBefore, expires, issuedAt);
             JwtHeader header = signingCredentials == null ? new JwtHeader() : new JwtHeader(signingCredentials, OutboundAlgorithmMap);
 
             if (subject?.Actor != null)
@@ -610,6 +663,22 @@ namespace System.IdentityModel.Tokens.Jwt
                     yield return claim;
                 }
             }
+        }
+
+        private IDictionary<string, object> OutboundClaimTypeTransform(IDictionary<string, object> claimCollection)
+        {
+            var claims = new Dictionary<string, object>();
+
+            foreach (string claimType in claimCollection.Keys)
+            {
+                if (_outboundClaimTypeMap.TryGetValue(claimType, out string type))
+                    claims[type] = claimCollection[claimType];
+
+                else
+                    claims[claimType] = claimCollection[claimType];
+            }
+
+            return claims;
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.TestUtils/Default.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/Default.cs
@@ -407,6 +407,50 @@ namespace Microsoft.IdentityModel.TestUtils
             };
         }
 
+        public static List<Claim> PayloadJsonClaims
+        {
+            get => new List<Claim>
+                    {
+                        new Claim(JwtRegisteredClaimNames.Aud, Audience, ClaimValueTypes.String),
+                        new Claim(JwtRegisteredClaimNames.Iss, Issuer, ClaimValueTypes.String),
+                        new Claim("ClaimValueTypes.String", "ClaimValueTypes.String.Value", ClaimValueTypes.String),
+                        new Claim("ClaimValueTypes.Boolean.true", "true", ClaimValueTypes.Boolean),
+                        new Claim("ClaimValueTypes.Boolean.false", "false", ClaimValueTypes.Boolean),
+                        new Claim("ClaimValueTypes.Double", "123.4", ClaimValueTypes.Double),
+                        new Claim("ClaimValueTypes.DateTime.IS8061", "2019-11-15T14:31:21.6101326Z", ClaimValueTypes.DateTime),
+                        new Claim("ClaimValueTypes.DateTime", "2019-11-15", ClaimValueTypes.DateTime),
+                        new Claim("ClaimValueTypes.JsonClaimValueTypes.Json1", @"{""jsonProperty1"":""jsonvalue1""}", System.IdentityModel.Tokens.Jwt.JsonClaimValueTypes.Json),
+                        new Claim("ClaimValueTypes.JsonClaimValueTypes.Json2", @"{""jsonProperty2"":""jsonvalue2""}", System.IdentityModel.Tokens.Jwt.JsonClaimValueTypes.Json),
+                        new Claim("ClaimValueTypes.JsonClaimValueTypes.JsonNull", "", System.IdentityModel.Tokens.Jwt.JsonClaimValueTypes.JsonNull),
+                        new Claim("ClaimValueTypes.JsonClaimValueTypes.JsonArray1", @"[1,2,3]", System.IdentityModel.Tokens.Jwt.JsonClaimValueTypes.JsonArray),
+                        new Claim("ClaimValueTypes.JsonClaimValueTypes.JsonArray2", @"[1,""2"",3]", System.IdentityModel.Tokens.Jwt.JsonClaimValueTypes.JsonArray),
+                        new Claim("ClaimValueTypes.JsonClaimValueTypes.Integer1", "1", ClaimValueTypes.Integer),
+                        new Claim(JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Default.Expires).ToString(), ClaimValueTypes.String, Issuer, Issuer)
+                    };
+        }
+
+        public static Dictionary<string, object> PayloadJsonDictionary
+        {
+            get => new Dictionary<string, object>()
+            {
+                { JwtRegisteredClaimNames.Aud, Audience },
+                { JwtRegisteredClaimNames.Iss, Issuer },
+                { "ClaimValueTypes.String", "ClaimValueTypes.String.Value" },
+                { "ClaimValueTypes.Boolean.true", true },
+                { "ClaimValueTypes.Boolean.false", false },
+                { "ClaimValueTypes.Double", 123.4 },
+                { "ClaimValueTypes.DateTime.IS8061", DateTime.TryParse("2019-11-15T14:31:21.6101326Z", out DateTime dateTimeValue1) ? dateTimeValue1 : new DateTime()},
+                { "ClaimValueTypes.DateTime", DateTime.TryParse("2019-11-15", out DateTime dateTimeValue2) ? dateTimeValue2 : new DateTime()},
+                { "ClaimValueTypes.JsonClaimValueTypes.Json1", JObject.Parse(@"{""jsonProperty1"":""jsonvalue1""}") },
+                { "ClaimValueTypes.JsonClaimValueTypes.Json2", JObject.Parse(@"{""jsonProperty2"":""jsonvalue2""}") },
+                { "ClaimValueTypes.JsonClaimValueTypes.JsonNull", "" },
+                { "ClaimValueTypes.JsonClaimValueTypes.JsonArray1", JArray.Parse(@"[1,2,3]") },
+                { "ClaimValueTypes.JsonClaimValueTypes.JsonArray2", JArray.Parse(@"[1,""2"",3]") },
+                { "ClaimValueTypes.JsonClaimValueTypes.Integer1", 1 },
+                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Default.Expires).ToString() }
+            };
+        }
+
         public static ClaimsIdentity PayloadClaimsIdentity
         {
             get => new ClaimsIdentity(PayloadClaims, "AuthenticationTypes.Federation");
@@ -622,6 +666,24 @@ namespace Microsoft.IdentityModel.TestUtils
                 new Claim(ClaimTypes.Role, "Sales", ClaimValueTypes.String, Issuer, OriginalIssuer),
                 new Claim(ClaimTypes.StreetAddress, "123AnyWhereStreet\r\nSomeTown/r/nUSA", ClaimValueTypes.String, Issuer, OriginalIssuer),
                 new Claim(ClaimsIdentity.DefaultNameClaimType, "Jean-Sébastien", ClaimValueTypes.String, Issuer, OriginalIssuer),
+            };
+        }
+
+        /// <summary>
+        /// SamlClaims require the ability to split into name / namespace
+        /// </summary>
+        public static Dictionary<string, object> SamlClaimsDictionary
+        {
+            get => new Dictionary<string, object>()
+            {
+                { ClaimTypes.Country, "USA"},
+                { ClaimTypes.NameIdentifier, "Bob" },
+                { ClaimTypes.Email, "Bob@contoso.com" },
+                { ClaimTypes.GivenName, "Bob" },
+                { ClaimTypes.HomePhone, "555.1212" },
+                { ClaimTypes.Role, new List<string>{"Developer", "Sales" } },
+                { ClaimTypes.StreetAddress, "123AnyWhereStreet\r\nSomeTown/r/nUSA" },
+                { ClaimsIdentity.DefaultNameClaimType, "Jean-Sébastien" }
             };
         }
 

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
 
         public static TheoryData<Saml2TheoryData> CanReadTokenTheoryData
         {
-            get =>  new TheoryData<Saml2TheoryData>
+            get => new TheoryData<Saml2TheoryData>
             {
                 new Saml2TheoryData
                 {
@@ -365,7 +365,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                     Expires = Default.Expires,
                     Issuer = Default.Issuer,
                     SigningCredentials = new SigningCredentials(key, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
-                    Subject = new ClaimsIdentity(Default.SamlClaims)
+                    Subject = new ClaimsIdentity(Default.SamlClaims),
                 };
 
                 var validationParameters = new TokenValidationParameters
@@ -481,7 +481,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
 
         public static TheoryData<Saml2TheoryData> RoundTripActorTheoryData
         {
-            get =>  new TheoryData<Saml2TheoryData>
+            get => new TheoryData<Saml2TheoryData>
             {
                 new Saml2TheoryData
                 {
@@ -931,7 +931,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                         }
                     },
                      new Saml2TheoryData
-                     { 
+                     {
                         Audiences = new List<string>(),
                         Token = ReferenceTokens.Saml2Token_NoAudienceRestrictions_NoSignature,
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenException), "IDX13002:"),
@@ -942,7 +942,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidAudience = "spn:fe78e0b4-6fe7-47e6-812c-fb75cee266a4",
                             ValidateLifetime = false,
                             ValidateIssuer = false,
-                            RequireSignedTokens = false                    
+                            RequireSignedTokens = false
                         }
                     },
                     new Saml2TheoryData
@@ -957,7 +957,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidAudience = "spn:fe78e0b4-6fe7-47e6-812c-fb75cee266a4",
                             ValidateLifetime = false,
                             ValidateIssuer = false,
-                            RequireSignedTokens = false                        
+                            RequireSignedTokens = false
                         },
                     },
                     new Saml2TheoryData
@@ -1089,7 +1089,184 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                 };
             }
         }
-    }
+
+        [Theory, MemberData(nameof(CreateSaml2TokenUsingTokenDescriptorTheoryData))]
+        public void CreateSaml2TokenUsingTokenDescriptor(CreateTokenTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.CreateSaml2TokenUsingTokenDescriptor", theoryData);
+            context.PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
+            {
+                { typeof(Saml2Assertion), new List<string> { "IssueInstant", "InclusiveNamespacesPrefixList", "Signature", "SigningCredentials", "CanonicalString" } },
+                { typeof(Saml2SecurityToken), new List<string> { "SigningKey" } },
+            };
+
+            try
+            {
+                SecurityToken samlTokenFromSecurityTokenDescriptor = theoryData.Saml2SecurityTokenHandler.CreateToken(theoryData.TokenDescriptor) as Saml2SecurityToken;
+                string tokenFromTokenDescriptor = theoryData.Saml2SecurityTokenHandler.WriteToken(samlTokenFromSecurityTokenDescriptor);
+
+                var claimsIdentityFromTokenDescriptor = theoryData.Saml2SecurityTokenHandler.ValidateToken(tokenFromTokenDescriptor, theoryData.ValidationParameters, out SecurityToken validatedTokenFromTokenDescriptor).Identity as ClaimsIdentity;
+                IdentityComparer.AreEqual(validatedTokenFromTokenDescriptor, samlTokenFromSecurityTokenDescriptor, context);
+
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<CreateTokenTheoryData> CreateSaml2TokenUsingTokenDescriptorTheoryData
+        {
+            get
+            {
+                var validationParameters = new TokenValidationParameters
+                {
+                    AuthenticationType = "Federation",
+                    ValidateAudience = false,
+                    ValidateIssuer = false,
+                    ValidateLifetime = false,
+                    IssuerSigningKey = KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256
+                };
+                return new TheoryData<CreateTokenTheoryData>
+                {
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "NotSupportedClaimValue",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Audience = Default.Audience,
+                            NotBefore = Default.NotBefore,
+                            Expires = Default.Expires,
+                            Issuer = Default.Issuer,
+                            SigningCredentials = new SigningCredentials(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
+                            EncryptingCredentials = null,
+                            Claims = new Dictionary<string, object>()
+                            {
+                                { "https://www.listinlist.com", new List<object>{ new List<object> { "bob", new SecurityTokenDescriptor(), 12, 1.45 }, new List<object> { "bob", new SecurityTokenDescriptor(), 12, 1.45 } } },
+                            },
+                        },
+                        Saml2SecurityTokenHandler = new Saml2SecurityTokenHandler(),
+                        ValidationParameters = validationParameters,
+                        ExpectedException = ExpectedException.NotSupportedException("IDX10105:")
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        First = true,
+                        TestId = "OnlySubjectClaims",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Audience = Default.Audience,
+                            NotBefore = Default.NotBefore,
+                            Expires = Default.Expires,
+                            Issuer = Default.Issuer,
+                            SigningCredentials = new SigningCredentials(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
+                            EncryptingCredentials = null,
+                            Subject = new ClaimsIdentity(Default.SamlClaims)
+                        },
+                        Saml2SecurityTokenHandler = new Saml2SecurityTokenHandler(),
+                        ValidationParameters = validationParameters
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "BothIdenticalClaims",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Audience = Default.Audience,
+                            NotBefore = Default.NotBefore,
+                            Expires = Default.Expires,
+                            Issuer = Default.Issuer,
+                            SigningCredentials = new SigningCredentials(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
+                            EncryptingCredentials = null,
+                            Claims = Default.SamlClaimsDictionary,
+                            Subject = new ClaimsIdentity(Default.SamlClaims)
+                        },
+                        Saml2SecurityTokenHandler = new Saml2SecurityTokenHandler(),
+                        ValidationParameters = validationParameters
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "MoreDictionaryClaims",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Audience = Default.Audience,
+                            NotBefore = Default.NotBefore,
+                            Expires = Default.Expires,
+                            Issuer = Default.Issuer,
+                            SigningCredentials = new SigningCredentials(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
+                            EncryptingCredentials = null,
+                            Claims = Default.SamlClaimsDictionary,
+                            Subject = new ClaimsIdentity
+                            (
+                                new List<Claim>
+                                {
+                                    new Claim(ClaimTypes.Country, "USA", ClaimValueTypes.String, Default.Issuer, Default.OriginalIssuer),
+                                    new Claim(ClaimTypes.NameIdentifier, "Bob", ClaimValueTypes.String, Default.Issuer, Default.OriginalIssuer),
+                                    new Claim(ClaimTypes.Email, "Bob@contoso.com", ClaimValueTypes.String, Default.Issuer, Default.OriginalIssuer)
+                                }
+                            )
+                        },
+                        Saml2SecurityTokenHandler = new Saml2SecurityTokenHandler(),
+                        ValidationParameters = validationParameters
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "MoreSubjectClaims",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Audience = Default.Audience,
+                            NotBefore = Default.NotBefore,
+                            Expires = Default.Expires,
+                            Issuer = Default.Issuer,
+                            SigningCredentials = new SigningCredentials(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
+                            EncryptingCredentials = null,
+                            Claims = new Dictionary<string, object>()
+                            {
+                                { ClaimTypes.Email, "Bob@contoso.com" },
+                                { ClaimTypes.GivenName, "Bob" },
+                                { ClaimTypes.Role, "HR" }
+                            },
+                            Subject = new ClaimsIdentity(Default.SamlClaims)
+                        },
+                        Saml2SecurityTokenHandler = new Saml2SecurityTokenHandler(),
+                        ValidationParameters = validationParameters
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "RepeatingClaimTypes",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Audience = Default.Audience,
+                            NotBefore = Default.NotBefore,
+                            Expires = Default.Expires,
+                            Issuer = Default.Issuer,
+                            SigningCredentials = new SigningCredentials(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
+                            EncryptingCredentials = null,
+                            Claims = new Dictionary<string, object>()
+                            {
+                                { ClaimTypes.Email, "Alice@contoso.com" },
+                                { ClaimTypes.GivenName, "Alice" },
+                                { ClaimTypes.Role, "HR" }
+                            },
+                            Subject = new ClaimsIdentity
+                            (
+                                new List<Claim>
+                                {
+                                    new Claim(ClaimTypes.Email, "Bob@contoso.com", ClaimValueTypes.String, Default.Issuer, Default.OriginalIssuer),
+                                    new Claim(ClaimTypes.GivenName, "Bob", ClaimValueTypes.String, Default.Issuer, Default.OriginalIssuer),
+                                    new Claim(ClaimTypes.Country, "India", ClaimValueTypes.String, Default.Issuer, Default.OriginalIssuer)
+                                }
+                            )
+                        },
+                        Saml2SecurityTokenHandler = new Saml2SecurityTokenHandler(),
+                        ValidationParameters = validationParameters
+                    },
+                };
+            }
+        }
+        }
 
     public class Saml2SecurityTokenHandlerPublic : Saml2SecurityTokenHandler
     {
@@ -1125,6 +1302,31 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             : base(assertion)
         {
         }
+    }
+
+    public class CreateTokenTheoryData : TheoryDataBase
+    {
+        public Dictionary<string, object> AdditionalHeaderClaims { get; set; }
+
+        public string Payload { get; set; }
+
+        public string CompressionAlgorithm { get; set; }
+
+        public CompressionProviderFactory CompressionProviderFactory { get; set; }
+
+        public EncryptingCredentials EncryptingCredentials { get; set; }
+
+        public bool IsValid { get; set; } = true;
+
+        public SigningCredentials SigningCredentials { get; set; }
+
+        public SecurityTokenDescriptor TokenDescriptor { get; set; }
+
+        public Saml2SecurityTokenHandler Saml2SecurityTokenHandler { get; set; }
+
+        public string SamlToken { get; set; }
+
+        public TokenValidationParameters ValidationParameters { get; set; }
     }
 }
 

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
@@ -874,7 +874,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                     Expires = Default.Expires,
                     Issuer = Default.Issuer,
                     SigningCredentials = new SigningCredentials(key, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
-                    Subject = new ClaimsIdentity(Default.SamlClaims)
+                    Subject = new ClaimsIdentity(Default.SamlClaims),
                 };
 
                 var validationParameters = new TokenValidationParameters
@@ -1060,6 +1060,199 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             }
         }
 
+        [Theory, MemberData(nameof(CreateSamlTokenUsingTokenDescriptorTheoryData))]
+        public void CreateSamlTokenUsingTokenDescriptor(CreateTokenTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.CreateSamlTokenUsingTokenDescriptor", theoryData);
+            context.PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
+            {
+                { typeof(SamlAssertion), new List<string> { "IssueInstant", "InclusiveNamespacesPrefixList", "Signature", "SigningCredentials", "CanonicalString" } },
+                { typeof(SamlSecurityToken), new List<string> { "SigningKey" } },
+            };
+
+            try
+            {
+                SecurityToken samlTokenFromSecurityTokenDescriptor = theoryData.SamlSecurityTokenHandler.CreateToken(theoryData.TokenDescriptor) as SamlSecurityToken;
+                string tokenFromTokenDescriptor = theoryData.SamlSecurityTokenHandler.WriteToken(samlTokenFromSecurityTokenDescriptor);
+
+                var claimsIdentityFromTokenDescriptor = theoryData.SamlSecurityTokenHandler.ValidateToken(tokenFromTokenDescriptor, theoryData.ValidationParameters, out SecurityToken validatedTokenFromTokenDescriptor).Identity as ClaimsIdentity;
+                IdentityComparer.AreEqual(validatedTokenFromTokenDescriptor, samlTokenFromSecurityTokenDescriptor, context);
+
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<CreateTokenTheoryData> CreateSamlTokenUsingTokenDescriptorTheoryData
+        {
+            get
+            {
+                var validationParameters = new TokenValidationParameters
+                {
+                    AuthenticationType = "Federation",
+                    ValidateAudience = false,
+                    ValidateIssuer = false,
+                    ValidateLifetime = false,
+                    IssuerSigningKey = KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256
+                };
+                return new TheoryData<CreateTokenTheoryData>
+                {
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "NotSupportedClaimValue",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Audience = Default.Audience,
+                            NotBefore = Default.NotBefore,
+                            Expires = Default.Expires,
+                            Issuer = Default.Issuer,
+                            SigningCredentials = new SigningCredentials(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
+                            EncryptingCredentials = null,
+                            Claims = new Dictionary<string, object>()
+                            {
+                                { "https://www.listinlist.com", new List<object>{ new List<object> { "bob", new SecurityTokenDescriptor(), 12, 1.45 }, new List<object> { "bob", new SecurityTokenDescriptor(), 12, 1.45 } } },
+                            },
+                        },
+                        SamlSecurityTokenHandler = new SamlSecurityTokenHandler(),
+                        ValidationParameters = validationParameters,
+                        ExpectedException = ExpectedException.NotSupportedException("IDX10105:")
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        First =true,
+                        TestId = "NoSubjectClaims",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Audience = Default.Audience,
+                            NotBefore = Default.NotBefore,
+                            Expires = Default.Expires,
+                            Issuer = Default.Issuer,
+                            SigningCredentials = new SigningCredentials(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
+                            EncryptingCredentials = null,
+                            Claims = Default.SamlClaimsDictionary,
+                        },
+                        SamlSecurityTokenHandler = new SamlSecurityTokenHandler(),
+                        ValidationParameters = validationParameters
+                    },
+                    new CreateTokenTheoryData
+                    { 
+                        TestId = "OnlySubjectClaims",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Audience = Default.Audience,
+                            NotBefore = Default.NotBefore,
+                            Expires = Default.Expires,
+                            Issuer = Default.Issuer,
+                            SigningCredentials = new SigningCredentials(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
+                            EncryptingCredentials = null,
+                            Subject = new ClaimsIdentity(Default.SamlClaims)
+                        },
+                        SamlSecurityTokenHandler = new SamlSecurityTokenHandler(),
+                        ValidationParameters = validationParameters
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "BothIdenticalClaims",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Audience = Default.Audience,
+                            NotBefore = Default.NotBefore,
+                            Expires = Default.Expires,
+                            Issuer = Default.Issuer,
+                            SigningCredentials = new SigningCredentials(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
+                            EncryptingCredentials = null,
+                            Claims = Default.SamlClaimsDictionary,
+                            Subject = new ClaimsIdentity(Default.SamlClaims)
+                        },
+                        SamlSecurityTokenHandler = new SamlSecurityTokenHandler(),
+                        ValidationParameters = validationParameters
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "MoreDictionaryClaims",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Audience = Default.Audience,
+                            NotBefore = Default.NotBefore,
+                            Expires = Default.Expires,
+                            Issuer = Default.Issuer,
+                            SigningCredentials = new SigningCredentials(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
+                            EncryptingCredentials = null,
+                            Claims = Default.SamlClaimsDictionary,
+                            Subject = new ClaimsIdentity
+                            (
+                                new List<Claim>
+                                {
+                                    new Claim(ClaimTypes.Country, "USA", ClaimValueTypes.String, Default.Issuer, Default.OriginalIssuer),
+                                    new Claim(ClaimTypes.NameIdentifier, "Bob", ClaimValueTypes.String, Default.Issuer, Default.OriginalIssuer),
+                                    new Claim(ClaimTypes.Email, "Bob@contoso.com", ClaimValueTypes.String, Default.Issuer, Default.OriginalIssuer)
+                                }
+                            )
+                        },
+                        SamlSecurityTokenHandler = new SamlSecurityTokenHandler(),
+                        ValidationParameters = validationParameters
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "MoreSubjectClaims",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Audience = Default.Audience,
+                            NotBefore = Default.NotBefore,
+                            Expires = Default.Expires,
+                            Issuer = Default.Issuer,
+                            SigningCredentials = new SigningCredentials(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
+                            EncryptingCredentials = null,
+                            Claims = new Dictionary<string, object>()
+                            {
+                                { ClaimTypes.Email, "Bob@contoso.com" },
+                                { ClaimTypes.GivenName, "Bob" },
+                                { ClaimTypes.Role, "HR" }
+                            },
+                            Subject = new ClaimsIdentity(Default.SamlClaims)
+                        },
+                        SamlSecurityTokenHandler = new SamlSecurityTokenHandler(),
+                        ValidationParameters = validationParameters
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "RepeatingClaimTypes",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            Audience = Default.Audience,
+                            NotBefore = Default.NotBefore,
+                            Expires = Default.Expires,
+                            Issuer = Default.Issuer,
+                            SigningCredentials = new SigningCredentials(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256Digest),
+                            EncryptingCredentials = null,
+                            Claims = new Dictionary<string, object>()
+                            {
+                                { ClaimTypes.Email, "Alice@contoso.com" },
+                                { ClaimTypes.GivenName, "Alice" },
+                                { ClaimTypes.Role, "HR" }
+                            },
+                            Subject = new ClaimsIdentity
+                            (
+                                new List<Claim>
+                                {
+                                    new Claim(ClaimTypes.Email, "Bob@contoso.com", ClaimValueTypes.String, Default.Issuer, Default.OriginalIssuer),
+                                    new Claim(ClaimTypes.GivenName, "Bob", ClaimValueTypes.String, Default.Issuer, Default.OriginalIssuer),
+                                    new Claim(ClaimTypes.Country, "India", ClaimValueTypes.String, Default.Issuer, Default.OriginalIssuer)
+                                }
+                            )
+                        },
+                        SamlSecurityTokenHandler = new SamlSecurityTokenHandler(),
+                        ValidationParameters = validationParameters
+                    },
+                };
+            }
+        }
+
         private class SamlSecurityTokenHandlerPublic : SamlSecurityTokenHandler
         {
             public IEnumerable<ClaimsIdentity> CreateClaimsIdentitiesPublic(SamlSecurityToken samlToken, string issuer, TokenValidationParameters validationParameters)
@@ -1076,6 +1269,31 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             {
                 return base.ValidateIssuer(issuer, token, validationParameters);
             }
+        }
+
+        public class CreateTokenTheoryData : TheoryDataBase
+        {
+            public Dictionary<string, object> AdditionalHeaderClaims { get; set; }
+
+            public string Payload { get; set; }
+
+            public string CompressionAlgorithm { get; set; }
+
+            public CompressionProviderFactory CompressionProviderFactory { get; set; }
+
+            public EncryptingCredentials EncryptingCredentials { get; set; }
+
+            public bool IsValid { get; set; } = true;
+
+            public SigningCredentials SigningCredentials { get; set; }
+
+            public SecurityTokenDescriptor TokenDescriptor { get; set; }
+
+            public SamlSecurityTokenHandler SamlSecurityTokenHandler { get; set; }
+
+            public string SamlToken { get; set; }
+
+            public TokenValidationParameters ValidationParameters { get; set; }
         }
     }
 }

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -32,6 +32,7 @@ using System.Security.Claims;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Json.Linq;
 using Xunit;
 
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
@@ -40,6 +41,156 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 {
     public class JwtSecurityTokenHandlerTests
     {
+        // Tests checks to make sure that the token string created by the JwtSecurityTokenHandler is consistent with the 
+        // token string created by the JasonWebTokenHandler.
+        [Theory, MemberData(nameof(CreateJWEUsingSecurityTokenDescriptorTheoryData))]
+        public void CreateJWEUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.CreateJWEUsingSecurityTokenDescriptor", theoryData);
+            try
+            {
+                SecurityToken jweFromJwtHandler = theoryData.JwtSecurityTokenHandler.CreateToken(theoryData.TokenDescriptor);
+                string tokenFromTokenDescriptor = theoryData.JwtSecurityTokenHandler.WriteToken(jweFromJwtHandler);
+
+                string jweFromJsonHandler = theoryData.JsonWebTokenHandler.CreateToken(theoryData.TokenDescriptor);
+
+                var claimsPrincipal = theoryData.JwtSecurityTokenHandler.ValidateToken(tokenFromTokenDescriptor, theoryData.ValidationParameters, out SecurityToken validatedTokenFromJwtHandler);
+                var validationResult = theoryData.JsonWebTokenHandler.ValidateToken(jweFromJsonHandler, theoryData.ValidationParameters);
+
+                IdentityComparer.AreEqual(validationResult.IsValid, theoryData.IsValid, context);
+                var validatedTokenFromJsonHandler = validationResult.SecurityToken;
+                var validationResult2 = theoryData.JsonWebTokenHandler.ValidateToken(tokenFromTokenDescriptor, theoryData.ValidationParameters);
+                IdentityComparer.AreEqual(validationResult.IsValid, theoryData.IsValid, context);
+                IdentityComparer.AreEqual(claimsPrincipal.Identity, validationResult.ClaimsIdentity, context);
+                IdentityComparer.AreEqual((validatedTokenFromJwtHandler as JwtSecurityToken).Claims, (validatedTokenFromJsonHandler as JsonWebToken).Claims, context);
+
+                theoryData.ExpectedException.ProcessNoException(context);
+                context.PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
+                {
+                    { typeof(JsonWebToken), new List<string> { "EncodedToken", "AuthenticationTag", "Ciphertext", "InitializationVector" } },
+                };
+
+                IdentityComparer.AreEqual(validationResult2.SecurityToken as JwtSecurityToken, validationResult.SecurityToken as JwtSecurityToken, context);
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<CreateTokenTheoryData> CreateJWEUsingSecurityTokenDescriptorTheoryData
+        {
+            get
+            {
+                var tokenHandler = new JwtSecurityTokenHandler
+                {
+                    SetDefaultTimesOnTokenCreation = false
+                };
+
+                tokenHandler.InboundClaimTypeMap.Clear();
+
+                var jsonTokenHandler = new JsonWebTokenHandler
+                {
+                    SetDefaultTimesOnTokenCreation = false
+                };
+
+                return new TheoryData<CreateTokenTheoryData>
+                {
+                    new CreateTokenTheoryData
+                    {
+                        First = true,
+                        TestId = "IdenticalClaims",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            SigningCredentials = Default.X509AsymmetricSigningCredentials,
+                            EncryptingCredentials = null,
+                            Claims = Default.PayloadJsonDictionary,
+                            Subject = new ClaimsIdentity(Default.PayloadJsonClaims)
+                        },
+                        JwtSecurityTokenHandler = tokenHandler,
+                        JsonWebTokenHandler = jsonTokenHandler,
+                        ValidationParameters = Default.AsymmetricSignTokenValidationParameters
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "RepeatingAndAdditionalClaimsInSubjectClaims",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            SigningCredentials = Default.AsymmetricSigningCredentials,
+                            EncryptingCredentials = null,
+                            Claims =new Dictionary<string, object>()
+                            {
+                                { "ClaimValueTypes.String", "ClaimValueTypes.String.Value" },
+                                { "ClaimValueTypes.Boolean.true", true },
+                                { "ClaimValueTypes.Double", 123.4 },
+                                { "ClaimValueTypes.DateTime.IS8061", DateTime.TryParse("2019-11-15T14:31:21.6101326Z", out DateTime dateTimeValue1) ? dateTimeValue1 : new DateTime()},
+                                { "ClaimValueTypes.DateTime", DateTime.TryParse("2019-11-15", out DateTime dateTimeValue2) ? dateTimeValue2 : new DateTime()},
+                                { "ClaimValueTypes.JsonClaimValueTypes.Json1", JObject.Parse(@"{""jsonProperty1"":""jsonvalue1""}") },
+                                { "ClaimValueTypes.JsonClaimValueTypes.JsonNull", "" },
+                                { "ClaimValueTypes.JsonClaimValueTypes.JsonArray1", JArray.Parse(@"[1,2,3,4]") },
+                                {"ClaimValueTypes.JsonClaimValueTypes.Integer1", 1 },
+                            },
+                            Subject = new ClaimsIdentity(Default.PayloadJsonClaims)
+                        },
+                        JwtSecurityTokenHandler = tokenHandler,
+                        JsonWebTokenHandler = jsonTokenHandler,
+                        ValidationParameters = Default.AsymmetricSignTokenValidationParameters,
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "NoSubjectClaims",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            SigningCredentials = Default.AsymmetricSigningCredentials,
+                            EncryptingCredentials = null,
+                            Claims = Default.PayloadJsonDictionary,
+                        },
+                        JwtSecurityTokenHandler = tokenHandler,
+                        JsonWebTokenHandler = jsonTokenHandler,
+                        ValidationParameters = Default.AsymmetricSignTokenValidationParameters
+                    },
+                     new CreateTokenTheoryData
+                    {
+                        TestId = "OnlySubjectClaims",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            SigningCredentials = Default.X509AsymmetricSigningCredentials,
+                            EncryptingCredentials = null,
+                            Subject = new ClaimsIdentity(Default.PayloadJsonClaims)
+                        },
+                        JwtSecurityTokenHandler = tokenHandler,
+                        JsonWebTokenHandler = jsonTokenHandler,
+                        ValidationParameters = Default.AsymmetricSignTokenValidationParameters
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "AdditionalClaimsInDictionary",
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            SigningCredentials = Default.AsymmetricSigningCredentials,
+                            Claims = Default.PayloadJsonDictionary,
+                            EncryptingCredentials = null,
+                            Subject = new ClaimsIdentity
+                            (
+                                new List<Claim>
+                                {
+                                    new Claim("BooleanValue", "true", ClaimValueTypes.Boolean),
+                                    new Claim("DoubleValue", "456.7", ClaimValueTypes.Double),
+                                    new Claim("DateTimeValue", "2020-03-15T14:31:21.6101326Z", ClaimValueTypes.DateTime)
+                                }
+                            )
+                        },
+                        JwtSecurityTokenHandler = tokenHandler,
+                        JsonWebTokenHandler = jsonTokenHandler,
+                        ValidationParameters = Default.AsymmetricSignTokenValidationParameters
+                    },
+                };
+            }
+        }
+
         [Theory, MemberData(nameof(ActorTheoryData))]
         public void Actor(JwtTheoryData theoryData)
         {
@@ -2228,6 +2379,33 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
     {
         public JwtSecurityToken token { get; set; } = new JwtSecurityToken();
         public TokenValidationParameters validationParameters { get; set; } = new TokenValidationParameters();
+    }
+
+    public class CreateTokenTheoryData : TheoryDataBase
+    {
+        public Dictionary<string, object> AdditionalHeaderClaims { get; set; }
+
+        public string Payload { get; set; }
+
+        public string CompressionAlgorithm { get; set; }
+
+        public CompressionProviderFactory CompressionProviderFactory { get; set; }
+
+        public EncryptingCredentials EncryptingCredentials { get; set; }
+
+        public bool IsValid { get; set; } = true;
+
+        public SigningCredentials SigningCredentials { get; set; }
+
+        public SecurityTokenDescriptor TokenDescriptor { get; set; }
+
+        public JsonWebTokenHandler JsonWebTokenHandler { get; set; }
+
+        public JwtSecurityTokenHandler JwtSecurityTokenHandler { get; set; }
+
+        public string JwtToken { get; set; }
+
+        public TokenValidationParameters ValidationParameters { get; set; }
     }
 }
 


### PR DESCRIPTION
Fixes #1155

1. Adding method to convert dictionary of claims to list of Claim objects.
2. Merging both SecurityTokenDescriptor.Claims and SecurityTokenDescriptor.Subject.Claims and using them in creating token.

[ New PR to resolve rebase issues from #1414 ]
