### PR TITLE
Make CanonicalString public

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlAssertion.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlAssertion.cs
@@ -160,7 +160,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         /// <summary>
         /// Gets the canonicalized (ExclusiveC14n) representation without comments.
         /// </summary>
-        internal string CanonicalString
+        public string CanonicalString
         {
             get
             {

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Assertion.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Assertion.cs
@@ -92,7 +92,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         /// <summary>
         /// Gets the canonicalized (ExclusiveC14n) representation without comments.
         /// </summary>
-        internal string CanonicalString
+        public string CanonicalString
         {
             get
             {


### PR DESCRIPTION
Makes `CanonicalString `property public on `SamlAssertion `and `Saml2Assertion`.