### PR TITLE
rename JwtHandler -> JsonWebTokenHandler

### DIFF
--- a/src/Microsoft.IdentityModel.TestExtensions/TestTokenCreator.cs
+++ b/src/Microsoft.IdentityModel.TestExtensions/TestTokenCreator.cs
@@ -182,7 +182,7 @@ namespace Microsoft.IdentityModel.TestExtensions
         {
             var tokenDescriptor = CreateTokenDescriptorWithInstanceOverrides();
             var token = CreateToken(tokenDescriptor);
-            return token.Substring(0, token.LastIndexOf('.')) + "InvalidSignature";
+            return token.Substring(0, token.LastIndexOf('.')) + ".InvalidSignature";
         }
 
         /// <summary>
@@ -193,7 +193,7 @@ namespace Microsoft.IdentityModel.TestExtensions
         {
             var tokenDescriptor = CreateTokenDescriptorWithInstanceOverrides();
             var token = CreateToken(tokenDescriptor);
-            return token.Substring(0, token.LastIndexOf('.'));
+            return token.Substring(0, token.LastIndexOf('.') + 1);
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.SampleTests/SampleTokenValidationClass.cs
+++ b/test/Microsoft.IdentityModel.SampleTests/SampleTokenValidationClass.cs
@@ -49,7 +49,7 @@ namespace Microsoft.IdentityModel.SampleTests
         /// </summary>
         public SampleTokenValidationClass()
         {
-            JwtHandler = new JsonWebTokenHandler();
+            JsonWebTokenHandler = new JsonWebTokenHandler();
             JwtSecurityTokenHandler = new JwtSecurityTokenHandler();
             TokenValidationParameters = new TokenValidationParameters()
             {
@@ -67,7 +67,7 @@ namespace Microsoft.IdentityModel.SampleTests
         /// <summary>
         /// Gets or sets the <see cref="JsonWebTokenHandler"/> instance used for the validation operations.
         /// </summary>
-        public JsonWebTokenHandler JwtHandler { get; set; }
+        public JsonWebTokenHandler JsonWebTokenHandler { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="JwtSecurityTokenHandler"/> instance used for the validation operations.
@@ -89,7 +89,7 @@ namespace Microsoft.IdentityModel.SampleTests
         /// <param name="token">The token to validate.</param>
         public void ValidateTokenShimWithDeprecatedModel(string token)
         {
-            var result = ValidateTokenShimWithDeprecatedModel(token, TokenValidationParameters);            
+            var result = ValidateTokenShimWithDeprecatedModel(token, TokenValidationParameters);
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace Microsoft.IdentityModel.SampleTests
         /// </param>
         public void ValidateTokenShim(string token, TokenValidationParameters tokenValidationParameters)
         {
-            var result = JwtHandler.ValidateToken(token, tokenValidationParameters);
+            var result = JsonWebTokenHandler.ValidateToken(token, tokenValidationParameters);
 
             if (!result.IsValid)
             {

--- a/test/Microsoft.IdentityModel.SampleTests/SampleTokenValidationClassTests.cs
+++ b/test/Microsoft.IdentityModel.SampleTests/SampleTokenValidationClassTests.cs
@@ -84,8 +84,8 @@ namespace Microsoft.IdentityModel.SampleTests
         {
             TestWithGeneratedToken(
                 testTokenCreator.CreateTokenWithNoSignature,
-                typeof(ArgumentException),
-                "IDX14111");
+                typeof(SecurityTokenInvalidSignatureException),
+                "IDX10504:");
         }
 
         /// <summary>
@@ -96,8 +96,8 @@ namespace Microsoft.IdentityModel.SampleTests
         {
             TestWithGeneratedToken(
                 testTokenCreator.CreateTokenWithInvalidSignature,
-                typeof(ArgumentException),
-                "IDX14111");
+                typeof(SecurityTokenInvalidSignatureException),
+                "IDX10511:");
         }
 
         /// <summary>
@@ -508,7 +508,7 @@ namespace Microsoft.IdentityModel.SampleTests
             {
                 action();
 
-                if (innerExceptionType != null || innerExceptionType != null)
+                if (innerExceptionType != null || !string.IsNullOrEmpty(innerExceptionMessagePart))
                     throw new TestException(
                         string.Format(
                             "Expected an exception of type '{0}' containing '{1}' in the message.",


### PR DESCRIPTION
Renamed JwtHandler -> JsonWebTokenHandler to make it easier to understand which handler is being used.
Adjust tests to throw invalid signature, the tests were throwing an ArgumentException as the JWT was not well formed.