### PR TITLE
Fix IIdentityLogger Unit Test

### DIFF
--- a/test/Microsoft.IdentityModel.Logging.Tests/LoggerTests.cs
+++ b/test/Microsoft.IdentityModel.Logging.Tests/LoggerTests.cs
@@ -312,6 +312,9 @@ namespace Microsoft.IdentityModel.Logging.Tests
 
     public class LoggerTheoryData : TheoryDataBase
     {
+        public LoggerTheoryData() : base(false)
+        { }
+
         public IIdentityLogger Logger { get; set; } = null;
 
         public bool ShouldMessageBeLogged { get; set; }


### PR DESCRIPTION
Issue:
Default constructor for TheoryDataBase sets IdentityModelEventSource.ShowPII property to True. Logger tests were utilizing the default constructor and causing PII tests to fail because ShowPII is static and its value persists between tests.

Fix:
Explicitly set ShowPII to false when creating classes that inherit TheeoryDataBase