### PR TITLE
Remove incorrect log message when an issuer is an empty string

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Validators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validators.cs
@@ -238,10 +238,7 @@ namespace Microsoft.IdentityModel.Tokens
                 foreach (string str in validationParameters.ValidIssuers)
                 {
                     if (string.IsNullOrEmpty(str))
-                    {
-                        LogHelper.LogInformation(LogMessages.IDX10235);
                         continue;
-                    }
                         
                     if (string.Equals(str, issuer, StringComparison.Ordinal))
                     {


### PR DESCRIPTION
Close #1673 