### PR TITLE
Reduce allocations of byte arrays

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMessage.cs
@@ -288,9 +288,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
                                         writer.WriteNode(xmlReader, true);
                                         writer.Flush();
                                     }
-                                    ms.Seek(0, SeekOrigin.Begin);
-                                    var tokenBytes = ms.ToArray();
-                                    token = Encoding.UTF8.GetString(tokenBytes);
+                                    token = Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length);
                                 }
 
                                 // </RequestedSecurityToken>

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlAssertion.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlAssertion.cs
@@ -181,7 +181,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                                 writer.StartCanonicalization(c14nStream, false, null);
                                 serializer.WriteAssertion(writer, this);
                                 writer.Flush();
-                                _canonicalString = Encoding.UTF8.GetString(c14nStream.ToArray());
+                                _canonicalString = Encoding.UTF8.GetString(c14nStream.GetBuffer(), 0, (int)c14nStream.Length);
                             }
                         }
                         catch

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -553,7 +553,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                     writer.Flush();
                 }
 
-                return Encoding.UTF8.GetString(ms.ToArray());
+                return Encoding.UTF8.GetString(ms.GetBuffer(), 0, (int)ms.Length);
             }
         }
 
@@ -1240,7 +1240,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 {
                     WriteToken(writer, samlToken);
                     writer.Flush();
-                    return Encoding.UTF8.GetString(memoryStream.ToArray());
+                    return Encoding.UTF8.GetString(memoryStream.GetBuffer(), 0, (int)memoryStream.Length);
                 }
             }
         }

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Assertion.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Assertion.cs
@@ -113,7 +113,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                                 writer.StartCanonicalization(c14nStream, false, null);
                                 serializer.WriteAssertion(writer, this);
                                 writer.Flush();
-                                _canonicalString = Encoding.UTF8.GetString(c14nStream.ToArray());
+                                _canonicalString = Encoding.UTF8.GetString(c14nStream.GetBuffer(), 0, (int)c14nStream.Length);
                             }
                         }
                         catch

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -820,7 +820,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                     dictionaryWriter.Flush();
                 }
 
-                return Encoding.UTF8.GetString(memoryStream.ToArray());
+                return Encoding.UTF8.GetString(memoryStream.GetBuffer(), 0, (int)memoryStream.Length);
             }
         }
 
@@ -1341,7 +1341,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                 {
                     WriteToken(writer, samlToken);
                     writer.Flush();
-                    return Encoding.UTF8.GetString(memoryStream.ToArray());
+                    return Encoding.UTF8.GetString(memoryStream.GetBuffer(), 0, (int)memoryStream.Length);
                 }
             }
         }

--- a/src/Microsoft.IdentityModel.Xml/CanonicalizingTransform.cs
+++ b/src/Microsoft.IdentityModel.Xml/CanonicalizingTransform.cs
@@ -86,7 +86,7 @@ namespace Microsoft.IdentityModel.Xml
                 streamWriter.WriteTo(writer);
                 writer.EndCanonicalization();
                 writer.Flush();
-                return Encoding.UTF8.GetString(stream.ToArray());
+                return Encoding.UTF8.GetString(stream.GetBuffer(), 0, (int)stream.Length);
             }
         }
     }

--- a/src/Microsoft.IdentityModel.Xml/EnvelopedSignatureWriter.cs
+++ b/src/Microsoft.IdentityModel.Xml/EnvelopedSignatureWriter.cs
@@ -189,7 +189,7 @@ namespace Microsoft.IdentityModel.Xml
                     reference = new Reference(new EnvelopedSignatureTransform(), new ExclusiveCanonicalizationTransform { InclusiveNamespacesPrefixList = _inclusiveNamespacesPrefixList })
                     {
                         Uri = _referenceUri,
-                        DigestValue = Convert.ToBase64String(hashAlgorithm.ComputeHash(_canonicalStream.ToArray())),
+                        DigestValue = Convert.ToBase64String(hashAlgorithm.ComputeHash(_canonicalStream.GetBuffer(), 0, (int)_canonicalStream.Length)),
                         DigestMethod = digestAlgorithm
                     };
                 }

--- a/src/Microsoft.IdentityModel.Xml/ExclusiveCanonicalizationTransform.cs
+++ b/src/Microsoft.IdentityModel.Xml/ExclusiveCanonicalizationTransform.cs
@@ -83,7 +83,7 @@ namespace Microsoft.IdentityModel.Xml
                 tokenStream.WriteTo(writer);
                 writer.EndCanonicalization();
                 writer.Flush();
-                return hash.ComputeHash(stream.ToArray());
+                return hash.ComputeHash(stream.GetBuffer(), 0, (int)stream.Length);
             }
         }
     }

--- a/test/Microsoft.IdentityModel.TestUtils/XmlGenerator.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/XmlGenerator.cs
@@ -358,7 +358,7 @@ namespace Microsoft.IdentityModel.TestUtils
             writer.Flush();
 
             // for debugging purposes use a local variable.
-            var retval = Encoding.UTF8.GetString(memoryStream.ToArray());
+            var retval = Encoding.UTF8.GetString(memoryStream.GetBuffer(), 0, (int)memoryStream.Length);
             return retval;
         }
 
@@ -370,7 +370,7 @@ namespace Microsoft.IdentityModel.TestUtils
             serializer.WriteSignedInfo(writer, signedInfo);
             writer.Flush();
 
-            var retval = Encoding.UTF8.GetString(memoryStream.ToArray());
+            var retval = Encoding.UTF8.GetString(memoryStream.GetBuffer(), 0, (int)memoryStream.Length);
             return retval;
         }
 
@@ -393,7 +393,7 @@ namespace Microsoft.IdentityModel.TestUtils
             serializer.WriteReference(writer, reference);
             writer.Flush();
 
-            var retval = Encoding.UTF8.GetString(memoryStream.ToArray());
+            var retval = Encoding.UTF8.GetString(memoryStream.GetBuffer(), 0, (int)memoryStream.Length);
             return retval;
         }
 


### PR DESCRIPTION
MemoryStream.ToArray() allocates a new array on heap if contain any data. Due to the fact that we operate on MemoryStream (it's just a wrapper on byte array buffer) we can access to the internal buffer directly by using GetBuffer method.

@brentschmaltz 