### PR TITLE
rollback ECB

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Encryption/SymmetricKeyWrapProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/SymmetricKeyWrapProvider.cs
@@ -180,7 +180,7 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 // Create the AES provider
                 SymmetricAlgorithm symmetricAlgorithm = Aes.Create();
-                symmetricAlgorithm.Mode = CipherMode.CBC;
+                symmetricAlgorithm.Mode = CipherMode.ECB;
                 symmetricAlgorithm.Padding = PaddingMode.None;
                 symmetricAlgorithm.KeySize = keyBytes.Length * 8;
                 symmetricAlgorithm.Key = keyBytes;


### PR DESCRIPTION
Our SymmetricKeyProvider does specify ECB when creating the SymmetricAlgorithm, the details of the algorithm satisfy CBC. We will modify this so we avoid alarming security scanners.
We have this test which was written to show we have implemented 
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/509ea41a0a077d9a37d04762ea2ad6fbddc74c93/test/Microsoft.IdentityModel.Tokens.Tests/ReferenceTests.cs#L172

The values were obtained from the spec defined here:
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/509ea41a0a077d9a37d04762ea2ad6fbddc74c93/test/Microsoft.IdentityModel.TestUtils/References.cs#L454