### PR TITLE
IsSupportedAlgorithm for SecurityKey issues: 453, 1419

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -113,8 +113,8 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="algorithm">the algorithm to use.</param>
         /// <exception cref="ArgumentNullException">thrown if <paramref name="key"/> is null.</exception>
         /// <exception cref="ArgumentNullException">thrown if <paramref name="algorithm"/> is null or empty.</exception>
-        /// <exception cref="ArgumentException">thrown if If <see cref="SecurityKey"/> and algorithm pair are not supported.</exception>
-        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assingable from <see cref="KeyWrapProvider"/>.</exception>
+        /// <exception cref="ArgumentException">thrown if <see cref="SecurityKey"/> and algorithm pair are not supported.</exception>
+        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assignable from <see cref="KeyWrapProvider"/>.</exception>
         /// <remarks>
         /// <para>If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.
         /// <see cref="ICryptoProvider.Create(string, object[])"/> is called to obtain the <see cref="AuthenticatedEncryptionProvider"/>.
@@ -152,8 +152,8 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="algorithm">the algorithm to use.</param>
         /// <exception cref="ArgumentNullException">thrown if <paramref name="key"/> is null.</exception>
         /// <exception cref="ArgumentNullException">thrown if <paramref name="algorithm"/> is null or empty.</exception>
-        /// <exception cref="NotSupportedException">thrown if If <see cref="SecurityKey"/> and algorithm pair are not supported.</exception>
-        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type not assingable from <see cref="KeyWrapProvider"/>.</exception>
+        /// <exception cref="NotSupportedException">thrown if <see cref="SecurityKey"/> and algorithm pair are not supported.</exception>
+        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type not assignable from <see cref="KeyWrapProvider"/>.</exception>
         /// <remarks>
         /// <para>If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.
         /// <see cref="ICryptoProvider.Create(string, object[])"/> is called to obtain the <see cref="KeyWrapProvider"/>.
@@ -207,9 +207,9 @@ namespace Microsoft.IdentityModel.Tokens
         /// <exception cref="ArgumentNullException">thrown if <paramref name="key"/> is null.</exception>
         /// <exception cref="ArgumentNullException">thrown if <paramref name="algorithm"/> is null or empty.</exception>
         /// <exception cref="ArgumentOutOfRangeException">thrown if <see cref="SecurityKey.KeySize"/> is too small.</exception>
-        /// <exception cref="NotSupportedException">thrown if <see cref="SecurityKey"/> is not assingable from <see cref="AsymmetricSecurityKey"/> or <see cref="SymmetricSecurityKey"/>.</exception>
+        /// <exception cref="NotSupportedException">thrown if <see cref="SecurityKey"/> is not assignable from <see cref="AsymmetricSecurityKey"/> or <see cref="SymmetricSecurityKey"/>.</exception>
         /// <exception cref="NotSupportedException">thrown if the key / algorithm is not supported.</exception>
-        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assingable from <see cref="SignatureProvider"/>.</exception>
+        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assignable from <see cref="SignatureProvider"/>.</exception>
         /// <remarks>
         /// <para>AsymmetricSignatureProviders require access to a PrivateKey for Signing.</para>
         /// <para>When finished with the <see cref="SignatureProvider"/> call <see cref="ReleaseSignatureProvider(SignatureProvider)"/>.</para>
@@ -240,9 +240,9 @@ namespace Microsoft.IdentityModel.Tokens
         /// <exception cref="ArgumentNullException">thrown if <paramref name="key"/> is null.</exception>
         /// <exception cref="ArgumentNullException">thrown if <paramref name="algorithm"/> is null or empty.</exception>
         /// <exception cref="ArgumentOutOfRangeException">thrown if <see cref="SecurityKey.KeySize"/> is too small.</exception>
-        /// <exception cref="NotSupportedException">thrown if <see cref="SecurityKey"/> is not assingable from <see cref="AsymmetricSecurityKey"/> or <see cref="SymmetricSecurityKey"/>.</exception>
+        /// <exception cref="NotSupportedException">thrown if <see cref="SecurityKey"/> is not assignable from <see cref="AsymmetricSecurityKey"/> or <see cref="SymmetricSecurityKey"/>.</exception>
         /// <exception cref="NotSupportedException">thrown if the key / algorithm is not supported.</exception>
-        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assingable from <see cref="SignatureProvider"/>.</exception>
+        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assignable from <see cref="SignatureProvider"/>.</exception>
         /// <remarks>When finished with the <see cref="SignatureProvider"/> call <see cref="ReleaseSignatureProvider(SignatureProvider)"/>.
         /// <para>If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.
         /// <see cref="ICryptoProvider.Create(string, object[])"/> is called to obtain the <see cref="SignatureProvider"/>.
@@ -269,7 +269,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         /// <param name="algorithm">the name of the hash algorithm to create.</param>
         /// <exception cref="ArgumentNullException">thrown if <paramref name="algorithm"/> is null or empty.</exception>
-        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assingable from <see cref="HashAlgorithm"/>.</exception>
+        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assignable from <see cref="HashAlgorithm"/>.</exception>
         /// <exception cref="NotSupportedException">thrown if <paramref name="algorithm"/> is not supported.</exception>
         /// <remarks>When finished with the <see cref="HashAlgorithm"/> call <see cref="ReleaseHashAlgorithm(HashAlgorithm)"/>.
         /// <para>If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.
@@ -306,7 +306,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         /// <param name="algorithm">the name of the hash algorithm to create.</param>
         /// <exception cref="ArgumentNullException">thrown if <paramref name="algorithm"/> is null or empty.</exception>
-        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assingable from <see cref="HashAlgorithm"/>.</exception>
+        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assignable from <see cref="HashAlgorithm"/>.</exception>
         /// <exception cref="NotSupportedException">thrown if <paramref name="algorithm"/> is not supported.</exception>
         /// <remarks>When finished with the <see cref="HashAlgorithm"/> call <see cref="ReleaseHashAlgorithm(HashAlgorithm)"/>.
         /// <para>If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.

--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -55,7 +55,7 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
-        /// Gets or sets the default value for caching
+        /// Gets or sets the default value for caching of <see cref="SignatureProvider"/>'s.
         /// </summary>
         [DefaultValue(true)]
         public static bool DefaultCacheSignatureProviders { get; set; } = true;
@@ -111,11 +111,17 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         /// <param name="key">the <see cref="SecurityKey"/> to use.</param>
         /// <param name="algorithm">the algorithm to use.</param>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="key"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="algorithm"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">thrown if If <see cref="SecurityKey"/> and algorithm pair are not supported.</exception>
+        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assingable from <see cref="KeyWrapProvider"/>.</exception>
+        /// <remarks>
+        /// <para>If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.
+        /// <see cref="ICryptoProvider.Create(string, object[])"/> is called to obtain the <see cref="AuthenticatedEncryptionProvider"/>.
+        /// </para>
+        /// <para>When finished with the <see cref="KeyWrapProvider"/> call <see cref="ReleaseKeyWrapProvider(KeyWrapProvider)"/>.</para>
+        /// </remarks>
         /// <returns>an instance of <see cref="AuthenticatedEncryptionProvider"/></returns>
-        /// <exception cref="ArgumentNullException">'key' is null.</exception>
-        /// <exception cref="ArgumentNullException">'algorithm' is null or empty.</exception>
-        /// <exception cref="ArgumentException">'key' is not a <see cref="SymmetricSecurityKey"/>.</exception>
-        /// <exception cref="ArgumentException">'algorithm, key' pair is not supported.</exception>
         public virtual AuthenticatedEncryptionProvider CreateAuthenticatedEncryptionProvider(SecurityKey key, string algorithm)
         {
             if (key == null)
@@ -144,17 +150,29 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         /// <param name="key">the <see cref="SecurityKey"/> to use.</param>
         /// <param name="algorithm">the algorithm to use.</param>
-        /// <returns>an instance of <see cref="KeyWrapProvider"/></returns>
-        /// <exception cref="ArgumentNullException">'key' is null.</exception>
-        /// <exception cref="ArgumentNullException">'algorithm' is null or empty.</exception>
-        /// <exception cref="ArgumentException">If <see cref="SecurityKey"/> and algorithm pair are not supported.</exception>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="key"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="algorithm"/> is null or empty.</exception>
+        /// <exception cref="NotSupportedException">thrown if If <see cref="SecurityKey"/> and algorithm pair are not supported.</exception>
+        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type not assingable from <see cref="KeyWrapProvider"/>.</exception>
         /// <remarks>
+        /// <para>If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.
+        /// <see cref="ICryptoProvider.Create(string, object[])"/> is called to obtain the <see cref="KeyWrapProvider"/>.
+        /// </para>
         /// <para>When finished with the <see cref="KeyWrapProvider"/> call <see cref="ReleaseKeyWrapProvider(KeyWrapProvider)"/>.</para>
         /// </remarks>
+        /// <returns>an instance of <see cref="KeyWrapProvider"/></returns>
         public virtual KeyWrapProvider CreateKeyWrapProvider(SecurityKey key, string algorithm)
         {
             return CreateKeyWrapProvider(key, algorithm, false);
         }
+
+#pragma warning disable 1573
+        /// <inheritdoc cref="CreateForSigning(SecurityKey, string)" />
+        public virtual KeyWrapProvider CreateKeyWrapProviderForUnwrap(SecurityKey key, string algorithm)
+        {
+            return CreateKeyWrapProvider(key, algorithm, true);
+        }
+#pragma warning restore 1573
 
         private KeyWrapProvider CreateKeyWrapProvider(SecurityKey key, string algorithm, bool willUnwrap)
         {
@@ -172,128 +190,93 @@ namespace Microsoft.IdentityModel.Tokens
                 return keyWrapProvider;
             }
 
-            if (key is RsaSecurityKey rsaKey && SupportedAlgorithms.IsSupportedRsaAlgorithm(algorithm, rsaKey))
+            if (SupportedAlgorithms.IsSupportedRsaKeyWrap(algorithm, key))
                 return new RsaKeyWrapProvider(key, algorithm, willUnwrap);
 
-            if (key is X509SecurityKey x509Key && SupportedAlgorithms.IsSupportedRsaAlgorithm(algorithm, x509Key))
-                return new RsaKeyWrapProvider(x509Key, algorithm, willUnwrap);
-
-            if (key is JsonWebKey jsonWebKey)
-            {
-                if (jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.RSA && SupportedAlgorithms.IsSupportedRsaAlgorithm(algorithm, key))
-                {
-                    return new RsaKeyWrapProvider(jsonWebKey, algorithm, willUnwrap);
-                }
-                else if (jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.Octet && SupportedAlgorithms.IsSupportedSymmetricAlgorithm(algorithm))
-                {
-                    return new SymmetricKeyWrapProvider(jsonWebKey, algorithm);
-                }
-            }
-
-            if (key is SymmetricSecurityKey symmetricKey && SupportedAlgorithms.IsSupportedSymmetricAlgorithm(algorithm))
-                return new SymmetricKeyWrapProvider(symmetricKey, algorithm);
+            if (SupportedAlgorithms.IsSupportedSymmetricKeyWrap(algorithm, key))
+                return new SymmetricKeyWrapProvider(key, algorithm);
 
             throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10661, algorithm, key)));
         }
 
         /// <summary>
-        /// Creates an instance of <see cref="KeyWrapProvider"/> for a specific &lt;SecurityKey, Algorithm>.
+        /// Creates a <see cref="SignatureProvider"/> that creates a signature with the algorithm and <see cref="SecurityKey"/>.
         /// </summary>
-        /// <param name="key">the <see cref="SecurityKey"/> to use.</param>
-        /// <param name="algorithm">the algorithm to use.</param>
-        /// <returns>an instance of <see cref="KeyWrapProvider"/></returns>
-        /// <exception cref="ArgumentNullException">'key' is null.</exception>
-        /// <exception cref="ArgumentNullException">'algorithm' is null or empty.</exception>
-        /// <exception cref="ArgumentException">If <see cref="SecurityKey"/> and algorithm pair are not supported.</exception>
+        /// <param name="key">the <see cref="SecurityKey"/> to use for signing.</param>
+        /// <param name="algorithm">the algorithm to use for signing.</param>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="key"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="algorithm"/> is null or empty.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">thrown if <see cref="SecurityKey.KeySize"/> is too small.</exception>
+        /// <exception cref="NotSupportedException">thrown if <see cref="SecurityKey"/> is not assingable from <see cref="AsymmetricSecurityKey"/> or <see cref="SymmetricSecurityKey"/>.</exception>
+        /// <exception cref="NotSupportedException">thrown if the key / algorithm is not supported.</exception>
+        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assingable from <see cref="SignatureProvider"/>.</exception>
         /// <remarks>
-        /// <para>When finished with the <see cref="KeyWrapProvider"/> call <see cref="ReleaseKeyWrapProvider(KeyWrapProvider)"/>.</para>
-        /// </remarks>
-        public virtual KeyWrapProvider CreateKeyWrapProviderForUnwrap(SecurityKey key, string algorithm)
-        {
-            return CreateKeyWrapProvider(key, algorithm, true);
-        }
-
-        /// <summary>
-        /// Creates a <see cref="SignatureProvider"/> that supports the <see cref="SecurityKey"/> and algorithm.
-        /// </summary>
-        /// <param name="key">The <see cref="SecurityKey"/> to use for signing.</param>
-        /// <param name="algorithm">The algorithm to use for signing.</param>
-        /// <exception cref="ArgumentNullException">'key' is null.</exception>
-        /// <exception cref="ArgumentNullException">'algorithm' is null or empty.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><see cref="AsymmetricSecurityKey"/>' is too small.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><see cref="SymmetricSecurityKey"/> is too small.</exception>
-        /// <exception cref="ArgumentException"><see cref="SecurityKey"/> is not a <see cref="AsymmetricSecurityKey"/> or a <see cref="SymmetricSecurityKey"/>.</exception>
-        /// <remarks>
-        /// AsymmetricSignatureProviders require access to a PrivateKey for Signing.
+        /// <para>AsymmetricSignatureProviders require access to a PrivateKey for Signing.</para>
         /// <para>When finished with the <see cref="SignatureProvider"/> call <see cref="ReleaseSignatureProvider(SignatureProvider)"/>.</para>
+        /// <para>If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.
+        /// <see cref="ICryptoProvider.Create(string, object[])"/> is called to obtain the <see cref="SignatureProvider"/>.
+        /// </para>
         /// </remarks>
+        /// <returns>A <see cref="SignatureProvider"/> that can be used to create a signature using the <see cref="SecurityKey"/> and algorithm.</returns>
         public virtual SignatureProvider CreateForSigning(SecurityKey key, string algorithm)
         {
             return CreateForSigning(key, algorithm, true);
         }
 
-        /// <summary>
-        /// Creates a <see cref="SignatureProvider"/> that supports the <see cref="SecurityKey"/> and algorithm.
-        /// </summary>
-        /// <param name="key">The <see cref="SecurityKey"/> to use for signing.</param>
-        /// <param name="algorithm">The algorithm to use for signing.</param>
-        /// <param name="cacheProvider">should the <see cref="SignatureProvider"/> be cached.</param>
-        /// <exception cref="ArgumentNullException">'key' is null.</exception>
-        /// <exception cref="ArgumentNullException">'algorithm' is null or empty.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><see cref="AsymmetricSecurityKey"/>' is too small.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><see cref="SymmetricSecurityKey"/> is too small.</exception>
-        /// <exception cref="ArgumentException"><see cref="SecurityKey"/> is not a <see cref="AsymmetricSecurityKey"/> or a <see cref="SymmetricSecurityKey"/>.</exception>
-        /// <remarks>
-        /// AsymmetricSignatureProviders require access to a PrivateKey for Signing.
-        /// <para>When finished with the <see cref="SignatureProvider"/> call <see cref="ReleaseSignatureProvider(SignatureProvider)"/>.</para>
-        /// </remarks>
+#pragma warning disable 1573
+        /// <inheritdoc cref="CreateForSigning(SecurityKey, string)" />
+        /// <param name="cacheProvider">indicates if the <see cref="SignatureProvider"/> should be cached for reuse.</param>
         public virtual SignatureProvider CreateForSigning(SecurityKey key, string algorithm, bool cacheProvider)
         {
             return CreateSignatureProvider(key, algorithm, true, cacheProvider);
         }
+#pragma warning restore 1573
 
         /// <summary>
-        /// Returns a <see cref="SignatureProvider"/> instance supports the <see cref="SecurityKey"/> and algorithm.
+        /// Creates a <see cref="SignatureProvider"/> that supports the <see cref="SecurityKey"/> and algorithm.
         /// </summary>
-        /// <param name="key">The <see cref="SecurityKey"/> to use for signing.</param>
+        /// <param name="key">The <see cref="SecurityKey"/> to use for signature verification.</param>
         /// <param name="algorithm">The algorithm to use for verifying.</param>
-        /// <exception cref="ArgumentNullException">'key' is null.</exception>
-        /// <exception cref="ArgumentNullException">'algorithm' is null or empty.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><see cref="AsymmetricSecurityKey"/> is too small.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><see cref="SymmetricSecurityKey"/> is too small.</exception>
-        /// <exception cref="ArgumentException"><see cref="SecurityKey"/>' is not a <see cref="AsymmetricSecurityKey"/> or a <see cref="SymmetricSecurityKey"/>.</exception>
-        /// <remarks>When finished with the <see cref="SignatureProvider"/> call <see cref="ReleaseSignatureProvider(SignatureProvider)"/>.</remarks>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="key"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="algorithm"/> is null or empty.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">thrown if <see cref="SecurityKey.KeySize"/> is too small.</exception>
+        /// <exception cref="NotSupportedException">thrown if <see cref="SecurityKey"/> is not assingable from <see cref="AsymmetricSecurityKey"/> or <see cref="SymmetricSecurityKey"/>.</exception>
+        /// <exception cref="NotSupportedException">thrown if the key / algorithm is not supported.</exception>
+        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assingable from <see cref="SignatureProvider"/>.</exception>
+        /// <remarks>When finished with the <see cref="SignatureProvider"/> call <see cref="ReleaseSignatureProvider(SignatureProvider)"/>.
+        /// <para>If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.
+        /// <see cref="ICryptoProvider.Create(string, object[])"/> is called to obtain the <see cref="SignatureProvider"/>.
+        /// </para>
+        /// </remarks>
+        /// <returns>A <see cref="SignatureProvider"/> that can be used to validate a signature using the <see cref="SecurityKey"/> and algorithm.</returns>
         public virtual SignatureProvider CreateForVerifying(SecurityKey key, string algorithm)
         {
             return CreateForVerifying(key, algorithm, true);
         }
 
-        /// <summary>
-        /// Returns a <see cref="SignatureProvider"/> instance supports the <see cref="SecurityKey"/> and algorithm.
-        /// </summary>
-        /// <param name="key">The <see cref="SecurityKey"/> to use for signing.</param>
-        /// <param name="algorithm">The algorithm to use for verifying.</param>
+#pragma warning disable 1573
+        /// <inheritdoc cref="CryptoProviderFactory.CreateForVerifying(SecurityKey, string)" />
         /// <param name="cacheProvider">should the <see cref="SignatureProvider"/> be cached.</param>
-        /// <exception cref="ArgumentNullException">'key' is null.</exception>
-        /// <exception cref="ArgumentNullException">'algorithm' is null or empty.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><see cref="AsymmetricSecurityKey"/> is too small.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><see cref="SymmetricSecurityKey"/> is too small.</exception>
-        /// <exception cref="ArgumentException"><see cref="SecurityKey"/>' is not a <see cref="AsymmetricSecurityKey"/> or a <see cref="SymmetricSecurityKey"/>.</exception>
-        /// <remarks>When finished with the <see cref="SignatureProvider"/> call <see cref="ReleaseSignatureProvider(SignatureProvider)"/>.</remarks>
         public virtual SignatureProvider CreateForVerifying(SecurityKey key, string algorithm, bool cacheProvider)
         {
             return CreateSignatureProvider(key, algorithm, false, cacheProvider);
         }
+#pragma warning restore 1573
 
 #if NET461 || NETSTANDARD2_0
         /// <summary>
-        /// Returns a <see cref="HashAlgorithm"/> for a specific algorithm.
+        /// Creates a <see cref="HashAlgorithm"/> for a specific algorithm.
         /// </summary>
         /// <param name="algorithm">the name of the hash algorithm to create.</param>
-        /// <returns>A <see cref="HashAlgorithm"/></returns>
-        /// <remarks>When finished with the <see cref="HashAlgorithm"/> call <see cref="ReleaseHashAlgorithm(HashAlgorithm)"/>.</remarks>
-        /// <exception cref="ArgumentNullException">'algorithm' is null or empty.</exception>
-        /// <exception cref="InvalidOperationException">'algorithm' is not supported.</exception>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="algorithm"/> is null or empty.</exception>
+        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assingable from <see cref="HashAlgorithm"/>.</exception>
+        /// <exception cref="NotSupportedException">thrown if <paramref name="algorithm"/> is not supported.</exception>
+        /// <remarks>When finished with the <see cref="HashAlgorithm"/> call <see cref="ReleaseHashAlgorithm(HashAlgorithm)"/>.
+        /// <para>If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.
+        /// <see cref="ICryptoProvider.Create(string, object[])"/> is called to obtain the <see cref="HashAlgorithm"/>.
+        /// </para>
+        /// </remarks>
+        /// <returns>A <see cref="HashAlgorithm"/>.</returns>
         public virtual HashAlgorithm CreateHashAlgorithm(HashAlgorithmName algorithm)
         {
             if (CustomCryptoProvider != null && CustomCryptoProvider.IsSupportedAlgorithm(algorithm.Name))
@@ -302,12 +285,11 @@ namespace Microsoft.IdentityModel.Tokens
                     throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10647, algorithm, typeof(HashAlgorithm))));
 
                 _typeToAlgorithmMap[hashAlgorithm.GetType().ToString()] = algorithm.Name;
-
                 return hashAlgorithm;
             }
 
             if (algorithm == HashAlgorithmName.SHA256)
-                    return SHA256.Create();
+                return SHA256.Create();
 
             if (algorithm == HashAlgorithmName.SHA384)
                 return SHA384.Create();
@@ -320,13 +302,18 @@ namespace Microsoft.IdentityModel.Tokens
 #endif
 
         /// <summary>
-        /// Returns a <see cref="HashAlgorithm"/> for a specific algorithm.
+        /// Creates a <see cref="HashAlgorithm"/> for a specific algorithm.
         /// </summary>
         /// <param name="algorithm">the name of the hash algorithm to create.</param>
-        /// <returns>A <see cref="HashAlgorithm"/></returns>
-        /// <remarks>When finished with the <see cref="HashAlgorithm"/> call <see cref="ReleaseHashAlgorithm(HashAlgorithm)"/>.</remarks>
-        /// <exception cref="ArgumentNullException">'algorithm' is null or empty.</exception>
-        /// <exception cref="InvalidOperationException">'algorithm' is not supported.</exception>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="algorithm"/> is null or empty.</exception>
+        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assingable from <see cref="HashAlgorithm"/>.</exception>
+        /// <exception cref="NotSupportedException">thrown if <paramref name="algorithm"/> is not supported.</exception>
+        /// <remarks>When finished with the <see cref="HashAlgorithm"/> call <see cref="ReleaseHashAlgorithm(HashAlgorithm)"/>.
+        /// <para>If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.
+        /// <see cref="ICryptoProvider.Create(string, object[])"/> is called to obtain the <see cref="HashAlgorithm"/>.
+        /// </para>
+        /// </remarks>
+        /// <returns>A <see cref="HashAlgorithm"/>.</returns>
         public virtual HashAlgorithm CreateHashAlgorithm(string algorithm)
         {
             if (string.IsNullOrEmpty(algorithm))
@@ -363,12 +350,18 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Returns a <see cref="KeyedHashAlgorithm"/> for a specific algorithm.
         /// </summary>
-        /// <param name="algorithm">the keyed hash algorithm to create.</param>
-        /// <param name="keyBytes">bytes to use to create the Keyed Hash</param>
-        /// <returns>A <see cref="HashAlgorithm"/></returns>
-        /// <remarks>When finished with the <see cref="HashAlgorithm"/> call <see cref="ReleaseHashAlgorithm(HashAlgorithm)"/>.</remarks>
-        /// <exception cref="ArgumentNullException">'algorithm' is null or empty.</exception>
-        /// <exception cref="InvalidOperationException">'algorithm' is not supported.</exception>
+        /// <param name="keyBytes">bytes to use to create the Keyed Hash.</param>
+        /// <param name="algorithm">the name of the keyed hash algorithm to create.</param>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="keyBytes"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="algorithm"/> is null or empty.</exception>
+        /// <exception cref="InvalidOperationException">thrown if <see cref="ICryptoProvider.Create(string, object[])"/> returns a type that is not assignable from <see cref="KeyedHashAlgorithm"/>.</exception>
+        /// <exception cref="NotSupportedException"><paramref name="algorithm"/> is not supported.</exception>
+        /// <remarks>When finished with the <see cref="KeyedHashAlgorithm"/> call <see cref="ReleaseHashAlgorithm(HashAlgorithm)"/>.
+        /// <para>If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.
+        /// <see cref="ICryptoProvider.Create(string, object[])"/> is called to obtain the <see cref="KeyedHashAlgorithm"/>.
+        /// </para>
+        /// </remarks>
+        /// <returns>A <see cref="KeyedHashAlgorithm"/>.</returns>
         public virtual KeyedHashAlgorithm CreateKeyedHashAlgorithm(byte[] keyBytes, string algorithm)
         {
             if (keyBytes == null)
@@ -412,7 +405,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (string.IsNullOrEmpty(algorithm))
                 throw LogHelper.LogArgumentNullException(nameof(algorithm));
 
-            SignatureProvider signatureProvider = null;
+            SignatureProvider signatureProvider;
             if (CustomCryptoProvider != null && CustomCryptoProvider.IsSupportedAlgorithm(algorithm, key, willCreateSignatures))
             {
                 signatureProvider = CustomCryptoProvider.Create(algorithm, key, willCreateSignatures) as SignatureProvider;
@@ -505,10 +498,17 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
-        /// Answers if an algorithm is supported
+        /// Checks if an algorithm is supported.
         /// </summary>
-        /// <param name="algorithm">the name of the cryptographic algorithm</param>
-        /// <returns></returns>
+        /// <param name="algorithm">the name of the Hash algorithm.</param>
+        /// <remarks>Only considers known Hash algorithms.</remarks>
+        /// <returns>true if:
+        /// <para>
+        /// If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.
+        /// </para>
+        /// <para>The algorithm is supported.
+        /// </para>
+        /// </returns>
         public virtual bool IsSupportedAlgorithm(string algorithm)
         {
             if (CustomCryptoProvider != null && CustomCryptoProvider.IsSupportedAlgorithm(algorithm))
@@ -518,11 +518,22 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
-        /// Checks if an 'algorithm, key' pair is supported.
+        /// Checks if the algorithm and <see cref="SecurityKey"/> is supported.
         /// </summary>
-        /// <param name="algorithm">the algorithm to check.</param>
+        /// <param name="algorithm">the security algorithm to apply.</param>
         /// <param name="key">the <see cref="SecurityKey"/>.</param>
-        /// <returns>true if 'algorithm, key' pair is supported.</returns>
+        /// <remarks>Algorithms are supported for specific key types.
+        /// For example:
+        /// <para><see cref="SecurityAlgorithms.RsaSha256"/> and <see cref="RsaSecurityKey"/> will return true.</para>
+        /// <para><see cref="SecurityAlgorithms.RsaSha256"/> and <see cref="SymmetricSecurityKey"/> will return false.</para>
+        /// </remarks>
+        /// <returns>true if:
+        /// <para>
+        /// If <see cref="CustomCryptoProvider"/> is set and <see cref="ICryptoProvider.IsSupportedAlgorithm(string, object[])"/> returns true.
+        /// </para>
+        /// <para>The algorithm / key pair is supported.
+        /// </para>
+        /// </returns>
         public virtual bool IsSupportedAlgorithm(string algorithm, SecurityKey key)
         {
             if (CustomCryptoProvider != null && CustomCryptoProvider.IsSupportedAlgorithm(algorithm, key))
@@ -539,6 +550,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// When finished with a <see cref="HashAlgorithm"/> call this method for cleanup. The default behavior is to call <see cref="HashAlgorithm.Dispose()"/>
         /// </summary>
         /// <param name="hashAlgorithm"><see cref="HashAlgorithm"/> to be released.</param>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="hashAlgorithm"/> is null.</exception>
         public virtual void ReleaseHashAlgorithm(HashAlgorithm hashAlgorithm)
         {
             if (hashAlgorithm == null)
@@ -553,6 +565,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// When finished with a <see cref="KeyWrapProvider"/> call this method for cleanup."/>
         /// </summary>
         /// <param name="provider"><see cref="KeyWrapProvider"/> to be released.</param>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="provider"/> is null.</exception>
         public virtual void ReleaseKeyWrapProvider(KeyWrapProvider provider)
         {
             if (provider == null)
@@ -567,6 +580,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// When finished with a <see cref="RsaKeyWrapProvider"/> call this method for cleanup."/>
         /// </summary>
         /// <param name="provider"><see cref="RsaKeyWrapProvider"/> to be released.</param>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="provider"/> is null.</exception>
         public virtual void ReleaseRsaKeyWrapProvider(RsaKeyWrapProvider provider)
         {
             if (provider == null)
@@ -581,6 +595,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// When finished with a <see cref="SignatureProvider"/> call this method for cleanup. The default behavior is to call <see cref="SignatureProvider.Dispose()"/>
         /// </summary>
         /// <param name="signatureProvider"><see cref="SignatureProvider"/> to be released.</param>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="signatureProvider"/> is null.</exception>
         public virtual void ReleaseSignatureProvider(SignatureProvider signatureProvider)
         {
             if (signatureProvider == null)

--- a/src/Microsoft.IdentityModel.Tokens/Encryption/RsaKeyWrapProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/RsaKeyWrapProvider.cs
@@ -108,7 +108,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns>true if the algorithm is supported; otherwise, false.</returns>
         protected virtual bool IsSupportedAlgorithm(SecurityKey key, string algorithm)
         {
-            return SupportedAlgorithms.IsSupportedKeyWrapAlgorithm(algorithm, key);
+            return SupportedAlgorithms.IsSupportedRsaKeyWrap(algorithm, key);
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using Microsoft.IdentityModel.Logging;
 
 namespace Microsoft.IdentityModel.Tokens
 {
@@ -74,5 +75,22 @@ namespace Microsoft.IdentityModel.Tokens
             : base(info, context)
         {
         }
+
+#if NETSTANDARD2_0
+        /// <summary>
+        /// When overridden in a derived class, sets the System.Runtime.Serialization.SerializationInfo
+        /// with information about the exception.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        /// <exception cref="ArgumentNullException">thrown if <paramref name="info"/> is null.</exception>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+                throw LogHelper.LogArgumentNullException(nameof(info));
+
+            base.GetObjectData(info, context);
+        }
+#endif
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Microsoft.IdentityModel.Tokens.csproj
+++ b/src/Microsoft.IdentityModel.Tokens/Microsoft.IdentityModel.Tokens.csproj
@@ -53,6 +53,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="SauceControl.InheritDoc" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
@@ -115,6 +115,17 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
+        /// Checks if <see cref="SecurityKey.CryptoProviderFactory"/> can perform the cryptographic operation specified by the <paramref name="algorithm"/> with this <see cref="SecurityKey"/>.
+        /// </summary>
+        /// <param name="algorithm">the algorithm to apply.</param>
+        /// <returns>true if <see cref="SecurityKey.CryptoProviderFactory"/> can perform the cryptographic operation sepecified by the <paramref name="algorithm"/> with this <see cref="SecurityKey"/>.</returns>
+        public virtual bool IsSupportedAlgorithm(string algorithm)
+        {
+            // do not throw if algorithm is null or empty to stay in sync with CryptoProviderFactory.IsSupportedAlgorithm.
+            return CryptoProviderFactory.IsSupportedAlgorithm(algorithm, this);
+        }
+
+        /// <summary>
         /// Sets the <see cref="InternalId"/> to value of <see cref="SecurityKey"/>'s JWK thumbprint if it can be computed, otherwise sets the <see cref="InternalId"/> to <see cref="string.Empty"/>.
         /// </summary>
         private void SetInternalId()

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -246,7 +246,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-
         public static TheoryData<CreateTokenTheoryData> CreateJWETheoryData
         {
             get
@@ -1462,10 +1461,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(RoundTripJWEDirectEncryptionTheoryData))]
-        public void RoundTripEncryptExistingJWSUsingDirectEncryption(CreateTokenTheoryData theoryData)
+        [Theory, MemberData(nameof(RoundTripJWEDirectTestCases))]
+        public void RoundTripJWEInnerJWSDirect(CreateTokenTheoryData theoryData)
         {
-            var context = TestUtilities.WriteHeader($"{this}.RoundTripEncryptExistingJWSUsingDirectEncryption", theoryData);
+            var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEInnerJWSDirect", theoryData);
             var jsonWebTokenHandler = new JsonWebTokenHandler();
             var innerJwt = jsonWebTokenHandler.CreateToken(theoryData.Payload, theoryData.SigningCredentials);
             var jweCreatedInMemory = jsonWebTokenHandler.EncryptToken(innerJwt, theoryData.EncryptingCredentials);
@@ -1494,10 +1493,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(RoundTripJWEDirectEncryptionTheoryData))]
-        public void RoundTripJWEDirectEncryption(CreateTokenTheoryData theoryData)
+        [Theory, MemberData(nameof(RoundTripJWEDirectTestCases))]
+        public void RoundTripJWEDirect(CreateTokenTheoryData theoryData)
         {
-            var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEDirectEncryption", theoryData);
+            var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEDirect", theoryData);
             var jsonWebTokenHandler = new JsonWebTokenHandler();
             var jwtSecurityTokenHandler = new JwtSecurityTokenHandler();
             jwtSecurityTokenHandler.InboundClaimTypeMap.Clear();
@@ -1531,7 +1530,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        public static TheoryData<CreateTokenTheoryData> RoundTripJWEDirectEncryptionTheoryData
+        public static TheoryData<CreateTokenTheoryData> RoundTripJWEDirectTestCases
         {
             get
             {
@@ -1578,15 +1577,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(RoundTripJWEKeyWrappingTheoryData))]
-        public void RoundTripEncryptExistingJWSUsingKeyWrapping(CreateTokenTheoryData theoryData)
+        [Theory, MemberData(nameof(RoundTripJWEKeyWrapTestCases))]
+        public void RoundTripJWEInnerJWSKeyWrap(CreateTokenTheoryData theoryData)
         {
-            var context = TestUtilities.WriteHeader($"{this}.RoundTripEncryptExistingJWSUsingKeyWrapping", theoryData);
+            var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEInnerJWSKeyWrap", theoryData);
             var jsonWebTokenHandler = new JsonWebTokenHandler();
             var innerJws = jsonWebTokenHandler.CreateToken(theoryData.Payload, theoryData.SigningCredentials);
-            var jweCreatedInMemory = jsonWebTokenHandler.EncryptToken(innerJws, theoryData.EncryptingCredentials);
             try
             {
+                var jweCreatedInMemory = jsonWebTokenHandler.EncryptToken(innerJws, theoryData.EncryptingCredentials);
                 var tokenValidationResult = jsonWebTokenHandler.ValidateToken(jweCreatedInMemory, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(tokenValidationResult.IsValid, theoryData.IsValid, context);
                 if (tokenValidationResult.Exception != null)
@@ -1610,16 +1609,16 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(RoundTripJWEKeyWrappingTheoryData))]
-        public void RoundTripJWEKeyWrapping(CreateTokenTheoryData theoryData)
+        [Theory, MemberData(nameof(RoundTripJWEKeyWrapTestCases))]
+        public void RoundTripJWEKeyWrap(CreateTokenTheoryData theoryData)
         {
-            var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEKeyWrapping", theoryData);
+            var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEKeyWrap", theoryData);
             var jsonWebTokenHandler = new JsonWebTokenHandler();
             var jwtSecurityTokenHandler = new JwtSecurityTokenHandler();
             jwtSecurityTokenHandler.InboundClaimTypeMap.Clear();
-            var jweCreatedInMemory = jsonWebTokenHandler.CreateToken(theoryData.Payload, theoryData.SigningCredentials, theoryData.EncryptingCredentials);
             try
             {
+                var jweCreatedInMemory = jsonWebTokenHandler.CreateToken(theoryData.Payload, theoryData.SigningCredentials, theoryData.EncryptingCredentials);
                 var tokenValidationResult = jsonWebTokenHandler.ValidateToken(jweCreatedInMemory, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(tokenValidationResult.IsValid, theoryData.IsValid, context);
                 if (tokenValidationResult.Exception != null)
@@ -1647,109 +1646,119 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        public static TheoryData<CreateTokenTheoryData> RoundTripJWEKeyWrappingTheoryData
+        public static TheoryData<CreateTokenTheoryData> RoundTripJWEKeyWrapTestCases
         {
             get
             {
                 return new TheoryData<CreateTokenTheoryData>
                 {
-                    new CreateTokenTheoryData()
+                    new CreateTokenTheoryData
                     {
                         First = true,
-                        TestId = "RsaPKCS1-Aes128CbcHmacSha256",
+                        TestId = "RsaPKCS1_Aes128CbcHmacSha256",
                         ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
                         Payload = Default.PayloadString,
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256)
                     },
-                    new CreateTokenTheoryData()
+                    new CreateTokenTheoryData
                     {
-                        TestId = "RsaPKCS1-Aes192CbcHmacSha384",
+                        TestId = "RsaPKCS1_Aes192CbcHmacSha384",
                         ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
                         Payload = Default.PayloadString,
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes192CbcHmacSha384)
                     },
-                    new CreateTokenTheoryData()
+                    new CreateTokenTheoryData
                     {
-                        TestId = "RsaPKCS1-Aes256CbcHmacSha512",
+                        TestId = "RsaPKCS1_Aes256CbcHmacSha512",
                         ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
                         Payload = Default.PayloadString,
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes256CbcHmacSha512)
                     },
-                    new CreateTokenTheoryData()
+                    new CreateTokenTheoryData
                     {
-                        TestId = "RsaOAEP-Aes128CbcHmacSha256",
+                        TestId = "RsaOAEP_Aes128CbcHmacSha256",
                         ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
                         Payload = Default.PayloadString,
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOAEP, SecurityAlgorithms.Aes128CbcHmacSha256)
                     },
-                    new CreateTokenTheoryData()
+                    new CreateTokenTheoryData
                     {
-                        TestId = "RsaOAEP-Aes192CbcHmacSha384",
+                        TestId = "RsaOAEP_Aes192CbcHmacSha384",
                         ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
                         Payload = Default.PayloadString,
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOAEP, SecurityAlgorithms.Aes192CbcHmacSha384)
                     },
-                    new CreateTokenTheoryData()
+                    new CreateTokenTheoryData
                     {
-                        TestId = "RsaOAEP-Aes256CbcHmacSha512",
+                        TestId = "RsaOAEP_Aes256CbcHmacSha512",
                         ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
                         Payload = Default.PayloadString,
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOAEP, SecurityAlgorithms.Aes256CbcHmacSha512)
                     },
-                    new CreateTokenTheoryData()
+                    new CreateTokenTheoryData
                     {
-                        TestId = "RsaOaepKeyWrap-Aes128CbcHmacSha256",
+                        TestId = "RsaOaepKeyWrap_Aes128CbcHmacSha256",
                         ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
                         Payload = Default.PayloadString,
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOaepKeyWrap, SecurityAlgorithms.Aes128CbcHmacSha256)
                     },
-                    new CreateTokenTheoryData()
+                    new CreateTokenTheoryData
                     {
-                        TestId = "RsaOaepKeyWrap-Aes192CbcHmacSha384",
+                        TestId = "RsaOaepKeyWrap_Aes192CbcHmacSha384",
                         ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
                         Payload = Default.PayloadString,
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOaepKeyWrap, SecurityAlgorithms.Aes192CbcHmacSha384)
                     },
-                    new CreateTokenTheoryData()
+                    new CreateTokenTheoryData
                     {
-                        TestId = "RsaOaepKeyWrap-Aes256CbcHmacSha512",
+                        TestId = "RsaOaepKeyWrap_Aes256CbcHmacSha512",
                         ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
                         Payload = Default.PayloadString,
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOaepKeyWrap, SecurityAlgorithms.Aes256CbcHmacSha512)
                     },
-                    new CreateTokenTheoryData()
+                    new CreateTokenTheoryData
                     {
-                        TestId = "SymmetricSecurityKey2_128-Aes128KW-Aes128CbcHmacSha256",
+                        TestId = "Aes128KeyWrap_Aes128CbcHmacSha256",
                         ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.SymmetricSecurityKey2_128, Default.SymmetricSigningKey256),
                         Payload = Default.PayloadString,
                         SigningCredentials = Default.SymmetricSigningCredentials,
-                        EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.SymmetricSecurityKey2_128, SecurityAlgorithms.Aes128KW, SecurityAlgorithms.Aes128CbcHmacSha256)
+                        EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.SymmetricSecurityKey2_128, SecurityAlgorithms.Aes128KeyWrap, SecurityAlgorithms.Aes128CbcHmacSha256)
                     },
-                    new CreateTokenTheoryData()
+                    new CreateTokenTheoryData
                     {
-                        TestId = "SymmetricEncryptionKey256-Aes256KW-Aes128CbcHmacSha256",
+                        TestId = "Aes256KeyWrap_Aes128CbcHmacSha256",
+                        ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.SymmetricSecurityKey2_128, Default.SymmetricSigningKey256),
+                        Payload = Default.PayloadString,
+                        SigningCredentials = Default.SymmetricSigningCredentials,
+                        EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.SymmetricSecurityKey2_128, SecurityAlgorithms.Aes256KeyWrap, SecurityAlgorithms.Aes128CbcHmacSha256),
+                        ExpectedException = ExpectedException.ArgumentOutOfRangeException("IDX10662:")
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "Aes128KW_Aes128CbcHmacSha256",
+                        ValidationParameters = Default.SymmetricEncryptSignTokenValidationParameters,
+                        Payload = Default.PayloadString,
+                        SigningCredentials = Default.SymmetricSigningCredentials,
+                        EncryptingCredentials = new EncryptingCredentials(Default.SymmetricEncryptionKey256, SecurityAlgorithms.Aes128KW, SecurityAlgorithms.Aes128CbcHmacSha256),
+                        ExpectedException = ExpectedException.ArgumentOutOfRangeException("IDX10662:")
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "Aes256KW_Aes128CbcHmacSha256",
                         ValidationParameters = Default.SymmetricEncryptSignTokenValidationParameters,
                         Payload = Default.PayloadString,
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         EncryptingCredentials = new EncryptingCredentials(Default.SymmetricEncryptionKey256, SecurityAlgorithms.Aes256KW, SecurityAlgorithms.Aes128CbcHmacSha256)
                     },
-                    new CreateTokenTheoryData()
-                    {
-                        TestId = "RsaOaepKeyWrap-Aes192CbcHmacSha384",
-                        ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
-                        Payload = Default.PayloadString,
-                        SigningCredentials = Default.SymmetricSigningCredentials,
-                        EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOaepKeyWrap, SecurityAlgorithms.Aes192CbcHmacSha384)
-                    }
                 };
             }
         }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ECDsaSecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ECDsaSecurityKeyTests.cs
@@ -71,30 +71,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             // there are no defaults.
         }
 
-        [Theory, MemberData(nameof(IsSupportedAlgDataSet))]
-        public void IsSupportedAlgorithm(ECDsaSecurityKey key, string alg, bool expectedResult)
-        {
-            if (key.CryptoProviderFactory.IsSupportedAlgorithm(alg, key) != expectedResult)
-                Assert.True(false, string.Format("{0} failed with alg: {1}. ExpectedResult: {2}", key, alg, expectedResult));
-        }
-
-        public static TheoryData<ECDsaSecurityKey, string, bool> IsSupportedAlgDataSet
-        {
-            get
-            {
-                var dataset = new TheoryData<ECDsaSecurityKey, string, bool>();
-                dataset.Add(KeyingMaterial.Ecdsa256Key, SecurityAlgorithms.EcdsaSha256, true);
-                dataset.Add(KeyingMaterial.Ecdsa256Key_Public, SecurityAlgorithms.EcdsaSha256Signature, true);
-                dataset.Add(KeyingMaterial.Ecdsa384Key, SecurityAlgorithms.Aes128Encryption, false);
-                dataset.Add(KeyingMaterial.Ecdsa521Key, SecurityAlgorithms.EcdsaSha384, true);
-                ECDsaSecurityKey testKey = new ECDsaSecurityKey(KeyingMaterial.Ecdsa256Key.ECDsa);
-                testKey.CryptoProviderFactory = new CustomCryptoProviderFactory(new string[] { SecurityAlgorithms.RsaSsaPssSha256Signature });
-                dataset.Add(testKey, SecurityAlgorithms.RsaSsaPssSha256Signature, true);
-                return dataset;
-
-            }
-        }
-
         [Fact]
         public void CanComputeJwkThumbprint()
         {

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyTests.cs
@@ -145,35 +145,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
         }
 
-        [Theory, MemberData(nameof(IsSupportedAlgDataSet))]
-        public void IsSupportedAlgorithm(JsonWebKey key, string alg, bool expectedResult)
-        {
-            if (key.CryptoProviderFactory.IsSupportedAlgorithm(alg, key) != expectedResult)
-                Assert.True(false, string.Format("{0} failed with alg: {1}. ExpectedResult: {2}", key, alg, expectedResult));
-        }
-
-        public static TheoryData<JsonWebKey, string, bool> IsSupportedAlgDataSet
-        {
-            get
-            {
-                var dataset = new TheoryData<JsonWebKey, string, bool>();
-                dataset.Add(KeyingMaterial.JsonWebKeyP256, SecurityAlgorithms.EcdsaSha256, true);
-                dataset.Add(KeyingMaterial.JsonWebKeyP256, SecurityAlgorithms.RsaSha256Signature, false);
-                dataset.Add(KeyingMaterial.JsonWebKeyRsa_2048, SecurityAlgorithms.RsaSha256, true);
-                dataset.Add(KeyingMaterial.JsonWebKeyRsa_2048, SecurityAlgorithms.EcdsaSha256, false);
-                dataset.Add(KeyingMaterial.JsonWebKeySymmetric256, SecurityAlgorithms.HmacSha256, true);
-                dataset.Add(KeyingMaterial.JsonWebKeySymmetric256, SecurityAlgorithms.RsaSha256Signature, false);
-                JsonWebKey testKey = new JsonWebKey
-                {
-                    Kty = JsonWebAlgorithmsKeyTypes.Octet,
-                    K = KeyingMaterial.DefaultSymmetricKeyEncoded_256
-                };
-                testKey.CryptoProviderFactory = new CustomCryptoProviderFactory(new string[] { SecurityAlgorithms.RsaSha256Signature });
-                dataset.Add(testKey, SecurityAlgorithms.RsaSha256Signature, true);
-                return dataset;
-            }
-        }
-
         // Tests to make sure conditional property serialization for JsonWebKeys is working properly.
         [Fact]
         public void ConditionalPropertySerialization()

--- a/test/Microsoft.IdentityModel.Tokens.Tests/KeyWrapProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/KeyWrapProviderTests.cs
@@ -53,51 +53,61 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     /// </summary>
     public class KeyWrapProviderTests
     {
-        [Theory, MemberData(nameof(KeyWrapConstructorTheoryData))]
-        public void Constructors(string testId, SecurityKey key, string algorithm, ExpectedException ee)
+        [Theory, MemberData(nameof(KeyWrapConstructorTestCases))]
+        public void Constructors(SupportedAlgorithmTheoryData theoryData)
         {
-            TestUtilities.WriteHeader("Constructors - " + testId, true);
+            var context = TestUtilities.WriteHeader($"{this}.Constructors", theoryData);
+
             try
             {
-                var context = Guid.NewGuid().ToString();
-                var provider = CryptoProviderFactory.Default.CreateKeyWrapProvider(key, algorithm);
-                provider.Context = context;
+                var providerContext = Guid.NewGuid().ToString();
+                var provider = CryptoProviderFactory.Default.CreateKeyWrapProvider(theoryData.SecurityKey, theoryData.Algorithm);
+                provider.Context = providerContext;
 
-                ee.ProcessNoException();
+                theoryData.ExpectedException.ProcessNoException(context);
+                if (provider.Algorithm != theoryData.Algorithm)
+                    context.AddDiff($"provider.Algorithm: '{provider.Algorithm}' != theoryData.Algorithm: '{theoryData.Algorithm}'.");
 
-                Assert.Equal(provider.Algorithm, algorithm);
-                Assert.Equal(provider.Context, context);
-                Assert.True(ReferenceEquals(provider.Key, key));
+                if (provider.Context != providerContext)
+                    context.AddDiff($"provider.Context: '{provider.Context}' != providerContext: '{providerContext}'.");
+
+                if (!ReferenceEquals(provider.Key, theoryData.SecurityKey))
+                    context.AddDiff("!ReferenceEquals(provider.Key, theoryData.SecurityKey))");
             }
             catch (Exception ex)
             {
-                ee.ProcessException(ex);
+                theoryData.ExpectedException.ProcessException(ex, context);
             }
+
+            TestUtilities.AssertFailIfErrors(context);
         }
 
-        public static TheoryData<string, SecurityKey, string, ExpectedException> KeyWrapConstructorTheoryData()
+        public static TheoryData<SupportedAlgorithmTheoryData> KeyWrapConstructorTestCases
         {
-            var theoryData = new TheoryData<string, SecurityKey, string, ExpectedException>();
+            get
+            {
+                var theoryData = new TheoryData<SupportedAlgorithmTheoryData>();
 
-            theoryData.Add("Test1", null, null, ExpectedException.ArgumentNullException());
-            theoryData.Add("Test2", Default.SymmetricEncryptionKey128, null, ExpectedException.ArgumentNullException());
-            theoryData.Add("Test3", Default.SymmetricEncryptionKey128, SecurityAlgorithms.Aes128Encryption, ExpectedException.NotSupportedException("IDX10661:"));
-            theoryData.Add("Test4", Default.SymmetricEncryptionKey128, SecurityAlgorithms.Aes128KW, ExpectedException.NoExceptionExpected);
-            theoryData.Add("Test5", Default.SymmetricEncryptionKey256, SecurityAlgorithms.Aes256KW, ExpectedException.NoExceptionExpected);
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes128KW, null, "SecurityKeyNull", theoryData, ExpectedException.ArgumentNullException("key"));
+                SupportedAlgorithmTheoryData.AddTestCase(null, Default.SymmetricEncryptionKey128, "AlgorithmNull", theoryData, ExpectedException.ArgumentNullException("algorithm"));
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes128Encryption, Default.SymmetricEncryptionKey128, "Aes128Encryption", theoryData, ExpectedException.NotSupportedException("IDX10661:"));
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes256KeyWrap, Default.SymmetricEncryptionKey128, "SymmetricKey_128_Aes256KeyWrap", theoryData, ExpectedException.ArgumentOutOfRangeException("IDX10662:"));
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes128KeyWrap, Default.SymmetricEncryptionKey256, "SymmetricKey_256_Aes128KeyWrap", theoryData, ExpectedException.ArgumentOutOfRangeException("IDX10662:"));
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes256KW, Default.SymmetricEncryptionKey128, "SymmetricKey_128_Aes256KW", theoryData, ExpectedException.ArgumentOutOfRangeException("IDX10662:"));
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes128KW, Default.SymmetricEncryptionKey256, "SymmetricKey_256_Aes128KW", theoryData, ExpectedException.ArgumentOutOfRangeException("IDX10662:"));
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes256KW, new JsonWebKey { Kty = JsonWebAlgorithmsKeyTypes.RSA, K = KeyingMaterial.JsonWebKeySymmetric128.K }, "JsonWebKey_RSA_Aes256KW", theoryData, ExpectedException.NotSupportedException("IDX10661:"));
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes256KW, KeyingMaterial.RsaSecurityKey_2048, "RsaSecurityKey_Aes256KW", theoryData, ExpectedException.NotSupportedException("IDX10661:"));
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes128KeyWrap, Default.SymmetricEncryptionKey128, "SymmetricKey_Aes128KeyWrap", theoryData);
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes256KeyWrap, Default.SymmetricEncryptionKey256, "SymmetricKey_Aes256KeyWrap", theoryData); ;
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes128KW, Default.SymmetricEncryptionKey128, "SymmetricKey_Aes128KW", theoryData);
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes256KW, Default.SymmetricEncryptionKey256, "SymmetricKey_Aes256KW", theoryData);
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes128KeyWrap, KeyingMaterial.JsonWebKeySymmetric128, "JsonWebKey_Aes128KeyWrap", theoryData);
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes256KeyWrap, KeyingMaterial.JsonWebKeySymmetric256, "JsonWebKey_Aes256KeyWrap", theoryData);
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes128KW, KeyingMaterial.JsonWebKeySymmetric128, "JsonWebKey_Aes128KW", theoryData);
+                SupportedAlgorithmTheoryData.AddTestCase(SecurityAlgorithms.Aes256KW, KeyingMaterial.JsonWebKeySymmetric256, "JsonWebKey_Aes256KW", theoryData);
 
-            theoryData.Add("Test6", Default.SymmetricEncryptionKey128, SecurityAlgorithms.Aes256KW, ExpectedException.ArgumentOutOfRangeException("IDX10662:"));
-            theoryData.Add("Test7", Default.SymmetricEncryptionKey256, SecurityAlgorithms.Aes128KW, ExpectedException.ArgumentOutOfRangeException("IDX10662:"));
-
-            JsonWebKey key = new JsonWebKey() { Kty = JsonWebAlgorithmsKeyTypes.Octet };
-            theoryData.Add("Test8", key, SecurityAlgorithms.Aes256KW, ExpectedException.NotSupportedException("IDX10661:"));
-
-            key = new JsonWebKey() { Kty = JsonWebAlgorithmsKeyTypes.RSA, K = KeyingMaterial.JsonWebKeySymmetric128.K };
-            theoryData.Add("Test9", key, SecurityAlgorithms.Aes256KW, ExpectedException.NotSupportedException("IDX10661:"));
-            theoryData.Add("Test10", KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.Aes256KW, ExpectedException.NotSupportedException("IDX10661:"));
-            theoryData.Add("Test11", KeyingMaterial.JsonWebKeySymmetric128, SecurityAlgorithms.Aes128KW, ExpectedException.NoExceptionExpected);
-            theoryData.Add("Test12", KeyingMaterial.JsonWebKeySymmetric256, SecurityAlgorithms.Aes256KW, ExpectedException.NoExceptionExpected);
-
-            return theoryData;
+                return theoryData;
+            }
         }
 
         [Fact]
@@ -221,6 +231,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             {
                 ExpectedException = ExpectedException.KeyWrapException("IDX10659:"),
                 Provider = provider,
+                TestId = testId,
                 WrapAlgorithm = algorithm,
                 WrapKey = key,
                 WrappedKey = wrappedKey

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaSecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaSecurityKeyTests.cs
@@ -165,31 +165,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Assert.True(KeyingMaterial.RsaSecurityKey_4096.KeySize == 4096, string.Format(CultureInfo.InvariantCulture, "Keysize '{0}' != 4096", KeyingMaterial.RsaSecurityKey_4096.KeySize));
         }
 
-        [Theory, MemberData(nameof(IsSupportedAlgDataSet))]
-        public void IsSupportedAlgorithm(RsaSecurityKey key, string alg, bool expectedResult)
-        {
-            if (key.CryptoProviderFactory.IsSupportedAlgorithm(alg, key) != expectedResult)
-                Assert.True(false, string.Format("{0} failed with alg: {1}. ExpectedResult: {2}", key, alg, expectedResult));
-       }
-
-        public static TheoryData<RsaSecurityKey, string, bool> IsSupportedAlgDataSet
-        {
-            get
-            {
-                var dataset = new TheoryData<RsaSecurityKey, string, bool>();
-#if NET452
-                dataset.Add(KeyingMaterial.RsaSecurityKeyWithCspProvider_2048, SecurityAlgorithms.RsaSha256Signature, true);
-                dataset.Add(KeyingMaterial.RsaSecurityKeyWithCspProvider_2048_Public, SecurityAlgorithms.RsaSha256, true);
-                dataset.Add(KeyingMaterial.RsaSecurityKeyWithCspProvider_2048, SecurityAlgorithms.EcdsaSha256, false);
-#endif
-                dataset.Add(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaSha256Signature, true);
-                RsaSecurityKey testKey = new RsaSecurityKey(KeyingMaterial.RsaParameters1);
-                testKey.CryptoProviderFactory = new CustomCryptoProviderFactory(new string[] { SecurityAlgorithms.EcdsaSha256 });
-                dataset.Add(testKey, SecurityAlgorithms.EcdsaSha256, true);
-                return dataset;
-            }
-        }
-
         [Fact]
         public void CanComputeJwkThumbprint()
         {

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
@@ -35,7 +35,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class SecurityKeyTests
     {
-
         [Fact]
         public void ComputeJwkThumbprint()
         {
@@ -51,7 +50,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 #endif
         }
 
-        [Theory, MemberData(nameof(ConversionKeyTheoryData))]
+        [Theory, MemberData(nameof(CompareJwkThumbprintsTestCases))]
         public void CompareJwkThumbprints(JsonWebKeyConverterTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CompareJwkThumbprints", theoryData);
@@ -74,7 +73,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        public static TheoryData<JsonWebKeyConverterTheoryData> ConversionKeyTheoryData
+        public static TheoryData<JsonWebKeyConverterTheoryData> CompareJwkThumbprintsTestCases
         {
             get
             {
@@ -135,7 +134,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateInternalIdsTheoryData))]
+        [Theory, MemberData(nameof(CreateInternalIdsTestCases))]
         public void CreateInternalIds(SecurityKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateInternalIds", theoryData);
@@ -154,14 +153,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Fact]
-        public void CanComputeJwkThumbprint()
-        {
-            Assert.False(new CustomSecurityKey().CanComputeJwkThumbprint(), "CustomSecurityKey shouldn't be able to compute JWK thumbprint if CanComputeJwkThumbprint() is not overriden.");
-        }
-
-
-        public static TheoryData<SecurityKeyTheoryData> CreateInternalIdsTheoryData
+        public static TheoryData<SecurityKeyTheoryData> CreateInternalIdsTestCases
         {
             get
             {
@@ -237,6 +229,12 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 #endif
                 };
             }
+        }
+
+        [Fact]
+        public void CanComputeJwkThumbprint()
+        {
+            Assert.False(new CustomSecurityKey().CanComputeJwkThumbprint(), "CustomSecurityKey shouldn't be able to compute JWK thumbprint if CanComputeJwkThumbprint() is not overriden.");
         }
 
         public class SecurityKeyTheoryData : TheoryDataBase

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SupportedAlgorithmTheoryData.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SupportedAlgorithmTheoryData.cs
@@ -48,7 +48,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
         public static void AddTestCase(string algorithm, SecurityKey securityKey, bool isSupportedAlgorithm, string testId, TheoryData<SupportedAlgorithmTheoryData> theoryData, ExpectedException expectedException = null)
         {
-
             theoryData.Add(new SupportedAlgorithmTheoryData
             {
                 Algorithm = algorithm,

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SupportedAlgorithmTheoryData.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SupportedAlgorithmTheoryData.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------------------------
+﻿//------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -29,49 +29,34 @@ using System;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
-using ALG = Microsoft.IdentityModel.Tokens.SecurityAlgorithms;
-using EE = Microsoft.IdentityModel.TestUtils.ExpectedException;
-using KEY = Microsoft.IdentityModel.TestUtils.KeyingMaterial;
-
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
 
 namespace Microsoft.IdentityModel.Tokens.Tests
 {
-    public class SymmetricSecurityKeyTests
+    public class SupportedAlgorithmTheoryData : TheoryDataBase
     {
+        public string Algorithm { get; set; }
 
-        [Theory, MemberData(nameof(ConstructorDataSet))]
-        public void Constructor(byte[] key, EE ee)
+        public bool IsSupportedAlgorithm { get; set; } = true;
+
+        public SecurityKey SecurityKey { get; set; }
+
+        public static void AddTestCase(string algorithm, SecurityKey securityKey, string testId, TheoryData<SupportedAlgorithmTheoryData> theoryData, ExpectedException expectedException = null)
         {
-            try
-            {
-                var symmetricSecurityKey = new SymmetricSecurityKey(key);
-                ee.ProcessNoException();
-            }
-            catch (Exception exception)
-            {
-                ee.ProcessException(exception);
-            }
+            AddTestCase(algorithm, securityKey, true, testId, theoryData, expectedException);
         }
 
-        public static TheoryData<byte[], EE> ConstructorDataSet
+        public static void AddTestCase(string algorithm, SecurityKey securityKey, bool isSupportedAlgorithm, string testId, TheoryData<SupportedAlgorithmTheoryData> theoryData, ExpectedException expectedException = null)
         {
-            get
-            {
-                var dataset = new TheoryData<byte[], EE>();
-                dataset.Add(KEY.DefaultSymmetricKeyBytes_256, EE.NoExceptionExpected);
-                dataset.Add(null, EE.ArgumentNullException());
-                dataset.Add(new byte[0], EE.ArgumentException());
-                return dataset;
-            }
-        }
 
-        [Fact]
-        public void CanComputeJwkThumbprint()
-        {
-            Assert.True(KEY.DefaultSymmetricSecurityKey_256.CanComputeJwkThumbprint(), "Couldn't compute JWK thumbprint on a SymmetricSecurityKey.");
+            theoryData.Add(new SupportedAlgorithmTheoryData
+            {
+                Algorithm = algorithm,
+                ExpectedException = expectedException ?? ExpectedException.NoExceptionExpected,
+                IsSupportedAlgorithm = isSupportedAlgorithm,
+                SecurityKey = securityKey,
+                TestId = testId
+            });
         }
     }
 }
-
-#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant

--- a/test/Microsoft.IdentityModel.Tokens.Tests/X509SecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/X509SecurityKeyTests.cs
@@ -28,7 +28,6 @@
 using System;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.IdentityModel.TestUtils;
-using Microsoft.IdentityModel.Tokens;
 using Xunit;
 
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
@@ -102,52 +101,11 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(IsAlgorithmSupportedTheoryData))]
-        public void IsSupportedAlgorithm(X509SecurityKeyTheoryData theoryData)
-        {
-            var context = TestUtilities.WriteHeader($"{this}.IsSupportedAlgorithm", theoryData);
-
-            try
-            {
-                if (theoryData.X509SecurityKey.CryptoProviderFactory.IsSupportedAlgorithm(theoryData.Algorithm, theoryData.X509SecurityKey) != theoryData.IsSupported)
-                    context.AddDiff($"CryptoProviderFactory.IsSupportedAlgorithm mismatch. theoryData.Algorithm: {theoryData.Algorithm}, theoryData.X509SecurityKey: {theoryData.X509SecurityKey}, theoryData.IsSupported: {theoryData.IsSupported}.");
-
-                theoryData.ExpectedException.ProcessNoException(context);
-            }
-            catch (Exception ex)
-            {
-                theoryData.ExpectedException.ProcessException(ex, context);
-            }
-
-            TestUtilities.AssertFailIfErrors(context);
-
-        }
-
-        public static TheoryData<X509SecurityKeyTheoryData> IsAlgorithmSupportedTheoryData
-        {
-            get => new TheoryData<X509SecurityKeyTheoryData>
-            {
-                new X509SecurityKeyTheoryData(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256, SecurityAlgorithms.RsaSha256Signature, true, SecurityAlgorithms.RsaSha256Signature),
-                new X509SecurityKeyTheoryData(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256_Public, SecurityAlgorithms.RsaSha256, true, SecurityAlgorithms.RsaSha256),
-                new X509SecurityKeyTheoryData(KeyingMaterial.X509SecurityKeySelfSigned2048_SHA512, SecurityAlgorithms.Aes128Encryption, false, SecurityAlgorithms.Aes128Encryption),
-                new X509SecurityKeyTheoryData(KeyingMaterial.X509SecurityKeySelfSigned1024_SHA256, SecurityAlgorithms.RsaSha384, true, SecurityAlgorithms.RsaSha384),
-                new X509SecurityKeyTheoryData(
-                    new X509SecurityKey(KeyingMaterial.CertSelfSigned2048_SHA256)
-                    {
-                        CryptoProviderFactory = new CustomCryptoProviderFactory(new string[] { SecurityAlgorithms.RsaSsaPssSha256Signature })
-                    },
-                    SecurityAlgorithms.RsaSsaPssSha256Signature,
-                    true,
-                    "CustomProvider:" + SecurityAlgorithms.RsaSsaPssSha256Signature),
-            };
-        }
-
         [Fact]
         public void CanComputeJwkThumbprint()
         {
             Assert.True(KeyingMaterial.DefaultX509Key_2048.CanComputeJwkThumbprint(), "Couldn't compute JWK thumbprint on an X509SecurityKey.");
         }
-
     }
 
     public class X509SecurityKeyTheoryData : TheoryDataBase


### PR DESCRIPTION
Issues:

https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/453 adds API: SecurityKey.IsSupportedAlgorithm(string algorithm). This allows a check if the CryptoProviderFactory associated with a SecurityKey supports a specific algorithm

https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1419 allows users to use both SecurityAlgorithm identitfiers for SymmetricKeyWrap { Aes128KW, Aes256KW, Aes128KeyWrap, Aes256KeyWrap }.

While addressing these issues it was noticed that the /// comments were not correct for CryptoProviderFactory. These were updated. In addition, SauceControl.InheritDoc is used to make use of "inheritdoc" to share /// docs between common methods.

Only CryptoProviderFactory was used to see how this works out, if we like it we can add it to additional places.
It was noticed that for .net core, Exception did not have comments for GetObjectData so the "inheritdoc" did not work for this method. A virtual was added for CORE for this method. SauceControl.InheritDoc flagged this as a warning.

SupportedAlgorithms tests were moved to a separate file and consolidated.
It was also noticed that there was inconsistency for determining if a Key / Algorithm is supported. Common code was refactored and consistency was improved.

Other test code was improved:
1. TestNames with '-' was replaces with "_"
2. Test methods that return TheoryData have the postfix: "...TestCases"
3. Tests that were accepting arbitrary arguments now use a TheoryDataBase derived class
4. TestId was added where it was missing.

