### PR TITLE
Add deterministic to CI build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -138,10 +138,10 @@ CreateArtifactsRoot($artifactsRoot);
 pushd
 Set-Location $root
 Write-Host ""
-Write-Host ">>> Start-Process -wait -NoNewWindow $msbuildexe /restore:True /p:UseSharedCompilation=false /nr:false /verbosity:m /p:Configuration=$buildType /p:RunApiCompat=$runApiCompat $slnFile"
+Write-Host ">>> Start-Process -wait -NoNewWindow $msbuildexe /restore:True /p:ContinuousIntegrationBuild=true /p:UseSharedCompilation=false /nr:false /verbosity:m /p:Configuration=$buildType /p:RunApiCompat=$runApiCompat $slnFile"
 Write-Host ""
 Write-Host "msbuildexe: " $msbuildexe
-$p = Start-Process -Wait -PassThru -NoNewWindow $msbuildexe "/r:True /p:UseSharedCompilation=false /nr:false /verbosity:m /p:Configuration=$buildType /p:RunApiCompat=$runApiCompat $slnFile"
+$p = Start-Process -Wait -PassThru -NoNewWindow $msbuildexe "/r:True /p:ContinuousIntegrationBuild=true /p:UseSharedCompilation=false /nr:false /verbosity:m /p:Configuration=$buildType /p:RunApiCompat=$runApiCompat $slnFile"
 
 if($p.ExitCode -ne 0)
 {


### PR DESCRIPTION
Get deterministic builds to work:
add the /p:ContinuousIntegrationBuild=true argument to the msbuild command.
This PR is for test only, need add it to MSBuild arguments during build step
