### PR TITLE
[DRAFT/SAMPLE] Jennyf/log message test

### DIFF
--- a/src/Microsoft.IdentityModel.Extensions.AspNetCore/IdentityModelLoggerAdapter.cs
+++ b/src/Microsoft.IdentityModel.Extensions.AspNetCore/IdentityModelLoggerAdapter.cs
@@ -102,7 +102,7 @@ namespace Microsoft.IdentityModel.Extensions.AspNetCore
         private static string FormatEntry(LogEntry entry)
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append(entry.CorrelationId).Append(";");
+            sb.Append(entry.CorrelationId).Append("");
             sb.Append(entry.Message);
             return sb.ToString();
         }


### PR DESCRIPTION
@sruke I was just looking at different ways of formatting the logs. Also turned the ";" to "" for CorrelationId.

<img width="668" alt="image" src="https://user-images.githubusercontent.com/19942418/167049973-c0778ab0-6cc4-4fc8-abcc-4c67d5296cc6.png">
