### PR TITLE
Custom log level Enum to remove dependency on EventLevel

### DIFF
--- a/src/Microsoft.IdentityModel.Abstractions/EventLogLevel.cs
+++ b/src/Microsoft.IdentityModel.Abstractions/EventLogLevel.cs
@@ -28,24 +28,42 @@
 namespace Microsoft.IdentityModel.Abstractions
 {
     /// <summary>
-    /// A minimalistic <see cref="IIdentityLogger"/> implementation that is disabled by default and doesn't log.
+    /// Defines Event Log Levels.
     /// </summary>
-    public sealed class NullIdentityModelLogger : IIdentityLogger
+    public enum EventLogLevel
     {
         /// <summary>
-        /// Default instance of <see cref="NullIdentityModelLogger"/>.
+        /// No level filtering is done on this log level. Log messages of all levels will be logged.
         /// </summary>
-        public static NullIdentityModelLogger Instance { get; } = new NullIdentityModelLogger();
+        LogAlways = 0,
 
-        private NullIdentityModelLogger() { }
+        /// <summary>
+        /// Logs that describe an unrecoverable application or system crash, or a catastrophic failure that requires
+        /// immediate attention.
+        /// </summary>
+        Critical = 1,
 
-        /// <inheritdoc/>
-        public bool IsEnabled(EventLogLevel eventLogLevel) => false;
+        /// <summary>
+        /// Logs that highlight when the current flow of execution is stopped due to a failure. These should indicate a
+        /// failure in the current activity, not an application-wide failure.
+        /// </summary>
+        Error = 2,
 
-        /// <inheritdoc/>
-        public void Log(LogEntry entry)
-        {
-            // no-op
-        }
+        /// <summary>
+        /// Logs that highlight an abnormal or unexpected event in the application flow, but do not otherwise cause the
+        /// application execution to stop.
+        /// </summary>
+        Warning = 3,
+
+        /// <summary>
+        /// Logs that track the general flow of the application. These logs should have long-term value.
+        /// </summary>
+        Informational = 4,
+
+        /// <summary>
+        /// Logs that are used for interactive investigation during development. These logs should primarily contain
+        /// information useful for debugging and have no long-term value.
+        /// </summary>
+        Verbose = 5
     }
 }

--- a/src/Microsoft.IdentityModel.Abstractions/IIdentityLogger.cs
+++ b/src/Microsoft.IdentityModel.Abstractions/IIdentityLogger.cs
@@ -25,8 +25,6 @@
 //
 //------------------------------------------------------------------------------
 
-using System.Diagnostics.Tracing;
-
 namespace Microsoft.IdentityModel.Abstractions
 {
     /// <summary>
@@ -35,15 +33,15 @@ namespace Microsoft.IdentityModel.Abstractions
     public interface IIdentityLogger
     {
         /// <summary>
-        /// Checks to see if logging is enabled at given <paramref name="eventLevel"/>.
+        /// Checks to see if logging is enabled at given <paramref name="eventLogLevel"/>.
         /// </summary>
-        /// <param name="eventLevel">Log level of an Event.</param>
-        bool IsEnabled(EventLevel eventLevel);
+        /// <param name="eventLogLevel">Log level of a message.</param>
+        bool IsEnabled(EventLogLevel eventLogLevel);
 
         /// <summary>
         /// Writes a log entry.
         /// </summary>
-        /// <param name="entry">Defines a structured message to be logged at the provided <see cref="LogEntry.EventLevel"/>.</param>
+        /// <param name="entry">Defines a structured message to be logged at the provided <see cref="LogEntry.EventLogLevel"/>.</param>
         void Log(LogEntry entry);
     }
 }

--- a/src/Microsoft.IdentityModel.Abstractions/LogEntry.cs
+++ b/src/Microsoft.IdentityModel.Abstractions/LogEntry.cs
@@ -25,8 +25,6 @@
 //
 //------------------------------------------------------------------------------
 
-using System.Diagnostics.Tracing;
-
 namespace Microsoft.IdentityModel.Abstractions
 {
     /// <summary>
@@ -35,9 +33,9 @@ namespace Microsoft.IdentityModel.Abstractions
     public class LogEntry
     {
         /// <summary>
-        /// Defines the <see cref="EventLevel"/>.
+        /// Defines the <see cref="EventLogLevel"/>.
         /// </summary>
-        public EventLevel EventLevel { get; set; }
+        public EventLogLevel EventLogLevel { get; set; }
 
         /// <summary>
         /// Message to be logged.

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/LogMessages.cs
@@ -49,7 +49,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         internal const string IDX21305 = "IDX21305: OpenIdConnectProtocolValidationContext.ProtocolMessage.Code is null, there is no 'code' in the OpenIdConnect Response to validate.";
         internal const string IDX21306 = "IDX21306: The 'c_hash' claim was not a string in the 'id_token', but a 'code' was in the OpenIdConnectMessage, 'id_token': '{0}'.";
         internal const string IDX21307 = "IDX21307: The 'c_hash' claim was not found in the id_token, but a 'code' was in the OpenIdConnectMessage, id_token: '{0}'";
-        internal const string IDX21308 = "IDX21308: 'Azp' claim exists in the 'id_token' but 'ciient_id' is null. Cannot validate the 'azp' claim.";
+        internal const string IDX21308 = "IDX21308: 'azp' claim exists in the 'id_token' but 'client_id' is null. Cannot validate the 'azp' claim.";
         internal const string IDX21309 = "IDX21309: Validating 'at_hash' using id_token and access_token.";
         internal const string IDX21310 = "IDX21310: OpenIdConnectProtocolValidationContext.ProtocolMessage.AccessToken is null, there is no 'token' in the OpenIdConnect Response to validate.";
         internal const string IDX21311 = "IDX21311: The 'at_hash' claim was not a string in the 'id_token', but an 'access_token' was in the OpenIdConnectMessage, 'id_token': '{0}'.";

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -57,7 +57,6 @@ namespace Microsoft.IdentityModel.Protocols
         /// </summary>
         static ConfigurationManager()
         {
-            LogHelper.LogVerbose("Assembly version info: " + LogHelper.MarkAsNonPII(typeof(ConfigurationManager<T>).AssemblyQualifiedName));
         }
 
         /// <summary>

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -101,7 +101,6 @@ namespace System.IdentityModel.Tokens.Jwt
         /// </summary>
         static JwtSecurityTokenHandler()
         {
-            LogHelper.LogVerbose("Assembly version info: " + LogHelper.MarkAsNonPII(typeof(JwtSecurityTokenHandler).AssemblyQualifiedName));
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.Logging.Tests/TestLogger.cs
+++ b/test/Microsoft.IdentityModel.Logging.Tests/TestLogger.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.IdentityModel.Abstractions;
+
+namespace Microsoft.IdentityModel.Logging.Tests
+{
+    public class TestLogger : IIdentityLogger
+    {
+        readonly List<Tuple<string, EventLogLevel>> _logs = new List<Tuple<string, EventLogLevel>>();
+
+        public bool IsLoggerEnabled { get; set; } = true;
+
+        public bool IsEnabled(EventLogLevel logLevel)
+        {
+            return IsLoggerEnabled;
+        }
+
+        public void Log(LogEntry entry)
+        {
+            _logs.Add(new Tuple<string, EventLogLevel>(entry.Message, entry.EventLogLevel));
+        }
+
+        public bool ContainsLog(string substring)
+        {
+            if (string.IsNullOrEmpty(substring))
+                return true;
+
+            return _logs.Any(x => x.Item1.Contains(substring));
+        }
+
+        public bool ContainsLogOfSpecificLevel(string substring, EventLogLevel logLevel)
+        {
+            if (string.IsNullOrEmpty(substring))
+                throw new ArgumentException("Provided value is null or empty.", nameof(substring));
+
+            return _logs.Any(x => x.Item1.Contains(substring) && x.Item2 == logLevel);
+        }
+    }
+}


### PR DESCRIPTION
Microsoft.IdentityModel.Abstractions currently depends on System.Diagnostics.Tracing.EventLevel. This PR removes that dependency and replaces it with a custom LogSeverityLevel Enum. 

This was done so that SDKs that consume this assembly won't run into compatibility issues. 