### PR TITLE
Adding the BaseConfigurationManager to the TokenValidationParameters

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -47,7 +47,6 @@ namespace Microsoft.IdentityModel.Protocols
         private bool _isFirstRefreshRequest = true;
 
         private readonly SemaphoreSlim _refreshLock;
-        private readonly string _metadataAddress;
         private readonly IDocumentRetriever _docRetriever;
         private readonly IConfigurationRetriever<T> _configRetriever;
 
@@ -100,7 +99,7 @@ namespace Microsoft.IdentityModel.Protocols
             if (docRetriever == null)
                 throw LogHelper.LogArgumentNullException(nameof(docRetriever));
 
-            _metadataAddress = metadataAddress;
+            MetadataAddress = metadataAddress;
             _docRetriever = docRetriever;
             _configRetriever = configRetriever;
             _refreshLock = new SemaphoreSlim(1);
@@ -150,7 +149,7 @@ namespace Microsoft.IdentityModel.Protocols
                     {
                         // Don't use the individual CT here, this is a shared operation that shouldn't be affected by an individual's cancellation.
                         // The transport should have it's own timeouts, etc..
-                        CurrentConfiguration = await _configRetriever.GetConfigurationAsync(_metadataAddress, _docRetriever, CancellationToken.None).ConfigureAwait(false) as BaseConfiguration;
+                        CurrentConfiguration = await _configRetriever.GetConfigurationAsync(MetadataAddress, _docRetriever, CancellationToken.None).ConfigureAwait(false) as BaseConfiguration;
                         Contract.Assert(CurrentConfiguration != null);
                         _lastRefresh = now;
                         _syncAfter = DateTimeUtil.Add(now.UtcDateTime, AutomaticRefreshInterval);
@@ -159,9 +158,9 @@ namespace Microsoft.IdentityModel.Protocols
                     {
                         _syncAfter = DateTimeUtil.Add(now.UtcDateTime, AutomaticRefreshInterval < RefreshInterval ? AutomaticRefreshInterval : RefreshInterval);
                         if (CurrentConfiguration == null) // Throw an exception if there's no configuration to return.
-                            throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX20803, (_metadataAddress ?? "null")), ex));
+                            throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX20803, (MetadataAddress ?? "null")), ex));
                         else
-                            LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX20806, (_metadataAddress ?? "null")), ex));
+                            LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX20806, (MetadataAddress ?? "null")), ex));
                     }
                 }
 
@@ -170,7 +169,7 @@ namespace Microsoft.IdentityModel.Protocols
                     return CurrentConfiguration;
                 else
                 {
-                    throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX20803, (_metadataAddress ?? "null"))));
+                    throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX20803, (MetadataAddress ?? "null"))));
                 }
             }
             finally

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/StaticConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/StaticConfigurationManager.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,8 +38,8 @@ namespace Microsoft.IdentityModel.Protocols
     /// In this case, the configuration is obtained and passed to the constructor.
     /// </summary>
     /// <typeparam name="T">must be a class.</typeparam>
-    public class StaticConfigurationManager<T> : IConfigurationManager<T> where T : class
-    {
+    public class StaticConfigurationManager<T> : BaseConfigurationManager, IConfigurationManager<T> where T : class
+    { 
         private T _configuration;
 
         /// <summary>
@@ -64,9 +65,19 @@ namespace Microsoft.IdentityModel.Protocols
         }
 
         /// <summary>
+        /// Obtains an updated version of Configuration.
+        /// </summary>
+        /// <param name="cancel"><see cref="CancellationToken"/>.</param>
+        /// <returns>Configuration of type T.</returns>
+        public override Task<BaseConfiguration> GetBaseConfigurationAsync(CancellationToken cancel)
+        {
+            return Task.FromResult(_configuration as BaseConfiguration);
+        }
+
+        /// <summary>
         /// For the this type, this is a no-op
         /// </summary>
-        public void RequestRefresh()
+        public override void RequestRefresh()
         {
         }
     }

--- a/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
@@ -72,9 +72,14 @@ namespace Microsoft.IdentityModel.Tokens
         public static readonly TimeSpan DefaultRefreshInterval = new TimeSpan(0, 0, 5, 0);
 
         /// <summary>
-        /// The last known good configuration (a configuration retrieved in the past that we were able to successfully validate a token against).
+        /// The last known good configuration or LKG (a configuration retrieved in the past that we were able to successfully validate a token against).
         /// </summary>
-        public BaseConfiguration LKGConfiguration { get; set; }
+        public BaseConfiguration LastKnownGoodConfiguration { get; set; }
+
+        /// <summary>
+        /// The metadata address to retrieve the configuration from.
+        /// </summary>
+        public string MetadataAddress { get; set; }
 
         /// <summary>
         /// 5 minutes is the minimum value for automatic refresh. <see cref="AutomaticRefreshInterval"/> can not be set less than this value.
@@ -102,9 +107,9 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
-        /// Indicates whether the LKG can be used, false by default.
+        /// Indicates whether the last known good configuraton (LKG) can be used, false by default.
         /// </summary>
-        public bool UseLKG { get; set; } = false;
+        public bool UseLastKnownGoodConfiguration { get; set; } = false;
 
         /// <summary>
         /// Obtains an updated version of <see cref="BaseConfiguration"/> if the appropriate refresh interval has passed.

--- a/src/Microsoft.IdentityModel.Tokens/CollectionUtilities.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CollectionUtilities.cs
@@ -1,0 +1,49 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// A class which contains useful methods for processing collections.
+    /// </summary>
+    public static class CollectionUtilities
+    {
+        /// <summary>
+        /// Checks whether <paramref name="enumerable"/> is null or empty.
+        /// </summary>
+        /// <typeparam name="T">The type of the <paramref name="enumerable"/>.</typeparam>
+        /// <param name="enumerable">The <see cref="IEnumerable{T}"/> to be checked.</param>
+        /// <returns>True if <paramref name="enumerable"/> is null or empty, false otherwise.</returns>
+        public static bool IsNullOrEmpty<T>(this IEnumerable<T> enumerable)
+        {
+            return enumerable == null || !enumerable.Any();
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -51,7 +51,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10108 = "IDX10108: When setting AutomaticRefreshInterval, the value must be greater than MinimumAutomaticRefreshInterval: '{0}'. value: '{1}'.";
 
         // token validation
-        public const string IDX10204 = "IDX10204: Unable to validate issuer. validationParameters.ValidIssuer is null or whitespace AND validationParameters.ValidIssuers is null.";
+        public const string IDX10204 = "IDX10204: Unable to validate issuer. validationParameters.ValidIssuer is null or whitespace AND validationParameters.ValidIssuers is null or empty.";
         public const string IDX10205 = "IDX10205: Issuer validation failed. Issuer: '{0}'. Did not match: validationParameters.ValidIssuer: '{1}' or validationParameters.ValidIssuers: '{2}'.";
         public const string IDX10206 = "IDX10206: Unable to validate audience. The 'audiences' parameter is empty.";
         public const string IDX10207 = "IDX10207: Unable to validate audience. The 'audiences' parameter is null.";
@@ -95,6 +95,8 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10256 = "IDX10256: Unable to validate the token type. TokenValidationParameters.ValidTypes is set, but the 'typ' header claim is null or empty.";
         public const string IDX10257 = "IDX10257: Token type validation failed. Type: '{0}'. Did not match: validationParameters.TokenTypes: '{1}'.";
         public const string IDX10258 = "IDX10258: Token type validated. Type: '{0}'.";
+        public const string IDX10260 = "IDX10260: Issuer validation failed. Issuer: '{0}'. Did not match: validationParameters.ValidIssuer: '{1}' or validationParameters.ValidIssuers: '{2}' or validationParameters.ConfigurationManager.CurrentConfiguration.Issuer: '{3}'.";
+        public const string IDX10261 = "IDX10261: Unable to retrieve configuration. \nProceeding with token validation as the relevant properties have been set manually on the TokenValidationParameters.";
 
         // 10500 - SignatureValidation
         public const string IDX10500 = "IDX10500: Signature validation failed. No security keys were provided to validate the signature.";

--- a/src/Microsoft.IdentityModel.Tokens/TokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenUtilities.cs
@@ -150,6 +150,10 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters.IssuerSigningKeys != null)
                 foreach (SecurityKey key in validationParameters.IssuerSigningKeys)
                     yield return key;
+
+            if (validationParameters.Configuration?.SigningKeys != null)
+                foreach (SecurityKey key in validationParameters.Configuration.SigningKeys)
+                    yield return key;
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -355,6 +355,24 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
+        /// This property represents the metadata (specifically the issuer and signing keys) retrieved by the <see cref="ConfigurationManager"/>.
+        /// It will be used along with the other properties set on the TokenValidationParameters in order to validate the token.
+        /// </summary>
+        /// <remarks>
+        /// This property can be set to the <see cref="BaseConfigurationManager.CurrentConfiguration"/> or the <see cref="BaseConfigurationManager.LastKnownGoodConfiguration"/>
+        /// depending on where in the Wilson call stack it is being used.
+        /// We make a copy of the TokenValidationParameters passed in to the JsonWebTokenHandler.ValidateToken(...) method, so the value of this
+        /// property will never change on the original object.
+        /// </remarks>
+        public BaseConfiguration Configuration { get; set; }
+
+        /// <summary>
+        /// If set, this property will be used to obtain the issuer and signing keys associated with the metadata endpoint of <see cref="BaseConfiguration.Issuer"/>.
+        /// The obtained issuer and signing keys will then be used along with those present on the TokenValidationParameters for validation of the incoming token.
+        /// </summary>
+        public BaseConfigurationManager ConfigurationManager { get; set; }
+
+        /// <summary>
         /// Users can override the default <see cref="CryptoProviderFactory"/> with this property. This factory will be used for creating signature providers.
         /// </summary>
         public CryptoProviderFactory CryptoProviderFactory { get; set; }

--- a/src/Microsoft.IdentityModel.Tokens/Validators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validators.cs
@@ -30,6 +30,7 @@ using System.Collections.Generic;
 using System;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 
 namespace Microsoft.IdentityModel.Tokens
 {
@@ -223,7 +224,7 @@ namespace Microsoft.IdentityModel.Tokens
                     { InvalidIssuer = issuer });
 
             // Throw if all possible places to validate against are null or empty
-            if (string.IsNullOrWhiteSpace(validationParameters.ValidIssuer) && (validationParameters.ValidIssuers == null))
+            if (string.IsNullOrWhiteSpace(validationParameters.ValidIssuer) && validationParameters.ValidIssuers.IsNullOrEmpty() && string.IsNullOrWhiteSpace(validationParameters.Configuration?.Issuer))
                 throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidIssuerException(LogMessages.IDX10204)
                     { InvalidIssuer = issuer });
 
@@ -249,6 +250,19 @@ namespace Microsoft.IdentityModel.Tokens
                         return issuer;
                     }
                 }
+            }
+
+            if (validationParameters.Configuration != null)
+            {
+                if (string.Equals(validationParameters.Configuration.Issuer, issuer, StringComparison.Ordinal))
+                {
+                    LogHelper.LogInformation(LogMessages.IDX10236, issuer);
+                    return issuer;
+                }
+
+                throw LogHelper.LogExceptionMessage(
+                    new SecurityTokenInvalidIssuerException(LogHelper.FormatInvariant(LogMessages.IDX10260, issuer, (validationParameters.ValidIssuer ?? "null"), Utility.SerializeAsSingleCommaDelimitedString(validationParameters.ValidIssuers), validationParameters.Configuration?.Issuer))
+                    { InvalidIssuer = issuer });
             }
 
             throw LogHelper.LogExceptionMessage(

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -115,8 +115,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), new FileDocumentRetriever());
             Type type = typeof(ConfigurationManager<OpenIdConnectConfiguration>);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 5)
-                Assert.True(false, "Number of properties has changed from 5 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 6)
+                Assert.True(false, "Number of properties has changed from 6 to: " + properties.Length + ", adjust tests");
 
             var defaultAutomaticRefreshInterval = ConfigurationManager<OpenIdConnectConfiguration>.DefaultAutomaticRefreshInterval;
             var defaultRefreshInterval = ConfigurationManager<OpenIdConnectConfiguration>.DefaultRefreshInterval;
@@ -134,8 +134,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             TestUtilities.SetGet(configManager, "RefreshInterval", TimeSpan.FromMilliseconds(1), ExpectedException.ArgumentOutOfRangeException(substringExpected: "IDX10107:"), context);
             TestUtilities.SetGet(configManager, "RefreshInterval", Timeout.InfiniteTimeSpan, ExpectedException.ArgumentOutOfRangeException(substringExpected: "IDX10107:"), context);
             TestUtilities.SetGet(configManager, "CurrentConfiguration", new OpenIdConnectConfiguration(), ExpectedException.NoExceptionExpected, context);
-            TestUtilities.SetGet(configManager, "LKGConfiguration", new OpenIdConnectConfiguration(), ExpectedException.NoExceptionExpected, context);
-            TestUtilities.SetGet(configManager, "UseLKG", true, ExpectedException.NoExceptionExpected, context);
+            TestUtilities.SetGet(configManager, "LastKnownGoodConfiguration", new OpenIdConnectConfiguration(), ExpectedException.NoExceptionExpected, context);
+            TestUtilities.SetGet(configManager, "UseLastKnownGoodConfiguration", true, ExpectedException.NoExceptionExpected, context);
+            TestUtilities.SetGet(configManager, "MetadataAddress", "OpenIdConnectMetadata2.json", ExpectedException.NoExceptionExpected, context);
             TestUtilities.AssertFailIfErrors("ConfigurationManager_GetSets", context.Errors);
         }
 
@@ -148,7 +149,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             // AutomaticRefreshInterval interval should return same config.
             var configuration = configManager.GetConfigurationAsync().Result;
-            TestUtilities.SetField(configManager, "_metadataAddress", "OpenIdConnectMetadata2.json");
+            configManager.MetadataAddress = "OpenIdConnectMetadata2.json";
             var configuration2 = configManager.GetConfigurationAsync().Result;
             IdentityComparer.AreEqual(configuration, configuration2, context);
             if (!object.ReferenceEquals(configuration, configuration2))
@@ -159,7 +160,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             configManager.RequestRefresh();
             configuration = configManager.GetConfigurationAsync().Result;
             TestUtilities.SetField(configManager, "_lastRefresh", DateTimeOffset.UtcNow - TimeSpan.FromHours(1));
-            TestUtilities.SetField(configManager, "_metadataAddress", "OpenIdConnectMetadata2.json");
+            configManager.MetadataAddress = "OpenIdConnectMetadata2.json";
             configManager.RequestRefresh();
             configuration2 = configManager.GetConfigurationAsync().Result;
             if (IdentityComparer.AreEqual(configuration, configuration2))
@@ -172,7 +173,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
             configuration = configManager.GetConfigurationAsync().Result;
             configManager.RefreshInterval = TimeSpan.MaxValue;
-            TestUtilities.SetField(configManager, "_metadataAddress", "OpenIdConnectMetadata2.json");
+            configManager.MetadataAddress = "OpenIdConnectMetadata2.json";
             configuration2 = configManager.GetConfigurationAsync().Result;
             IdentityComparer.AreEqual(configuration, configuration2, context);
             if (!object.ReferenceEquals(configuration, configuration2))
@@ -182,7 +183,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             configuration = configManager.GetConfigurationAsync().Result;
             // First force refresh should pickup new config
             configManager.RequestRefresh();
-            TestUtilities.SetField(configManager, "_metadataAddress", "OpenIdConnectMetadata2.json");
+            configManager.MetadataAddress = "OpenIdConnectMetadata2.json";
             configuration2 = configManager.GetConfigurationAsync().Result;
             if (IdentityComparer.AreEqual(configuration, configuration2))
                 context.Diffs.Add("IdentityComparer.AreEqual(configuration, configuration2), should be different");
@@ -190,7 +191,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 context.Diffs.Add("object.ReferenceEquals(configuration, configuration2) (4)");
             // Next force refresh shouldn't pickup new config, as RefreshInterval hasn't passed
             configManager.RequestRefresh();
-            TestUtilities.SetField(configManager, "_metadataAddress", "OpenIdConnectMetadata.json");
+            configManager.MetadataAddress = "OpenIdConnectMetadata.json";
             var configuration3 = configManager.GetConfigurationAsync().Result;
             IdentityComparer.AreEqual(configuration2, configuration3, context);
             if (!object.ReferenceEquals(configuration2, configuration3))
@@ -210,7 +211,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             configuration = configManager.GetConfigurationAsync().Result;
             TestUtilities.SetField(configManager, "_lastRefresh", DateTimeOffset.UtcNow - TimeSpan.FromHours(1));
             configManager.RequestRefresh();
-            TestUtilities.SetField(configManager, "_metadataAddress", "OpenIdConnectMetadata2.json");
+            configManager.MetadataAddress = "OpenIdConnectMetadata2.json";
             configuration2 = configManager.GetConfigurationAsync().Result;
             if (IdentityComparer.AreEqual(configuration, configuration2))
                 context.Diffs.Add("IdentityComparer.AreEqual(configuration, configuration2), should be different");
@@ -290,7 +291,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             configuration = configManager.GetConfigurationAsync().Result;
             TestUtilities.SetField(configManager, "_lastRefresh", DateTimeOffset.UtcNow - TimeSpan.FromHours(1));
             configManager.RequestRefresh();
-            TestUtilities.SetField(configManager, "_metadataAddress", "http://someaddress.com");
+            configManager.MetadataAddress = "http://someaddress.com";
             configuration2 = configManager.GetConfigurationAsync().Result;
             IdentityComparer.AreEqual(configuration, configuration2, context);
             if (!object.ReferenceEquals(configuration, configuration2))

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
@@ -29,6 +29,9 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Security.Claims;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols.WsFederation;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -42,8 +45,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 43)
-                Assert.True(false, "Number of properties has changed from 43 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 45)
+                Assert.True(false, "Number of properties has changed from 45 to: " + properties.Length + ", adjust tests");
 
             TokenValidationParameters actorValidationParameters = new TokenValidationParameters();
             SecurityKey issuerSigningKey = KeyingMaterial.DefaultX509Key_2048_Public;
@@ -161,8 +164,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 43)
-                Assert.True(false, "Number of public fields has changed from 43 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 45)
+                Assert.True(false, "Number of public fields has changed from 45 to: " + properties.Length + ", adjust tests");
 
             GetSetContext context =
                 new GetSetContext
@@ -188,6 +191,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         new KeyValuePair<string, List<object>>("ValidateLifetime", new List<object>{true, false, true}),
                         new KeyValuePair<string, List<object>>("ValidateTokenReplay", new List<object>{false, true, false}),
                         new KeyValuePair<string, List<object>>("ValidIssuer", new List<object>{(string)null, Guid.NewGuid().ToString(), Guid.NewGuid().ToString()}),
+                        new KeyValuePair<string, List<object>>("Configuration", new List<object>{(BaseConfiguration)null, new OpenIdConnectConfiguration(), new WsFederationConfiguration()}),
+                        new KeyValuePair<string, List<object>>("ConfigurationManager", new List<object>{(BaseConfigurationManager)null, new ConfigurationManager<OpenIdConnectConfiguration>("http://someaddress.com", new OpenIdConnectConfigurationRetriever()), new ConfigurationManager<WsFederationConfiguration>("http://someaddress.com", new WsFederationConfigurationRetriever()) }),
                     },
                     Object = validationParameters,
                 };

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -1448,7 +1448,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     },
                     new JwtTheoryData
                     {
-                        ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidIssuerException), substringExpected: "IDX10205", propertiesExpected: properties),
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidIssuerException), substringExpected: "IDX10204", propertiesExpected: properties),
                         TestId = "ValidIssuers = List<string>()",
                         Token = jwt,
                         ValidationParameters = ValidateIssuerValidationParameters(null, new List<string>(), null, true)


### PR DESCRIPTION
This will need to go in once the BaseConfiguration and BaseConfigurationManager classes PR is merged in (#1679). 

I've added some of the reasoning behind the design decisions in the comments below.