### PR TITLE
Code cleanup to remove warning

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/GlobalSuppressions.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/GlobalSuppressions.cs
@@ -31,4 +31,3 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Doesn't own object", Scope = "member", Target = "~M:Microsoft.IdentityModel.Protocols.WsFederation.WsFederationMetadataSerializer.ReadEntityDescriptor(System.Xml.XmlReader)~Microsoft.IdentityModel.Protocols.WsFederation.WsFederationConfiguration")]
 
 [assembly: SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Breaking change", Scope = "member", Target = "~P:Microsoft.IdentityModel.Protocols.WsFederation.SecurityTokenServiceTypeRoleDescriptor.KeyInfos")]
-[assembly: SuppressMessage("Security", "CA3075:Insecure DTD processing in XML", Justification = "Not created from factory, dtd is still prohibited", Scope = "member", Target = "~M:Microsoft.IdentityModel.Protocols.WsFederation.WsFederationMessage.GetTokenUsingXmlReader~System.String")]

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMessage.cs
@@ -251,11 +251,8 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
 
             string token = null;
             using (var sr = new StringReader(Wresult))
-            using (var xmlReader = new XmlTextReader(sr) { DtdProcessing = DtdProcessing.Prohibit })
+            using (var xmlReader = new XmlTextReader(sr) { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null })
             {
-                if (xmlReader.Settings != null)
-                    xmlReader.Settings.DtdProcessing = DtdProcessing.Prohibit;
-
                 // Read StartElement <RequestSecurityTokenResponseCollection> this is possible for wstrust 1.3 and 1.4
                 if (XmlUtil.IsStartElement(xmlReader, WsTrustConstants.Elements.RequestSecurityTokenResponseCollection, WsTrustNamespaceNon2005List))
                     xmlReader.ReadStartElement();


### PR DESCRIPTION
The code removed triggered a warning, also set XmlResolver to null as a precautionary item.
This cleans up https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1501