### PR TITLE
Xiao/better exception for get OIDC configuration async

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/Configuration/HttpDocumentRetriever.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/HttpDocumentRetriever.cs
@@ -44,6 +44,11 @@ namespace Microsoft.IdentityModel.Protocols
         private HttpClient _httpClient;
         private static readonly HttpClient _defaultHttpClient = new HttpClient();
 
+#pragma warning disable 1591
+        public const string StatusCode = "status_code";
+        public const string ResponseContent = "response_content";
+#pragma warning disable 1591
+
         /// <summary>
         /// Gets or sets whether additional default headers are added to a <see cref="HttpRequestMessage"/> headers. Set to true by default.
         /// </summary>
@@ -120,7 +125,14 @@ namespace Microsoft.IdentityModel.Protocols
                 if (response.IsSuccessStatusCode)
                     return responseContent;
 
-                 unsuccessfulHttpResponseException = new IOException(LogHelper.FormatInvariant(LogMessages.IDX20807, address, response, responseContent));
+                 unsuccessfulHttpResponseException = new IOException(LogHelper.FormatInvariant(LogMessages.IDX20807, address, response, responseContent))
+                 {
+                     Data =
+                     {
+                         { StatusCode, response.StatusCode },
+                         { ResponseContent, responseContent }
+                     }
+                 };
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/HttpDocumentRetriever.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/HttpDocumentRetriever.cs
@@ -44,10 +44,15 @@ namespace Microsoft.IdentityModel.Protocols
         private HttpClient _httpClient;
         private static readonly HttpClient _defaultHttpClient = new HttpClient();
 
-#pragma warning disable 1591
+        /// <summary>
+        /// The key is used to add status code into ex.Data.
+        /// </summary>
         public const string StatusCode = "status_code";
+
+        /// <summary>
+        /// The key is used to add response content into ex.Data.
+        /// </summary>
         public const string ResponseContent = "response_content";
-#pragma warning disable 1591
 
         /// <summary>
         /// Gets or sets whether additional default headers are added to a <see cref="HttpRequestMessage"/> headers. Set to true by default.

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/HttpDocumentRetriever.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/HttpDocumentRetriever.cs
@@ -125,14 +125,9 @@ namespace Microsoft.IdentityModel.Protocols
                 if (response.IsSuccessStatusCode)
                     return responseContent;
 
-                 unsuccessfulHttpResponseException = new IOException(LogHelper.FormatInvariant(LogMessages.IDX20807, address, response, responseContent))
-                 {
-                     Data =
-                     {
-                         { StatusCode, response.StatusCode },
-                         { ResponseContent, responseContent }
-                     }
-                 };
+                unsuccessfulHttpResponseException = new IOException(LogHelper.FormatInvariant(LogMessages.IDX20807, address, response, responseContent));
+                unsuccessfulHttpResponseException.Data.Add(StatusCode, response.StatusCode);
+                unsuccessfulHttpResponseException.Data.Add(ResponseContent, responseContent);
             }
             catch (Exception ex)
             {

--- a/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.IdentityModel.Protocols.Tests
         [Theory, MemberData(nameof(GetMetadataTheoryData))]
         public void GetMetadataTest(DocumentRetrieverTheoryData theoryData)
         {
-            TestUtilities.WriteHeader($"{this}.GetMetadataTest", theoryData);
+            var context = TestUtilities.WriteHeader($"{this}.GetMetadataTest", theoryData);
             try
             {
                 string doc = theoryData.DocumentRetriever.GetDocumentAsync(theoryData.Address, CancellationToken.None).Result;
@@ -94,14 +94,18 @@ namespace Microsoft.IdentityModel.Protocols.Tests
                 {
                     if (x.Data.Count > 0)
                     {
-                        Assert.True(x.Data.Contains(HttpDocumentRetriever.StatusCode));
-                        Assert.True(x.Data.Contains(HttpDocumentRetriever.ResponseContent));
-                        Assert.Equal(x.Data[HttpDocumentRetriever.StatusCode], theoryData.ExpectedStatusCode);
+                        if (!x.Data.Contains(HttpDocumentRetriever.StatusCode))
+                            context.AddDiff("!x.Data.Contains(HttpDocumentRetriever.StatusCode)");
+                        if (!x.Data.Contains(HttpDocumentRetriever.ResponseContent))
+                            context.AddDiff("!x.Data.Contains(HttpDocumentRetriever.ResponseContent)");
+                        IdentityComparer.AreEqual(x.Data[HttpDocumentRetriever.StatusCode], theoryData.ExpectedStatusCode, context);
                     }
                     theoryData.ExpectedException.ProcessException(x);
                     return true;
                 });
             }
+
+            TestUtilities.AssertFailIfErrors(context);
         }
 
         public static TheoryData<DocumentRetrieverTheoryData> GetMetadataTheoryData

--- a/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
@@ -159,6 +159,14 @@ namespace Microsoft.IdentityModel.Protocols.Tests
                     TestId = "AAD common: WsFed"
                 });
 
+                theoryData.Add(new DocumentRetrieverTheoryData
+                {
+                    Address = "https://login.windows.net/f686d426-8d16-42db-81b7-ab578e110ccd/.well-known/openid-configuration",
+                    DocumentRetriever = documentRetriever,
+                    ExpectedException = new ExpectedException(typeof(IOException), "IDX20807:"),
+                    TestId = "Client Miss Configuration"
+                });
+
                 return theoryData;
             }
         }

--- a/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
 using System.Reflection;
 using System.Threading;
 using Microsoft.IdentityModel.TestUtils;
@@ -91,6 +92,12 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             {
                 aex.Handle((x) =>
                 {
+                    if (x.Data.Count > 0)
+                    {
+                        Assert.True(x.Data.Contains(HttpDocumentRetriever.StatusCode));
+                        Assert.True(x.Data.Contains(HttpDocumentRetriever.ResponseContent));
+                        Assert.Equal(x.Data[HttpDocumentRetriever.StatusCode], theoryData.ExpectedStatusCode);
+                    }
                     theoryData.ExpectedException.ProcessException(x);
                     return true;
                 });
@@ -164,6 +171,7 @@ namespace Microsoft.IdentityModel.Protocols.Tests
                     Address = "https://login.windows.net/f686d426-8d16-42db-81b7-ab578e110ccd/.well-known/openid-configuration",
                     DocumentRetriever = documentRetriever,
                     ExpectedException = new ExpectedException(typeof(IOException), "IDX20807:"),
+                    ExpectedStatusCode = HttpStatusCode.BadRequest,
                     TestId = "Client Miss Configuration"
                 });
 
@@ -177,6 +185,8 @@ namespace Microsoft.IdentityModel.Protocols.Tests
         public string Address { get; set; }
 
         public IDocumentRetriever DocumentRetriever { get; set; }
+
+        public HttpStatusCode ExpectedStatusCode { get; set; }
 
         public override string ToString()
         {


### PR DESCRIPTION
Modify wilson to include http status code and response string in exception.Data dictionary so that SAL can parse the response from exception.Data and populate properties on the new exception.