### PR TITLE
fixed a test failure because the event queue task needs more time to …

### DIFF
--- a/test/Microsoft.IdentityModel.Tokens.Tests/EventBasedLRUCacheTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/EventBasedLRUCacheTests.cs
@@ -105,10 +105,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             AddItemsToCache(cache, 3 * capacity, expiredInSeconds);
 
             // allows the event queue task to be started to compact the cache
-            Thread.Sleep(100);
-
-            // wait until the event queue is empty
             cache.WaitForProcessing();
+            Thread.Sleep(waitInMiliSeconds);
 
             // the number of cached items should be below the capacity after compaction
             if (cache.MapCount > capacity)

--- a/test/Microsoft.IdentityModel.Tokens.Tests/EventBasedLRUCacheTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/EventBasedLRUCacheTests.cs
@@ -104,11 +104,17 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             // add 3 times the capacity to start the compaction process
             AddItemsToCache(cache, 3 * capacity, expiredInSeconds);
 
-            // allows the event queue task to be started to compact the cache
+            // allows the compaction event to be processed
             cache.WaitForProcessing();
-            Thread.Sleep(waitInMiliSeconds);
 
-            // the number of cached items should be below the capacity after compaction
+            // keep checking the cache size, up to 1 min, until it is reduced
+            for (int i = 0; i < 10; i++)
+            {
+                // wait 0.1 sec if the cache size > the capacity
+                if (cache.MapCount > capacity)
+                    Thread.Sleep(100); // sleep 0.1 sec
+            }
+
             if (cache.MapCount > capacity)
                 context.AddDiff($"The cache size should be less than {capacity}.");
 


### PR DESCRIPTION
This change is to increase the wait time in the CaompactCache() unit test to ensure that the event queue thread can be started to perform the cache compaction action.