### PR TITLE
Addressing the slow build times and associated test failures

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
+++ b/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
@@ -63,15 +63,8 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogArgumentNullException(nameof(cryptoProviderCacheOptions));
 
             _cryptoProviderCacheOptions = cryptoProviderCacheOptions;
-            _signingSignatureProviders = new EventBasedLRUCache<string, SignatureProvider>(cryptoProviderCacheOptions.SizeLimit, removeExpiredValues: false, comparer: StringComparer.Ordinal) { OnItemRemoved = OnSignatureProviderRemovedFromCache };
-            _verifyingSignatureProviders = new EventBasedLRUCache<string, SignatureProvider>(cryptoProviderCacheOptions.SizeLimit, removeExpiredValues: false, comparer: StringComparer.Ordinal) { OnItemRemoved = OnSignatureProviderRemovedFromCache };
-        }
-
-        private void OnSignatureProviderRemovedFromCache(SignatureProvider signatureProvider)
-        {
-            signatureProvider.CryptoProviderCache = null;
-            if (signatureProvider.RefCount == 0)
-                signatureProvider.Dispose();
+            _signingSignatureProviders = new EventBasedLRUCache<string, SignatureProvider>(cryptoProviderCacheOptions.SizeLimit, removeExpiredValues: false, comparer: StringComparer.Ordinal) { OnItemRemoved = (SignatureProvider signatureProvider) => signatureProvider.CryptoProviderCache = null };
+            _verifyingSignatureProviders = new EventBasedLRUCache<string, SignatureProvider>(cryptoProviderCacheOptions.SizeLimit, removeExpiredValues: false, comparer: StringComparer.Ordinal) { OnItemRemoved = (SignatureProvider signatureProvider) => signatureProvider.CryptoProviderCache = null };
         }
 
         /// <summary>
@@ -89,8 +82,8 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogArgumentException<ArgumentException>(nameof(tryTakeTimeout), $"{nameof(tryTakeTimeout)} must be greater than zero");
 
             _cryptoProviderCacheOptions = cryptoProviderCacheOptions;
-            _signingSignatureProviders = new EventBasedLRUCache<string, SignatureProvider>(cryptoProviderCacheOptions.SizeLimit, options, StringComparer.Ordinal, false) { OnItemRemoved = OnSignatureProviderRemovedFromCache };
-            _verifyingSignatureProviders = new EventBasedLRUCache<string, SignatureProvider>(cryptoProviderCacheOptions.SizeLimit, options, StringComparer.Ordinal, false) { OnItemRemoved = OnSignatureProviderRemovedFromCache };
+            _signingSignatureProviders = new EventBasedLRUCache<string, SignatureProvider>(cryptoProviderCacheOptions.SizeLimit, options, StringComparer.Ordinal, false) { OnItemRemoved = (SignatureProvider signatureProvider) => signatureProvider.CryptoProviderCache = null };
+            _verifyingSignatureProviders = new EventBasedLRUCache<string, SignatureProvider>(cryptoProviderCacheOptions.SizeLimit, options, StringComparer.Ordinal, false) { OnItemRemoved = (SignatureProvider signatureProvider) => signatureProvider.CryptoProviderCache = null };
         }
 
         /// <summary>
@@ -330,6 +323,7 @@ namespace Microsoft.IdentityModel.Tokens
                 _verifyingSignatureProviders.EventQueueTaskIdleTimeoutInSeconds = value;
             }
         }
-#endregion
+
+        #endregion
     }
 }

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
@@ -712,7 +712,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                         ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPopKeyException), "IDX23022", null, true),
                         TestId = "InvalidHttpNoContentReturned",
                     },
-                    //// TODO - find out why test is failing
+                    // TODO - find out why test is timing out in the AzureDevOps build, appears to be unrelated to the caching changes
                     //new ResolvePopKeyTheoryData
                     //{
                     //    JkuSetUrl = "http://www.contoso.com",


### PR DESCRIPTION
Made some modifications to the logic of the EventBasedLRUCache in order to reduce test times:
- got rid of the _disposed bool (it was never set to true, so it was essentially the same as while(true))
- added StartEventQueueTaskIfNotRunning() to the Get and Remove APIs
- added a polling interval to avoid continuous execution of the task when the _eventQueue is empty
- the EventQueueTaskIdleTimeoutInSeconds has been changed for certain tests

We will need to run performance tests on these changes to ensure that they don't introduce any other issues.