### PR TITLE
Adding netstandard1.3 target to Abstractions assembly

### DIFF
--- a/src/Microsoft.IdentityModel.Abstractions/Microsoft.IdentityModel.Abstractions.csproj
+++ b/src/Microsoft.IdentityModel.Abstractions/Microsoft.IdentityModel.Abstractions.csproj
@@ -8,6 +8,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Microsoft.IdentityModel.Abstractions</PackageId>
     <PackageTags>.NET;Windows;Authentication;Identity;Abstractions</PackageTags>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(SrcTargets);netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">$(SrcStandardTargets);netstandard1.3</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
MSAL needs to take a dependency on Microsoft.IdentityModel.Abstractions assembly to implement IIdentityLogger interface.
MSAL targets netstandard1.3 but Wilson doesn't.

This PR adds a target to netstandard1.3 to Abstractions assembly alone in Wilson to support MSAL.
