### PR TITLE
add GitHub Templates for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ Note that to get help, you need to run the latest version.
  * [ ] M.IM.Tokens
  * [ ] M.IM.Tokens.Jwt
  * [ ] M.IM.Validators
-* Other (please describe)
+ * Other (please describe)
 
 **Is this a new or an existing app?**
 <!-- Ex:
@@ -39,7 +39,8 @@ A clear and concise description of what you expected to happen (or code).
 A clear and concise description of what happens, e.g. an exception is thrown, UI freezes.
 
 **Possible solution**
-<!--- Only if you have suggestions on a fix for the bug. -->
+<!-- Only if you have suggestions on a fix for the bug. -->
 
 **Additional context / logs / screenshots / links to code**
+<!-- Please do not include any customer data or Personal Identifiable Information (PII) in any content posted to GitHub. See https://docs.microsoft.com/en-us/compliance/regulatory/gdpr#gdpr-faqs for more info on PII.-->
 Add any other context about the problem here, such as logs and screenshots or links to code.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -51,5 +51,5 @@ A clear and concise description of what happens, e.g. an exception is thrown, UI
 <!-- Only if you have suggestions on a fix for the bug. -->
 
 **Additional context / logs / screenshots / links to code**
-<!-- Please do not include any customer data or Personal Identifiable Information (PII) in any content posted to GitHub. See https://docs.microsoft.com/en-us/compliance/regulatory/gdpr#gdpr-faqs for more info on PII.-->
+<!-- Please do not include any customer data or Personal Identifiable Information (PII) in any content posted to GitHub. See https://docs.microsoft.com/compliance/regulatory/gdpr#gdpr-faqs for more info on PII.-->
 Add any other context about the problem here, such as logs and screenshots or links to code.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: Please do NOT file bugs without filling in this form.
+title: '[Bug] '
+labels: ''
+assignees: ''
+
+---
+
+**Which version of Microsoft.IdentityModel are you using?**
+Note that to get help, you need to run the latest version. 
+<!-- E.g. Microsoft.IdentityModel 6.14 -->
+
+**Where is the issue?**
+ * [ ] M.IM.JsonWebTokens
+ * [ ] M.IM.Protocols.OpenIdConnect
+ * [ ] M.IM.Tokens
+ * [ ] M.IM.Tokens.Jwt
+ * [ ] M.IM.Validators
+* Other (please describe)
+
+**Is this a new or an existing app?**
+<!-- Ex:
+a. The app is in production and I have upgraded to a new version of Microsoft.IdentityModel.*
+b. The app is in production and I haven't upgraded Microsoft.IdentityModel.*, but started seeing this issue.
+c. This is a new app or an experiment.
+-->
+
+**Repro**
+
+```csharp
+var your = (code) => here;
+```
+
+**Expected behavior**
+A clear and concise description of what you expected to happen (or code).
+
+**Actual behavior**
+A clear and concise description of what happens, e.g. an exception is thrown, UI freezes.
+
+**Possible solution**
+<!--- Only if you have suggestions on a fix for the bug. -->
+
+**Additional context / logs / screenshots / links to code**
+Add any other context about the problem here, such as logs and screenshots or links to code.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,10 +13,19 @@ Note that to get help, you need to run the latest version.
 
 **Where is the issue?**
  * [ ] M.IM.JsonWebTokens
+ * [ ] M.IM.Protocols
  * [ ] M.IM.Protocols.OpenIdConnect
+ * [ ] M.IM.Protocols.SignedHttpRequest
+ * [ ] M.IM.Protocols.WsFederation
  * [ ] M.IM.Tokens
- * [ ] M.IM.Tokens.Jwt
+ * [ ] S.IM.Tokens.Jwt
+ * [ ] M.IM.Tokens.Saml
  * [ ] M.IM.Validators
+ * [ ] M.IM.Logging
+ * [ ] M.IM.Xml
+ * [ ] M.IM.KeyVaultExtensions
+ * [ ] M.IM.ManagedKeyVaultSecurityKey
+ * [ ] M.IM.TestExtensions
  * Other (please describe)
 
 **Is this a new or an existing app?**

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,22 @@
+---
+name: Documentation
+about: Suggest a change to the documentation.
+title: '[Documentation] '
+labels: documentation
+assignees: ''
+
+---
+
+### Documentation related to component
+<!-- Type name of component here (e.g. "Contribute", or "Logging" ) -->
+
+### Please check all that apply
+
+- [ ] typo
+- [ ] documentation doesn't exist
+- [ ] documentation needs clarification
+- [ ] error(s) in the example
+- [ ] needs an example
+
+### Description of the issue
+<!-- Describe the issue in detail here -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project.
+title: "[Feature Request] "
+labels: enhancement, Feature Request
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...].
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
#1486 

I look the same format we have in Id.Web and MSAL.NET.

[ASP.NET Core](https://github.com/dotnet/aspnetcore/tree/main/.github/ISSUE_TEMPLATE) as a few more templates, like for API/design proposals. If you want something similar, lmk.