### PR TITLE
Removing references to Microsoft.Extensions.Caching.Memory from the netstandard2.0 target

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,6 +1,5 @@
 <Project>
   <PropertyGroup>
-    <CachingVersion>2.1.1</CachingVersion>
     <MicrosoftAzureKeyVaultVersion>3.0.5</MicrosoftAzureKeyVaultVersion>
     <MicrosoftAzureServicesAppAuthenticationVersion>1.0.3</MicrosoftAzureServicesAppAuthenticationVersion>
     <MicrosoftCSharpVersion>4.5.0</MicrosoftCSharpVersion>

--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderCacheOptions.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderCacheOptions.cs
@@ -32,13 +32,8 @@ namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
     /// Specifies the CryptoProviderCacheOptions which can be used to configure the internal cryptoprovider cache.
-    /// For the netstandard2.0 target we are using the Microsoft.Extensions.Caching.Memory.MemoryCache class:
-    /// https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.caching.memory.memorycache
-    /// For the net45, net461, and net472 desktop targets we are using our own simple LRU caching implementation.
+    /// We are using our own simple LRU caching implementation across all targets. 
     /// See <see cref="EventBasedLRUCache{TKey, TValue}"/> for more details.
-    /// We recommend upgrading to netstandard2.0 for a more comprehensive caching experience.
-    /// Any property on these CryptoProviderCacheOptions that corresponds directly to a property 
-    /// used by Microsoft.Extensions.Caching.Memory.MemoryCache has the same name.
     /// </summary>
     public class CryptoProviderCacheOptions
     {
@@ -52,12 +47,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Gets or sets the size of the cache (in number of items). 
         /// 20% of the cache will be evicted whenever the cache gets to 95% of this size.
-        /// On the netstandard2.0 target, items will be evicted in the following order:
-        /// 1) All expired items.
-        /// 2) Least recently used items.
-        /// 3) Items with the earliest absolute expiration.
-        /// On the net45, net461, and net472 targets, only #2 (least recently used items) will be
-        /// taken into consideration.
+        /// Items will be evicted from least recently used to most recently used.
         /// </summary>
         public int SizeLimit
         {

--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -29,7 +29,6 @@ using System;
 using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Security.Cryptography;
-using System.Threading;
 using Microsoft.IdentityModel.Logging;
 
 namespace Microsoft.IdentityModel.Tokens

--- a/src/Microsoft.IdentityModel.Tokens/EventBasedLRUCache.cs
+++ b/src/Microsoft.IdentityModel.Tokens/EventBasedLRUCache.cs
@@ -43,6 +43,8 @@ namespace Microsoft.IdentityModel.Tokens
     /// the map is a <see cref="ConcurrentDictionary{TKey, TValue}"/> which may be modified directly inside an API call or
     /// through eventual processing of the event queue. This implementation relies on the principle of 'eventual consistency':
     /// though the map and it's corresponding linked list may be out of sync at any given point in time, they will eventually line up.
+    /// See here for more details:
+    /// https://aka.ms/identitymodel/caching
     /// </summary>
     /// <typeparam name="TKey">The key type to be used by the cache.</typeparam>
     /// <typeparam name="TValue">The value type to be used by the cache</typeparam>

--- a/src/Microsoft.IdentityModel.Tokens/Microsoft.IdentityModel.Tokens.csproj
+++ b/src/Microsoft.IdentityModel.Tokens/Microsoft.IdentityModel.Tokens.csproj
@@ -36,7 +36,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.CSharp" Version="$(MicrosoftCSharpVersion)" />
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(CachingVersion)" /> 
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
@@ -1495,11 +1495,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(validator, SecurityAlgorithms.ExclusiveC14nWithComments, customHashAlgorithm.GetType(), ExpectedException.NoExceptionExpected);
 
-#if NETCOREAPP
-                var cryptoProviderFactory = new CryptoProviderFactory();
-#else
                 var cryptoProviderFactory = new CryptoProviderFactory(new InMemoryCryptoProviderCache(new CryptoProviderCacheOptions(), TaskCreationOptions.None, 50));
-#endif
 
                 // Default CryptoProviderFactory faults on this 'hash' algorithm
                 validator = new OpenIdConnectProtocolValidator()

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestE2ETests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestE2ETests.cs
@@ -47,11 +47,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
     {
         public static Func<CryptoProviderFactory> CreateCryptoProviderFactory = new Func<CryptoProviderFactory>(() =>
         {
-#if NETCOREAPP
-            return new CryptoProviderFactory();
-#else
             return new CryptoProviderFactory(new InMemoryCryptoProviderCache(new CryptoProviderCacheOptions(), TaskCreationOptions.None, 50));
-#endif
         });
 
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderCacheTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderCacheTests.cs
@@ -44,11 +44,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     {
         public static Func<CryptoProviderCache> CreateCacheForTesting = new Func<CryptoProviderCache>(() =>
         {
-#if NETCOREAPP
-            return new InMemoryCryptoProviderCache();
-#else
             return new InMemoryCryptoProviderCache(new CryptoProviderCacheOptions(), TaskCreationOptions.None, 50);
-#endif
         });
 
         [Fact]
@@ -658,14 +654,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
     public class InMemoryCryptoProviderCachePublic : InMemoryCryptoProviderCache
     {
-#if NETCOREAPP
-        public InMemoryCryptoProviderCachePublic() : base()
-        {}
-
-#elif NET452 || NET461 || NET472
         public InMemoryCryptoProviderCachePublic() : base(new CryptoProviderCacheOptions(), TaskCreationOptions.None, 50)
         {}
-#endif
 
         public bool DisposeCalled { get; set; } = false;
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CustomCryptoProviders.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CustomCryptoProviders.cs
@@ -125,16 +125,9 @@ namespace Microsoft.IdentityModel.TestUtils
 
     public class CustomCryptoProviderFactory : CryptoProviderFactory
     {
-
-#if NETCOREAPP
-        public CustomCryptoProviderFactory()
-        {
-        }
-#else
         public CustomCryptoProviderFactory() : base(new InMemoryCryptoProviderCache(new CryptoProviderCacheOptions(), TaskCreationOptions.None, 50))
         {
         }
-#endif
 
         public CustomCryptoProviderFactory(ICryptoProvider cryptoProvider)
         {

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
@@ -348,11 +348,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             var handler = new JwtSecurityTokenHandler();
             var asymmetricSecurityTokenDescriptor = Default.AsymmetricSignSecurityTokenDescriptor(null);
 
-#if NETCOREAPP
-            var cache = new InMemoryCryptoProviderCache();
-#else
             var cache = new InMemoryCryptoProviderCache(new CryptoProviderCacheOptions(), TaskCreationOptions.None, 50);
-#endif
 
             var cryptorProviderFactory = new CryptoProviderFactory(cache);
             asymmetricSecurityTokenDescriptor.SigningCredentials.CryptoProviderFactory = cryptorProviderFactory;


### PR DESCRIPTION
The results of the performance tests have shown that our EventBasedLRUCache only differs 1% or 2% from the Microsoft.Extensions.Caching.Memory.MemoryCache. Because of this, we've decided that we can just use the EventBasedLRUCache across all targets.