### PR TITLE
Has is valid or exception been read

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -49,6 +49,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10106 = "IDX10106: The parameter {0} had an invalid value: '{1}'.";
         public const string IDX10107 = "IDX10107: When setting RefreshInterval, the value must be greater than MinimumRefreshInterval: '{0}'. value: '{1}'.";
         public const string IDX10108 = "IDX10108: When setting AutomaticRefreshInterval, the value must be greater than MinimumAutomaticRefreshInterval: '{0}'. value: '{1}'.";
+        public const string IDX10109 = "IDX10109: WARNING: Claims is being accessed without first checking whether the property TokenValidationResult.IsValid is true or not. This could be a potential security issue.";
 
         // token validation
         public const string IDX10204 = "IDX10204: Unable to validate issuer. validationParameters.ValidIssuer is null or whitespace AND validationParameters.ValidIssuers is null or empty.";

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -49,7 +49,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10106 = "IDX10106: The parameter {0} had an invalid value: '{1}'.";
         public const string IDX10107 = "IDX10107: When setting RefreshInterval, the value must be greater than MinimumRefreshInterval: '{0}'. value: '{1}'.";
         public const string IDX10108 = "IDX10108: When setting AutomaticRefreshInterval, the value must be greater than MinimumAutomaticRefreshInterval: '{0}'. value: '{1}'.";
-        public const string IDX10109 = "IDX10109: WARNING: Claims is being accessed without first checking whether the property TokenValidationResult.IsValid is true or not. This could be a potential security issue.";
+        public const string IDX10109 = "IDX10109: Warning: Claims is being accessed without first reading the properties TokenValidationResult.IsValid or TokenValidationResult.Exception. This could be a potential security issue.";
 
         // token validation
         public const string IDX10204 = "IDX10204: Unable to validate issuer. validationParameters.ValidIssuer is null or whitespace AND validationParameters.ValidIssuers is null or empty.";

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
@@ -50,9 +50,7 @@ namespace Microsoft.IdentityModel.Tokens
             get
             {
                 if (!_hasIsValidBeenRead)
-                {
                     LogHelper.LogWarning(LogMessages.IDX10109);
-                }
 
                 return _claims.Value;
             }
@@ -61,7 +59,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// The <see cref="ClaimsIdentity"/> created from the validated security token.
         /// </summary>
-        public ClaimsIdentity ClaimsIdentity { set; get; }
+        public ClaimsIdentity ClaimsIdentity { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="Exception"/> that occurred during validation.

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
@@ -40,7 +40,8 @@ namespace Microsoft.IdentityModel.Tokens
         private Lazy<IDictionary<string, object>> _claims => new Lazy<IDictionary<string, object>>(() => TokenUtilities.CreateDictionaryFromClaims(ClaimsIdentity?.Claims));
 
         private bool _isValid;
-        private bool _hasIsValidBeenRead = false;
+        private bool _hasIsValidOrExceptionBeenRead = false;
+        private Exception _exception;
 
         /// <summary>
         /// The <see cref="Dictionary{String, Object}"/> created from the validated security token.
@@ -49,7 +50,7 @@ namespace Microsoft.IdentityModel.Tokens
         {
             get
             {
-                if (!_hasIsValidBeenRead)
+                if (!_hasIsValidOrExceptionBeenRead)
                     LogHelper.LogWarning(LogMessages.IDX10109);
 
                 return _claims.Value;
@@ -64,7 +65,18 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Gets or sets the <see cref="Exception"/> that occurred during validation.
         /// </summary>
-        public Exception Exception { get; set; }
+        public Exception Exception
+        {
+            get
+            {
+                _hasIsValidOrExceptionBeenRead = true;
+                return _exception;
+            }
+            set
+            {
+                _exception = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the issuer that was found in the token.
@@ -78,12 +90,12 @@ namespace Microsoft.IdentityModel.Tokens
         {
             get
             {
-                _hasIsValidBeenRead = true;
+                _hasIsValidOrExceptionBeenRead = true;
                 return _isValid;
             }
             set
             {
-                _hasIsValidBeenRead = false;
+                _hasIsValidOrExceptionBeenRead = false;
                 _isValid = value;
             }
         }

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
+using Microsoft.IdentityModel.Logging;
 
 namespace Microsoft.IdentityModel.Tokens
 {
@@ -38,6 +39,9 @@ namespace Microsoft.IdentityModel.Tokens
     {
         private Lazy<IDictionary<string, object>> _claims => new Lazy<IDictionary<string, object>>(() => TokenUtilities.CreateDictionaryFromClaims(ClaimsIdentity?.Claims));
 
+        private bool _isValid;
+        private bool _hasIsValidBeenRead = false;
+
         /// <summary>
         /// The <see cref="Dictionary{String, Object}"/> created from the validated security token.
         /// </summary>
@@ -45,6 +49,11 @@ namespace Microsoft.IdentityModel.Tokens
         {
             get
             {
+                if (!_hasIsValidBeenRead)
+                {
+                    LogHelper.LogWarning(LogMessages.IDX10109);
+                }
+
                 return _claims.Value;
             }
         }
@@ -52,7 +61,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// The <see cref="ClaimsIdentity"/> created from the validated security token.
         /// </summary>
-        public ClaimsIdentity ClaimsIdentity { get; set; }
+        public ClaimsIdentity ClaimsIdentity { set; get; }
 
         /// <summary>
         /// Gets or sets the <see cref="Exception"/> that occurred during validation.
@@ -67,7 +76,19 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// True if the token was successfully validated, false otherwise.
         /// </summary>
-        public bool IsValid { get; set; }
+        public bool IsValid
+        {
+            get
+            {
+                _hasIsValidBeenRead = true;
+                return _isValid;
+            }
+            set
+            {
+                _hasIsValidBeenRead = false;
+                _isValid = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the <see cref="IDictionary{String, Object}"/> that contains a collection of custom key/value pairs. This allows addition of data that could be used in custom scenarios. This uses <see cref="StringComparer.Ordinal"/> for case-sensitive comparison of keys.

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
@@ -95,7 +95,6 @@ namespace Microsoft.IdentityModel.Tokens
             }
             set
             {
-                _hasIsValidOrExceptionBeenRead = false;
                 _isValid = value;
             }
         }

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -96,6 +96,48 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             Assert.Equal(tokenValidationResult.Claims, TokenUtilities.CreateDictionaryFromClaims(tokenValidationResult.ClaimsIdentity.Claims));
         }
 
+        [Fact]
+        public void ValidateTokenValidationResultThrowsWarning()
+        {
+            var context = TestUtilities.WriteHeader($"{this}.ValidateTokenValidationResultThrowsWarning", "ValidateTokenValidationResultThrowsWarning", true);
+
+            var tokenHandler = new JsonWebTokenHandler();
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(Default.PayloadClaims),
+                SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
+            };
+
+            var accessToken = tokenHandler.CreateToken(tokenDescriptor);
+            // similar to: "eyJhbGciOiJSUzI1NiIsImtpZCI6IlJzYVNlY3VyaXR5S2V5XzIwNDgiLCJ0eXAiOiJKV1QifQ.eyJlbWFpbCI6IkJvYkBjb250b3NvLmNvbSIsImdpdmVuX25hbWUiOiJCb2IiLCJpc3MiOiJodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tIiwiYXVkIjoiaHR0cDovL0RlZmF1bHQuQXVkaWVuY2UuY29tIiwibmJmIjoiMTQ4OTc3NTYxNyIsImV4cCI6IjE2MTYwMDYwMTcifQ.GcIi6FGp1JS5VF70_ULa8g6GTRos9Y7rUZvPAo4hm10bBNfGhdd5uXgsJspiQzS8vwJQyPlq8a_BpL9TVKQyFIRQMnoZWe90htmNWszNYbd7zbLJZ9AuiDqDzqzomEmgcfkIrJ0VfbER57U46XPnUZQNng2XgMXrXmIKUqEph_vLGXYRQ4ndfwtRrR6BxQFd1PS1T5KpEoUTusI4VEsMcutzfXUygLDiRKIcnLFA0kQpeoHllO4Nb_Sxv63GCb0d1076FfSEYtyRxF4YSCz1In-ee5dwEK8Mw3nHscu-1hn0Fe98RBs-4OrUzI0WcV8mq9IIB3i-U-CqCJEP_hVCiA";
+
+            var tokenValidationParameters = new TokenValidationParameters()
+            {
+                ValidAudience = "http://Default.Audience.com",
+                ValidateLifetime = false,
+                ValidIssuer = "http://Default.Issuer.com",
+                IssuerSigningKey = KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key,
+            };
+
+            var tokenValidationResult = tokenHandler.ValidateToken(accessToken, tokenValidationParameters);
+            //IdentityModelEventSource.Logger
+            tokenValidationResult.TokenContext = new CallContext();
+            tokenValidationResult.TokenContext.CaptureLogs = true;
+
+            var claims = tokenValidationResult.Claims;
+            var warningId = "IDX10109";
+            var logs = IdentityModelEventSource.GetSources();
+            foreach(var log in logs)
+            {
+                var s = log.ToString();
+                var n = log.Name;
+                var e = log.ConstructionException;
+                
+            }
+            Assert.True(logs.Any(x => x.ToString().Contains(warningId)),
+                $"Claims was accessed and substring '{warningId}' was not found in TokenContext.Logs"); ;
+        }
+
         [Theory, MemberData(nameof(SegmentTheoryData))]
         public void SegmentCanRead(JwtTheoryData theoryData)
         {

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 using System.IdentityModel.Tokens.Jwt;
 using System.IdentityModel.Tokens.Jwt.Tests;
 using System.IO;
@@ -99,18 +100,19 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         [Fact]
         public void ValidateTokenValidationResultThrowsWarning()
         {
-            var context = TestUtilities.WriteHeader($"{this}.ValidateTokenValidationResultThrowsWarning", "ValidateTokenValidationResultThrowsWarning", true);
+            //create a listener and enable it for logs
+            SampleListener listener = new SampleListener();
+            IdentityModelEventSource.Logger.LogLevel = EventLevel.Warning;
+            listener.EnableEvents(IdentityModelEventSource.Logger, EventLevel.Warning);
 
+            //create token and token validation parameters
             var tokenHandler = new JsonWebTokenHandler();
             var tokenDescriptor = new SecurityTokenDescriptor
             {
                 Subject = new ClaimsIdentity(Default.PayloadClaims),
                 SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
             };
-
             var accessToken = tokenHandler.CreateToken(tokenDescriptor);
-            // similar to: "eyJhbGciOiJSUzI1NiIsImtpZCI6IlJzYVNlY3VyaXR5S2V5XzIwNDgiLCJ0eXAiOiJKV1QifQ.eyJlbWFpbCI6IkJvYkBjb250b3NvLmNvbSIsImdpdmVuX25hbWUiOiJCb2IiLCJpc3MiOiJodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tIiwiYXVkIjoiaHR0cDovL0RlZmF1bHQuQXVkaWVuY2UuY29tIiwibmJmIjoiMTQ4OTc3NTYxNyIsImV4cCI6IjE2MTYwMDYwMTcifQ.GcIi6FGp1JS5VF70_ULa8g6GTRos9Y7rUZvPAo4hm10bBNfGhdd5uXgsJspiQzS8vwJQyPlq8a_BpL9TVKQyFIRQMnoZWe90htmNWszNYbd7zbLJZ9AuiDqDzqzomEmgcfkIrJ0VfbER57U46XPnUZQNng2XgMXrXmIKUqEph_vLGXYRQ4ndfwtRrR6BxQFd1PS1T5KpEoUTusI4VEsMcutzfXUygLDiRKIcnLFA0kQpeoHllO4Nb_Sxv63GCb0d1076FfSEYtyRxF4YSCz1In-ee5dwEK8Mw3nHscu-1hn0Fe98RBs-4OrUzI0WcV8mq9IIB3i-U-CqCJEP_hVCiA";
-
             var tokenValidationParameters = new TokenValidationParameters()
             {
                 ValidAudience = "http://Default.Audience.com",
@@ -119,23 +121,51 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 IssuerSigningKey = KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key,
             };
 
+            //validate token
             var tokenValidationResult = tokenHandler.ValidateToken(accessToken, tokenValidationParameters);
-            //IdentityModelEventSource.Logger
-            tokenValidationResult.TokenContext = new CallContext();
-            tokenValidationResult.TokenContext.CaptureLogs = true;
 
+            //access claims without checking IsValid 
             var claims = tokenValidationResult.Claims;
+
+            //check if warning message was logged
             var warningId = "IDX10109";
-            var logs = IdentityModelEventSource.GetSources();
-            foreach(var log in logs)
+            Assert.Contains(warningId, listener.TraceBuffer);
+        }
+
+        [Fact]
+        public void ValidateTokenValidationResultDoesNotThrowWarning()
+        {
+            //create a listener and enable it for logs
+            SampleListener listener = new SampleListener();
+            IdentityModelEventSource.Logger.LogLevel = EventLevel.Warning;
+            listener.EnableEvents(IdentityModelEventSource.Logger, EventLevel.Warning);
+
+            //create token and token validation parameters
+            var tokenHandler = new JsonWebTokenHandler();
+            var tokenDescriptor = new SecurityTokenDescriptor
             {
-                var s = log.ToString();
-                var n = log.Name;
-                var e = log.ConstructionException;
-                
-            }
-            Assert.True(logs.Any(x => x.ToString().Contains(warningId)),
-                $"Claims was accessed and substring '{warningId}' was not found in TokenContext.Logs"); ;
+                Subject = new ClaimsIdentity(Default.PayloadClaims),
+                SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
+            };
+            var accessToken = tokenHandler.CreateToken(tokenDescriptor);
+            var tokenValidationParameters = new TokenValidationParameters()
+            {
+                ValidAudience = "http://Default.Audience.com",
+                ValidateLifetime = false,
+                ValidIssuer = "http://Default.Issuer.com",
+                IssuerSigningKey = KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key,
+            };
+
+            //validate token
+            var tokenValidationResult = tokenHandler.ValidateToken(accessToken, tokenValidationParameters);
+
+            //checking IsValid first, then access claims
+            var isValid = tokenValidationResult.IsValid;
+            var claims = tokenValidationResult.Claims;
+
+            //check if warning message was logged
+            var warningId = "IDX10109";
+            Assert.DoesNotContain(warningId, listener.TraceBuffer);
         }
 
         [Theory, MemberData(nameof(SegmentTheoryData))]

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTheoryData.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTheoryData.cs
@@ -1,0 +1,40 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.IdentityModel.JsonWebTokens.Tests
+{
+    public class JsonWebTokenTheoryData
+    {
+        public TokenValidationParameters ValidationParameters { get; set; }
+
+        public JsonWebTokenHandler TokenHandler { get; set; }
+
+        public string AccessToken { get; set; }
+    }
+}

--- a/test/Microsoft.IdentityModel.Logging.Tests/LoggerTests.cs
+++ b/test/Microsoft.IdentityModel.Logging.Tests/LoggerTests.cs
@@ -29,6 +29,7 @@ using System;
 using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.IO;
+using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
 namespace Microsoft.IdentityModel.Logging.Tests
@@ -238,16 +239,5 @@ namespace Microsoft.IdentityModel.Logging.Tests
         }
     }
 
-    class SampleListener : EventListener
-    {
-        public string TraceBuffer { get; set; }
 
-        protected override void OnEventWritten(EventWrittenEventArgs eventData)
-        {
-            if (eventData != null && eventData.Payload.Count > 0)
-            {
-                TraceBuffer += eventData.Payload[0] + "\n";
-            }
-        }
-    }
 }

--- a/test/Microsoft.IdentityModel.Logging.Tests/PIITests.cs
+++ b/test/Microsoft.IdentityModel.Logging.Tests/PIITests.cs
@@ -29,6 +29,7 @@ using System;
 using System.Diagnostics.Tracing;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Protocols.WsFederation;
+using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.IdentityModel.Tokens.Saml;
 using Microsoft.IdentityModel.Tokens.Saml2;

--- a/test/Microsoft.IdentityModel.TestUtils/SampleListener.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/SampleListener.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System.Diagnostics.Tracing;
+using Microsoft.IdentityModel.Logging;
 
 namespace Microsoft.IdentityModel.TestUtils
 {
@@ -39,6 +40,14 @@ namespace Microsoft.IdentityModel.TestUtils
             {
                 TraceBuffer += eventData.Payload[0] + "\n";
             }
+        }
+
+        public static SampleListener CreateLoggerListener(EventLevel eventLevel)
+        {
+            SampleListener listener = new SampleListener();
+            IdentityModelEventSource.Logger.LogLevel = eventLevel;
+            listener.EnableEvents(IdentityModelEventSource.Logger, eventLevel);
+            return listener;
         }
     }
 }

--- a/test/Microsoft.IdentityModel.TestUtils/SampleListener.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/SampleListener.cs
@@ -1,0 +1,44 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.IdentityModel.TestUtils
+{
+    public class SampleListener : EventListener
+    {
+        public string TraceBuffer { get; set; }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData != null && eventData.Payload.Count > 0)
+            {
+                TraceBuffer += eventData.Payload[0] + "\n";
+            }
+        }
+    }
+}


### PR DESCRIPTION
When claims are getting evaluated we should be able to know if IsValid or Exception were read. If they were not, that could indicate an unsafe usage of the API and we should log.

Introducing private variables for properties IsValid and Exception so they can have a body in their getters
Introducing a private variable to track whether or not IsValid or Exception have been read
Bodies to IsValid and Exception to set new private variable
Getter body to Claims so we can check if IsValid or Exception have been read, and log if they have not.
New warning message to describe the situation
Unit Tests to test the described behavior above
Moved SampleLogger to Utils so it can be easier to access across different unit tests when test depends on log reads