### PR TITLE
add early alerting for governance

### DIFF
--- a/build/releaseBuild.yml
+++ b/build/releaseBuild.yml
@@ -187,6 +187,10 @@ jobs:
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
+    inputs:
+      scanType: 'Register'
+      verbosity: 'Verbose'
+      alertWarningLevel: 'High'
 
   - task: PublishSymbols@2
     displayName: 'Publish symbols on symweb (cross publish)'


### PR DESCRIPTION
@jmprieur found this: https://docs.opensource.microsoft.com/tools/cg/how-to/pull-request-integration/ 

We will get alerts early, once a release build runs (daily) for any governance issues, before they become S360 action items