### PR TITLE
Remove wait on first force refresh

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -67,6 +67,7 @@ namespace Microsoft.IdentityModel.Protocols
         private DateTimeOffset _syncAfter = DateTimeOffset.MinValue;
         private DateTimeOffset _lastRefresh = DateTimeOffset.MinValue;
         private DateTimeOffset _lastForceRefresh = DateTimeOffset.MinValue;
+        private Random _jitterer = new Random();
 
         private readonly SemaphoreSlim _refreshLock;
         private readonly string _metadataAddress;
@@ -229,7 +230,8 @@ namespace Microsoft.IdentityModel.Protocols
         public void RequestRefresh()
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;
-            if (now >= DateTimeUtil.Add(_lastForceRefresh.UtcDateTime, RefreshInterval))
+            var jitter = new TimeSpan((long)(RefreshInterval.Ticks * _jitterer.Next(0, 100) * 0.01));
+            if (now >= DateTimeUtil.Add(_lastForceRefresh.UtcDateTime, RefreshInterval.Add(jitter)))
             {
                 _syncAfter = now;
                 _lastForceRefresh = now;

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -66,6 +66,7 @@ namespace Microsoft.IdentityModel.Protocols
         private TimeSpan _refreshInterval = DefaultRefreshInterval;
         private DateTimeOffset _syncAfter = DateTimeOffset.MinValue;
         private DateTimeOffset _lastRefresh = DateTimeOffset.MinValue;
+        private DateTimeOffset _lastForceRefresh = DateTimeOffset.MinValue;
 
         private readonly SemaphoreSlim _refreshLock;
         private readonly string _metadataAddress;
@@ -222,15 +223,16 @@ namespace Microsoft.IdentityModel.Protocols
 
         /// <summary>
         /// Requests that then next call to <see cref="GetConfigurationAsync()"/> obtain new configuration.
-        /// <para>If the last refresh was greater than <see cref="RefreshInterval"/> then the next call to <see cref="GetConfigurationAsync()"/> will retrieve new configuration.</para>
+        /// <para>If the last force refresh was greater than <see cref="RefreshInterval"/> then the next call to <see cref="GetConfigurationAsync()"/> will retrieve new configuration.</para>
         /// <para>If <see cref="RefreshInterval"/> == <see cref="TimeSpan.MaxValue"/> then this method does nothing.</para>
         /// </summary>
         public void RequestRefresh()
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;
-            if (now >= DateTimeUtil.Add(_lastRefresh.UtcDateTime, RefreshInterval))
+            if (now >= DateTimeUtil.Add(_lastForceRefresh.UtcDateTime, RefreshInterval))
             {
                 _syncAfter = now;
+                _lastForceRefresh = now;
             }
         }
     }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -195,7 +195,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 context.Diffs.Add("!object.ReferenceEquals(configuration2, configuration3) (5)");
             // Next force refresh should pickup config since, RefreshInterval is set to 1s
             configManager.RefreshInterval = TimeSpan.FromSeconds(1);
-            Thread.Sleep(1000);
+            Thread.Sleep(2000);
             configManager.RequestRefresh();
             var configuration4 = configManager.GetConfigurationAsync().Result;
             if (IdentityComparer.AreEqual(configuration2, configuration4))

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
             TestUtilities.SetField(configManager, "_automaticRefreshInterval", TimeSpan.FromMilliseconds(1));
             configuration = configManager.GetConfigurationAsync().Result;
-            TestUtilities.SetField(configManager, "_lastForceRefresh", DateTimeOffset.UtcNow - TimeSpan.FromHours(1));
+            TestUtilities.SetField(configManager, "_lastRefresh", DateTimeOffset.UtcNow - TimeSpan.FromHours(1));
             TestUtilities.SetField(configManager, "_metadataAddress", "OpenIdConnectMetadata2.json");
             configManager.RequestRefresh();
             configuration2 = configManager.GetConfigurationAsync().Result;
@@ -206,7 +206,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             // Refresh should force pickup of new config
             configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
             configuration = configManager.GetConfigurationAsync().Result;
-            TestUtilities.SetField(configManager, "_lastForceRefresh", DateTimeOffset.UtcNow - TimeSpan.FromHours(1));
+            TestUtilities.SetField(configManager, "_lastRefresh", DateTimeOffset.UtcNow - TimeSpan.FromHours(1));
             configManager.RequestRefresh();
             TestUtilities.SetField(configManager, "_metadataAddress", "OpenIdConnectMetadata2.json");
             configuration2 = configManager.GetConfigurationAsync().Result;
@@ -286,7 +286,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             // Unable to obtain a new configuration, but _currentConfiguration is not null so it should be returned.
             configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
             configuration = configManager.GetConfigurationAsync().Result;
-            TestUtilities.SetField(configManager, "_lastForceRefresh", DateTimeOffset.UtcNow - TimeSpan.FromHours(1));
+            TestUtilities.SetField(configManager, "_lastRefresh", DateTimeOffset.UtcNow - TimeSpan.FromHours(1));
             configManager.RequestRefresh();
             TestUtilities.SetField(configManager, "_metadataAddress", "http://someaddress.com");
             configuration2 = configManager.GetConfigurationAsync().Result;

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -124,7 +124,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             {
                 PropertyNamesAndSetGetValue = new List<KeyValuePair<string, List<object>>>
                 {
-                    new KeyValuePair<string, List<object>>("AutomaticRefreshInterval", new List<object>{defaultAutomaticRefreshInterval, TimeSpan.FromHours(1), TimeSpan.FromHours(10)}),
                     new KeyValuePair<string, List<object>>("RefreshInterval", new List<object>{defaultRefreshInterval, TimeSpan.FromHours(1), TimeSpan.FromHours(10)}),
                 },
                 Object = configManager,
@@ -195,7 +194,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 context.Diffs.Add("!object.ReferenceEquals(configuration2, configuration3) (5)");
             // Next force refresh should pickup config since, RefreshInterval is set to 1s
             configManager.RefreshInterval = TimeSpan.FromSeconds(1);
-            Thread.Sleep(2000);
+            Thread.Sleep(1000);
             configManager.RequestRefresh();
             var configuration4 = configManager.GetConfigurationAsync().Result;
             if (IdentityComparer.AreEqual(configuration2, configuration4))


### PR DESCRIPTION
If RequestRefresh call is made for the first time, the next call to GetConfigurationAsync() will obtain new configuration, all the subsequent calls to RequestRefresh will have to wait for RefreshInterval(5mins) to pass.