### PR TITLE
Modify CanonicalString accessibility

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlAssertion.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlAssertion.cs
@@ -160,7 +160,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         /// <summary>
         /// Gets the canonicalized (ExclusiveC14n) representation without comments.
         /// </summary>
-        internal string CanonicalString
+        public string CanonicalString
         {
             get
             {
@@ -191,7 +191,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
 
                 return _canonicalString;
             }
-            set
+            internal set
             {
                 _canonicalString = string.IsNullOrEmpty(value) ? throw LogArgumentNullException(nameof(value)) : value;
             }

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Assertion.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Assertion.cs
@@ -92,7 +92,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         /// <summary>
         /// Gets the canonicalized (ExclusiveC14n) representation without comments.
         /// </summary>
-        internal string CanonicalString
+        public string CanonicalString
         {
             get
             {
@@ -123,7 +123,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
 
                 return _canonicalString;
             }
-            set
+            internal set
             {
                 _canonicalString = string.IsNullOrEmpty(value) ? throw LogArgumentNullException(nameof(value)) : value;
             }


### PR DESCRIPTION
Make CanonicalString on SamlAssertion and Saml2Assertion publicly accessible.
#1476 