### PR TITLE
Adding BaseConfigurationManager and BaseConfiguration classes in M.IM.Tokens

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfiguration.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfiguration.cs
@@ -39,7 +39,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
     /// Contains OpenIdConnect configuration that can be populated from a json string.
     /// </summary>
     [JsonObject]
-    public class OpenIdConnectConfiguration
+    public class OpenIdConnectConfiguration : BaseConfiguration
     {
         /// <summary>
         /// Deserializes the json string into an <see cref="OpenIdConnectConfiguration"/> object.
@@ -224,7 +224,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         /// Gets or sets the 'issuer'.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore, PropertyName = OpenIdProviderMetadataNames.Issuer, Required = Required.Default)]
-        public string Issuer { get; set; }
+        public override string Issuer { get; set; }
 
         /// <summary>
         /// Gets or sets the 'jwks_uri'
@@ -325,7 +325,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         /// Gets the <see cref="ICollection{SecurityKey}"/> that the IdentityProvider indicates are to be used signing tokens.
         /// </summary>
         [JsonIgnore]
-        public ICollection<SecurityKey> SigningKeys { get; } = new Collection<SecurityKey>();
+        public override ICollection<SecurityKey> SigningKeys { get; } = new Collection<SecurityKey>();
 
         /// <summary>
         /// Gets the collection of 'subject_types_supported'.

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -40,31 +40,8 @@ namespace Microsoft.IdentityModel.Protocols
     /// </summary>
     /// <typeparam name="T">The type of <see cref="IDocumentRetriever"/>.</typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable")]
-    public class ConfigurationManager<T> : IConfigurationManager<T> where T : class
+    public class ConfigurationManager<T> : BaseConfigurationManager, IConfigurationManager<T> where T : class
     {
-        /// <summary>
-        /// 12 hours is the default time interval that afterwards, <see cref="GetConfigurationAsync()"/> will obtain new configuration.
-        /// </summary>
-        public static readonly TimeSpan DefaultAutomaticRefreshInterval = new TimeSpan(0, 12, 0, 0);
-
-        /// <summary>
-        /// 5 minutes is the default time interval that must pass for <see cref="RequestRefresh"/> to obtain a new configuration.
-        /// </summary>
-        public static readonly TimeSpan DefaultRefreshInterval = new TimeSpan(0, 0, 5, 0);
-
-        /// <summary>
-        /// 5 minutes is the minimum value for automatic refresh. <see cref="AutomaticRefreshInterval"/> can not be set less than this value.
-        /// </summary>
-        public static readonly TimeSpan MinimumAutomaticRefreshInterval = new TimeSpan(0, 0, 5, 0);
-
-        /// <summary>
-        /// 1 second is the minimum time interval that must pass for <see cref="RequestRefresh"/> to obtain new configuration.
-        /// </summary>
-        public static readonly TimeSpan MinimumRefreshInterval = new TimeSpan(0, 0, 0, 1);
-
-        private static TimeSpan _jitter = new TimeSpan(0,1,0,0);
-        private TimeSpan _automaticRefreshInterval = DefaultAutomaticRefreshInterval.Add(TimeSpan.FromMinutes(new Random().Next((int)_jitter.TotalMinutes)));
-        private TimeSpan _refreshInterval = DefaultRefreshInterval;
         private DateTimeOffset _syncAfter = DateTimeOffset.MinValue;
         private DateTimeOffset _lastRefresh = DateTimeOffset.MinValue;
         private bool _isFirstRefreshRequest = true;
@@ -73,7 +50,6 @@ namespace Microsoft.IdentityModel.Protocols
         private readonly string _metadataAddress;
         private readonly IDocumentRetriever _docRetriever;
         private readonly IConfigurationRetriever<T> _configRetriever;
-        private T _currentConfiguration;
 
         /// <summary>
         /// Static initializer for a new object. Static initializers run before the first instance of the type is created.
@@ -131,40 +107,10 @@ namespace Microsoft.IdentityModel.Protocols
         }
 
         /// <summary>
-        /// Gets or sets the <see cref="TimeSpan"/> that controls how often an automatic metadata refresh should occur.
-        /// </summary>
-        public TimeSpan AutomaticRefreshInterval
-        {
-            get { return _automaticRefreshInterval; }
-            set
-            {
-                if (value < MinimumAutomaticRefreshInterval)
-                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant(LogMessages.IDX20107, MinimumAutomaticRefreshInterval, value)));
-
-                _automaticRefreshInterval = value;
-            }
-        }
-
-        /// <summary>
-        /// The minimum time between retrievals, in the event that a retrieval failed, or that a refresh was explicitly requested.
-        /// </summary>
-        public TimeSpan RefreshInterval
-        {
-            get { return _refreshInterval; }
-            set
-            {
-                if (value < MinimumRefreshInterval)
-                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant(LogMessages.IDX20106, MinimumRefreshInterval, value)));
-
-                _refreshInterval = value;
-            }
-        }
-
-        /// <summary>
         /// Obtains an updated version of Configuration.
         /// </summary>
         /// <returns>Configuration of type T.</returns>
-        /// <remarks>If the time since the last call is less than <see cref="AutomaticRefreshInterval"/> then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.</remarks>
+        /// <remarks>If the time since the last call is less than <see cref="BaseConfigurationManager.AutomaticRefreshInterval"/> then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.</remarks>
         public async Task<T> GetConfigurationAsync()
         {
             return await GetConfigurationAsync(CancellationToken.None).ConfigureAwait(false);
@@ -175,13 +121,24 @@ namespace Microsoft.IdentityModel.Protocols
         /// </summary>
         /// <param name="cancel">CancellationToken</param>
         /// <returns>Configuration of type T.</returns>
-        /// <remarks>If the time since the last call is less than <see cref="AutomaticRefreshInterval"/> then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.</remarks>
+        /// <remarks>If the time since the last call is less than <see cref="BaseConfigurationManager.AutomaticRefreshInterval"/> then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.</remarks>
         public async Task<T> GetConfigurationAsync(CancellationToken cancel)
         {
+            return await GetBaseConfigurationAsync(cancel).ConfigureAwait(false) as T;
+        }
+
+        /// <summary>
+        /// Obtains an updated version of Configuration.
+        /// </summary>
+        /// <param name="cancel">CancellationToken</param>
+        /// <returns>Configuration of type StandardConfiguration.</returns>
+        /// <remarks>If the time since the last call is less than <see cref="BaseConfigurationManager.AutomaticRefreshInterval"/> then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.</remarks>
+        public override async Task<BaseConfiguration> GetBaseConfigurationAsync(CancellationToken cancel)
+        {
             DateTimeOffset now = DateTimeOffset.UtcNow;
-            if (_currentConfiguration != null && _syncAfter > now)
+            if (CurrentConfiguration != null && _syncAfter > now)
             {
-                return _currentConfiguration;
+                return CurrentConfiguration;
             }
 
             await _refreshLock.WaitAsync(cancel).ConfigureAwait(false);
@@ -193,15 +150,15 @@ namespace Microsoft.IdentityModel.Protocols
                     {
                         // Don't use the individual CT here, this is a shared operation that shouldn't be affected by an individual's cancellation.
                         // The transport should have it's own timeouts, etc..
-                        _currentConfiguration = await _configRetriever.GetConfigurationAsync(_metadataAddress, _docRetriever, CancellationToken.None).ConfigureAwait(false);
-                        Contract.Assert(_currentConfiguration != null);
+                        CurrentConfiguration = await _configRetriever.GetConfigurationAsync(_metadataAddress, _docRetriever, CancellationToken.None).ConfigureAwait(false) as BaseConfiguration;
+                        Contract.Assert(CurrentConfiguration != null);
                         _lastRefresh = now;
-                        _syncAfter = DateTimeUtil.Add(now.UtcDateTime, _automaticRefreshInterval);
+                        _syncAfter = DateTimeUtil.Add(now.UtcDateTime, AutomaticRefreshInterval);
                     }
                     catch (Exception ex)
                     {
-                        _syncAfter = DateTimeUtil.Add(now.UtcDateTime, _automaticRefreshInterval < _refreshInterval ? _automaticRefreshInterval : _refreshInterval);
-                        if (_currentConfiguration == null) // Throw an exception if there's no configuration to return.
+                        _syncAfter = DateTimeUtil.Add(now.UtcDateTime, AutomaticRefreshInterval < RefreshInterval ? AutomaticRefreshInterval : RefreshInterval);
+                        if (CurrentConfiguration == null) // Throw an exception if there's no configuration to return.
                             throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX20803, (_metadataAddress ?? "null")), ex));
                         else
                             LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX20806, (_metadataAddress ?? "null")), ex));
@@ -209,8 +166,8 @@ namespace Microsoft.IdentityModel.Protocols
                 }
 
                 // Stale metadata is better than no metadata
-                if (_currentConfiguration != null)
-                    return _currentConfiguration;
+                if (CurrentConfiguration != null)
+                    return CurrentConfiguration;
                 else
                 {
                     throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX20803, (_metadataAddress ?? "null"))));
@@ -224,10 +181,10 @@ namespace Microsoft.IdentityModel.Protocols
 
         /// <summary>
         /// Requests that then next call to <see cref="GetConfigurationAsync()"/> obtain new configuration.
-        /// <para>If it is a first force refresh or the last refresh was greater than <see cref="RefreshInterval"/> then the next call to <see cref="GetConfigurationAsync()"/> will retrieve new configuration.</para>
-        /// <para>If <see cref="RefreshInterval"/> == <see cref="TimeSpan.MaxValue"/> then this method does nothing.</para>
+        /// <para>If it is a first force refresh or the last refresh was greater than <see cref="BaseConfigurationManager.RefreshInterval"/> then the next call to <see cref="GetConfigurationAsync()"/> will retrieve new configuration.</para>
+        /// <para>If <see cref="BaseConfigurationManager.RefreshInterval"/> == <see cref="TimeSpan.MaxValue"/> then this method does nothing.</para>
         /// </summary>
-        public void RequestRefresh()
+        public override void RequestRefresh()
         {
             DateTimeOffset now = DateTimeOffset.UtcNow;
             if (_isFirstRefreshRequest)
@@ -240,5 +197,25 @@ namespace Microsoft.IdentityModel.Protocols
                 _syncAfter = now;
             }
         }
+
+        /// <summary>
+        /// 12 hours is the default time interval that afterwards, <see cref="GetBaseConfigurationAsync(CancellationToken)"/> will obtain new configuration.
+        /// </summary>
+        public new static readonly TimeSpan DefaultAutomaticRefreshInterval = BaseConfigurationManager.DefaultAutomaticRefreshInterval;
+
+        /// <summary>
+        /// 5 minutes is the default time interval that must pass for <see cref="RequestRefresh"/> to obtain a new configuration.
+        /// </summary>
+        public new static readonly TimeSpan DefaultRefreshInterval = BaseConfigurationManager.DefaultRefreshInterval;
+
+        /// <summary>
+        /// 5 minutes is the minimum value for automatic refresh. <see cref="MinimumAutomaticRefreshInterval"/> can not be set less than this value.
+        /// </summary>
+        public new static readonly TimeSpan MinimumAutomaticRefreshInterval = BaseConfigurationManager.MinimumAutomaticRefreshInterval;
+
+        /// <summary>
+        /// 1 second is the minimum time interval that must pass for <see cref="MinimumRefreshInterval"/> to  obtain new configuration.
+        /// </summary>
+        public new static readonly TimeSpan MinimumRefreshInterval = BaseConfigurationManager.MinimumRefreshInterval;
     }
 }

--- a/src/Microsoft.IdentityModel.Protocols/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols/LogMessages.cs
@@ -40,8 +40,8 @@ namespace Microsoft.IdentityModel.Protocols
         internal const string IDX20000 = "IDX20000: The parameter '{0}' cannot be a 'null' or an empty object.";
 
         // properties, configuration 
-        internal const string IDX20106 = "IDX20106: When setting RefreshInterval, the value must be greater than MinimumRefreshInterval: '{0}'. value: '{1}'.";
-        internal const string IDX20107 = "IDX20107: When setting AutomaticRefreshInterval, the value must be greater than MinimumAutomaticRefreshInterval: '{0}'. value: '{1}'.";
+        // internal const string IDX20106 = "";
+        // internal const string IDX20107 = "";
         internal const string IDX20108 = "IDX20108: The address specified '{0}' is not valid as per HTTPS scheme. Please specify an https address for security reasons. If you want to test with http address, set the RequireHttps property  on IDocumentRetriever to false.";
 
         // configuration retrieval errors

--- a/src/Microsoft.IdentityModel.Tokens/BaseConfiguration.cs
+++ b/src/Microsoft.IdentityModel.Tokens/BaseConfiguration.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------------------------
+﻿//------------------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -26,56 +26,26 @@
 //------------------------------------------------------------------------------
 
 using System.Collections.Generic;
-using Microsoft.IdentityModel.Tokens;
-using Microsoft.IdentityModel.Xml;
+using System.Collections.ObjectModel;
 
-namespace Microsoft.IdentityModel.Protocols.WsFederation
+namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
-    /// Contains WsFederation metadata that can be populated from a XML string.
+    ///  Represents a generic metadata configuration which is applicable for both XML and JSON based configurations.
     /// </summary>
-    public class WsFederationConfiguration : BaseConfiguration
+    public abstract class BaseConfiguration
     {
         /// <summary>
-        /// Initializes an new instance of <see cref="WsFederationConfiguration"/>.
+        /// Gets the issuer specified via the metadata endpoint.
         /// </summary>
-        public WsFederationConfiguration()
-        {
-        }
+        public virtual string Issuer { get; set; }
 
         /// <summary>
-        /// The <see cref="Xml.Signature"/> element that was found when reading metadata.
+        /// Gets the <see cref="ICollection{SecurityKey}"/> that the IdentityProvider indicates are to be used in order to sign tokens.
         /// </summary>
-        public Signature Signature
+        public virtual ICollection<SecurityKey> SigningKeys
         {
             get;
-            set;
-        }
-
-        /// <summary>
-        /// The <see cref="Tokens.SigningCredentials"/> that was used to sign the metadata.
-        /// </summary>
-        public SigningCredentials SigningCredentials
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Get the <see cref="IList{KeyInfo}"/> that the IdentityProvider indicates are to be used signing keys.
-        /// </summary>
-        public ICollection<KeyInfo> KeyInfos
-        {
-            get;
-        } = new List<KeyInfo>();
-
-        /// <summary>
-        /// Gets or sets token endpoint.
-        /// </summary>
-        public string TokenEndpoint
-        {
-            get;
-            set;
-        }
+        } = new Collection<SecurityKey>();
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
@@ -1,0 +1,122 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Logging;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Represents a generic configuration manager.
+    /// </summary>
+    public abstract class BaseConfigurationManager
+    {
+        private TimeSpan _automaticRefreshInterval = DefaultAutomaticRefreshInterval;
+        private TimeSpan _refreshInterval = DefaultRefreshInterval;
+
+        /// <summary>
+        /// Gets or sets the <see cref="TimeSpan"/> that controls how often an automatic metadata refresh should occur.
+        /// </summary>
+        public TimeSpan AutomaticRefreshInterval
+        {
+            get { return _automaticRefreshInterval; }
+            set
+            {
+                if (value < MinimumAutomaticRefreshInterval)
+                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant(LogMessages.IDX10108, MinimumAutomaticRefreshInterval, value)));
+
+                _automaticRefreshInterval = value;
+            }
+        }
+
+        /// <summary>
+        /// The most recently retrieved configuration.
+        /// </summary>
+        public BaseConfiguration CurrentConfiguration { get; set; }
+
+        /// <summary>
+        /// 12 hours is the default time interval that afterwards, <see cref="GetBaseConfigurationAsync(CancellationToken)"/> will obtain new configuration.
+        /// </summary>
+        public static readonly TimeSpan DefaultAutomaticRefreshInterval = new TimeSpan(0, 12, 0, 0);
+
+        /// <summary>
+        /// 5 minutes is the default time interval that must pass for <see cref="RequestRefresh"/> to obtain a new configuration.
+        /// </summary>
+        public static readonly TimeSpan DefaultRefreshInterval = new TimeSpan(0, 0, 5, 0);
+
+        /// <summary>
+        /// The last known good configuration (a configuration retrieved in the past that we were able to successfully validate a token against).
+        /// </summary>
+        public BaseConfiguration LKGConfiguration { get; set; }
+
+        /// <summary>
+        /// 5 minutes is the minimum value for automatic refresh. <see cref="AutomaticRefreshInterval"/> can not be set less than this value.
+        /// </summary>
+        public static readonly TimeSpan MinimumAutomaticRefreshInterval = new TimeSpan(0, 0, 5, 0);
+
+        /// <summary>
+        /// 1 second is the minimum time interval that must pass for <see cref="RequestRefresh"/> to  obtain new configuration.
+        /// </summary>
+        public static readonly TimeSpan MinimumRefreshInterval = new TimeSpan(0, 0, 0, 1);
+
+        /// <summary>
+        /// The minimum time between retrievals, in the event that a retrieval failed, or that a refresh was explicitly requested.
+        /// </summary>
+        public TimeSpan RefreshInterval
+        {
+            get { return _refreshInterval; }
+            set
+            {
+                if (value < MinimumRefreshInterval)
+                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant(LogMessages.IDX10107, MinimumRefreshInterval, value)));
+
+                _refreshInterval = value;
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether the LKG can be used, false by default.
+        /// </summary>
+        public bool UseLKG { get; set; } = false;
+
+        /// <summary>
+        /// Obtains an updated version of <see cref="BaseConfiguration"/> if the appropriate refresh interval has passed.
+        /// This method may return a cached version of the configuration.
+        /// </summary>
+        /// <param name="cancel">CancellationToken</param>
+        /// <returns>Configuration of type Configuration.</returns>
+        public abstract Task<BaseConfiguration> GetBaseConfigurationAsync(CancellationToken cancel);
+
+        /// <summary>
+        /// Indicate that the configuration may be stale (as indicated by failing to process incoming tokens).
+        /// </summary>
+        public abstract void RequestRefresh();
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -47,6 +47,8 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10104 = "IDX10104: TokenLifetimeInMinutes must be greater than zero. value: '{0}'";
         public const string IDX10105 = "IDX10105: ClaimValue that is a collection of collections is not supported. Such ClaimValue is found for ClaimType : '{0}'";
         public const string IDX10106 = "IDX10106: The parameter {0} had an invalid value: '{1}'.";
+        public const string IDX10107 = "IDX10107: When setting RefreshInterval, the value must be greater than MinimumRefreshInterval: '{0}'. value: '{1}'.";
+        public const string IDX10108 = "IDX10108: When setting AutomaticRefreshInterval, the value must be greater than MinimumAutomaticRefreshInterval: '{0}'. value: '{1}'.";
 
         // token validation
         public const string IDX10204 = "IDX10204: Unable to validate issuer. validationParameters.ValidIssuer is null or whitespace AND validationParameters.ValidIssuers is null.";

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -115,8 +115,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), new FileDocumentRetriever());
             Type type = typeof(ConfigurationManager<OpenIdConnectConfiguration>);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 2)
-                Assert.True(false, "Number of properties has changed from 2 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 5)
+                Assert.True(false, "Number of properties has changed from 5 to: " + properties.Length + ", adjust tests");
 
             var defaultAutomaticRefreshInterval = ConfigurationManager<OpenIdConnectConfiguration>.DefaultAutomaticRefreshInterval;
             var defaultRefreshInterval = ConfigurationManager<OpenIdConnectConfiguration>.DefaultRefreshInterval;
@@ -130,9 +130,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             };
 
             TestUtilities.GetSet(context);
-            TestUtilities.SetGet(configManager, "AutomaticRefreshInterval", TimeSpan.FromMilliseconds(1), ExpectedException.ArgumentOutOfRangeException(substringExpected: "IDX20107:"), context);
-            TestUtilities.SetGet(configManager, "RefreshInterval", TimeSpan.FromMilliseconds(1), ExpectedException.ArgumentOutOfRangeException(substringExpected: "IDX20106:"), context);
-            TestUtilities.SetGet(configManager, "RefreshInterval", Timeout.InfiniteTimeSpan, ExpectedException.ArgumentOutOfRangeException(substringExpected: "IDX20106:"), context);
+            TestUtilities.SetGet(configManager, "AutomaticRefreshInterval", TimeSpan.FromMilliseconds(1), ExpectedException.ArgumentOutOfRangeException(substringExpected: "IDX10108:"), context);
+            TestUtilities.SetGet(configManager, "RefreshInterval", TimeSpan.FromMilliseconds(1), ExpectedException.ArgumentOutOfRangeException(substringExpected: "IDX10107:"), context);
+            TestUtilities.SetGet(configManager, "RefreshInterval", Timeout.InfiniteTimeSpan, ExpectedException.ArgumentOutOfRangeException(substringExpected: "IDX10107:"), context);
+            TestUtilities.SetGet(configManager, "CurrentConfiguration", new OpenIdConnectConfiguration(), ExpectedException.NoExceptionExpected, context);
+            TestUtilities.SetGet(configManager, "LKGConfiguration", new OpenIdConnectConfiguration(), ExpectedException.NoExceptionExpected, context);
+            TestUtilities.SetGet(configManager, "UseLKG", true, ExpectedException.NoExceptionExpected, context);
             TestUtilities.AssertFailIfErrors("ConfigurationManager_GetSets", context.Errors);
         }
 
@@ -153,7 +156,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             // AutomaticRefreshInterval should pick up new bits.
             configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
-            TestUtilities.SetField(configManager, "_automaticRefreshInterval", TimeSpan.FromMilliseconds(1));
+            configManager.RequestRefresh();
             configuration = configManager.GetConfigurationAsync().Result;
             TestUtilities.SetField(configManager, "_lastRefresh", DateTimeOffset.UtcNow - TimeSpan.FromHours(1));
             TestUtilities.SetField(configManager, "_metadataAddress", "OpenIdConnectMetadata2.json");

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderFactoryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderFactoryTests.cs
@@ -1217,7 +1217,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         /// </summary>
         /// <param name="taskExecutionTimeInSeconds">The time the event queue task runs.</param>
         /// <returns>2 times of the taskExecutionTimeInSeconds. Note that 2 is just a reasonable factor which should provide enough time for the task to exit but not keeping tests waiting/sleeping for too long.</returns>
-        private long WaitTimeForTaskToStopInSeconds(long taskExecutionTimeInSeconds) => 2 * taskExecutionTimeInSeconds;
+        private long WaitTimeForTaskToStopInSeconds(long taskExecutionTimeInSeconds) => 3 * taskExecutionTimeInSeconds;
 
         /// <summary>
         /// Helper method to wait for the event queue tasks to start, up to the specified time in seconds.


### PR DESCRIPTION
These classes will be necessary in order to add a ValidateToken(...) API on the JsonWebTokenHandler that takes in a ConfigurationManager object in addition to the TokenValidationParameters. This API will be added in a future PR.
 
Some notes on the changes made:

- JsonWebTokenHandler is the class that will be responsible for setting UseLKG and UseCurrentConfiguration when going through its validation flow.
- I am not sure whether moving AutomaticRefreshInterval and other public static properties to the StandardConfigurationManager base abstract class is considered a breaking change or not. Would love to hear perspectives on this.
- Also not sure about the implications of having the RequestRefresh() API on both the StandardConfigurationManager abstract class and the IConfigurationManager.
- A property for timing how long we've been using the LKG may also need to be needed to the StandardConfigurationManager class (so that we know when it's stale and we should set UseLKG = false)
- Configuration had to be renamed to StandardConfiguration as it conflicted with System.Configuration in the .NET Framework (lots of extremely misleading Visual Studio errors on this one, haha).