### PR TITLE
Stop the event queue task when event queue is empty

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
+++ b/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
@@ -320,6 +320,11 @@ namespace Microsoft.IdentityModel.Tokens
         /// FOR TESTING PURPOSES ONLY.
         /// </summary>
         internal long TaskCount => _signingSignatureProviders.TaskCount + _verifyingSignatureProviders.TaskCount;
-#endregion
+
+        /// <summary>
+        /// FOR TESTING PURPOSES ONLY.
+        /// </summary>
+        internal long TaskExecutionTimeInSeconds => _signingSignatureProviders.TaskExecutionTimeInSeconds;
+        #endregion
     }
 }


### PR DESCRIPTION
This change set include:
1. Stop the event queue task when the queue is empty and the current time has passed the task stop time.
2. Simplify the implementation by not disposing the event queue task, it is not needed as we are not using the internal wait handle.
3. Simply the implementation by removing the OnLinkedListItemRemoved(), no longer needed
4. Introduced the _eventQueueRunDurationInSeconds to reduce possible overhead of restarting tasks.