### PR TITLE
Check if Exp and Nbf values exist.

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -994,8 +994,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
         private TokenValidationResult ValidateTokenPayload(JsonWebToken jsonWebToken, TokenValidationParameters validationParameters)
         {
-            var expires = jsonWebToken.ValidTo;
-            var notBefore = jsonWebToken.ValidFrom;
+            var expires = jsonWebToken.TryGetClaim(JwtRegisteredClaimNames.Exp, out var _) ? (DateTime?)jsonWebToken.ValidTo : null;
+            var notBefore = jsonWebToken.TryGetClaim(JwtRegisteredClaimNames.Nbf, out var _) ? (DateTime?)jsonWebToken.ValidFrom : null;
 
             Validators.ValidateLifetime(notBefore, expires, jsonWebToken, validationParameters);
             Validators.ValidateAudience(jsonWebToken.Audiences, jsonWebToken, validationParameters);

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -2040,6 +2040,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         {
             get
             {
+                var handlerWithNoDefaultTimes = new JsonWebTokenHandler();
+                handlerWithNoDefaultTimes.SetDefaultTimesOnTokenCreation = false;
                 return new TheoryData<JwtTheoryData>
                 {
                      new JwtTheoryData
@@ -2273,6 +2275,22 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             ValidateLifetime = false,
                             ValidAlgorithms = new List<string> { SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256, SecurityAlgorithms.HmacSha256Signature }
                         },
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = "JWS_NoExp",
+                        Token = handlerWithNoDefaultTimes.CreateToken(new SecurityTokenDescriptor
+                        {
+                            SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
+                            Claims = Default.PayloadDictionary.RemoveClaim(JwtRegisteredClaimNames.Exp)
+                        }),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key,
+                            ValidAudience = Default.Audience,
+                            ValidIssuer = Default.Issuer
+                        },
+                        ExpectedException = ExpectedException.SecurityTokenNoExpirationException("IDX10225:")
                     },
                     new JwtTheoryData
                     {

--- a/test/Microsoft.IdentityModel.TestUtils/Default.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/Default.cs
@@ -474,6 +474,12 @@ namespace Microsoft.IdentityModel.TestUtils
                 { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Default.Expires).ToString() }
             };
         }
+
+        public static Dictionary<string, object> RemoveClaim(this Dictionary<string, object> payloadClaims, string claimName)
+        {
+            payloadClaims.Remove(claimName);
+            return payloadClaims;
+        }
 #endif
 
 #if !CrossVersionTokenValidation


### PR DESCRIPTION
1. Instead of using JsonWebToken.Validto/ValidFrom in payload validation, adding logic to check for the presence of 'exp' and 'nbf' values in the token and returning the value accordingly. This means DateTime.MinValue will not be returned if these claims are absent.
2. Adding tests to verify if it throws when 'exp' claim is not present.