### PR TITLE
fixes issue with SamlSerializer and adds tests

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSerializer.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSerializer.cs
@@ -230,7 +230,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 XmlUtil.ValidateXsiType(envelopeReader, SamlConstants.Types.AssertionType, SamlConstants.Namespace);
 
                 // @MajorVersion - required - must be "1"
-                var majorVersion = envelopeReader.GetAttribute(SamlConstants.Attributes.MajorVersion, null);
+                var majorVersion = envelopeReader.GetAttribute(SamlConstants.Attributes.MajorVersion);
                 if (string.IsNullOrEmpty(majorVersion))
                     throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.Assertion, SamlConstants.Attributes.MajorVersion);
 
@@ -238,7 +238,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                     throw LogReadException(LogMessages.IDX11116, majorVersion);
 
                 // @MinorVersion - required - must be "1"
-                var minorVersion = envelopeReader.GetAttribute(SamlConstants.Attributes.MinorVersion, null);
+                var minorVersion = envelopeReader.GetAttribute(SamlConstants.Attributes.MinorVersion);
                 if (string.IsNullOrEmpty(minorVersion))
                     throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.Assertion, SamlConstants.Attributes.MinorVersion);
 
@@ -246,7 +246,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                     throw LogReadException(LogMessages.IDX11117, minorVersion);
 
                 // @AssertionId - required
-                var assertionId = envelopeReader.GetAttribute(SamlConstants.Attributes.AssertionID, null);
+                var assertionId = envelopeReader.GetAttribute(SamlConstants.Attributes.AssertionID);
                 if (string.IsNullOrEmpty(assertionId))
                     throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.Assertion, SamlConstants.Attributes.AssertionID);
 
@@ -254,12 +254,12 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                     throw LogReadException(LogMessages.IDX11121, assertionId);
 
                 // @Issuer - required
-                var issuer = envelopeReader.GetAttribute(SamlConstants.Attributes.Issuer, null);
+                var issuer = envelopeReader.GetAttribute(SamlConstants.Attributes.Issuer);
                 if (string.IsNullOrEmpty(issuer))
                     throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.Assertion, SamlConstants.Attributes.Issuer);
 
                 // @IssueInstant - required
-                var issueInstantAttribute = envelopeReader.GetAttribute(SamlConstants.Attributes.IssueInstant, null);
+                var issueInstantAttribute = envelopeReader.GetAttribute(SamlConstants.Attributes.IssueInstant);
                 if (string.IsNullOrEmpty(issueInstantAttribute))
                     throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.Assertion, SamlConstants.Attributes.IssueInstant);
 
@@ -340,11 +340,11 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 // @xsi:type
                 XmlUtil.ValidateXsiType(reader, SamlConstants.Types.AttributeType, SamlConstants.Namespace);
 
-                attribute.Name = reader.GetAttribute(SamlConstants.Attributes.AttributeName, null);
+                attribute.Name = reader.GetAttribute(SamlConstants.Attributes.AttributeName);
                 if (string.IsNullOrEmpty(attribute.Name))
                     throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.Attribute, SamlConstants.Attributes.AttributeName);
 
-                attribute.Namespace = reader.GetAttribute(SamlConstants.Attributes.AttributeNamespace, null);
+                attribute.Namespace = reader.GetAttribute(SamlConstants.Attributes.AttributeNamespace);
                 if (string.IsNullOrEmpty(attribute.Namespace))
                     throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.Attribute, SamlConstants.Attributes.AttributeNamespace);
 
@@ -511,14 +511,14 @@ namespace Microsoft.IdentityModel.Tokens.Saml
 
                 var authenticationStatement = new SamlAuthenticationStatement();
 
-                var authInstance = reader.GetAttribute(SamlConstants.Attributes.AuthenticationInstant, null);
+                var authInstance = reader.GetAttribute(SamlConstants.Attributes.AuthenticationInstant);
                 if (string.IsNullOrEmpty(authInstance))
                     throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.AuthenticationStatement, SamlConstants.Attributes.AuthenticationInstant);
 
                 authenticationStatement.AuthenticationInstant = DateTime.ParseExact(
                     authInstance, SamlConstants.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
 
-                var authenticationMethod = reader.GetAttribute(SamlConstants.Attributes.AuthenticationMethod, null);
+                var authenticationMethod = reader.GetAttribute(SamlConstants.Attributes.AuthenticationMethod);
                 if (string.IsNullOrEmpty(authenticationMethod))
                     throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.AuthenticationStatement, SamlConstants.Attributes.AuthenticationMethod);
 
@@ -528,8 +528,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 authenticationStatement.Subject = ReadSubject(reader);
                 if (reader.IsStartElement(SamlConstants.Elements.SubjectLocality, SamlConstants.Namespace))
                 {
-                    authenticationStatement.DnsAddress = reader.GetAttribute(SamlConstants.Elements.DNSAddress, null);
-                    authenticationStatement.IPAddress = reader.GetAttribute(SamlConstants.Elements.IPAddress, null);
+                    authenticationStatement.DnsAddress = reader.GetAttribute(SamlConstants.Elements.DNSAddress);
+                    authenticationStatement.IPAddress = reader.GetAttribute(SamlConstants.Elements.IPAddress);
 
                     bool isEmptyElement = reader.IsEmptyElement;
                     reader.MoveToContent();
@@ -572,7 +572,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 // @xsi:type
                 XmlUtil.ValidateXsiType(reader, SamlConstants.Types.AuthorityBindingType, SamlConstants.Namespace);
 
-                var authKind = reader.GetAttribute(SamlConstants.Attributes.AuthorityKind, null);
+                var authKind = reader.GetAttribute(SamlConstants.Attributes.AuthorityKind);
                 if (string.IsNullOrEmpty(authKind))
                     throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.AuthorityBinding, SamlConstants.Attributes.AuthorityKind);
 
@@ -602,11 +602,11 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 else
                     authorityKind = new XmlQualifiedName(localName, nameSpace);
 
-                var binding = reader.GetAttribute(SamlConstants.Attributes.Binding, null);
+                var binding = reader.GetAttribute(SamlConstants.Attributes.Binding);
                 if (string.IsNullOrEmpty(binding))
                     throw LogExceptionMessage(new SamlSecurityTokenException(LogMessages.IDX11512));
 
-                var location = reader.GetAttribute(SamlConstants.Attributes.Location, null);
+                var location = reader.GetAttribute(SamlConstants.Attributes.Location);
                 if (string.IsNullOrEmpty(location))
                     throw LogExceptionMessage(new SamlSecurityTokenException(LogMessages.IDX11513));
 
@@ -646,13 +646,13 @@ namespace Microsoft.IdentityModel.Tokens.Saml
 
                 var statement = new SamlAuthorizationDecisionStatement();
 
-                var resource = reader.GetAttribute(SamlConstants.Attributes.Resource, null);
+                var resource = reader.GetAttribute(SamlConstants.Attributes.Resource);
                 if (string.IsNullOrEmpty(resource))
                     throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.AuthorizationDecisionStatement, SamlConstants.Attributes.Resource);
 
                 statement.Resource = resource;
 
-                var decision = reader.GetAttribute(SamlConstants.Attributes.Decision, null);
+                var decision = reader.GetAttribute(SamlConstants.Attributes.Decision);
                 if (string.IsNullOrEmpty(decision))
                     throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.AuthorizationDecisionStatement, SamlConstants.Attributes.Decision);
 
@@ -732,12 +732,12 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 XmlUtil.ValidateXsiType(reader, SamlConstants.Types.ConditionsType, SamlConstants.Namespace);
 
                 var nbf = DateTimeUtil.GetMinValue(DateTimeKind.Utc);
-                var time = reader.GetAttribute(SamlConstants.Attributes.NotBefore, null);
+                var time = reader.GetAttribute(SamlConstants.Attributes.NotBefore);
                 if (!string.IsNullOrEmpty(time))
                     nbf = DateTime.ParseExact(time, SamlConstants.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
 
                 var notOnOrAfter = DateTimeUtil.GetMaxValue(DateTimeKind.Utc);
-                time = reader.GetAttribute(SamlConstants.Attributes.NotOnOrAfter, null);
+                time = reader.GetAttribute(SamlConstants.Attributes.NotOnOrAfter);
                 if (!string.IsNullOrEmpty(time))
                     notOnOrAfter = DateTime.ParseExact(time, SamlConstants.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
 
@@ -897,11 +897,11 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                     // @xsi:type
                     XmlUtil.ValidateXsiType(reader, SamlConstants.Types.NameIDType, SamlConstants.Namespace);
 
-                    var nameFormat = reader.GetAttribute(SamlConstants.Attributes.Format, null);
+                    var nameFormat = reader.GetAttribute(SamlConstants.Attributes.Format);
                     if (!string.IsNullOrEmpty(nameFormat))
                         subject.NameFormat = nameFormat;
 
-                    var nameQualifier = reader.GetAttribute(SamlConstants.Attributes.NameQualifier, null);
+                    var nameQualifier = reader.GetAttribute(SamlConstants.Attributes.NameQualifier);
                     if (!string.IsNullOrEmpty(nameQualifier))
                         subject.NameQualifier = nameQualifier;
 

--- a/test/Microsoft.IdentityModel.TestUtils/XmlUtilities.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/XmlUtilities.cs
@@ -30,6 +30,7 @@ using System.Xml;
 using Microsoft.IdentityModel.Xml;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
+using System.Xml.Linq;
 
 namespace Microsoft.IdentityModel.TestUtils
 {
@@ -60,6 +61,14 @@ namespace Microsoft.IdentityModel.TestUtils
                 return null;
 
             return XmlDictionaryReader.CreateTextReader(Encoding.UTF8.GetBytes(xml), XmlDictionaryReaderQuotas.Max);
+        }
+
+        public static XmlReader CreateXDocumentReader(string xml)
+        {
+            if (string.IsNullOrEmpty(xml))
+                return null;
+
+            return XDocument.Parse(xml).CreateReader();
         }
 
         public static EnvelopedSignatureReader CreateEnvelopedSignatureReader(string xml)

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SerializerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SerializerTests.cs
@@ -127,7 +127,47 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             var context = TestUtilities.WriteHeader($"{this}.ReadAssertion", theoryData);
             try
             {
+                var reader = XmlUtilities.CreateXmlReader(theoryData.Xml);
+                var assertion = (theoryData.Saml2Serializer as Saml2SerializerPublic).ReadAssertionPublic(reader);
+                theoryData.ExpectedException.ProcessNoException(context);
+
+                IdentityComparer.AreEqual(assertion, theoryData.Assertion, context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Theory, MemberData(nameof(ReadAssertionTheoryData))]
+        public void ReadAssertionUsingDictionaryReader(Saml2TheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.ReadAssertionUsingDictionaryReader", theoryData);
+            try
+            {
                 var reader = XmlUtilities.CreateDictionaryReader(theoryData.Xml);
+                var assertion = (theoryData.Saml2Serializer as Saml2SerializerPublic).ReadAssertionPublic(reader);
+                theoryData.ExpectedException.ProcessNoException(context);
+
+                IdentityComparer.AreEqual(assertion, theoryData.Assertion, context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Theory, MemberData(nameof(ReadAssertionTheoryData))]
+        public void ReadAssertionUsingXDocumentReader(Saml2TheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.ReadAssertionUsingXDocumentReader", theoryData);
+            try
+            {
+                var reader = XmlUtilities.CreateXDocumentReader(theoryData.Xml);
                 var assertion = (theoryData.Saml2Serializer as Saml2SerializerPublic).ReadAssertionPublic(reader);
                 theoryData.ExpectedException.ProcessNoException(context);
 
@@ -514,7 +554,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                 return base.ReadAdvice(reader);
             }
 
-            public Saml2Assertion ReadAssertionPublic(XmlDictionaryReader reader)
+            public Saml2Assertion ReadAssertionPublic(XmlReader reader)
             {
                 return base.ReadAssertion(reader);
             }

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSerializerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSerializerTests.cs
@@ -191,7 +191,49 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             var context = TestUtilities.WriteHeader($"{this}.ReadAssertion", theoryData);
             try
             {
+                var reader = XmlUtilities.CreateXmlReader(theoryData.AssertionTestSet.Xml);
+                var assertion = (theoryData.SamlSerializer as SamlSerializerPublic).ReadAssertionPublic(reader);
+                theoryData.ExpectedException.ProcessNoException(context);
+
+                context.PropertiesToIgnoreWhenComparing.Add(typeof(SamlAssertion), new List<string> { "CanonicalString" });
+                IdentityComparer.AreEqual(assertion, theoryData.AssertionTestSet.Assertion, context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Theory, MemberData(nameof(ReadAssertionTheoryData))]
+        public void ReadAssertionUsingDictionaryReader(SamlTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.ReadAssertionUsingDictionaryReader", theoryData);
+            try
+            {
                 var reader = XmlUtilities.CreateDictionaryReader(theoryData.AssertionTestSet.Xml);
+                var assertion = (theoryData.SamlSerializer as SamlSerializerPublic).ReadAssertionPublic(reader);
+                theoryData.ExpectedException.ProcessNoException(context);
+
+                context.PropertiesToIgnoreWhenComparing.Add(typeof(SamlAssertion), new List<string> { "CanonicalString" });
+                IdentityComparer.AreEqual(assertion, theoryData.AssertionTestSet.Assertion, context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Theory, MemberData(nameof(ReadAssertionTheoryData))]
+        public void ReadAssertionUsingXDocumentReader(SamlTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.ReadAssertionUsingXDocumentReader", theoryData);
+            try
+            {
+                var reader = XmlUtilities.CreateXDocumentReader(theoryData.AssertionTestSet.Xml);
                 var assertion = (theoryData.SamlSerializer as SamlSerializerPublic).ReadAssertionPublic(reader);
                 theoryData.ExpectedException.ProcessNoException(context);
 
@@ -1090,7 +1132,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                 return base.ReadAdvice(reader);
             }
 
-            public SamlAssertion ReadAssertionPublic(XmlDictionaryReader reader)
+            public SamlAssertion ReadAssertionPublic(XmlReader reader)
             {
                 return base.ReadAssertion(reader);
             }


### PR DESCRIPTION
This PR fixes an issue #1436 by remove the null value that is passed to XmlReader.GetAttribute in SamlSerializer.

Tests are added to make sure that Saml and Saml2 Assertions can be read using a standard XmlReader and an XDocument created XmlReader.