### PR TITLE
Remove deprecated "language" attribute

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/AuthenticationProtocolMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols/AuthenticationProtocolMessage.cs
@@ -40,7 +40,7 @@ namespace Microsoft.IdentityModel.Protocols
     public abstract class AuthenticationProtocolMessage
     {
         private string _postTitle = "Working...";
-        private string _script = "<script language=\"javascript\">window.setTimeout(function() {document.forms[0].submit();}, 0);</script>"; 
+        private string _script = "<script>window.setTimeout(function() {document.forms[0].submit();}, 0);</script>"; 
         private string _scriptButtonText = "Submit";
         private string _scriptDisabledText = "Script is disabled. Click Submit to continue.";
 


### PR DESCRIPTION
The "language" attribute is deprecated.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#deprecated_attributes