### PR TITLE
Restict RSACng tests to NET452, NET461, NET472

### DIFF
--- a/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
@@ -34,9 +34,10 @@ namespace Microsoft.IdentityModel.TestUtils
 {
     static public class KeyingMaterial
     {
+#if NET452 || NET461 || NET472
         static Type _rsaCngType = typeof(CngKey).Assembly.GetType("System.Security.Cryptography.RSACng", false);
         private static Lazy<object> _rsaCng = new Lazy<object>(CreateRSACng2048);
-
+#endif
         public static string AADJWKS { get => @"{""keys"":[{""kty"":""RSA"",""use"":""sig"",""kid"":""a3QN0BZS7s4nN-BdrjbF0Y_LdMM"",""x5t"":""a3QN0BZS7s4nN-BdrjbF0Y_LdMM"",""n"":""wESLNTU4mazfVL-vLuJq_8ggJhW1DYxE-EeFiSccia1TTeyBWTVfG5vgYPtHXmL1RYgZvNhIYppS0ZT2U_nnCt8ukONCMSBpeLh8TqZxkHBr2pzbaKzbcHpHrsoxxXLHINZ6L4g_ewqYJwxfshuyD65tlSm8obFdnbtiCoVM-oJPbOcPsrzVgp_L5JWDe5bp6lbXXjJnMKVNCVqum1i4Taa6PGNm3HtlSXBz0CFWLwJ6IvAY7XDNOal3-5y2md6vqhzffmu90mKQ2ZzVwUoIr7aKt7DVuBQke434skDTLmJVcq-iOIpnYiLtApefX1KyDUWgnfHY1YDTrBzQKeu4uw"",""e"":""AQAB"",""x5c"":[""MIIDBTCCAe2gAwIBAgIQY4RNIR0dX6dBZggnkhCRoDANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE3MDIxMzAwMDAwMFoXDTE5MDIxNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMBEizU1OJms31S/ry7iav/IICYVtQ2MRPhHhYknHImtU03sgVk1Xxub4GD7R15i9UWIGbzYSGKaUtGU9lP55wrfLpDjQjEgaXi4fE6mcZBwa9qc22is23B6R67KMcVyxyDWei+IP3sKmCcMX7Ibsg+ubZUpvKGxXZ27YgqFTPqCT2znD7K81YKfy+SVg3uW6epW114yZzClTQlarptYuE2mujxjZtx7ZUlwc9AhVi8CeiLwGO1wzTmpd/uctpner6oc335rvdJikNmc1cFKCK+2irew1bgUJHuN+LJA0y5iVXKvojiKZ2Ii7QKXn19Ssg1FoJ3x2NWA06wc0CnruLsCAwEAAaMhMB8wHQYDVR0OBBYEFDAr/HCMaGqmcDJa5oualVdWAEBEMA0GCSqGSIb3DQEBCwUAA4IBAQAiUke5mA86R/X4visjceUlv5jVzCn/SIq6Gm9/wCqtSxYvifRXxwNpQTOyvHhrY/IJLRUp2g9/fDELYd65t9Dp+N8SznhfB6/Cl7P7FRo99rIlj/q7JXa8UB/vLJPDlr+NREvAkMwUs1sDhL3kSuNBoxrbLC5Jo4es+juQLXd9HcRraE4U3UZVhUS2xqjFOfaGsCbJEqqkjihssruofaxdKT1CPzPMANfREFJznNzkpJt4H0aMDgVzq69NxZ7t1JiIuc43xRjeiixQMRGMi1mAB75fTyfFJ/rWQ5J/9kh0HMZVtHsqICBF1tHMTMIK5rwoweY0cuCIpN7A/zMOQtoD""]},{""kty"":""RSA"",""use"":""sig"",""kid"":""2S4SCVGs8Sg9LS6AqLIq6DpW-g8"",""x5t"":""2S4SCVGs8Sg9LS6AqLIq6DpW-g8"",""n"":""oZ-QQrNuB4ei9ATYrT61ebPtvwwYWnsrTpp4ISSp6niZYb92XM0oUTNgqd_C1vGN8J-y9wCbaJWkpBf46CjdZehrqczPhzhHau8WcRXocSB1u_tuZhv1ooAZ4bAcy79UkeLiG60HkuTNJJC8CfaTp1R97szBhuk0Vz5yt4r5SpfewIlBCnZUYwkDS172H9WapQu-3P2Qjh0l-JLyCkdrhvizZUk0atq5_AIDKRU-A0pRGc-EZhUL0LqUMz6c6M2s_4GnQaScv44A5iZUDD15B6e8Apb2yARohkWmOnmRcTVfes8EkfxjzZEzm3cNkvP0ogILyISHKlkzy2OmlU6iXw"",""e"":""AQAB"",""x5c"":[""MIIDKDCCAhCgAwIBAgIQBHJvVNxP1oZO4HYKh+rypDANBgkqhkiG9w0BAQsFADAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwHhcNMTYxMTE2MDgwMDAwWhcNMTgxMTE2MDgwMDAwWjAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQChn5BCs24Hh6L0BNitPrV5s+2/DBhaeytOmnghJKnqeJlhv3ZczShRM2Cp38LW8Y3wn7L3AJtolaSkF/joKN1l6GupzM+HOEdq7xZxFehxIHW7+25mG/WigBnhsBzLv1SR4uIbrQeS5M0kkLwJ9pOnVH3uzMGG6TRXPnK3ivlKl97AiUEKdlRjCQNLXvYf1ZqlC77c/ZCOHSX4kvIKR2uG+LNlSTRq2rn8AgMpFT4DSlEZz4RmFQvQupQzPpzozaz/gadBpJy/jgDmJlQMPXkHp7wClvbIBGiGRaY6eZFxNV96zwSR/GPNkTObdw2S8/SiAgvIhIcqWTPLY6aVTqJfAgMBAAGjWDBWMFQGA1UdAQRNMEuAEDUj0BrjP0RTbmoRPTRMY3WhJTAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXOCEARyb1TcT9aGTuB2Cofq8qQwDQYJKoZIhvcNAQELBQADggEBAGnLhDHVz2gLDiu9L34V3ro/6xZDiSWhGyHcGqky7UlzQH3pT5so8iF5P0WzYqVtogPsyC2LPJYSTt2vmQugD4xlu/wbvMFLcV0hmNoTKCF1QTVtEQiAiy0Aq+eoF7Al5fV1S3Sune0uQHimuUFHCmUuF190MLcHcdWnPAmzIc8fv7quRUUsExXmxSX2ktUYQXzqFyIOSnDCuWFm6tpfK5JXS8fW5bpqTlrysXXz/OW/8NFGq/alfjrya4ojrOYLpunGriEtNPwK7hxj1AlCYEWaRHRXaUIW1ByoSff/6Y6+ZhXPUe0cDlNRt/qIz5aflwO7+W8baTS4O8m/icu7ItE=""]}]}"; }
         public static JsonWebKeySet AADJsonWebKeySet { get => new JsonWebKeySet(AADJWKS); }
         public static string AADCertData { get => "MIIDBTCCAe2gAwIBAgIQY4RNIR0dX6dBZggnkhCRoDANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE3MDIxMzAwMDAwMFoXDTE5MDIxNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMBEizU1OJms31S/ry7iav/IICYVtQ2MRPhHhYknHImtU03sgVk1Xxub4GD7R15i9UWIGbzYSGKaUtGU9lP55wrfLpDjQjEgaXi4fE6mcZBwa9qc22is23B6R67KMcVyxyDWei+IP3sKmCcMX7Ibsg+ubZUpvKGxXZ27YgqFTPqCT2znD7K81YKfy+SVg3uW6epW114yZzClTQlarptYuE2mujxjZtx7ZUlwc9AhVi8CeiLwGO1wzTmpd/uctpner6oc335rvdJikNmc1cFKCK+2irew1bgUJHuN+LJA0y5iVXKvojiKZ2Ii7QKXn19Ssg1FoJ3x2NWA06wc0CnruLsCAwEAAaMhMB8wHQYDVR0OBBYEFDAr/HCMaGqmcDJa5oualVdWAEBEMA0GCSqGSIb3DQEBCwUAA4IBAQAiUke5mA86R/X4visjceUlv5jVzCn/SIq6Gm9/wCqtSxYvifRXxwNpQTOyvHhrY/IJLRUp2g9/fDELYd65t9Dp+N8SznhfB6/Cl7P7FRo99rIlj/q7JXa8UB/vLJPDlr+NREvAkMwUs1sDhL3kSuNBoxrbLC5Jo4es+juQLXd9HcRraE4U3UZVhUS2xqjFOfaGsCbJEqqkjihssruofaxdKT1CPzPMANfREFJznNzkpJt4H0aMDgVzq69NxZ7t1JiIuc43xRjeiixQMRGMi1mAB75fTyfFJ/rWQ5J/9kh0HMZVtHsqICBF1tHMTMIK5rwoweY0cuCIpN7A/zMOQtoD"; }
@@ -596,13 +597,14 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static RsaSecurityKey RsaSecurityKey_2048 => new RsaSecurityKey(RsaParameters_2048) { KeyId = "RsaSecurityKey_2048" };
 
+#if NET452 || NET461 || NET472
         public static RsaSecurityKey RsaSecurityKeyCng_2048 => new RsaSecurityKey(_rsaCng.Value as RSA) { KeyId = "RsaSecurityKeyRsaCng_2048" };
 
         private static object CreateRSACng2048()
         {
             return Activator.CreateInstance(_rsaCngType, 2048);
         }
-
+#endif
         public static SecurityKey DefaultRsaSecurityKey1
         {
             get

--- a/test/Microsoft.IdentityModel.Tokens.Tests/MultiThreadingTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/MultiThreadingTests.cs
@@ -124,22 +124,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
                 var jwtRsa = jwtSecurityTokenHandler.CreateEncodedJwt(securityTokenDescriptorRsa);
 
-                // RSACng
-                var securityTokenDescriptorRsaCng = new SecurityTokenDescriptor
-                {
-                    Claims = Default.PayloadDictionary,
-                    SigningCredentials = new SigningCredentials(KeyingMaterial.RsaSecurityKeyCng_2048, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256),
-                };
-
-                var tokenValidationParametersRsaCng = new TokenValidationParameters
-                {
-                    IssuerSigningKey = KeyingMaterial.RsaSecurityKeyCng_2048,
-                    ValidAudience = Default.Audience,
-                    ValidIssuer = Default.Issuer
-                };
-
-                var jwtRsaCng = jwtSecurityTokenHandler.CreateEncodedJwt(securityTokenDescriptorRsaCng);
-
                 // Symmetric
                 var securityTokenDescriptorSymmetric = new SecurityTokenDescriptor
                 {
@@ -174,6 +158,40 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
                 var jwtEncryptedRsaKW = jwtSecurityTokenHandler.CreateEncodedJwt(securityTokenDescriptorEncryptedRsaKW);
 
+                // Encrypted "dir"
+                var securityTokenDescriptorEncryptedDir = new SecurityTokenDescriptor
+                {
+                    Claims = Default.PayloadDictionary,
+                    SigningCredentials = new SigningCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256),
+                    EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.SymmetricSecurityKey2_256, "dir", SecurityAlgorithms.Aes128CbcHmacSha256)
+                };
+
+                var tokenValidationParametersEncryptedDir = new TokenValidationParameters
+                {
+                    TokenDecryptionKey = KeyingMaterial.SymmetricSecurityKey2_256,
+                    IssuerSigningKey = KeyingMaterial.RsaSecurityKey_2048,
+                    ValidAudience = Default.Audience,
+                    ValidIssuer = Default.Issuer
+                };
+
+                var jwtEncryptedDir = jwtSecurityTokenHandler.CreateEncodedJwt(securityTokenDescriptorEncryptedDir);
+
+#if NET452 || NET461 || NET472
+                // RSACng 
+                var securityTokenDescriptorRsaCng = new SecurityTokenDescriptor
+                {
+                    Claims = Default.PayloadDictionary,
+                    SigningCredentials = new SigningCredentials(KeyingMaterial.RsaSecurityKeyCng_2048, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256),
+                };
+
+                var tokenValidationParametersRsaCng = new TokenValidationParameters
+                {
+                    IssuerSigningKey = KeyingMaterial.RsaSecurityKeyCng_2048,
+                    ValidAudience = Default.Audience,
+                    ValidIssuer = Default.Issuer
+                };
+
+                var jwtRsaCng = jwtSecurityTokenHandler.CreateEncodedJwt(securityTokenDescriptorRsaCng);
                 // Encrypted "RSA keywrap"
                 // RsaSecurityKeyRsaKWCng_2048
                 var securityTokenDescriptorEncryptedRsaKWCng = new SecurityTokenDescriptor
@@ -192,24 +210,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 };
 
                 var jwtEncryptedRsaKWCng = jwtSecurityTokenHandler.CreateEncodedJwt(securityTokenDescriptorEncryptedRsaKWCng);
-
-                // Encrypted "dir"
-                var securityTokenDescriptorEncryptedDir = new SecurityTokenDescriptor
-                {
-                    Claims = Default.PayloadDictionary,
-                    SigningCredentials = new SigningCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256),
-                    EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.SymmetricSecurityKey2_256, "dir", SecurityAlgorithms.Aes128CbcHmacSha256)
-                };
-
-                var tokenValidationParametersEncryptedDir = new TokenValidationParameters
-                {
-                    TokenDecryptionKey = KeyingMaterial.SymmetricSecurityKey2_256,
-                    IssuerSigningKey = KeyingMaterial.RsaSecurityKey_2048,
-                    ValidAudience = Default.Audience,
-                    ValidIssuer = Default.Issuer
-                };
-
-                var jwtEncryptedDir = jwtSecurityTokenHandler.CreateEncodedJwt(securityTokenDescriptorEncryptedDir);
+#endif
 
                 return new TheoryData<MultiThreadingTheoryData>()
                 {
@@ -235,15 +236,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     {
                         JwtSecurityTokenHandler = jwtSecurityTokenHandler,
                         JsonWebTokenHandler = jsonWebTokenHandler,
-                        Jwt = jwtRsaCng,
-                        TestId = "JwtRsaCng",
-                        TokenDescriptor = securityTokenDescriptorRsaCng,
-                        ValidationParameters = tokenValidationParametersRsaCng
-                    },
-                    new MultiThreadingTheoryData
-                    {
-                        JwtSecurityTokenHandler = jwtSecurityTokenHandler,
-                        JsonWebTokenHandler = jsonWebTokenHandler,
                         Jwt = jwtEcd,
                         TestId = "JwtEcd",
                         TokenDescriptor = securityTokenDescriptorEcd,
@@ -262,20 +254,31 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     {
                         JwtSecurityTokenHandler = jwtSecurityTokenHandler,
                         JsonWebTokenHandler = jsonWebTokenHandler,
-                        Jwt = jwtEncryptedRsaKWCng,
-                        TestId = "JwtRsaEncryptedRsaKWCng",
-                        TokenDescriptor = securityTokenDescriptorEncryptedRsaKWCng,
-                        ValidationParameters = tokenValidationParametersEncryptedRsaKWCng
-                    },
-                    new MultiThreadingTheoryData
-                    {
-                        JwtSecurityTokenHandler = jwtSecurityTokenHandler,
-                        JsonWebTokenHandler = jsonWebTokenHandler,
                         Jwt = jwtEncryptedDir,
                         TestId = "JwtRsaEncryptedDir",
                         TokenDescriptor = securityTokenDescriptorEncryptedDir,
                         ValidationParameters = tokenValidationParametersEncryptedDir
                     },
+#if NET452 || NET461 || NET472
+                    new MultiThreadingTheoryData
+                    {
+                        JwtSecurityTokenHandler = jwtSecurityTokenHandler,
+                        JsonWebTokenHandler = jsonWebTokenHandler,
+                        Jwt = jwtRsaCng,
+                        TestId = "JwtRsaCng",
+                        TokenDescriptor = securityTokenDescriptorRsaCng,
+                        ValidationParameters = tokenValidationParametersRsaCng
+                    },
+                    new MultiThreadingTheoryData
+                    {
+                        JwtSecurityTokenHandler = jwtSecurityTokenHandler,
+                        JsonWebTokenHandler = jsonWebTokenHandler,
+                        Jwt = jwtEncryptedRsaKWCng,
+                        TestId = "JwtRsaEncryptedRsaKWCng",
+                        TokenDescriptor = securityTokenDescriptorEncryptedRsaKWCng,
+                        ValidationParameters = tokenValidationParametersEncryptedRsaKWCng
+                    },
+#endif
                 };
             }
         }


### PR DESCRIPTION
Core does note need these tests and they will cause errors on Linux and MAC builds.