### PR TITLE
Fix errors from Sonar

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -1096,8 +1096,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
         private TokenValidationResult ValidateTokenPayload(JsonWebToken jsonWebToken, TokenValidationParameters validationParameters)
         {
-            var expires = (jsonWebToken.ValidTo == null) ? null : new DateTime?(jsonWebToken.ValidTo);
-            var notBefore = (jsonWebToken.ValidFrom == null) ? null : new DateTime?(jsonWebToken.ValidFrom);
+            var expires = jsonWebToken.ValidTo;
+            var notBefore = jsonWebToken.ValidFrom;
 
             Validators.ValidateLifetime(notBefore, expires, jsonWebToken, validationParameters);
             Validators.ValidateAudience(jsonWebToken.Audiences, jsonWebToken, validationParameters);
@@ -1138,7 +1138,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
                 var validatedJsonWebToken = validatedToken as JsonWebToken;
                 if (validatedJsonWebToken == null)
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10506, typeof(JsonWebToken), validatedJsonWebToken.GetType(), token)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10506, typeof(JsonWebToken), validatedToken.GetType(), token)));
 
                 return validatedJsonWebToken;
             }
@@ -1220,7 +1220,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                             LogHelper.LogInformation(TokenLogMessages.IDX10242, token);
                             jwtToken.SigningKey = key;
                             return jwtToken;
-                        };
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/src/Microsoft.IdentityModel.Tokens/CallContext.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CallContext.cs
@@ -48,9 +48,6 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         public CallContext(Guid activityId)
         {
-            if (activityId == null)
-                throw new ArgumentNullException(nameof(activityId));
-
             ActivityId = activityId;
         }
 

--- a/src/Microsoft.IdentityModel.Xml/IssuerSerial.cs
+++ b/src/Microsoft.IdentityModel.Xml/IssuerSerial.cs
@@ -65,10 +65,13 @@ namespace Microsoft.IdentityModel.Xml
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            int hashCode = -1073543679;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(IssuerName);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SerialNumber);
-            return hashCode;
+            unchecked
+            {
+                int hashCode = -1073543679;
+                hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(IssuerName);
+                hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SerialNumber);
+                return hashCode;
+            }
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Xml/IssuerSerial.cs
+++ b/src/Microsoft.IdentityModel.Xml/IssuerSerial.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.IdentityModel.Xml
 {
@@ -53,27 +54,21 @@ namespace Microsoft.IdentityModel.Xml
             SerialNumber = serialNumber;
         }
 
-        /// <summary>
-        /// Compares two IssuerSerial objects.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            var other = obj as IssuerSerial;
-            if (other == null)
-                return false;
-            else if (string.Compare(IssuerName, other.IssuerName, StringComparison.OrdinalIgnoreCase) != 0
-                || string.Compare(SerialNumber, other.SerialNumber, StringComparison.OrdinalIgnoreCase) != 0)
-                return false;
-            return true;
+            return obj is IssuerSerial serial &&
+                string.Equals(IssuerName, serial.IssuerName, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(SerialNumber, serial.SerialNumber, StringComparison.OrdinalIgnoreCase);
         }
 
-        /// <summary>
-        /// Serves as a hash function for IssuerSerial.
-        /// </summary>
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            int hashCode = -1073543679;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(IssuerName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SerialNumber);
+            return hashCode;
         }
-
     }
 }

--- a/src/Microsoft.IdentityModel.Xml/KeyInfo.cs
+++ b/src/Microsoft.IdentityModel.Xml/KeyInfo.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.IdentityModel.Tokens;
@@ -122,20 +123,17 @@ namespace Microsoft.IdentityModel.Xml
                 string.Equals(KeyName, info.KeyName, StringComparison.OrdinalIgnoreCase) &&
                 string.Equals(RetrievalMethodUri, info.RetrievalMethodUri, StringComparison.OrdinalIgnoreCase) &&
                 EqualityComparer<RSAKeyValue>.Default.Equals(RSAKeyValue, info.RSAKeyValue) &&
-                EqualityComparer<ICollection<X509Data>>.Default.Equals(X509Data, info.X509Data);
+                Enumerable.SequenceEqual(X509Data, info.X509Data);
         }
 
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            int hashCode = 1840145486;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Id);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Prefix);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(KeyName);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(RetrievalMethodUri);
-            hashCode = hashCode * -1521134295 + EqualityComparer<RSAKeyValue>.Default.GetHashCode(RSAKeyValue);
-            hashCode = hashCode * -1521134295 + EqualityComparer<ICollection<X509Data>>.Default.GetHashCode(X509Data);
-            return hashCode;
+            unchecked
+            {
+                // X509Data reference is the only immutable property
+                return -811635255 + EqualityComparer<ICollection<X509Data>>.Default.GetHashCode(X509Data);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Xml/KeyInfo.cs
+++ b/src/Microsoft.IdentityModel.Xml/KeyInfo.cs
@@ -28,7 +28,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Globalization;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.IdentityModel.Tokens;
@@ -116,29 +115,27 @@ namespace Microsoft.IdentityModel.Xml
         /// </summary>
         public ICollection<X509Data> X509Data { get; } = new Collection<X509Data>();
 
-        /// <summary>
-        /// Compares two KeyInfo objects.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool Equals(object obj)
-        {   
-            KeyInfo other = obj as KeyInfo;
-            if (other == null)
-                return false;
-            else if (string.Compare(KeyName, other.KeyName, StringComparison.OrdinalIgnoreCase) != 0
-                ||string.Compare(RetrievalMethodUri, other.RetrievalMethodUri, StringComparison.OrdinalIgnoreCase) != 0
-                || (RSAKeyValue != null && !RSAKeyValue.Equals(other.RSAKeyValue)
-                || !new HashSet<X509Data>(X509Data).SetEquals(other.X509Data)))
-                return false;
-
-            return true;
+        {
+            return obj is KeyInfo info &&
+                string.Equals(KeyName, info.KeyName, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(RetrievalMethodUri, info.RetrievalMethodUri, StringComparison.OrdinalIgnoreCase) &&
+                EqualityComparer<RSAKeyValue>.Default.Equals(RSAKeyValue, info.RSAKeyValue) &&
+                EqualityComparer<ICollection<X509Data>>.Default.Equals(X509Data, info.X509Data);
         }
 
-        /// <summary>
-        /// Serves as a hash function for KeyInfo.
-        /// </summary>
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            int hashCode = 1840145486;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Id);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Prefix);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(KeyName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(RetrievalMethodUri);
+            hashCode = hashCode * -1521134295 + EqualityComparer<RSAKeyValue>.Default.GetHashCode(RSAKeyValue);
+            hashCode = hashCode * -1521134295 + EqualityComparer<ICollection<X509Data>>.Default.GetHashCode(X509Data);
+            return hashCode;
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Xml/RSAKeyValue.cs
+++ b/src/Microsoft.IdentityModel.Xml/RSAKeyValue.cs
@@ -65,10 +65,13 @@ namespace Microsoft.IdentityModel.Xml
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            int hashCode = 936145456;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Modulus);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Exponent);
-            return hashCode;
+            unchecked
+            {
+                int hashCode = 936145456;
+                hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Modulus);
+                hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Exponent);
+                return hashCode;
+            }
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Xml/RSAKeyValue.cs
+++ b/src/Microsoft.IdentityModel.Xml/RSAKeyValue.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.IdentityModel.Xml
 {
@@ -53,27 +54,21 @@ namespace Microsoft.IdentityModel.Xml
             Exponent = exponent;
         }
 
-        /// <summary>
-        /// Compares two RSAKeyValue objects.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            var other = obj as RSAKeyValue;
-            if (other == null)
-                return false;
-            else if (string.Compare(Modulus, other.Modulus, StringComparison.OrdinalIgnoreCase) != 0
-                || string.Compare(Exponent, other.Exponent, StringComparison.OrdinalIgnoreCase) != 0)
-                    return false;
-            return true;
+            return obj is RSAKeyValue value &&
+                string.Equals(Modulus, value.Modulus, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(Exponent, value.Exponent, StringComparison.OrdinalIgnoreCase);
         }
 
-        /// <summary>
-        /// Serves as a hash function for RSAKeyValue.
-        /// </summary>
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            int hashCode = 936145456;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Modulus);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Exponent);
+            return hashCode;
         }
-
     }
 }

--- a/src/Microsoft.IdentityModel.Xml/X509Data.cs
+++ b/src/Microsoft.IdentityModel.Xml/X509Data.cs
@@ -120,31 +120,27 @@ namespace Microsoft.IdentityModel.Xml
             set;
         }
 
-        /// <summary>
-        /// Compares two X509Data objects.
-        /// </summary>
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            var other = obj as X509Data;
-            if (other == null)
-                return false;
-            else if (!IssuerSerial.Equals(other.IssuerSerial) ||
-                string.Compare(SKI, other.SKI, StringComparison.OrdinalIgnoreCase) != 0 || 
-                string.Compare(SubjectName, other.SubjectName, StringComparison.OrdinalIgnoreCase) != 0 ||
-                // certificates may need to be compared in a special way instead of generic string comparison?
-                !Enumerable.SequenceEqual(Certificates.OrderBy(t => t), other.Certificates.OrderBy(t => t)) ||
-                string.Compare(CRL, other.CRL, StringComparison.OrdinalIgnoreCase) != 0)
-                    return false;
-            return true;
+            return obj is X509Data data &&
+                EqualityComparer<IssuerSerial>.Default.Equals(IssuerSerial, data.IssuerSerial) &&
+                string.Equals(SKI, data.SKI, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(SubjectName, data.SubjectName, StringComparison.OrdinalIgnoreCase) &&
+                EqualityComparer<ICollection<string>>.Default.Equals(Certificates, data.Certificates) &&
+                string.Equals(CRL, data.CRL, StringComparison.OrdinalIgnoreCase);
         }
 
-        /// <summary>
-        /// Serves as a hash function for X509Data.
-        /// </summary>
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            int hashCode = 1279802945;
+            hashCode = hashCode * -1521134295 + EqualityComparer<IssuerSerial>.Default.GetHashCode(IssuerSerial);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SKI);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SubjectName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<ICollection<string>>.Default.GetHashCode(Certificates);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CRL);
+            return hashCode;
         }
-
     }
 }

--- a/src/Microsoft.IdentityModel.Xml/X509Data.cs
+++ b/src/Microsoft.IdentityModel.Xml/X509Data.cs
@@ -127,20 +127,17 @@ namespace Microsoft.IdentityModel.Xml
                 EqualityComparer<IssuerSerial>.Default.Equals(IssuerSerial, data.IssuerSerial) &&
                 string.Equals(SKI, data.SKI, StringComparison.OrdinalIgnoreCase) &&
                 string.Equals(SubjectName, data.SubjectName, StringComparison.OrdinalIgnoreCase) &&
-                EqualityComparer<ICollection<string>>.Default.Equals(Certificates, data.Certificates) &&
+                Enumerable.SequenceEqual(Certificates.OrderBy(t => t), data.Certificates.OrderBy(t => t)) &&
                 string.Equals(CRL, data.CRL, StringComparison.OrdinalIgnoreCase);
         }
-
         /// <inheritdoc/>
         public override int GetHashCode()
         {
-            int hashCode = 1279802945;
-            hashCode = hashCode * -1521134295 + EqualityComparer<IssuerSerial>.Default.GetHashCode(IssuerSerial);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SKI);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SubjectName);
-            hashCode = hashCode * -1521134295 + EqualityComparer<ICollection<string>>.Default.GetHashCode(Certificates);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CRL);
-            return hashCode;
+            unchecked
+            {
+                // Certificates is the only immutable property
+                return 794516417 + EqualityComparer<ICollection<string>>.Default.GetHashCode(Certificates);
+            }
         }
     }
 }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -565,13 +565,13 @@ namespace System.IdentityModel.Tokens.Jwt
 
         private JwtSecurityToken EncryptToken(JwtSecurityToken innerJwt, EncryptingCredentials encryptingCredentials)
         {
+            if (encryptingCredentials == null)
+                throw LogHelper.LogArgumentNullException(nameof(encryptingCredentials));
+
             var cryptoProviderFactory = encryptingCredentials.CryptoProviderFactory ?? encryptingCredentials.Key.CryptoProviderFactory;
 
             if (cryptoProviderFactory == null)
                 throw LogHelper.LogExceptionMessage(new ArgumentException(LogMessages.IDX12733));
-
-            if (encryptingCredentials == null)
-                throw LogHelper.LogArgumentNullException(nameof(encryptingCredentials));
 
             // if direct algorithm, look for support
             if (JwtConstants.DirectKeyUseAlg.Equals(encryptingCredentials.Alg, StringComparison.Ordinal))

--- a/test/Microsoft.IdentityModel.Xml.Tests/IssuerSerialTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/IssuerSerialTests.cs
@@ -1,0 +1,136 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using Microsoft.IdentityModel.TestUtils;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Xml.Tests
+{
+#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
+    public class IssuerSerialTests
+    {
+        [Theory, MemberData(nameof(IssuerSerialComparisonData))]
+        public void IssuerSerial_HashCodeTests(IssuerSerialComparisonTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(IssuerSerial_HashCodeTests)}", theoryData);
+            try
+            {
+                var firstHashCode = theoryData.FirstIssuerSerial.GetHashCode();
+                var secondHashCode = theoryData.SecondIssuerSerial.GetHashCode();
+
+                Assert.Equal(theoryData.ShouldMatch, firstHashCode.Equals(secondHashCode));
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Theory, MemberData(nameof(IssuerSerialComparisonData))]
+        public void IssuerSerial_EqualsTests(IssuerSerialComparisonTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(IssuerSerial_EqualsTests)}", theoryData);
+            try
+            {
+                Assert.Equal(theoryData.ShouldMatch, theoryData.FirstIssuerSerial.Equals(theoryData.SecondIssuerSerial));
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<IssuerSerialComparisonTheoryData> IssuerSerialComparisonData
+        {
+            get
+            {
+                return new TheoryData<IssuerSerialComparisonTheoryData>
+                {
+                    new IssuerSerialComparisonTheoryData
+                    {
+                        TestId = "Matching_empty",
+                        FirstIssuerSerial = new IssuerSerial(string.Empty, string.Empty),
+                        SecondIssuerSerial = new IssuerSerial(string.Empty, string.Empty),
+                        ShouldMatch = true,
+                    },
+                    new IssuerSerialComparisonTheoryData
+                    {
+                        TestId = "Matching_NotEmpty",
+                        FirstIssuerSerial = new IssuerSerial("IssuerName", "SerialNumber"),
+                        SecondIssuerSerial = new IssuerSerial("IssuerName", "SerialNumber"),
+                        ShouldMatch = true,
+                    },
+                    new IssuerSerialComparisonTheoryData
+                    {
+                        TestId = "NotMatching_EmptySerialNumber",
+                        FirstIssuerSerial = new IssuerSerial("IssuerName", string.Empty),
+                        SecondIssuerSerial = new IssuerSerial("IssuerName", "SerialNumber"),
+                    },
+                    new IssuerSerialComparisonTheoryData
+                    {
+                        TestId = "NotMatching_EmptyIssuerName",
+                        FirstIssuerSerial = new IssuerSerial(string.Empty, "SerialNumber"),
+                        SecondIssuerSerial = new IssuerSerial("IssuerName", "SerialNumber"),
+                    },
+                    new IssuerSerialComparisonTheoryData
+                    {
+                        TestId = "NotMatching_DifferentIssuerName",
+                        FirstIssuerSerial = new IssuerSerial("DifferentIssuerName", "SerialNumber"),
+                        SecondIssuerSerial = new IssuerSerial("IssuerName", "SerialNumber"),
+                    },
+                    new IssuerSerialComparisonTheoryData
+                    {
+                        TestId = "NotMatching_DifferentSerialNumber",
+                        FirstIssuerSerial = new IssuerSerial("IssuerName", "DifferentSerialNumber"),
+                        SecondIssuerSerial = new IssuerSerial("IssuerName", "SerialNumber"),
+                    },
+                    new IssuerSerialComparisonTheoryData
+                    {
+                        TestId = "NotMatching_DifferentIssuerNameAndSerialNumber",
+                        FirstIssuerSerial = new IssuerSerial("DifferentIssuerName", "DifferentSerialNumber"),
+                        SecondIssuerSerial = new IssuerSerial("IssuerName", "SerialNumber"),
+                    },
+                };
+            }
+        }
+
+        public class IssuerSerialComparisonTheoryData : TheoryDataBase
+        {
+            public IssuerSerial FirstIssuerSerial { get; set; }
+
+            public IssuerSerial SecondIssuerSerial { get; set; }
+
+            public bool ShouldMatch { get; set; }
+        }
+    }
+#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
+}

--- a/test/Microsoft.IdentityModel.Xml.Tests/IssuerSerialTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/IssuerSerialTests.cs
@@ -26,6 +26,8 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -34,6 +36,37 @@ namespace Microsoft.IdentityModel.Xml.Tests
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
     public class IssuerSerialTests
     {
+        [Fact]
+        public void IssuerSerial_HashSetCollectionTests()
+        {
+            var set = new HashSet<IssuerSerial>();
+
+            var issuerSerial = new IssuerSerial(string.Empty, string.Empty);
+
+            set.Add(issuerSerial);
+
+            bool inCollection = set.Contains(issuerSerial);
+            Assert.True(inCollection);
+
+            var secondIssuerSerial = new IssuerSerial(string.Empty, string.Empty);
+
+            // hashcode is determined by immutable values, not reference
+            inCollection = set.Contains(secondIssuerSerial);
+            Assert.True(inCollection);
+        }
+
+        [Fact]
+        public void IssuerSerial_ListCollectionTests()
+        {
+            var issuerSerial = new IssuerSerial(string.Empty, string.Empty);
+            var secondIssuerSerial = new IssuerSerial("issuerName", "serialNumber");
+
+            var list = new List<IssuerSerial> { issuerSerial, secondIssuerSerial };
+            var secondList = new List<IssuerSerial> { issuerSerial, secondIssuerSerial };
+
+            Assert.True(Enumerable.SequenceEqual(list, secondList));
+        }
+
         [Theory, MemberData(nameof(IssuerSerialComparisonData))]
         public void IssuerSerial_HashCodeTests(IssuerSerialComparisonTheoryData theoryData)
         {

--- a/test/Microsoft.IdentityModel.Xml.Tests/KeyInfoTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/KeyInfoTests.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -60,26 +61,43 @@ namespace Microsoft.IdentityModel.Xml.Tests
             TestUtilities.GetSet(context);
             TestUtilities.AssertFailIfErrors($"{this}.GetSets", context.Errors);
         }
-    }
 
-    public class KeyInfoTheoryData : TheoryDataBase
-    {
-        public DSigSerializer Serializer
+        [Fact]
+        public void KeyInfo_ListCollectionTests()
         {
-            get;
-            set;
-        } = new DSigSerializer();
+            var keyInfo = new KeyInfo();
+            var secondKeyInfo = new KeyInfo()
+            {
+                KeyName = "anotherKeyName",
+                RetrievalMethodUri = "anotherRetrievalMethodUri",
+                RSAKeyValue = new RSAKeyValue(string.Empty, string.Empty),
+            };
 
-        public KeyInfo KeyInfo
-        {
-            get;
-            set;
+            secondKeyInfo.X509Data.Add(new X509Data(ReferenceMetadata.X509Certificate1));
+
+            var list = new List<KeyInfo> { keyInfo, secondKeyInfo };
+            var secondList = new List<KeyInfo> { keyInfo, secondKeyInfo };
+
+            Assert.True(Enumerable.SequenceEqual(list, secondList));
         }
 
-        public string Xml
+        [Fact]
+        public void KeyInfo_HashCodeCollectionTests()
         {
-            get;
-            set;
+            var set = new HashSet<KeyInfo>();
+
+            var keyInfo = new KeyInfo();
+
+            set.Add(keyInfo);
+
+            // modify each property to check that hashcode is stable
+            keyInfo.KeyName = "anotherKeyName";
+            keyInfo.RetrievalMethodUri = "anotherRetrievalMethodUri";
+            keyInfo.RSAKeyValue = new RSAKeyValue(string.Empty, string.Empty);
+            keyInfo.X509Data.Add(new X509Data(ReferenceMetadata.X509Certificate1));
+
+            bool inCollection = set.Contains(keyInfo);
+            Assert.True(inCollection);
         }
 
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
@@ -235,16 +253,39 @@ namespace Microsoft.IdentityModel.Xml.Tests
             }
         }
 
-        public class KeyInfoComparisonTheoryData : TheoryDataBase
-        {
-            public KeyInfo FirstKeyInfo { get; set; }
 
-            public KeyInfo SecondKeyInfo { get; set; }
-
-            public bool HashShouldMatch { get; set; }
-
-            public bool ShouldBeConsideredEqual { get; set; }
-        }
 #pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
+    }
+
+    public class KeyInfoComparisonTheoryData : TheoryDataBase
+    {
+        public KeyInfo FirstKeyInfo { get; set; }
+
+        public KeyInfo SecondKeyInfo { get; set; }
+
+        public bool HashShouldMatch { get; set; }
+
+        public bool ShouldBeConsideredEqual { get; set; }
+    }
+
+    public class KeyInfoTheoryData : TheoryDataBase
+    {
+        public DSigSerializer Serializer
+        {
+            get;
+            set;
+        } = new DSigSerializer();
+
+        public KeyInfo KeyInfo
+        {
+            get;
+            set;
+        }
+
+        public string Xml
+        {
+            get;
+            set;
+        }
     }
 }

--- a/test/Microsoft.IdentityModel.Xml.Tests/KeyInfoTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/KeyInfoTests.cs
@@ -81,5 +81,170 @@ namespace Microsoft.IdentityModel.Xml.Tests
             get;
             set;
         }
+
+#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
+
+        [Theory, MemberData(nameof(KeyInfoDataComparisonData))]
+        public void KeyInfo_HashCodeTests(KeyInfoComparisonTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.${nameof(KeyInfo_HashCodeTests)}", theoryData);
+            try
+            {
+                var firstHashCode = theoryData.FirstKeyInfo.GetHashCode();
+                var secondHashCode = theoryData.SecondKeyInfo.GetHashCode();
+
+                Assert.Equal(theoryData.HashShouldMatch, firstHashCode.Equals(secondHashCode));
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+
+        [Theory, MemberData(nameof(KeyInfoDataComparisonData))]
+        public void KeyInfo_EqualsTests(KeyInfoComparisonTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(KeyInfo_EqualsTests)}", theoryData);
+            try
+            {
+                Assert.Equal(theoryData.ShouldBeConsideredEqual, theoryData.FirstKeyInfo.Equals(theoryData.SecondKeyInfo));
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<KeyInfoComparisonTheoryData> KeyInfoDataComparisonData
+        {
+            get
+            {
+                return new TheoryData<KeyInfoComparisonTheoryData>
+                {
+                    new KeyInfoComparisonTheoryData
+                    {
+                        TestId = "Matching_empty",
+                        FirstKeyInfo = new KeyInfo(),
+                        SecondKeyInfo = new KeyInfo(),
+                        ShouldBeConsideredEqual = true,
+                        // Hashcode will never match as the only immutable field is a reference that will always differ
+                        HashShouldMatch = false,
+                    },
+                    new KeyInfoComparisonTheoryData
+                    {
+                        TestId = "Matching_KeyName",
+                        FirstKeyInfo = new KeyInfo()
+                        {
+                            KeyName = "KeyNameSampleString"
+                        },
+                        SecondKeyInfo = new KeyInfo()
+                        {
+                            KeyName = "KeyNameSampleString"
+                        },
+                        ShouldBeConsideredEqual = true,
+                    },
+                    new KeyInfoComparisonTheoryData
+                    {
+                        TestId = "Nonmatching_KeyName",
+                        FirstKeyInfo = new KeyInfo()
+                        {
+                            KeyName = "KeyNameSampleString"
+                        },
+                        SecondKeyInfo = new KeyInfo()
+                        {
+                            KeyName = "AnotherKeyNameSampleString"
+                        },
+                    },
+                    new KeyInfoComparisonTheoryData
+                    {
+                        TestId = "Matching_RetrievalMethodUri",
+                        FirstKeyInfo = new KeyInfo()
+                        {
+                            RetrievalMethodUri = "RetrievalMethodUriSampleString"
+                        },
+                        SecondKeyInfo = new KeyInfo()
+                        {
+                            RetrievalMethodUri = "RetrievalMethodUriSampleString"
+                        },
+                        ShouldBeConsideredEqual = true,
+                    },
+                    new KeyInfoComparisonTheoryData
+                    {
+                        TestId = "Nonmatching_RetrievalMethodUri",
+                        FirstKeyInfo = new KeyInfo()
+                        {
+                            RetrievalMethodUri = "RetrievalMethodUriSampleString"
+                        },
+                        SecondKeyInfo = new KeyInfo()
+                        {
+                            RetrievalMethodUri = "AnotherRetrievalMethodUriSampleString"
+                        },
+                    },
+                    new KeyInfoComparisonTheoryData
+                    {
+                        TestId = "Matching_RSAKeyValue",
+                        FirstKeyInfo = new KeyInfo()
+                        {
+                            RSAKeyValue = new RSAKeyValue(
+                            "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                            "AQAB"),
+                        },
+                        SecondKeyInfo = new KeyInfo()
+                        {
+                            RSAKeyValue = new RSAKeyValue(
+                            "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                            "AQAB"),
+                        },
+                        ShouldBeConsideredEqual = true,
+                    },
+                    new KeyInfoComparisonTheoryData
+                    {
+                        TestId = "Nonmatching_RSAKeyValue",
+                        FirstKeyInfo = new KeyInfo()
+                        {
+                            RSAKeyValue = new RSAKeyValue(
+                            "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                            "AQAB"),
+                        },
+                        SecondKeyInfo = new KeyInfo()
+                        {
+                            RSAKeyValue = new RSAKeyValue(
+                            "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                            string.Empty),
+                        },
+                    },
+                    new KeyInfoComparisonTheoryData
+                    {
+                        TestId = "Matching_X509Data",
+                        FirstKeyInfo = new KeyInfo(ReferenceMetadata.X509Certificate1),
+                        SecondKeyInfo = new KeyInfo(ReferenceMetadata.X509Certificate1),
+                        ShouldBeConsideredEqual = true,
+                    },
+                    new KeyInfoComparisonTheoryData
+                    {
+                        TestId = "Nonmatching_X509Data",
+                        FirstKeyInfo = new KeyInfo(ReferenceMetadata.X509Certificate1),
+                        SecondKeyInfo = new KeyInfo(ReferenceMetadata.X509Certificate2),
+                    },
+                };
+            }
+        }
+
+        public class KeyInfoComparisonTheoryData : TheoryDataBase
+        {
+            public KeyInfo FirstKeyInfo { get; set; }
+
+            public KeyInfo SecondKeyInfo { get; set; }
+
+            public bool HashShouldMatch { get; set; }
+
+            public bool ShouldBeConsideredEqual { get; set; }
+        }
+#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
     }
 }

--- a/test/Microsoft.IdentityModel.Xml.Tests/RsaKeyValueTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/RsaKeyValueTests.cs
@@ -26,6 +26,8 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -34,6 +36,36 @@ namespace Microsoft.IdentityModel.Xml.Tests
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
     public class RsaKeyValueTests
     {
+        [Fact]
+        public void RsaKeyValue_ListCollectionTests()
+        {
+            var rsaKeyValue = new RSAKeyValue(string.Empty, string.Empty);
+            var secondrsaKeyValue = new RSAKeyValue("modulus", "exponent");
+
+            var list = new List<RSAKeyValue> { rsaKeyValue, secondrsaKeyValue };
+            var secondList = new List<RSAKeyValue> { rsaKeyValue, secondrsaKeyValue };
+
+            Assert.True(Enumerable.SequenceEqual(list, secondList));
+        }
+
+        [Fact]
+        public void RsaKeyValue_HashSetCollectionTests()
+        {
+            var set = new HashSet<RSAKeyValue>();
+            var rsaKeyValue = new RSAKeyValue(string.Empty, string.Empty);
+
+            set.Add(rsaKeyValue);
+
+            bool inCollection = set.Contains(rsaKeyValue);
+            Assert.True(inCollection);
+
+            var secondRSAKeyValue = new RSAKeyValue(string.Empty, string.Empty);
+
+            // hashcode is determined by immutable property values, not reference
+            inCollection = set.Contains(secondRSAKeyValue);
+            Assert.True(inCollection);
+        }
+
         [Theory, MemberData(nameof(IssuerSerialComparisonData))]
         public void RsaKeyValue_HashCodeTests(RsaKeyValueComparisonTheoryData theoryData)
         {

--- a/test/Microsoft.IdentityModel.Xml.Tests/RsaKeyValueTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/RsaKeyValueTests.cs
@@ -1,0 +1,173 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using Microsoft.IdentityModel.TestUtils;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Xml.Tests
+{
+#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
+    public class RsaKeyValueTests
+    {
+        [Theory, MemberData(nameof(IssuerSerialComparisonData))]
+        public void RsaKeyValue_HashCodeTests(RsaKeyValueComparisonTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(RsaKeyValue_HashCodeTests)}", theoryData);
+            try
+            {
+                var firstHashCode = theoryData.FirstRsaKeyValue.GetHashCode();
+                var secondHashCode = theoryData.SecondRsaKeyValue.GetHashCode();
+
+                Assert.Equal(theoryData.ShouldMatchHashCode, firstHashCode.Equals(secondHashCode));
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Theory, MemberData(nameof(IssuerSerialComparisonData))]
+        public void RsaKeyValue_EqualsTests(RsaKeyValueComparisonTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(RsaKeyValue_EqualsTests)}", theoryData);
+            try
+            {
+                Assert.Equal(theoryData.ShouldBeConsideredEqual, theoryData.FirstRsaKeyValue.Equals(theoryData.SecondRsaKeyValue));
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<RsaKeyValueComparisonTheoryData> IssuerSerialComparisonData
+        {
+            get
+            {
+                return new TheoryData<RsaKeyValueComparisonTheoryData>
+                {
+                    new RsaKeyValueComparisonTheoryData
+                    {
+                        TestId = "Matching_empty",
+                        FirstRsaKeyValue = new RSAKeyValue(string.Empty, string.Empty),
+                        SecondRsaKeyValue = new RSAKeyValue(string.Empty, string.Empty),
+                        ShouldMatchHashCode = true,
+                        ShouldBeConsideredEqual = true,
+                    },
+                    new RsaKeyValueComparisonTheoryData
+                    {
+                        TestId = "Matching_ModulusAndExponent",
+                        FirstRsaKeyValue = new RSAKeyValue(
+                            "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                            "AQAB"),
+                        SecondRsaKeyValue = new RSAKeyValue(
+                            "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                            "AQAB"),
+                        ShouldMatchHashCode = true,
+                        ShouldBeConsideredEqual = true,
+                    },
+                    new RsaKeyValueComparisonTheoryData
+                    {
+                        TestId = "NotMatching_EmptyModulus",
+                        FirstRsaKeyValue = new RSAKeyValue(string.Empty, "AQAB"),
+                        SecondRsaKeyValue = new RSAKeyValue(
+                            "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                            "AQAB"),
+                    },
+                    new RsaKeyValueComparisonTheoryData
+                    {
+                        TestId = "NotMatching_EmptyExponent",
+                        FirstRsaKeyValue = new RSAKeyValue(
+                            "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                            string.Empty),
+                        SecondRsaKeyValue = new RSAKeyValue(
+                            "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                            "AQAB"),
+                    },
+                    new RsaKeyValueComparisonTheoryData
+                    {
+                        TestId = "NotMatching_DifferentExponent",
+                        FirstRsaKeyValue = new RSAKeyValue(
+                            "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                            "differentExponent"),
+                        SecondRsaKeyValue = new RSAKeyValue(
+                            "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                            "AQAB"),
+                    },
+                    new RsaKeyValueComparisonTheoryData
+                    {
+                        TestId = "NotMatching_DifferentModulus",
+                        FirstRsaKeyValue = new RSAKeyValue(
+                            "differentModulus",
+                            "AQAB"),
+                        SecondRsaKeyValue = new RSAKeyValue(
+                            "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                            "AQAB"),
+                    },
+                    new RsaKeyValueComparisonTheoryData
+                    {
+                        TestId = "NotMatching_DifferentModulusAndExponent",
+                        FirstRsaKeyValue = new RSAKeyValue(
+                            "differentModulus",
+                            "differentExponent"),
+                        SecondRsaKeyValue = new RSAKeyValue(
+                            "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                            "AQAB"),
+                    },
+                    new RsaKeyValueComparisonTheoryData
+                    {
+                        TestId = "ModulusAndExponentAreCaseInsensitive",
+                        FirstRsaKeyValue = new RSAKeyValue(
+                            "modulus",
+                            "exponent"),
+                        SecondRsaKeyValue = new RSAKeyValue(
+                            "MODULUS",
+                            "EXPONENT"),
+                        ShouldBeConsideredEqual = true,
+                    },
+                };
+            }
+        }
+
+        public class RsaKeyValueComparisonTheoryData : TheoryDataBase
+        {
+            public RSAKeyValue FirstRsaKeyValue { get; set; }
+
+            public RSAKeyValue SecondRsaKeyValue { get; set; }
+
+            public bool ShouldMatchHashCode { get; set; }
+
+            public bool ShouldBeConsideredEqual { get; set; }
+        }
+    }
+#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
+}

--- a/test/Microsoft.IdentityModel.Xml.Tests/X509DataTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/X509DataTests.cs
@@ -26,6 +26,8 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -34,6 +36,46 @@ namespace Microsoft.IdentityModel.Xml.Tests
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
     public class X509DataTests
     {
+        [Fact]
+        public void X509Data_ListCollectionTests()
+        {
+            var x509Data = new X509Data()
+            {
+                SKI = "anotherSKI",
+                SubjectName = "anotherSubjectName",
+                CRL = "anotherCRL",
+                IssuerSerial = new IssuerSerial(string.Empty, string.Empty),
+            };
+            x509Data.Certificates.Add(ReferenceMetadata.X509CertificateData1);
+
+            var secondx509Data = new X509Data();
+
+            var list = new List<X509Data> { x509Data, secondx509Data };
+            var secondList = new List<X509Data> { x509Data, secondx509Data };
+
+            Assert.True(Enumerable.SequenceEqual(list, secondList));
+        }
+
+        [Fact]
+        public void X509Data_HashSetCollectionTests()
+        {
+            var set = new HashSet<X509Data>();
+
+            var x509Data = new X509Data();
+
+            set.Add(x509Data);
+
+            // modify each property to check that hashcode is stable
+            x509Data.SKI = "anotherSKI";
+            x509Data.SubjectName = "anotherSubjectName";
+            x509Data.CRL = "anotherCRL";
+            x509Data.IssuerSerial = new IssuerSerial(string.Empty, string.Empty);
+            x509Data.Certificates.Add(ReferenceMetadata.X509CertificateData1);
+
+            bool inCollection = set.Contains(x509Data);
+            Assert.True(inCollection);
+        }
+
         [Theory, MemberData(nameof(X509DataComparisonData))]
         public void X509Data_HashCodeTests(X509DataComparisonTheoryData theoryData)
         {

--- a/test/Microsoft.IdentityModel.Xml.Tests/X509DataTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/X509DataTests.cs
@@ -1,0 +1,205 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using Microsoft.IdentityModel.TestUtils;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Xml.Tests
+{
+#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
+    public class X509DataTests
+    {
+        [Theory, MemberData(nameof(X509DataComparisonData))]
+        public void X509Data_HashCodeTests(X509DataComparisonTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(X509Data_HashCodeTests)}", theoryData);
+            try
+            {
+                var firstHashCode = theoryData.FirstX509Data.GetHashCode();
+                var secondHashCode = theoryData.SecondX509Data.GetHashCode();
+
+                Assert.Equal(theoryData.HashShouldMatch, firstHashCode.Equals(secondHashCode));
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+
+        [Theory, MemberData(nameof(X509DataComparisonData))]
+        public void X509Data_EqualsTests(X509DataComparisonTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(X509Data_EqualsTests)}", theoryData);
+            try
+            {
+                Assert.Equal(theoryData.ShouldBeConsideredEqual, theoryData.FirstX509Data.Equals(theoryData.SecondX509Data));
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<X509DataComparisonTheoryData> X509DataComparisonData
+        {
+            get
+            {
+                return new TheoryData<X509DataComparisonTheoryData>
+                {
+                    new X509DataComparisonTheoryData
+                    {
+                        TestId = "Matching_empty",
+                        FirstX509Data = new X509Data(),
+                        SecondX509Data = new X509Data(),
+                        ShouldBeConsideredEqual = true,
+                        // Hash will always differ
+                        HashShouldMatch = false,
+                    },
+                    new X509DataComparisonTheoryData
+                    {
+                        TestId = "Matching_Certificates",
+                        FirstX509Data = new X509Data(ReferenceMetadata.X509Certificate1),
+                        SecondX509Data = new X509Data(ReferenceMetadata.X509Certificate1),
+                        ShouldBeConsideredEqual = true,
+                    },
+                    new X509DataComparisonTheoryData
+                    {
+                        TestId = "Nonmatching_Certificates",
+                        FirstX509Data = new X509Data(ReferenceMetadata.X509Certificate1),
+                        SecondX509Data = new X509Data(ReferenceMetadata.X509Certificate2),
+                    },
+                    new X509DataComparisonTheoryData
+                    {
+                        TestId = "Matching_MultipleCertificates",
+                        FirstX509Data = new X509Data(new [] { ReferenceMetadata.X509Certificate1, ReferenceMetadata.X509Certificate2 }),
+                        SecondX509Data = new X509Data(new [] { ReferenceMetadata.X509Certificate1, ReferenceMetadata.X509Certificate2 }),
+                        ShouldBeConsideredEqual = true,
+                    },
+                    new X509DataComparisonTheoryData
+                    {
+                        TestId = "Nonmatching_MultipleCertificates",
+                        FirstX509Data = new X509Data(new [] { ReferenceMetadata.X509Certificate1, ReferenceMetadata.X509Certificate2 }),
+                        SecondX509Data = new X509Data(new [] { ReferenceMetadata.X509Certificate1, ReferenceMetadata.X509Certificate3 }),
+                    },
+                    new X509DataComparisonTheoryData
+                    {
+                        TestId = "Matching_SKI",
+                        FirstX509Data = new X509Data()
+                        {
+                            SKI = "SKISampleString"
+                        },
+                        SecondX509Data = new X509Data()
+                        {
+                            SKI = "SKISampleString"
+                        },
+                        ShouldBeConsideredEqual = true,
+                    },
+                    new X509DataComparisonTheoryData
+                    {
+                        TestId = "Nonmatching_SKI",
+                        FirstX509Data = new X509Data()
+                        {
+                            SKI = "SKISampleString"
+                        },
+                        SecondX509Data = new X509Data()
+                        {
+                            SKI = "AnotherSKISampleString"
+                        },
+                    },
+                    new X509DataComparisonTheoryData
+                    {
+                        TestId = "Matching_CRL",
+                        FirstX509Data = new X509Data()
+                        {
+                            CRL = "CRLSampleString"
+                        },
+                        SecondX509Data = new X509Data()
+                        {
+                            CRL = "CRLSampleString"
+                        },
+                        ShouldBeConsideredEqual = true,
+                    },
+                    new X509DataComparisonTheoryData
+                    {
+                        TestId = "Nonmatching_CRL",
+                        FirstX509Data = new X509Data()
+                        {
+                            CRL = "CRLSampleString"
+                        },
+                        SecondX509Data = new X509Data()
+                        {
+                            CRL = "AnotherCRLSampleString"
+                        },
+                    },
+                    new X509DataComparisonTheoryData
+                    {
+                        TestId = "Matching_IssuerSerial",
+                        FirstX509Data = new X509Data()
+                        {
+                            IssuerSerial = new IssuerSerial("IssuerName", "SerialNumber"),
+                        },
+                        SecondX509Data = new X509Data()
+                        {
+                            IssuerSerial = new IssuerSerial("IssuerName", "SerialNumber"),
+                        },
+                        ShouldBeConsideredEqual = true,
+                    },
+                    new X509DataComparisonTheoryData
+                    {
+                        TestId = "Nonmatching_IssuerSerial",
+                        FirstX509Data = new X509Data()
+                        {
+                            IssuerSerial = new IssuerSerial("IssuerName", "SerialNumber"),
+                        },
+                        SecondX509Data = new X509Data()
+                        {
+                            IssuerSerial = new IssuerSerial("AnotherIssuerName", "AnotherSerialNumber"),
+                        },
+                    }
+                };
+            }
+        }
+
+        public class X509DataComparisonTheoryData : TheoryDataBase
+        {
+            public X509Data FirstX509Data { get; set; }
+
+            public X509Data SecondX509Data { get; set; }
+
+            public bool ShouldBeConsideredEqual { get; set; }
+
+            public bool HashShouldMatch { get; set; }
+        }
+    }
+#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant
+}


### PR DESCRIPTION
Fixes these findings: https://sonarcloud.io/project/issues?id=AzureAD_azure-activedirectory-identitymodel-extensions-for-dotnet&resolved=false&types=BUG

Fixed, simplified, and added tests for `Equals` and `GetHashCode` to data transfer objects in M.IM.Xml assembly. Generated methods for `Equals` and `GetHashCode` then edited to respect previous behavior for string casing, and expected behavior for collection types for `Equals`. Added `unchecked` for `GetHashCode` as it was another Sonar finding

Removed null checks on value type objects

Moved null check before first access

Fixed NRE condition when calling `GetType` on a null object