### PR TITLE
Changing XmlUtil.GetXsiTypeAsQualifiedName to retrieve the attribute …

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Serializer.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Serializer.cs
@@ -1662,7 +1662,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                     if ((xsiTypePrefix != null) && (xsiTypeSuffix != null))
                     {
                         writer.WriteAttributeString(XmlSignatureConstants.XmlNamepspacePrefix, Saml2Constants.ClaimValueTypeSerializationPrefix, null, xsiTypePrefix);
-                        writer.WriteAttributeString(XmlSignatureConstants.Attributes.Type, XmlSignatureConstants.XmlSchemaNamespace, string.Concat(Saml2Constants.ClaimValueTypeSerializationPrefixWithColon, xsiTypeSuffix));
+                        writer.WriteAttributeString(XmlSignatureConstants.Attributes.TypeLowerCase, XmlSignatureConstants.XmlSchemaNamespace, string.Concat(Saml2Constants.ClaimValueTypeSerializationPrefixWithColon, xsiTypeSuffix));
                     }
 
                     writer.WriteString(value);
@@ -2193,7 +2193,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
 
             // @xsi:type
             if (subjectConfirmationData.KeyInfos.Count > 0)
-                writer.WriteAttributeString(XmlSignatureConstants.Attributes.Type, XmlSignatureConstants.XmlSchemaNamespace, Saml2Constants.Types.KeyInfoConfirmationDataType);
+                writer.WriteAttributeString(XmlSignatureConstants.Attributes.TypeLowerCase, XmlSignatureConstants.XmlSchemaNamespace, Saml2Constants.Types.KeyInfoConfirmationDataType);
 
             // @Address - optional
             if (!string.IsNullOrEmpty(subjectConfirmationData.Address))

--- a/src/Microsoft.IdentityModel.Xml/DsigSerializer.cs
+++ b/src/Microsoft.IdentityModel.Xml/DsigSerializer.cs
@@ -434,7 +434,7 @@ namespace Microsoft.IdentityModel.Xml
                 {
                     Prefix = reader.Prefix,
                     Id = reader.GetAttribute(XmlSignatureConstants.Attributes.Id, null),
-                    Type = reader.GetAttribute(XmlSignatureConstants.Attributes.Type, null),
+                    Type = reader.GetAttribute(XmlSignatureConstants.Attributes.TypeLowerCase, null),
                     Uri = reader.GetAttribute(XmlSignatureConstants.Attributes.URI, null)
                 };
 
@@ -781,7 +781,7 @@ namespace Microsoft.IdentityModel.Xml
 
             // @Type
             if (reference.Type != null)
-                writer.WriteAttributeString(XmlSignatureConstants.Attributes.Type, null, reference.Type);
+                writer.WriteAttributeString(XmlSignatureConstants.Attributes.TypeLowerCase, null, reference.Type);
 
             // <Transforms>
             writer.WriteStartElement(Prefix, XmlSignatureConstants.Elements.Transforms, XmlSignatureConstants.Namespace);

--- a/src/Microsoft.IdentityModel.Xml/XmlSignatureConstants.cs
+++ b/src/Microsoft.IdentityModel.Xml/XmlSignatureConstants.cs
@@ -56,6 +56,10 @@ namespace Microsoft.IdentityModel.Xml
             public const string Nil = "nil";
             public const string PrefixList = "PrefixList";
             public const string Type = "Type";
+            /// <summary>
+            /// Lowercase type used for comliance with https://www.w3.org/TR/xmlschema-1/#xsi_type 
+            /// </summary>
+            public const string TypeLowerCase = "type";
             public const string URI = "URI";
         }
 

--- a/src/Microsoft.IdentityModel.Xml/XmlUtil.cs
+++ b/src/Microsoft.IdentityModel.Xml/XmlUtil.cs
@@ -190,7 +190,7 @@ namespace Microsoft.IdentityModel.Xml
             if (reader.NodeType != XmlNodeType.Element)
                 return null;
 
-            string xsiType = reader.GetAttribute(XmlSignatureConstants.Attributes.Type, XmlSignatureConstants.XmlSchemaNamespace);
+            string xsiType = reader.GetAttribute(XmlSignatureConstants.Attributes.TypeLowerCase, XmlSignatureConstants.XmlSchemaNamespace);
             if (string.IsNullOrEmpty(xsiType))
                 return null;
 


### PR DESCRIPTION
Changing XmlUtil.GetXsiTypeAsQualifiedName to retrieve the attribute as type instead of Type per the W3C XML schema recommendation.

Based on issue:
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1550

A bit concerned if this will have back-compat issues or not, not sure how to validate.
