### PR TITLE
Adding the IDisposable interface to ECDsaSecurityKey, RsaSecurityKey and X509SecurityKey

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/ECDsaSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ECDsaSecurityKey.cs
@@ -34,8 +34,9 @@ namespace Microsoft.IdentityModel.Tokens
     /// <summary>
     /// Represents a ECDsa security key.
     /// </summary>
-    public class ECDsaSecurityKey : AsymmetricSecurityKey
+    public class ECDsaSecurityKey : AsymmetricSecurityKey, IDisposable
     {
+        private bool _disposed = false;
         private bool? _hasPrivateKey;
 
         internal ECDsaSecurityKey(JsonWebKey webKey, bool usePrivateKey)
@@ -139,6 +140,31 @@ namespace Microsoft.IdentityModel.Tokens
             }
 #endif
             throw LogHelper.LogExceptionMessage(new PlatformNotSupportedException(LogMessages.IDX10695));
+        }
+
+        /// <summary>
+        /// Calls <see cref="Dispose(bool)"/> and <see cref="GC.SuppressFinalize"/>
+        /// </summary>
+        public void Dispose()
+        {
+            // Dispose of unmanaged resources.
+            Dispose(true);
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// If <paramref name="disposing"/> is true, this method disposes of <see cref="ECDsa"/>.
+        /// </summary>
+        /// <param name="disposing">True if called from the <see cref="Dispose()"/> method, false otherwise.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            if (disposing)
+                ECDsa.Dispose();           
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/RsaSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaSecurityKey.cs
@@ -34,13 +34,15 @@ namespace Microsoft.IdentityModel.Tokens
     /// <summary>
     /// Represents a Rsa security key.
     /// </summary>
-    public class RsaSecurityKey : AsymmetricSecurityKey
+    public class RsaSecurityKey : AsymmetricSecurityKey, IDisposable
     {
-        private bool? _hasPrivateKey;
+        private bool _disposed = false;
 
         private bool _foundPrivateKeyDetermined = false;
 
         private PrivateKeyStatus _foundPrivateKey;
+
+        private bool? _hasPrivateKey;
 
         internal RsaSecurityKey(JsonWebKey webKey)
             : base(webKey)
@@ -210,6 +212,31 @@ namespace Microsoft.IdentityModel.Tokens
 
             var canonicalJwk = $@"{{""{JsonWebKeyParameterNames.E}"":""{Base64UrlEncoder.Encode(rsaParameters.Exponent)}"",""{JsonWebKeyParameterNames.Kty}"":""{JsonWebAlgorithmsKeyTypes.RSA}"",""{JsonWebKeyParameterNames.N}"":""{Base64UrlEncoder.Encode(rsaParameters.Modulus)}""}}";
             return Utility.GenerateSha256Hash(canonicalJwk);
+        }
+
+        /// <summary>
+        /// Calls <see cref="Dispose(bool)"/> and <see cref="GC.SuppressFinalize"/>
+        /// </summary>
+        public void Dispose()
+        {
+            // Dispose of unmanaged resources.
+            Dispose(true);
+            // Suppress finalization.
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// If <paramref name="disposing"/> is true and <see cref="Rsa"/> != null, this method disposes of <see cref="Rsa"/>.
+        /// </summary>
+        /// <param name="disposing">True if called from the <see cref="Dispose()"/> method, false otherwise.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            if (disposing && Rsa != null)
+                Rsa.Dispose();
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ECDsaSecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ECDsaSecurityKeyTests.cs
@@ -39,7 +39,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         [Fact]
         public void Constructor()
         {
-
             // testing constructor that takes ECDsa instance
             ECDsaSecurityKeyConstructorWithEcdsa(null, ExpectedException.ArgumentNullException("ecdsa"));
 #if !NET_CORE
@@ -80,7 +79,39 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Assert.False(KeyingMaterial.Ecdsa256Key.CanComputeJwkThumbprint(), "ECDsaSecurityKey shouldn't be able to compute JWK thumbprint on Desktop (net452 and net461 targets).");
 #endif
         }
+
+        /// <summary>
+        /// Checks that the Dispose() method is properly called on the ECDsaSecurityKey.
+        [Fact]
+        public void ECDsaSecurityKeyDispose()
+        {
+            TestUtilities.WriteHeader($"{this}.ECDsaSecurityKeyDispose");
+            var context = new CompareContext();
+#if !NET_CORE
+            var ecdsa = new ECDsaCng();
+#elif NET_CORE
+            var ecdsa = ECDsa.Create();
+#endif
+            var ecdsaSecurityKey = new ECDsaSecurityKeyMock(ecdsa);
+            ecdsaSecurityKey.Dispose();
+            if (!ecdsaSecurityKey.DisposeCalled)
+                context.AddDiff("ECDsaSecurityKeyMock was not properly disposed of.");
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+    }
+
+    public class ECDsaSecurityKeyMock : ECDsaSecurityKey
+    {
+        public bool DisposeCalled { get; set; } = false;
+
+        public ECDsaSecurityKeyMock(ECDsa ecdsa) : base(ecdsa) { }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCalled = true;
+            base.Dispose(disposing);
+        }
     }
 }
-
 #pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaSecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaSecurityKeyTests.cs
@@ -61,6 +61,27 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 #endif
         }
 
+        /// <summary>
+        /// Checks that the Dispose() method is properly called on the RsaSecurityKey.
+        [Fact]
+        public void RsaSecurityKeyDispose()
+        {
+            TestUtilities.WriteHeader($"{this}.RsaSecurityKeyDispose");
+            var context = new CompareContext();
+#if NET_CORE
+                var adHocRsa = RSA.Create();
+                adHocRsa.KeySize = 2048;
+#else
+            var adHocRsa = new RSACryptoServiceProvider(2048);
+#endif
+            var adHocRsaSecurityKey = new RsaSecurityKeyMock(adHocRsa);
+            adHocRsaSecurityKey.Dispose();
+            if (!adHocRsaSecurityKey.DisposeCalled)
+                context.AddDiff("RsaSecurityKeyMock was not properly disposed of.");
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
         private void RsaSecurityKeyConstructor(RSAParameters parameters, ExpectedException ee)
         {
             try
@@ -169,6 +190,19 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         public void CanComputeJwkThumbprint()
         {
             Assert.True(KeyingMaterial.DefaultRsaSecurityKey1.CanComputeJwkThumbprint(), "Couldn't compute JWK thumbprint on an RSASecurityKey.");
+        }
+    }
+
+    public class RsaSecurityKeyMock : RsaSecurityKey
+    {
+        public bool DisposeCalled { get; set; } = false;
+
+        public RsaSecurityKeyMock(RSA rsa) : base(rsa) { }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCalled = true;
+            base.Dispose(disposing);
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/X509SecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/X509SecurityKeyTests.cs
@@ -106,6 +106,22 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             Assert.True(KeyingMaterial.DefaultX509Key_2048.CanComputeJwkThumbprint(), "Couldn't compute JWK thumbprint on an X509SecurityKey.");
         }
+
+        /// <summary>
+        /// Checks that the Dispose() method is properly called on the X509SecurityKey.
+        [Fact]
+        public void X509SecurityKeyDispose()
+        {
+            TestUtilities.WriteHeader($"{this}.X509SecurityKeyDispose");
+            var context = new CompareContext();
+
+            var x509SecurityKey = new X509SecurityKeyMock(KeyingMaterial.DefaultCert_2048);
+            x509SecurityKey.Dispose();
+            if (!x509SecurityKey.DisposeCalled)
+                context.AddDiff("X509SecurityKeyMock was not properly disposed of.");
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
     }
 
     public class X509SecurityKeyTheoryData : TheoryDataBase
@@ -133,6 +149,18 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         public X509Certificate X509Certificate { get; set; }
 
         public X509SecurityKey X509SecurityKey { get; set; }
+    }
+    public class X509SecurityKeyMock : X509SecurityKey
+    {
+        public bool DisposeCalled { get; set; } = false;
+
+        public X509SecurityKeyMock(X509Certificate2 certificate) : base(certificate) { }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCalled = true;
+            base.Dispose(disposing);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1434.

One of the points brought up in the issue mentioned above is that we should avoid caching and retrieving signature providers that have been disposed of. I've made a note to handle this in the caching PR (https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/1575).