### PR TITLE
Remove locks in SignatureProviders

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -67,18 +67,12 @@ namespace Microsoft.IdentityModel.Tokens
 
 #if NET461 || NETSTANDARD2_0
         private RSAEncryptionPadding _rsaEncryptionPadding;
-        private object _signRsaLock = new object();
 #endif
 
         private bool _disposeCryptoOperators = false;
         private bool _disposed = false;
         private SignDelegate SignatureFunction;
         private VerifyDelegate VerifyFunction;
-
-
-        private object _signEcdsaLock = new object();
-        private object _verifyRsaLock = new object();
-        private object _verifyEcdsaLock = new object();
 
 #if NET461 || NETSTANDARD2_0
         // HasAlgorithmName was introduced into Net46
@@ -344,19 +338,13 @@ namespace Microsoft.IdentityModel.Tokens
 
         private byte[] SignWithECDsa(byte[] bytes)
         {
-            lock (_signEcdsaLock)
-            {
-                return ECDsaSecurityKey.ECDsa.SignHash(HashAlgorithm.ComputeHash(bytes));
-            }
+            return ECDsaSecurityKey.ECDsa.SignHash(HashAlgorithm.ComputeHash(bytes));
         }
 
 #if NET461 || NETSTANDARD2_0
         private byte[] SignWithRsa(byte[] bytes)
         {
-            lock (_signRsaLock)
-            {
-                return RSA.SignHash(HashAlgorithm.ComputeHash(bytes), HashAlgorithmName, RSASignaturePadding);
-            }
+            return RSA.SignHash(HashAlgorithm.ComputeHash(bytes), HashAlgorithmName, RSASignaturePadding);
         }
 #endif
 
@@ -378,29 +366,20 @@ namespace Microsoft.IdentityModel.Tokens
 
         private bool VerifyWithECDsa(byte[] bytes, byte[] signature)
         {
-            lock (_verifyEcdsaLock)
-            {
-                return ECDsaSecurityKey.ECDsa.VerifyHash(HashAlgorithm.ComputeHash(bytes), signature);
-            }
+            return ECDsaSecurityKey.ECDsa.VerifyHash(HashAlgorithm.ComputeHash(bytes), signature);
         }
 
 #if NET461 || NETSTANDARD2_0
         private bool VerifyWithRsa(byte[] bytes, byte[] signature)
         {
-            lock (_verifyRsaLock)
-            {
-                return RSA.VerifyHash(HashAlgorithm.ComputeHash(bytes), signature, HashAlgorithmName, RSASignaturePadding);
-            }
+            return RSA.VerifyHash(HashAlgorithm.ComputeHash(bytes), signature, HashAlgorithmName, RSASignaturePadding);
         }
 #endif
 
 #if DESKTOP
         private bool VerifyWithRsaCryptoServiceProviderProxy(byte[] bytes, byte[] signature)
         {
-            lock (_verifyRsaLock)
-            {
-                return RsaCryptoServiceProviderProxy.VerifyData(bytes, HashAlgorithm, signature);
-            }
+            return RsaCryptoServiceProviderProxy.VerifyData(bytes, HashAlgorithm, signature);
         }
 #endif
 

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -71,8 +71,8 @@ namespace Microsoft.IdentityModel.Tokens
 
         private bool _disposeCryptoOperators = false;
         private bool _disposed = false;
-        private SignDelegate SignatureFunction;
-        private VerifyDelegate VerifyFunction;
+        private SignDelegate SignatureFunction = SignatureFunctionNotFound;
+        private VerifyDelegate VerifyFunction = VerifyFunctionNotFound;
 
 #if NET461 || NETSTANDARD2_0
         // HasAlgorithmName was introduced into Net46
@@ -329,11 +329,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         internal byte[] Sign(byte[] bytes)
         {
-            if (SignatureFunction != null)
-                return SignatureFunction(bytes);
-
-            // we should never get here, its a bug if we do.
-            throw LogHelper.LogExceptionMessage(new CryptographicException(LogMessages.IDX10685));
+            return SignatureFunction(bytes);
         }
 
         private byte[] SignWithECDsa(byte[] bytes)
@@ -355,13 +351,15 @@ namespace Microsoft.IdentityModel.Tokens
         }
 #endif
 
+        internal static byte[] SignatureFunctionNotFound(byte[] bytes)
+        {
+            // we should never get here, its a bug if we do.
+            throw LogHelper.LogExceptionMessage(new CryptographicException(LogMessages.IDX10685));
+        }
+
         internal bool Verify(byte[] bytes, byte[] signature)
         {
-            if (VerifyFunction != null)
-                return VerifyFunction(bytes, signature);
-
-            // we should never get here, its a bug if we do.
-            throw LogHelper.LogExceptionMessage(new NotSupportedException(LogMessages.IDX10686));
+            return VerifyFunction(bytes, signature);
         }
 
         private bool VerifyWithECDsa(byte[] bytes, byte[] signature)
@@ -382,6 +380,12 @@ namespace Microsoft.IdentityModel.Tokens
             return RsaCryptoServiceProviderProxy.VerifyData(bytes, HashAlgorithm, signature);
         }
 #endif
+
+        internal static bool VerifyFunctionNotFound(byte[] bytes, byte[] signature)
+        {
+            // we should never get here, its a bug if we do.
+            throw LogHelper.LogExceptionMessage(new NotSupportedException(LogMessages.IDX10686));
+        }
 
         // Put all the 'lightup' code here.
 #if NET45

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -155,7 +155,7 @@ namespace Microsoft.IdentityModel.Tokens
 
             WillCreateSignatures = willCreateSignatures;
             ValidateAsymmetricSecurityKeySize(key, algorithm, WillCreateSignatures);
-            _asymmetricAdapterObjectPool = new DisposableObjectPool<AsymmetricAdapter>(CreateAsymmetricAdapter);
+            _asymmetricAdapterObjectPool = new DisposableObjectPool<AsymmetricAdapter>(CreateAsymmetricAdapter, _cryptoProviderFactory.SignatureProviderObjectPoolCacheSize);
     }
 
         /// <summary>
@@ -232,6 +232,11 @@ namespace Microsoft.IdentityModel.Tokens
             return new AsymmetricAdapter(Key, Algorithm, _cryptoProviderFactory.CreateHashAlgorithm(GetHashAlgorithmString(Algorithm)), WillCreateSignatures);
         }
 #endif
+
+        /// <summary>
+        /// For testing purposes
+        /// </summary>
+        internal override int ObjectPoolSize => _asymmetricAdapterObjectPool.Size;
 
         /// <summary>
         /// Produces a signature over the 'input' using the <see cref="AsymmetricSecurityKey"/> and algorithm passed to <see cref="AsymmetricSignatureProvider( SecurityKey, string, bool )"/>.

--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -220,7 +220,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns>A <see cref="SignatureProvider"/> that can be used to create a signature using the <see cref="SecurityKey"/> and algorithm.</returns>
         public virtual SignatureProvider CreateForSigning(SecurityKey key, string algorithm)
         {
-            return CreateForSigning(key, algorithm, true);
+            return CreateForSigning(key, algorithm, CacheSignatureProviders);
         }
 
 #pragma warning disable 1573
@@ -251,7 +251,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns>A <see cref="SignatureProvider"/> that can be used to validate a signature using the <see cref="SecurityKey"/> and algorithm.</returns>
         public virtual SignatureProvider CreateForVerifying(SecurityKey key, string algorithm)
         {
-            return CreateForVerifying(key, algorithm, true);
+            return CreateForVerifying(key, algorithm, CacheSignatureProviders);
         }
 
 #pragma warning disable 1573
@@ -557,7 +557,7 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogArgumentNullException(nameof(hashAlgorithm));
             else if (CustomCryptoProvider != null && _typeToAlgorithmMap.TryGetValue(hashAlgorithm.GetType().ToString(), out var algorithm) && CustomCryptoProvider.IsSupportedAlgorithm(algorithm))
                 CustomCryptoProvider.Release(hashAlgorithm);
-            else 
+            else
                 hashAlgorithm.Dispose();
         }
 

--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -41,6 +41,8 @@ namespace Microsoft.IdentityModel.Tokens
         private static CryptoProviderFactory _default;
         private static ConcurrentDictionary<string, string> _typeToAlgorithmMap = new ConcurrentDictionary<string, string>();
         private static object _cacheLock = new object();
+        private static int _defaultSignatureProviderObjectPoolCacheSize = Environment.ProcessorCount * 4;
+        private int _signatureProviderObjectPoolCacheSize = _defaultSignatureProviderObjectPoolCacheSize;
 
         /// <summary>
         /// Returns the default <see cref="CryptoProviderFactory"/> instance.
@@ -59,6 +61,15 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         [DefaultValue(true)]
         public static bool DefaultCacheSignatureProviders { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the maximum size of the object pool used by the SignatureProvider that are used for crypto objects.
+        /// </summary>
+        public static int DefaultSignatureProviderObjectPoolCacheSize
+        {
+            get => _defaultSignatureProviderObjectPoolCacheSize;
+            set => _defaultSignatureProviderObjectPoolCacheSize = value > 0 ? value : throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant(LogMessages.IDX10698, value)));
+        }
 
         /// <summary>
         /// Static constructor that initializes the default <see cref="CryptoProviderFactory"/>.
@@ -85,6 +96,8 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogArgumentNullException(nameof(other));
 
             CustomCryptoProvider = other.CustomCryptoProvider;
+            CacheSignatureProviders = other.CacheSignatureProviders;
+            SignatureProviderObjectPoolCacheSize = other.SignatureProviderObjectPoolCacheSize;
         }
 
         /// <summary>
@@ -105,6 +118,16 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         [DefaultValue(true)]
         public bool CacheSignatureProviders { get; set; } = DefaultCacheSignatureProviders;
+
+        /// <summary>
+        /// Gets or sets the maximum size of the object pool used by the SignatureProvider that are used for crypto objects.
+        /// </summary>
+        public int SignatureProviderObjectPoolCacheSize
+        {
+            get => _signatureProviderObjectPoolCacheSize;
+
+            set => _signatureProviderObjectPoolCacheSize = value > 0 ? value : throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant(LogMessages.IDX10698, value)));
+        }
 
         /// <summary>
         /// Creates an instance of <see cref="AuthenticatedEncryptionProvider"/> for a specific &lt;SecurityKey, Algorithm>.

--- a/src/Microsoft.IdentityModel.Tokens/ECDsaAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ECDsaAdapter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.IdentityModel.Tokens
     /// </summary>
     internal class ECDsaAdapter
     {
-        internal readonly CreateECDsaDelegate CreateECDsaFunction = null;
+        internal readonly CreateECDsaDelegate CreateECDsaFunction = ECDsaNotSupported;
         internal static ECDsaAdapter Instance = new ECDsaAdapter();
 
         /// <summary>
@@ -67,11 +67,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         internal ECDsa CreateECDsa(JsonWebKey jsonWebKey, bool usePrivateKey)
         {
-            if (CreateECDsaFunction != null)
-                return CreateECDsaFunction(jsonWebKey, usePrivateKey);
-
-            // we will get here on platforms that are not supported.
-            throw LogHelper.LogExceptionMessage(new PlatformNotSupportedException(LogMessages.IDX10690));
+            return CreateECDsaFunction(jsonWebKey, usePrivateKey);
         }
 
         /// <summary>
@@ -168,6 +164,12 @@ namespace Microsoft.IdentityModel.Tokens
                 if (keyBlobHandle != null && keyBlobHandle.IsAllocated)
                     keyBlobHandle.Free();
             }
+        }
+
+        internal static ECDsa ECDsaNotSupported(JsonWebKey jsonWebKey, bool usePrivateKey)
+        {
+            // we will get here on platforms that are not supported.
+            throw LogHelper.LogExceptionMessage(new PlatformNotSupportedException(LogMessages.IDX10690));
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -206,6 +206,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10695 = "IDX10695: Unable to create a JsonWebKey from an ECDsa object. Required ECParameters structure is not supported by .NET Framework < 4.7.";
         public const string IDX10696 = "IDX10696: The algorithm '{0}' is not in the user-defined accepted list of algorithms.";
         public const string IDX10697 = "IDX10697: The user defined 'Delegate' AlgorithmValidator specified on TokenValidationParameters returned false when validating Algorithm: '{0}', SecurityKey: '{1}'.";
+        public const string IDX10698 = "IDX10698: The SignatureProviderObjectPoolCacheSize must be greater than 0. Value: '{0}'.";
 
         // security keys
         public const string IDX10700 = "IDX10700: {0} is unable to use 'rsaParameters'. {1} is null.";

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -185,7 +185,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10674 = "IDX10674: JsonWebKeyConverter does not support SecurityKey of type: {0}";
         public const string IDX10675 = "IDX10675: Cannot create a ECDsa object from the '{0}', the bytes from the decoded value of '{1}' must be less than the size associated with the curve: '{2}'. Size was: '{3}'.";
         // public const string IDX10676 = "IDX10676:";
-        public const string IDX10677 = "IDX10677: GetKeyedHashAlgorithm threw, key: {0}, algorithm {1}.";
+        // public const string IDX10677 = "IDX10677:";
         // public const string IDX10678 = "IDX10678:";
         public const string IDX10679 = "IDX10679: Failed to decompress using algorithm '{0}'.";
         public const string IDX10680 = "IDX10680: Failed to compress using algorithm '{0}'.";

--- a/src/Microsoft.IdentityModel.Tokens/ObjectPools.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ObjectPools.cs
@@ -67,10 +67,13 @@ namespace Microsoft.IdentityModel.Tokens
         {
             _factory = factory;
             Items = new Element[size];
+            Size = size;
         }
 
         // storage for the pool objects.
         internal Element[] Items { get; }
+
+        internal int Size { get; }
 
         private T CreateInstance()
         {

--- a/src/Microsoft.IdentityModel.Tokens/ObjectPools.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ObjectPools.cs
@@ -1,0 +1,139 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Generic implementation of object pooling pattern with predefined pool size limit. The main
+    /// purpose is that limited number of frequently used objects can be kept in the pool for
+    /// further recycling.
+    ///
+    /// Notes: 
+    /// 1) it is not the goal to keep all returned objects. Pool is not meant for storage. If there
+    ///    is no space in the pool, extra returned objects will be dropped.
+    ///
+    /// 2) it is implied that if object was obtained from a pool, the caller will return it back in
+    ///    a relatively short time. Keeping checked out objects for long durations is ok, but
+    ///    reduces usefulness of pooling. Just new up your own.
+    ///
+    /// Not returning objects to the pool in not detrimental to the pool's work, but is a bad practice.
+    /// Rationale:
+    ///    If there is no intent for reusing the object, do not use pool - just use "new".
+    /// </summary>
+    internal sealed class DisposableObjectPool<T> where T : class, IDisposable
+    {
+        internal struct Element
+        {
+            internal T Value;
+        }
+
+        // factory is stored for the lifetime of the pool. We will call this only when pool needs to
+        // expand. compared to "new T()", Func gives more flexibility to implementers and faster
+        // than "new T()".
+        private readonly Func<T> _factory;
+
+        internal DisposableObjectPool(Func<T> factory)
+            : this(factory, Environment.ProcessorCount * 2)
+        { }
+
+        internal DisposableObjectPool(Func<T> factory, int size)
+        {
+            _factory = factory;
+            Items = new Element[size];
+        }
+
+        // storage for the pool objects.
+        internal Element[] Items { get; }
+
+        private T CreateInstance()
+        {
+            var inst = _factory();
+            return inst;
+        }
+
+        /// <summary>
+        /// Produces an instance.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically
+        /// reducing how far we will typically search.
+        /// </remarks>
+        internal T Allocate()
+        {
+            var items = Items;
+            T inst;
+
+            for (int i = 0; i < items.Length; i++)
+            {
+                // Note that the read is optimistically not synchronized. That is intentional. 
+                // We will interlock only when we have a candidate. in a worst case we may miss some
+                // recently returned objects. Not a big deal.
+                inst = items[i].Value;
+                if (inst != null)
+                {
+                    if (inst == Interlocked.CompareExchange(ref items[i].Value, null, inst))
+                    {
+                        goto gotInstance;
+                    }
+                }
+            }
+
+            inst = CreateInstance();
+        gotInstance:
+
+            return inst;
+        }
+
+        /// <summary>
+        /// Returns objects to the pool.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically
+        /// reducing how far we will typically search in Allocate.
+        /// </remarks>
+        internal void Free(T obj)
+        {
+            var items = Items;
+            for (int i = 0; i < items.Length; i++)
+            {
+                if (items[i].Value == null)
+                {
+                    // Intentionally not using interlocked here. 
+                    // In a worst case scenario two objects may be stored into same slot.
+                    // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                    items[i].Value = obj;
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
@@ -52,9 +52,6 @@ namespace Microsoft.IdentityModel.Tokens
         private bool _disposed = false;
         private bool _disposeRsa = false;
 
-        private object _signLock = new object();
-        private object _verifyLock = new object();
-
         // Only dispose of the RsaCryptoServiceProvider object if we created a new instance that supports SHA-256,
         // otherwise do not disposed of the referenced RsaCryptoServiceProvider
         //private bool _disposeRsa;
@@ -195,10 +192,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (hash == null)
                 throw LogHelper.LogArgumentNullException(nameof(hash));
 
-            lock (_signLock)
-            {
-                return _rsa.SignData(input, hash);
-            }
+            return _rsa.SignData(input, hash);
         }
 
         /// <summary>
@@ -222,10 +216,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (signature == null || signature.Length == 0)
                 throw LogHelper.LogArgumentNullException(nameof(signature));
 
-            lock (_verifyLock)
-            {
-                return _rsa.VerifyData(input, hash, signature);
-            }
+            return _rsa.VerifyData(input, hash, signature);
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/SignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SignatureProvider.cs
@@ -85,6 +85,11 @@ namespace Microsoft.IdentityModel.Tokens
         public SecurityKey Key { get; private set; }
 
         /// <summary>
+        /// For testing purposes
+        /// </summary>
+        internal virtual int ObjectPoolSize => 0;
+
+        /// <summary>
         /// This must be overridden to produce a signature over the 'input'.
         /// </summary>
         /// <param name="input">bytes to sign.</param>

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricAdapterTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricAdapterTests.cs
@@ -1,0 +1,168 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Microsoft.IdentityModel.TestUtils;
+using Xunit;
+
+#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
+
+namespace Microsoft.IdentityModel.Tokens.Tests
+{
+    public class AsymmetricAdapterTests
+    {
+        [Theory, MemberData(nameof(AsymmetricAdapterUsageTestCases))]
+        public void AsymmetricAdapterUsageTests(AsymmetricAdatperTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.AsymmetricAdapterUsageTests", theoryData);
+
+            byte[] bytes = Encoding.UTF8.GetBytes("var context = TestUtilities.WriteHeader($'{ this}.AsymmetricAdapterUsageTests', theoryData);");
+            HashAlgorithm hashAlgorithm = CryptoProviderFactory.Default.CreateHashAlgorithm(theoryData.HashAlorithmString);
+
+            try
+            {
+#if NET461 || NETCOREAPP2_1
+                AsymmetricAdapter asymmetricdapter = new AsymmetricAdapter(theoryData.SecurityKey, theoryData.Algorithm, hashAlgorithm, SupportedAlgorithms.GetHashAlgorithmName(theoryData.Algorithm), true);
+#else
+                AsymmetricAdapter asymmetricdapter = new AsymmetricAdapter(theoryData.SecurityKey, theoryData.Algorithm, hashAlgorithm, true);
+#endif
+                byte[] signature = asymmetricdapter.Sign(bytes);
+                if (!asymmetricdapter.Verify(bytes, signature))
+                    context.AddDiff($"Verify failed for test: {theoryData.TestId}");
+
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<AsymmetricAdatperTheoryData> AsymmetricAdapterUsageTestCases
+        {
+            get => new TheoryData<AsymmetricAdatperTheoryData>
+            {
+                // X509
+                new AsymmetricAdatperTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    HashAlorithmString = SupportedAlgorithms.GetDigestFromSignatureAlgorithm(SecurityAlgorithms.RsaSha256),
+                    SecurityKey = new X509SecurityKey(KeyingMaterial.CertSelfSigned2048_SHA256),
+                    TestId = "KeyingMaterial_CertSelfSigned2048_SHA256"
+                },
+
+                // RSA
+                // RSACertificateExtensions.GetRSAPrivateKey - this results in 
+                #if NET461 || NETCOREAPP2_1
+                new AsymmetricAdatperTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    HashAlorithmString = SupportedAlgorithms.GetDigestFromSignatureAlgorithm(SecurityAlgorithms.RsaSha256),
+                    SecurityKey = new RsaSecurityKey(RSACertificateExtensions.GetRSAPrivateKey(KeyingMaterial.CertSelfSigned2048_SHA256) as RSA),
+                    TestId = "RSACertificateExtensions_GetRSAPrivateKey"
+                },
+                #endif
+
+                // X509Certificte2.PrivateKey - this results in the RSA being of type RSACryptoServiceProviderProxy
+                new AsymmetricAdatperTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    HashAlorithmString = SupportedAlgorithms.GetDigestFromSignatureAlgorithm(SecurityAlgorithms.RsaSha256),
+                    SecurityKey = new RsaSecurityKey(KeyingMaterial.CertSelfSigned2048_SHA256.PrivateKey as RSA),
+                    TestId = "KeyingMaterial_CertSelfSigned2048_SHA256_PrivateKey"
+                },
+
+                // RSA.Create
+                #if NETCOREAPP2_1
+                new AsymmetricAdatperTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    HashAlorithmString = SupportedAlgorithms.GetDigestFromSignatureAlgorithm(SecurityAlgorithms.RsaSha256),
+                    SecurityKey = new RsaSecurityKey(RSA.Create(2048)),
+                    TestId = "RSA_Create(2048)"
+                },
+                #endif
+
+                // RSACryptoServiceProvider
+                new AsymmetricAdatperTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    HashAlorithmString = SupportedAlgorithms.GetDigestFromSignatureAlgorithm(SecurityAlgorithms.RsaSha256),
+                    SecurityKey = new RsaSecurityKey(new RSACryptoServiceProvider(2048)),
+                    TestId = "RSACryptoServiceProvider(2048)"
+                },
+
+                // RsaParameters
+                new AsymmetricAdatperTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaSha256,
+                    HashAlorithmString = SupportedAlgorithms.GetDigestFromSignatureAlgorithm(SecurityAlgorithms.RsaSha256),
+                    SecurityKey = new RsaSecurityKey(KeyingMaterial.RsaParameters_2048),
+                    TestId = "KeyingMaterial_RsaParameters_2048"
+                },
+
+                // ECD
+                // ECD object
+                new AsymmetricAdatperTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.EcdsaSha256,
+                    HashAlorithmString = SupportedAlgorithms.GetDigestFromSignatureAlgorithm(SecurityAlgorithms.EcdsaSha256),
+                    SecurityKey = KeyingMaterial.Ecdsa256Key,
+                    TestId = "KeyingMaterial_Ecdsa256Key"
+                },
+
+                #if NET_CORE
+                new AsymmetricAdatperTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.EcdsaSha256,
+                    HashAlorithmString = SupportedAlgorithms.GetDigestFromSignatureAlgorithm(SecurityAlgorithms.EcdsaSha256),
+                    SecurityKey = KeyingMaterial.JsonWebKeyP256,
+                    TestId = "KeyingMaterial_JsonWebKeyP256"
+                },
+                #endif
+
+            };
+        }
+
+        public class AsymmetricAdatperTheoryData : TheoryDataBase
+        {
+            public string Algorithm { get; set; }
+
+            public string HashAlorithmString { get; set; }
+
+            public SecurityKey SecurityKey { get; set; }
+
+        }
+    }
+}
+
+#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
@@ -51,10 +51,9 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 #if NET461 || NET_CORE
             var expectedException = ExpectedException.NoExceptionExpected;
 #endif
-
             try
             {
-                new AsymmetricSignatureProvider(new RsaSecurityKey(new DerivedRsa(2048)), SecurityAlgorithms.RsaSha256, false);
+                new AsymmetricAdapter(new RsaSecurityKey(new DerivedRsa(2048)), SecurityAlgorithms.RsaSha256, false);
                 expectedException.ProcessNoException(context);
             }
             catch (Exception ex)
@@ -64,7 +63,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
 #if NET452
             // RSA-PSS is not available on .NET 4.5.2
-            expectedException = ExpectedException.NotSupportedException("IDX10634:");
+            expectedException = ExpectedException.NotSupportedException("IDX10687:");
 #endif
 
 #if NET461 || NET_CORE
@@ -73,7 +72,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
             try
             {
-                new AsymmetricSignatureProvider(KeyingMaterial.DefaultRsaSecurityKey1, SecurityAlgorithms.RsaSsaPssSha256, false);
+                new AsymmetricAdapter(new RsaSecurityKey(new DerivedRsa(2048)), SecurityAlgorithms.RsaSha256, false);
                 expectedException.ProcessNoException(context);
             }
             catch (Exception ex)

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -148,6 +148,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             var context = TestUtilities.WriteHeader($"{this}.AsymmetricSignAndVerify", theoryData);
             try
             {
+                theoryData.VerifyKey.CryptoProviderFactory = theoryData.CryptoProviderFactory;
                 var signatureProviderVerify = theoryData.CryptoProviderFactory.CreateForVerifying(theoryData.VerifyKey, theoryData.VerifyAlgorithm);
                 var signatureProviderSign = theoryData.CryptoProviderFactory.CreateForSigning(theoryData.SigningKey, theoryData.SigningAlgorithm);
                 var bytes = Encoding.UTF8.GetBytes("GenerateASignature");
@@ -155,6 +156,9 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 var isValid = signatureProviderVerify.Verify(bytes, signature);
                 if (isValid != theoryData.IsValid)
                     context.AddDiff($"isValid != theoryData.IsValid. '{isValid}', '{theoryData.IsValid}'.");
+
+                if (signatureProviderVerify.ObjectPoolSize != theoryData.CryptoProviderFactory.SignatureProviderObjectPoolCacheSize)
+                    context.AddDiff($"signatureProviderVerify.ObjectPoolSize != theoryData.CryptoProviderFactory.SignatureProviderObjectPoolCacheSize. '{signatureProviderVerify.ObjectPoolSize}, {theoryData.CryptoProviderFactory.SignatureProviderObjectPoolCacheSize}'.");
 
                 theoryData.ExpectedException.ProcessNoException(context);
             }
@@ -181,7 +185,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 new SignatureProviderTheoryData("ECDsa9", ALG.EcdsaSha512, ALG.EcdsaSha512, KEY.Ecdsa521Key, KEY.Ecdsa521Key_Public),
 
                 // JsonWebKey
-                new SignatureProviderTheoryData("JsonWebKeyEcdsa1", ALG.EcdsaSha256, ALG.EcdsaSha256, KEY.JsonWebKeyP256, KEY.JsonWebKeyP256_Public),
+                new SignatureProviderTheoryData("JsonWebKeyEcdsa1", ALG.EcdsaSha256, ALG.EcdsaSha256, KEY.JsonWebKeyP256, KEY.JsonWebKeyP256_Public){ CryptoProviderFactory = new CryptoProviderFactory{ CacheSignatureProviders = false, SignatureProviderObjectPoolCacheSize = 10 } },
                 new SignatureProviderTheoryData("JsonWebKeyEcdsa2", ALG.EcdsaSha256Signature, ALG.EcdsaSha256Signature, KEY.JsonWebKeyP256, KEY.JsonWebKeyP256_Public),
                 new SignatureProviderTheoryData("JsonWebKeyEcdsa3", ALG.Aes256KeyWrap, ALG.EcdsaSha256Signature, KEY.JsonWebKeyP256, KEY.JsonWebKeyP256_Public, EE.NotSupportedException("IDX10634:")),
                 new SignatureProviderTheoryData("JsonWebKeyEcdsa4", ALG.EcdsaSha256, ALG.EcdsaSha256, KEY.JsonWebKeyP256, KEY.JsonWebKeyP256_Public),
@@ -192,7 +196,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 new SignatureProviderTheoryData("JsonWebKeyRsa2", ALG.RsaSha256Signature, ALG.RsaSha256Signature, KEY.JsonWebKeyRsa_2048, KEY.JsonWebKeyRsa_2048_Public),
                 new SignatureProviderTheoryData("JsonWebKeyRsa3", ALG.Aes192KeyWrap, ALG.RsaSha256Signature, KEY.JsonWebKeyRsa_2048, KEY.JsonWebKeyRsa_2048_Public, EE.NotSupportedException("IDX10634:")),
 
-                new SignatureProviderTheoryData("RsaSecurityKey1", ALG.RsaSha256, ALG.RsaSha256, KEY.RsaSecurityKey_2048, KEY.RsaSecurityKey_2048_Public),
+                new SignatureProviderTheoryData("RsaSecurityKey1", ALG.RsaSha256, ALG.RsaSha256, KEY.RsaSecurityKey_2048, KEY.RsaSecurityKey_2048_Public){ CryptoProviderFactory = new CryptoProviderFactory{ CacheSignatureProviders = false, SignatureProviderObjectPoolCacheSize = 100 } },
                 new SignatureProviderTheoryData("RsaSecurityKey2", ALG.RsaSha256Signature, ALG.RsaSha256Signature, KEY.RsaSecurityKey_2048, KEY.RsaSecurityKey_2048_Public),
                 new SignatureProviderTheoryData("RsaSecurityKey3", ALG.RsaSha384, ALG.RsaSha384, KEY.RsaSecurityKey_2048, KEY.RsaSecurityKey_2048_Public),
                 new SignatureProviderTheoryData("RsaSecurityKey4", ALG.RsaSha384Signature, ALG.RsaSha384Signature, KEY.RsaSecurityKey_2048, KEY.RsaSecurityKey_2048_Public),
@@ -242,12 +246,16 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             var context = TestUtilities.WriteHeader($"{this}.SignAndVerify", theoryData);
             try
             {
+                theoryData.VerifyKey.CryptoProviderFactory = theoryData.CryptoProviderFactory;
                 var signatureProviderVerify = theoryData.CryptoProviderFactory.CreateForVerifying(theoryData.VerifyKey, theoryData.VerifyAlgorithm);
                 var signatureProviderSign = theoryData.CryptoProviderFactory.CreateForSigning(theoryData.SigningKey, theoryData.SigningAlgorithm);
                 var bytes = Encoding.UTF8.GetBytes("GenerateASignature");
                 var signature = signatureProviderSign.Sign(bytes);
                 if (!signatureProviderVerify.Verify(bytes, signature))
                     throw new SecurityTokenInvalidSignatureException("SignatureFailed");
+
+                if (signatureProviderVerify.ObjectPoolSize != theoryData.CryptoProviderFactory.SignatureProviderObjectPoolCacheSize)
+                    context.AddDiff($"signatureProviderVerify.ObjectPoolSize != theoryData.CryptoProviderFactory.SignatureProviderObjectPoolCacheSize. '{signatureProviderVerify.ObjectPoolSize}, {theoryData.CryptoProviderFactory.SignatureProviderObjectPoolCacheSize}'.");
 
                 theoryData.ExpectedException.ProcessNoException(context);
             }
@@ -264,12 +272,12 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             get => new TheoryData<SignatureProviderTheoryData>
             {
                 // JsonWebKey
-                new SignatureProviderTheoryData("JsonWebKeySymmetric1", ALG.HmacSha256, ALG.HmacSha256, KEY.JsonWebKeySymmetric256, KEY.JsonWebKeySymmetric256),
+                new SignatureProviderTheoryData("JsonWebKeySymmetric1", ALG.HmacSha256, ALG.HmacSha256, KEY.JsonWebKeySymmetric256, KEY.JsonWebKeySymmetric256){ CryptoProviderFactory = new CryptoProviderFactory{ CacheSignatureProviders = false, SignatureProviderObjectPoolCacheSize = 10 } },
                 new SignatureProviderTheoryData("JsonWebKeySymmetric2", ALG.HmacSha256Signature, ALG.HmacSha256Signature, KEY.JsonWebKeySymmetric256, KEY.JsonWebKeySymmetric256),
                 new SignatureProviderTheoryData("JsonWebKeySymmetric3", ALG.RsaSha256Signature, ALG.RsaSha256Signature, KEY.JsonWebKeySymmetric256, KEY.JsonWebKeyRsa_2048_Public, EE.NotSupportedException("IDX10634:")),
                 new SignatureProviderTheoryData("JsonWebKeySymmetric4", ALG.EcdsaSha512Signature, ALG.EcdsaSha512Signature, KEY.JsonWebKeySymmetric256, KEY.JsonWebKeyRsa_2048_Public, EE.NotSupportedException("IDX10634:")),
 
-                new SignatureProviderTheoryData("SymmetricSecurityKey1", ALG.HmacSha256, ALG.HmacSha256, KEY.SymmetricSecurityKey2_256, KEY.SymmetricSecurityKey2_256),
+                new SignatureProviderTheoryData("SymmetricSecurityKey1", ALG.HmacSha256, ALG.HmacSha256, KEY.SymmetricSecurityKey2_256, KEY.SymmetricSecurityKey2_256){ CryptoProviderFactory = new CryptoProviderFactory{ CacheSignatureProviders = false, SignatureProviderObjectPoolCacheSize = 42 } },
                 new SignatureProviderTheoryData("SymmetricSecurityKey2", ALG.HmacSha256, ALG.HmacSha256, Default.SymmetricSigningKey256,  Default.SymmetricSigningKey256),
                 
                 // HmacSha256 <-> HmacSha256Signature


### PR DESCRIPTION
This PR adds an object pool that allows for the removal of locks when preforming crypto operations involving signatures. The 'objectpool' was copied from .net core as it is not available in 4.x.