### PR TITLE
Uses CultureInfo.InvariantCulture to parse claim values

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -254,13 +254,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
             if (claim.ValueType == ClaimValueTypes.Double)
             {
-                if (double.TryParse(claim.Value, out double doubleValue))
+                if (double.TryParse(claim.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out double doubleValue))
                     return doubleValue;
             }
 
             if (claim.ValueType == ClaimValueTypes.Integer || claim.ValueType == ClaimValueTypes.Integer32)
             {
-                if (int.TryParse(claim.Value, out int intValue))
+                if (int.TryParse(claim.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out int intValue))
                     return intValue;
             }
 

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
@@ -352,16 +352,16 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                         break;
 
                     case ClaimValueTypes.Double:
-                        jsonValue = double.Parse(claim.Value);
+                        jsonValue = double.Parse(claim.Value, CultureInfo.InvariantCulture);
                         break;
 
                     case ClaimValueTypes.Integer:
                     case ClaimValueTypes.Integer32:
-                        jsonValue = int.Parse(claim.Value);
+                        jsonValue = int.Parse(claim.Value, CultureInfo.InvariantCulture);
                         break;
 
                     case ClaimValueTypes.Integer64:
-                        jsonValue = long.Parse(claim.Value);
+                        jsonValue = long.Parse(claim.Value, CultureInfo.InvariantCulture);
                         break;
 
                     case ClaimValueTypes.DateTime:


### PR DESCRIPTION
Fixes issue #1467 by using CultureInfo.InvariantCulture to parse number claim values.