### PR TITLE
added the SecurityToken.RawToken property to support more token types including MSA

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -272,7 +272,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <summary>
         /// Gets the original raw data of this instance when it was created.
         /// </summary>
-        public string EncodedToken { get; private set; }
+        public string EncodedToken { get => RawToken; private set { RawToken = value; } }
 
         /// <summary>
         /// Not implemented.
@@ -346,7 +346,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             else
                 DecodeJws(tokenParts);
 
-            EncodedToken = rawData;
+            RawToken = rawData;
         }
 
         private static void AddClaimsFromJToken(List<Claim> claims, string claimType, JToken jtoken, string issuer)

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -1224,6 +1224,9 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 throw LogExceptionMessage(new SecurityTokenValidationException(
                     FormatInvariant(TokenLogMessages.IDX10254, LogHelper.MarkAsNonPII(_className), LogHelper.MarkAsNonPII("ValidateToken"), LogHelper.MarkAsNonPII(GetType()), LogHelper.MarkAsNonPII("ValidateSignature"), LogHelper.MarkAsNonPII(typeof(SamlSecurityToken)))));
 
+            // save the original raw token
+            samlToken.RawToken = token;
+
             return ValidateToken(samlToken, token, validationParameters, out validatedToken);
         }
 

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -290,6 +290,10 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
 
             ValidateIssuerSecurityKey(samlToken.SigningKey, samlToken, validationParameters);
             validatedToken = samlToken;
+
+            // save the original raw token
+            validatedToken.RawToken = token;
+
             var identity = CreateClaimsIdentity(samlToken, issuer, validationParameters);
             if (validationParameters.SaveSigninToken)
                 identity.BootstrapContext = samlToken.Assertion.CanonicalString;

--- a/src/Microsoft.IdentityModel.Tokens/SecurityToken.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityToken.cs
@@ -68,6 +68,6 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Gets the original raw data of this instance when it was created.
         /// </summary>
-        public string RawToken { get; protected internal set; }
+        public string RawToken { get; set; }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/SecurityToken.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityToken.cs
@@ -64,5 +64,10 @@ namespace Microsoft.IdentityModel.Tokens
         /// This must be overridden to get the time when this <see cref="SecurityToken"/> is no longer Valid.
         /// </summary>
         public abstract DateTime ValidTo { get; }
+
+        /// <summary>
+        /// Gets the original raw data of this instance when it was created.
+        /// </summary>
+        public string RawToken { get; protected internal set; }
     }
 }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
@@ -349,7 +349,7 @@ namespace System.IdentityModel.Tokens.Jwt
         /// </summary>
         /// <remarks>The original JSON Compact serialized format passed to one of the two constructors <see cref="JwtSecurityToken(string)"/>
         /// or <see cref="JwtSecurityToken( JwtHeader, JwtPayload, string, string, string )"/></remarks>
-        public string RawData { get; private set; }
+        public string RawData { get => RawToken; private set { RawToken = value; } }
 
         /// <summary>
         /// Gets the original raw data of this instance when it was created.
@@ -515,7 +515,7 @@ namespace System.IdentityModel.Tokens.Jwt
             else
                 DecodeJws(tokenParts);
 
-            RawData = rawData;
+            RawToken = rawData;
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -485,7 +485,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 theoryData.ExpectedException.ProcessNoException(context);
                 context.PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
                 {
-                    { typeof(JsonWebToken), new List<string> { "EncodedToken", "AuthenticationTag", "Ciphertext", "InitializationVector" } },
+                    { typeof(JsonWebToken), new List<string> { "EncodedToken", "AuthenticationTag", "Ciphertext", "InitializationVector", "RawToken" } },
                 };
 
                 var jweTokenFromJwtHandler = new JsonWebToken(jweFromJwtHandler);
@@ -716,7 +716,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
                 context.PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
                 {
-                    { typeof(JsonWebToken), new List<string> { "EncodedToken", "AuthenticationTag", "Ciphertext", "InitializationVector" } },
+                    { typeof(JsonWebToken), new List<string> { "EncodedToken", "AuthenticationTag", "Ciphertext", "InitializationVector", "RawToken" } },
                 };
 
                 IdentityComparer.AreEqual(jweTokenFromSecurityTokenDescriptor, jweTokenFromString, context);
@@ -1229,7 +1229,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
             context.PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
             {
-                { typeof(JsonWebToken), new List<string> { "EncodedToken", "AuthenticationTag", "Ciphertext", "InitializationVector", "EncryptedKey" } },
+                { typeof(JsonWebToken), new List<string> { "EncodedToken", "AuthenticationTag", "Ciphertext", "InitializationVector", "EncryptedKey", "RawToken" } },
             };
             IdentityComparer.AreEqual(jwtToken, jwtTokenToCompare, context);
 
@@ -1751,7 +1751,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         //RsaPss produces different signatures
                         PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
                         {
-                            { typeof(JsonWebToken), new List<string> { "EncodedToken", "EncodedSignature" } },
+                            { typeof(JsonWebToken), new List<string> { "EncodedToken", "EncodedSignature", "RawToken" } },
                         },
                         TokenDescriptor =  new SecurityTokenDescriptor
                         {

--- a/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/WsFederationMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/WsFederationMessageTests.cs
@@ -776,7 +776,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
         {
             public WsFederationSigninMessageTheoryData()
             {
-                PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>> { { typeof(SamlAssertion), new List<string> { "Signature", "SigningCredentials", "CanonicalString" } }, { typeof(Saml2Assertion), new List<string> { "Signature", "SigningCredentials", "CanonicalString" } } };
+                PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>> { { typeof(SamlAssertion), new List<string> { "Signature", "SigningCredentials", "CanonicalString" } }, { typeof(Saml2Assertion), new List<string> { "Signature", "SigningCredentials", "CanonicalString" } }, { typeof(SamlSecurityToken), new List<string> { "RawToken" } }, { typeof(Saml2SecurityToken), new List<string> { "RawToken" } } };
                 TokenValidationParameters = new TokenValidationParameters
                 {
                     IssuerSigningKey = Default.AsymmetricSigningKey,

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/RoundTripSamlTokenTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/RoundTripSamlTokenTests.cs
@@ -78,6 +78,9 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                 // ensure the SamlAssertion.CanonicalString can be validated needed for OnBehalfOf flows.
                 var principal5 = theoryData.Handler.ValidateToken((principal.Identity as ClaimsIdentity).BootstrapContext as string, theoryData.ValidationParameters, out SecurityToken validatedToken5);
 
+                // the RawToken values can be different and should have no effect on other property values and need to be ignored
+                context.PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>> { { typeof(SamlSecurityToken), new List<string> { "RawToken" } }, { typeof(Saml2SecurityToken), new List<string> { "RawToken" } } };
+
                 IdentityComparer.AreEqual(validatedToken, validatedToken2, context);
                 IdentityComparer.AreEqual(validatedToken, validatedToken3, context);
                 IdentityComparer.AreEqual(validatedToken, validatedToken4, context);

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
@@ -328,7 +328,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             context.PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
             {
                 { typeof(Saml2Assertion), new List<string> { "IssueInstant", "InclusiveNamespacesPrefixList", "Signature", "SigningCredentials", "CanonicalString" } },
-                { typeof(Saml2SecurityToken), new List<string> { "SigningKey" } },
+                { typeof(Saml2SecurityToken), new List<string> { "SigningKey", "RawToken" } },
             };
 
             try
@@ -1127,7 +1127,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             context.PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
             {
                 { typeof(Saml2Assertion), new List<string> { "IssueInstant", "InclusiveNamespacesPrefixList", "Signature", "SigningCredentials", "CanonicalString" } },
-                { typeof(Saml2SecurityToken), new List<string> { "SigningKey" } },
+                { typeof(Saml2SecurityToken), new List<string> { "SigningKey", "RawToken" } },
             };
 
             try

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
@@ -867,7 +867,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             context.PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
             {
                 { typeof(SamlAssertion), new List<string> { "IssueInstant", "InclusiveNamespacesPrefixList", "Signature", "SigningCredentials", "CanonicalString" } },
-                { typeof(SamlSecurityToken), new List<string> { "SigningKey" } },
+                { typeof(SamlSecurityToken), new List<string> { "SigningKey", "RawToken" } },
             };
 
             try
@@ -1099,7 +1099,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             context.PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
             {
                 { typeof(SamlAssertion), new List<string> { "IssueInstant", "InclusiveNamespacesPrefixList", "Signature", "SigningCredentials", "CanonicalString" } },
-                { typeof(SamlSecurityToken), new List<string> { "SigningKey" } },
+                { typeof(SamlSecurityToken), new List<string> { "SigningKey", "RawToken" } },
             };
 
             try

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
@@ -245,7 +245,8 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
                 {
                     { typeof(JwtHeader), new List<string> { "Item" } },
-                    { typeof(JwtPayload), new List<string> { "Item" } }
+                    { typeof(JwtPayload), new List<string> { "Item" } },
+                    { typeof(JwtSecurityToken), new List<string> { "RawToken" } }
                 }
             };
 
@@ -649,7 +650,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 //RsaPss produces different signatures
                 PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
                 {
-                    { typeof(JwtSecurityToken), new List<string> { "RawSignature", "RawData" } },
+                    { typeof(JwtSecurityToken), new List<string> { "RawSignature", "RawData", "RawToken" } },
                 },
                 ValidationParameters = new TokenValidationParameters
                 {


### PR DESCRIPTION
Currently the classes deriving from the SecurityToken have their own properties for setting the raw token values including:

1. JsonWebToken.EncodedToken
2. JwtSecurityToken.RawDara

With the addition of the MsaToken(and other types to be supported), a new property, RawToken, is now added to the SecurityToken class to capture the raw value of a token.
