### PR TITLE
Add const for the standard scope "phone"

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectScope.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectScope.cs
@@ -56,6 +56,11 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         public const string OpenIdProfile = "openid profile";
 
         /// <summary>
+        /// Indicates phone profile scope see: https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims.
+        /// </summary>
+        public const string Phone = "phone";
+
+        /// <summary>
         /// Indicates user_impersonation scope see: http://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims.
         /// </summary>
         public const string UserImpersonation = "user_impersonation";


### PR DESCRIPTION
The "phone" scope is a standard scope part of the OpenID specification.
See: https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims

> phone
    OPTIONAL. This scope value requests access to the `phone_number` and `phone_number_verified` Claims. 