### PR TITLE
Base64UrlEncoder performance improvements

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Base64UrlEncoder.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Base64UrlEncoder.cs
@@ -86,30 +86,17 @@ namespace Microsoft.IdentityModel.Tokens
         {
             _ = inArray ?? throw LogHelper.LogArgumentNullException("inArray");
 
-            if (length < 0)
-            {
-                throw LogHelper.LogArgumentException<ArgumentException>(nameof(length), $"{nameof(length)} must be greater or equal than zero");
-            }
-
-            if (offset < 0)
-            {
-                throw LogHelper.LogArgumentException<ArgumentException>(nameof(offset), $"{nameof(offset)} must be greater or equal than zero");
-            }
-
             if (length == 0)
-            {
                 return string.Empty;
-            }
 
-            if (inArray.Length < offset)
-            {
-                throw LogHelper.LogArgumentException<ArgumentException>(nameof(offset), $"Invalid value for {nameof(offset)} parameter");
-            }
+            if (length < 0)
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10106, nameof(length), length)));
+
+            if (offset < 0 || inArray.Length < offset)
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10106, nameof(offset), offset)));
 
             if (inArray.Length < offset + length)
-            {
-                throw LogHelper.LogArgumentException<ArgumentException>(nameof(length), $"Invalid value for {nameof(length)} parameter");
-            }
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10106, nameof(length), length)));
 
             int i;
             char[] table = s_base64Table;

--- a/src/Microsoft.IdentityModel.Tokens/Base64UrlEncoder.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Base64UrlEncoder.cs
@@ -67,7 +67,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns>Base64Url encoding of the UTF8 bytes.</returns>
         public static string Encode(string arg)
         {
-            _ = arg ?? throw LogHelper.LogArgumentNullException("arg");
+            _ = arg ?? throw LogHelper.LogArgumentNullException(nameof(arg));
 
             return Encode(Encoding.UTF8.GetBytes(arg));
         }
@@ -84,7 +84,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <exception cref="ArgumentOutOfRangeException">offset or length is negative OR offset plus length is greater than the length of inArray.</exception>
         public static string Encode(byte[] inArray, int offset, int length)
         {
-            _ = inArray ?? throw LogHelper.LogArgumentNullException("inArray");
+            _ = inArray ?? throw LogHelper.LogArgumentNullException(nameof(inArray));
 
             if (length == 0)
                 return string.Empty;
@@ -98,22 +98,22 @@ namespace Microsoft.IdentityModel.Tokens
             if (inArray.Length < offset + length)
                 throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(LogHelper.FormatInvariant(LogMessages.IDX10106, nameof(length), length)));
 
-            int i;
-            char[] table = s_base64Table;
-            int j = 0;
             int lengthmod3 = length % 3;
             int limit = offset + (length - lengthmod3);
             char[] output = new char[(length + 2) / 3 * 4];
+            char[] table = s_base64Table;
+            int i, j = 0;
 
+            // takes 3 bytes from inArray and insert 4 bytes into output
             for (i = offset; i < limit; i += 3)
             {
                 byte d0 = inArray[i];
                 byte d1 = inArray[i + 1];
                 byte d2 = inArray[i + 2];
 
-                output[j + 0] = table[(d0 & 0xfc) >> 2];
-                output[j + 1] = table[((d0 & 0x03) << 4) | ((d1 & 0xf0) >> 4)];
-                output[j + 2] = table[((d1 & 0x0f) << 2) | ((d2 & 0xc0) >> 6)];
+                output[j + 0] = table[d0 >> 2];
+                output[j + 1] = table[((d0 & 0x03) << 4) | (d1 >> 4)];
+                output[j + 2] = table[((d1 & 0x0f) << 2) | (d2 >> 6)];
                 output[j + 3] = table[d2 & 0x3f];
                 j += 4;
             }
@@ -128,8 +128,8 @@ namespace Microsoft.IdentityModel.Tokens
                         byte d0 = inArray[i];
                         byte d1 = inArray[i + 1];
 
-                        output[j + 0] = table[(d0 & 0xfc) >> 2];
-                        output[j + 1] = table[((d0 & 0x03) << 4) | ((d1 & 0xf0) >> 4)];
+                        output[j + 0] = table[d0 >> 2];
+                        output[j + 1] = table[((d0 & 0x03) << 4) | (d1 >> 4)];
                         output[j + 2] = table[(d1 & 0x0f) << 2];
                         j += 3;
                     }
@@ -161,14 +161,14 @@ namespace Microsoft.IdentityModel.Tokens
         /// <exception cref="ArgumentOutOfRangeException">offset or length is negative OR offset plus length is greater than the length of inArray.</exception>
         public static string Encode(byte[] inArray)
         {
-            _ = inArray ?? throw LogHelper.LogArgumentNullException("inArray");
+            _ = inArray ?? throw LogHelper.LogArgumentNullException(nameof(inArray));
 
             return Encode(inArray, 0, inArray.Length);
         }
 
         internal static string EncodeString(string str)
         {
-            _ = str ?? throw LogHelper.LogArgumentNullException("str");
+            _ = str ?? throw LogHelper.LogArgumentNullException(nameof(str));
 
             return Encode(Encoding.UTF8.GetBytes(str));
         }

--- a/src/Microsoft.IdentityModel.Tokens/Base64UrlEncoder.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Base64UrlEncoder.cs
@@ -36,14 +36,14 @@ namespace Microsoft.IdentityModel.Tokens
     /// </summary>
     public static class Base64UrlEncoder
     {
-        private static char base64PadCharacter = '=';
+        private const char base64PadCharacter = '=';
 #if NET45
-        private static string doubleBase64PadCharacter = "==";
+        private const string doubleBase64PadCharacter = "==";
 #endif
-        private static char base64Character62 = '+';
-        private static char base64Character63 = '/';
-        private static char base64UrlCharacter62 = '-';
-        private static char base64UrlCharacter63 = '_';
+        private const char base64Character62 = '+';
+        private const char base64Character63 = '/';
+        private const char base64UrlCharacter62 = '-';
+        private const char base64UrlCharacter63 = '_';
 
         /// <summary>
         /// Encoding table

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -46,6 +46,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10103 = "IDX10103: RoleClaimType cannot be null or whitespace.";
         public const string IDX10104 = "IDX10104: TokenLifetimeInMinutes must be greater than zero. value: '{0}'";
         public const string IDX10105 = "IDX10105: ClaimValue that is a collection of collections is not supported. Such ClaimValue is found for ClaimType : '{0}'";
+        public const string IDX10106 = "IDX10105: The parameter {0} had an invalid value: '{1}'.";
 
         // token validation
         public const string IDX10204 = "IDX10204: Unable to validate issuer. validationParameters.ValidIssuer is null or whitespace AND validationParameters.ValidIssuers is null.";

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -46,7 +46,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10103 = "IDX10103: RoleClaimType cannot be null or whitespace.";
         public const string IDX10104 = "IDX10104: TokenLifetimeInMinutes must be greater than zero. value: '{0}'";
         public const string IDX10105 = "IDX10105: ClaimValue that is a collection of collections is not supported. Such ClaimValue is found for ClaimType : '{0}'";
-        public const string IDX10106 = "IDX10105: The parameter {0} had an invalid value: '{1}'.";
+        public const string IDX10106 = "IDX10106: The parameter {0} had an invalid value: '{1}'.";
 
         // token validation
         public const string IDX10204 = "IDX10204: Unable to validate issuer. validationParameters.ValidIssuer is null or whitespace AND validationParameters.ValidIssuers is null.";


### PR DESCRIPTION
Changed code paths to encode with bytes always. Temporaly breaking paths to EncodeString TBD if we can remove it.

Encode(byte, int, int) is optimized, as well as current UnsafeEncode (part of the EncodeString code path)