### PR TITLE
handle multi-schemes in AadIssuerValidator

### DIFF
--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -183,17 +183,14 @@ namespace Microsoft.IdentityModel.Validators
             if(string.IsNullOrEmpty(aadAuthority))
                 throw LogHelper.LogArgumentNullException(nameof(aadAuthority));
 
-            Uri.TryCreate(aadAuthority, UriKind.Absolute, out Uri authorityUri);
-            string authorityHost = authorityUri?.Authority ?? new Uri(AadIssuerValidatorConstants.FallbackAuthority).Authority;
-
-            if (s_issuerValidators.TryGetValue(authorityHost, out AadIssuerValidator aadIssuerValidator))
+            if (s_issuerValidators.TryGetValue(aadAuthority, out AadIssuerValidator aadIssuerValidator))
                 return aadIssuerValidator;
 
-            s_issuerValidators[authorityHost] = new AadIssuerValidator(
+            s_issuerValidators[aadAuthority] = new AadIssuerValidator(
                 httpClient,
                 aadAuthority);
 
-            return s_issuerValidators[authorityHost];
+            return s_issuerValidators[aadAuthority];
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.Validators.Tests/MicrosoftIdentityIssuerValidatorTest.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/MicrosoftIdentityIssuerValidatorTest.cs
@@ -86,6 +86,24 @@ namespace Microsoft.IdentityModel.Validators.Tests
         }
 
         [Fact]
+        public void GetIssuerValidator_TwoTenants()
+        {
+            var context = new CompareContext();
+            var validator = CreateIssuerValidator(ValidatorConstants.AuthorityV1);
+
+            IdentityComparer.AreEqual(ValidatorConstants.AuthorityV1, validator.AadAuthorityV1, context);
+            IdentityComparer.AreEqual(ValidatorConstants.AuthorityCommonTenantWithV2, validator.AadAuthorityV2, context);
+            IdentityComparer.AreBoolsEqual(false, validator.IsV2Authority, context);
+
+            validator = CreateIssuerValidator(ValidatorConstants.AuthorityWithTenantSpecified);
+            IdentityComparer.AreEqual(ValidatorConstants.AuthorityWithTenantSpecified, validator.AadAuthorityV1, context);
+            IdentityComparer.AreEqual(ValidatorConstants.AuthorityWithTenantSpecifiedWithV2, validator.AadAuthorityV2, context);
+            IdentityComparer.AreBoolsEqual(false, validator.IsV2Authority, context);
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Fact]
         public void GetIssuerValidator_CommonAuthorityInAliases()
         {
             var context = new CompareContext();


### PR DESCRIPTION
#1752 

We need to use the full authority, not just the authority host for multi-auth scheme scenarios.