### PR TITLE
AadIssuerValidator bug fix

### DIFF
--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -125,7 +125,7 @@ namespace Microsoft.IdentityModel.Validators
                     {
                         if (IsV2Authority)
                         {
-                            AadIssuerV2 = validationParameters.Configuration.Issuer;
+                            AadIssuerV2 = validationParameters.Configuration != null ? validationParameters.Configuration.Issuer : CreateConfigManager(AadAuthorityV2).GetConfigurationAsync().ConfigureAwait(false).GetAwaiter().GetResult().Issuer;
                         }
                         else
                         {
@@ -150,7 +150,7 @@ namespace Microsoft.IdentityModel.Validators
                         }
                         else
                         {
-                            AadIssuerV1 = validationParameters.Configuration.Issuer;
+                            AadIssuerV1 = validationParameters.Configuration != null ? validationParameters.Configuration.Issuer : CreateConfigManager(AadAuthorityV1).GetConfigurationAsync().ConfigureAwait(false).GetAwaiter().GetResult().Issuer;
                         }
                     }
 


### PR DESCRIPTION
When the configuration is not set, make a call to discovery end point.