### PR TITLE
Fix double instantiation of Uri in IsHttps()

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Utility.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Utility.cs
@@ -118,7 +118,7 @@ namespace Microsoft.IdentityModel.Tokens
             try
             {
                 Uri uri = new Uri(address);
-                return IsHttps(new Uri(address));
+                return IsHttps(uri);
             }
             catch (UriFormatException)
             {


### PR DESCRIPTION
Uri instance is created two times from the address.