### PR TITLE
change method to protected virtual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,30 @@
 See the [release notes](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Release-Notes) for details on bug fixes and added features.
 
 
+Next release (6.22.1 or 6.23.0)
+=========
+### New Features:
+Microsoft.IdentityModel has two assemblies to manipulate JWT tokens:
 
+System.IdentityModel.Tokens.Jwt, which is the legacy assembly. It defines JwtSecurityTokenHandler class to manipulate JWT tokens.
+Microsoft.IdentityModel.JsonWebTokens, which defines the JsonWebToken class and JsonWebTokenHandler, more modern, and more efficient.
+When using JwtSecurityTokenHandler, the short named claims (oid, tid), used to be transformed into the long named claims (with a namespace). With JsonWebTokenHandler this is no longer the case, but when you migrate your application from using JwtSecurityTokenHandler to JsonWebTokenHandler (or use a framework that does), you will only get original claims sent by the IdP. This is more efficient, and occupies less space, but might trigger a lot of changes in your application. In order to make it easier for people to migrate without changing their app too much, this PR offers extensibility to re-add the claims mapping.
+
+### Bug Fixes:
+
+
+6.22.0
+=========
+
+### New Features:
+
+**Unmasked non-PII properties in log messages -**
+In Microsoft.IdentityModel logs, previously only system metadata (DateTime, class name, httpmethod etc.) was displayed in clear text. For all other log arguments, the type was being logged to prevent Personally Identifiable Information (PII) from being displayed when ShowPII flag is turned OFF. To improve troubleshooting experience non-PII properties - Issuer, Audience, Key location, Key Id (kid) and some SAML constants will now be displayed in clear text. See issue #1903 for more details.
+
+**Prefix Wilson header message to the first log message -**
+To always log the Wilson header (Version, DateTime, PII ON/OFF message), EventLogLevel.LogAlways was mapped to LogLevel.Critical in Microsoft.IdentityModel.LoggingExtensions.IdentityLoggerAdapter class which caused confusion on why header was being displayed as a fatal log.
+To address this, header is now prefixed to the first message logged by Wilson and separated with a newline. EventLogLevel.LogAlways has been remapped to LogLevel.Trace. See issue #1907 for more details.
+
+### Bug Fixes:
+
+**[Copy the IssuerSigningKeyResolverUsingConfiguration delegate in Clone()](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/commit/652d5d8d7371c2882306d3e95fc6e0de21ac7411)** #1909

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -679,9 +679,24 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             return CreateClaimsIdentity(jwtToken, validationParameters, actualIssuer);
         }
 
-        private ClaimsIdentity CreateClaimsIdentity(JsonWebToken jwtToken, TokenValidationParameters validationParameters, string actualIssuer)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="jwtToken"></param>
+        /// <param name="validationParameters"></param>
+        /// <param name="issuer"></param>
+        /// <returns></returns>
+        protected virtual ClaimsIdentity CreateClaimsIdentity(JsonWebToken jwtToken, TokenValidationParameters validationParameters, string issuer)
         {
-            ClaimsIdentity identity = validationParameters.CreateClaimsIdentity(jwtToken, actualIssuer);
+
+            if (jwtToken == null)
+                throw LogHelper.LogArgumentNullException(nameof(jwtToken));
+
+            if (validationParameters == null)
+                throw LogHelper.LogArgumentNullException(nameof(validationParameters));
+
+
+            ClaimsIdentity identity = validationParameters.CreateClaimsIdentity(jwtToken, issuer);
             foreach (Claim jwtClaim in jwtToken.Claims)
             {
                 string claimType = jwtClaim.Type;
@@ -693,17 +708,17 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     if (CanReadToken(jwtClaim.Value))
                     {
                         JsonWebToken actor = ReadToken(jwtClaim.Value) as JsonWebToken;
-                        identity.Actor = CreateClaimsIdentity(actor, validationParameters, actualIssuer);
+                        identity.Actor = CreateClaimsIdentity(actor, validationParameters, issuer);
                     }
                 }
 
                 if (jwtClaim.Properties.Count == 0)
                 {
-                    identity.AddClaim(new Claim(claimType, jwtClaim.Value, jwtClaim.ValueType, actualIssuer, actualIssuer, identity));
+                    identity.AddClaim(new Claim(claimType, jwtClaim.Value, jwtClaim.ValueType, issuer, issuer, identity));
                 }
                 else
                 {
-                    Claim claim = new Claim(claimType, jwtClaim.Value, jwtClaim.ValueType, actualIssuer, actualIssuer, identity);
+                    Claim claim = new Claim(claimType, jwtClaim.Value, jwtClaim.ValueType, issuer, issuer, identity);
 
                     foreach (var kv in jwtClaim.Properties)
                         claim.Properties[kv.Key] = kv.Value;

--- a/test/Microsoft.IdentityModel.TestUtils/Default.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/Default.cs
@@ -362,6 +362,18 @@ namespace Microsoft.IdentityModel.TestUtils
         {
             get => "<OuterXml></OuterXml>";
         }
+
+        public static string Birthdate = EpochTime.GetIntDate(DateTime.Parse("2000-03-18")).ToString();
+        public static string Email = "bob@contoso.com";
+        public static string Gender = "male";
+        public static string Name2 = "Name2";
+        public static string NameId = "NameId1";
+        public static string Idp2 = @"https://sts.windows.net2/add29489-7269-41f4-8841-b63c95564422/";
+        public static string IdpAddr = "50.46.159.51";
+        public static string IdpAddr2 = "50.46.159.52";
+        public static string Version = "1.0";
+        public static string Version2 = "2.0";
+
 #if !CrossVersionTokenValidation
         public static string AadPayloadString
         {
@@ -487,6 +499,97 @@ namespace Microsoft.IdentityModel.TestUtils
         {
             payloadClaims.Remove(claimName);
             return payloadClaims;
+        }
+
+        public static List<Claim> PayloadAllShortClaims
+        {
+            get => new List<Claim>()
+            {
+                new Claim(JwtRegisteredClaimNames.Email, "Bob@contoso.com", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.GivenName, "Bob", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Iss, Default.Issuer, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Aud, Default.Audience, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(Default.IssueInstant).ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(Default.NotBefore).ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Default.Expires).ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("idtyp", "app", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Acr, "contoso-loa-1", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Actort, string.Format("{0},{1},{2}",
+                    Guid.NewGuid().ToString(),
+                    Guid.NewGuid().ToString(),
+                    Guid.NewGuid().ToString()),
+                    ClaimValueTypes.String,
+                    Issuer,
+                    Issuer),
+                new Claim(JwtRegisteredClaimNames.Amr, Amr, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Birthdate, Birthdate, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Email, Email, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Gender, Gender, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.NameId, NameId, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Website, Uri.ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("adfs1email", "adfs@contoso.com", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("authmethod", "introspection_endpoint_auth_methods_supported", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certapppolicy", "certapppolicy", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certauthoritykeyidentifier", Guid.NewGuid().ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certbasicconstraints", "not_null", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certeku", Guid.NewGuid().ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certissuer", Issuer, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certissuername", Name2, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certkeyusage", "signing", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certnotafter", EpochTime.GetIntDate(DateTime.UtcNow.AddDays(7)).ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certnotbefore", EpochTime.GetIntDate(DateTime.UtcNow.AddDays(-1)).ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certpolicy", "certpolicy", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certpublickey", Default.X509AsymmetricSigningCredentials.Key.ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certrawdata", "raw data", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certserialnumber", Guid.NewGuid().ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certsignaturealgorithm", Default.X509AsymmetricSigningCredentials.Algorithm, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certsubject", "welcome", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certsubjectaltname", Name2, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certsubjectkeyidentifier", Guid.NewGuid().ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certsubjectname", Name2, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certtemplateinformation", "information", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certtemplatename", "templatename", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certthumbprint", Guid.NewGuid().ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("certx509version", Default.X509AsymmetricSigningCredentials.Certificate.Version.ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("clientapplication", "clientapplication", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("clientip", IdpAddr, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("clientuseragent", new JObject() {
+                    {"applicationVersion", Version2 },
+                    {"headerValue", "user-agent header" },
+                    {"platform", "windows" },
+                    {"productFamily", "teams" }}.ToString(),
+                    ClaimValueTypes.String,
+                    Issuer,
+                    Issuer),
+                new Claim("commonname", Uri.ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("denyonlyprimarygroupsid", Uri.ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("denyonlyprimarysid", Uri.ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("denyonlysid", Uri.ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("devicedispname", Uri.ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("deviceid", Guid.NewGuid().ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("deviceismanaged", "false", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("deviceostype", "windows", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("deviceosver", "2017", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("deviceowner", "Microsoft", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("deviceregid", "deviceregid", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("endpointpath", "/resource/a", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("forwardedclientip", IdpAddr2, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("group", "group", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("groupsid", Guid.NewGuid().ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("idp", Idp2, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("insidecorporatenetwork", "true", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("isregistereduser", "true", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("ppid", Guid.NewGuid().ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("primarygroupsid", Guid.NewGuid().ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("primarysid", Guid.NewGuid().ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("proxy", "proxy", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("pwdchgurl", "pwdchgurl", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("pwdexpdays", "90", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("pwdexptime", EpochTime.GetIntDate(DateTime.UtcNow.AddDays(90)).ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("relyingpartytrustid", Guid.NewGuid().ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("role", "Sales", ClaimValueTypes.String, Issuer, Issuer),
+                new Claim("winaccountname", Name2, ClaimValueTypes.String, Issuer, Issuer),
+            };
         }
 #endif
 


### PR DESCRIPTION
Change to protected virtual method ClaimsIdentity CreateclaimsIdentity(JsonWebToken, TokenValidationVarameters, Issuer).

**Why?**
Microsoft.IdentityModel has two assemblies to manipulate JWT tokens:
- System.IdentityModel.Tokens.Jwt, which is the legacy assembly. It defines [JwtSecurityTokenHandler](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs) class to manipulate JWT tokens.
- Microsoft.IdentityModel.JsonWebTokens, which defines the JsonWebToken class and [JsonWebTokenHandler](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs), more modern, and more efficient.

When using `JwtSecurityTokenHandler`, the short named claims (oid, tid), used to be transformed into the long named claims (with a namespace). With JsonWebTokenHandler this is no longer the case, but when you migrate your application from using JwtSecurityTokenHandler to JsonWebTokenHandler (or use a framework that does), you will only get original claims sent by the IdP. This is more efficient, and occupies less space, but might trigger a lot of changes in your application. In order to make it easier for people to migrate without changing their app too much, this PR offers extensibility to re-add the claims mapping.