### PR TITLE
Improve logging for tokens

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -331,7 +331,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <param name="rawData">the original token.</param>
         private void Decode(string[] tokenParts, string rawData)
         {
-            LogHelper.LogInformation(LogMessages.IDX14106, rawData);
             try
             {
                 Header = JObject.Parse(Base64UrlEncoder.Decode(tokenParts[0]));

--- a/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
@@ -46,7 +46,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         internal const string IDX14102 = "IDX14102: Unable to decode the header '{0}' as Base64Url encoded string. jwtEncodedString: '{1}'.";
         internal const string IDX14103 = "IDX14103: Failed to create the token encryption provider.";
         internal const string IDX14105 = "IDX14105: Header.Cty != null, assuming JWS. Cty: '{0}'.";
-        internal const string IDX14106 = "IDX14106: Decoding token: '{0}' into header, payload and signature.";
+        // internal const string IDX14106 = "IDX14106:";
         internal const string IDX14107 = "IDX14107: Token string does not match the token formats: JWE (header.encryptedKey.iv.ciphertext.tag) or JWS (header.payload.signature)";
         internal const string IDX14111 = "IDX14111: JWT: '{0}' must have three segments (JWS) or five segments (JWE).";
         internal const string IDX14112 = "IDX14112: Only a single 'Actor' is supported. Found second claim of type: '{0}', value: '{1}'";

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
@@ -500,7 +500,6 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <param name="rawData">the original token.</param>
         internal void Decode(string[] tokenParts, string rawData)
         {
-            LogHelper.LogInformation(LogMessages.IDX12716, rawData);
             try
             {
                 Header = JwtHeader.Base64UrlDeserialize(tokenParts[0]);

--- a/src/System.IdentityModel.Tokens.Jwt/LogMessages.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/LogMessages.cs
@@ -50,7 +50,7 @@ namespace System.IdentityModel.Tokens.Jwt
         internal const string IDX12713 = "IDX12713: Creating actor value using actor.BootstrapContext(as string)";
         internal const string IDX12714 = "IDX12714: Creating actor value using actor.BootstrapContext.rawData";
         internal const string IDX12715 = "IDX12715: Creating actor value by writing the JwtSecurityToken created from actor.BootstrapContext";
-        internal const string IDX12716 = "IDX12716: Decoding token: '{0}' into header, payload and signature.";
+        // internal const string IDX12716 = "IDX12716:";
         internal const string IDX12720 = "IDX12720: Token string does not match the token formats: JWE (header.encryptedKey.iv.ciphertext.tag) or JWS (header.payload.signature)";
         internal const string IDX12721 = "IDX12721: Creating JwtSecurityToken: Issuer: '{0}', Audience: '{1}'";
         internal const string IDX12722 = "IDX12722: Creating security token from the header: '{0}', payload: '{1}' and raw signature: '{2}'.";


### PR DESCRIPTION
Tokens shouldn't be logged with signatures when they are in encoded or encrypted formats. 