### PR TITLE
Modify header logic. Unmask non-PII attributes.

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -1490,13 +1490,14 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 {
                     var isKidInTVP = keysInTokenValidationParameters.Any(x => x.KeyId.Equals(jwtToken.Kid));
                     var keyLocation = isKidInTVP ? "TokenValidationParameters" : "Configuration";
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(
-                        LogHelper.FormatInvariant(TokenLogMessages.IDX10511,
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10511,
                         keysAttempted,
                         LogHelper.MarkAsNonPII(numKeysInTokenValidationParameters),
                         LogHelper.MarkAsNonPII(numKeysInConfiguration),
                         LogHelper.MarkAsNonPII(keyLocation),
-                        jwtToken.Kid, exceptionStrings, jwtToken)));
+                        LogHelper.MarkAsNonPII(jwtToken.Kid),
+                        exceptionStrings,
+                        jwtToken)));
                 }
 
                 var expires = jwtToken.TryGetClaim(JwtRegisteredClaimNames.Exp, out var _) ? (DateTime?)jwtToken.ValidTo : null;
@@ -1515,12 +1516,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             }
 
             if (keysAttempted.Length > 0)
-                throw LogHelper.LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(
-                    LogHelper.FormatInvariant(TokenLogMessages.IDX10503,
+                throw LogHelper.LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(LogHelper.FormatInvariant(TokenLogMessages.IDX10503,
                     keysAttempted,
                     LogHelper.MarkAsNonPII(numKeysInTokenValidationParameters),
                     LogHelper.MarkAsNonPII(numKeysInConfiguration),
-                    exceptionStrings, jwtToken)));
+                    exceptionStrings,
+                    jwtToken)));
 
             throw LogHelper.LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(TokenLogMessages.IDX10500));
         }

--- a/src/Microsoft.IdentityModel.LoggingExtensions/IdentityLoggerAdapter.cs
+++ b/src/Microsoft.IdentityModel.LoggingExtensions/IdentityLoggerAdapter.cs
@@ -64,7 +64,6 @@ namespace Microsoft.IdentityModel.LoggingExtensions
                 switch (entry.EventLogLevel)
                 {
                     case EventLogLevel.Critical:
-                    case EventLogLevel.LogAlways:
                         _logger.LogCritical(entry.Message);
                         break;
 
@@ -84,6 +83,10 @@ namespace Microsoft.IdentityModel.LoggingExtensions
                         _logger.LogDebug(entry.Message);
                         break;
 
+                    case EventLogLevel.LogAlways:
+                        _logger.LogTrace(entry.Message);
+                        break;
+
                     default:
                         break;
                 }
@@ -95,7 +98,6 @@ namespace Microsoft.IdentityModel.LoggingExtensions
             switch (eventLogLevel)
             {
                 case EventLogLevel.Critical:
-                case EventLogLevel.LogAlways:
                     return LogLevel.Critical;
 
                 case EventLogLevel.Error:
@@ -106,6 +108,9 @@ namespace Microsoft.IdentityModel.LoggingExtensions
 
                 case EventLogLevel.Informational:
                     return LogLevel.Information;
+
+                case EventLogLevel.LogAlways:
+                    return LogLevel.Trace;
 
                 case EventLogLevel.Verbose:
                 default:

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -1105,7 +1105,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                         return key;
                 }
 
-                throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPopKeyException(LogHelper.FormatInvariant(LogMessages.IDX23021, kid, string.Join(", ", popKeys.Select(x => x.KeyId ?? "Null")))));
+                throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPopKeyException(LogHelper.FormatInvariant(LogMessages.IDX23021, LogHelper.MarkAsNonPII(kid), string.Join(", ", popKeys.Select(x => x.KeyId ?? "Null")))));
             }
             else
             {

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSerializer.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSerializer.cs
@@ -232,23 +232,23 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 // @MajorVersion - required - must be "1"
                 var majorVersion = envelopeReader.GetAttribute(SamlConstants.Attributes.MajorVersion);
                 if (string.IsNullOrEmpty(majorVersion))
-                    throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.Assertion, SamlConstants.Attributes.MajorVersion);
+                    throw LogReadException(LogMessages.IDX11115, MarkAsNonPII(SamlConstants.Elements.Assertion), MarkAsNonPII(SamlConstants.Attributes.MajorVersion));
 
                 if (!majorVersion.Equals(SamlConstants.MajorVersionValue))
-                    throw LogReadException(LogMessages.IDX11116, majorVersion);
+                    throw LogReadException(LogMessages.IDX11116, MarkAsNonPII(majorVersion));
 
                 // @MinorVersion - required - must be "1"
                 var minorVersion = envelopeReader.GetAttribute(SamlConstants.Attributes.MinorVersion);
                 if (string.IsNullOrEmpty(minorVersion))
-                    throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.Assertion, SamlConstants.Attributes.MinorVersion);
+                    throw LogReadException(LogMessages.IDX11115, MarkAsNonPII(SamlConstants.Elements.Assertion), MarkAsNonPII(SamlConstants.Attributes.MinorVersion));
 
                 if (!minorVersion.Equals(SamlConstants.MinorVersionValue))
-                    throw LogReadException(LogMessages.IDX11117, minorVersion);
+                    throw LogReadException(LogMessages.IDX11117, MarkAsNonPII(minorVersion));
 
                 // @AssertionId - required
                 var assertionId = envelopeReader.GetAttribute(SamlConstants.Attributes.AssertionID);
                 if (string.IsNullOrEmpty(assertionId))
-                    throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.Assertion, SamlConstants.Attributes.AssertionID);
+                    throw LogReadException(LogMessages.IDX11115, MarkAsNonPII(SamlConstants.Elements.Assertion), MarkAsNonPII(SamlConstants.Attributes.AssertionID));
 
                 if (!IsAssertionIdValid(assertionId))
                     throw LogReadException(LogMessages.IDX11121, assertionId);
@@ -256,12 +256,12 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 // @Issuer - required
                 var issuer = envelopeReader.GetAttribute(SamlConstants.Attributes.Issuer);
                 if (string.IsNullOrEmpty(issuer))
-                    throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.Assertion, SamlConstants.Attributes.Issuer);
+                    throw LogReadException(LogMessages.IDX11115, MarkAsNonPII(SamlConstants.Elements.Assertion), MarkAsNonPII(SamlConstants.Attributes.Issuer));
 
                 // @IssueInstant - required
                 var issueInstantAttribute = envelopeReader.GetAttribute(SamlConstants.Attributes.IssueInstant);
                 if (string.IsNullOrEmpty(issueInstantAttribute))
-                    throw LogReadException(LogMessages.IDX11115, SamlConstants.Elements.Assertion, SamlConstants.Attributes.IssueInstant);
+                    throw LogReadException(LogMessages.IDX11115, MarkAsNonPII(SamlConstants.Elements.Assertion), MarkAsNonPII(SamlConstants.Attributes.IssueInstant));
 
                 var issueInstant = DateTime.ParseExact(issueInstantAttribute, SamlConstants.AcceptedDateTimeFormats, DateTimeFormatInfo.InvariantInfo, DateTimeStyles.None).ToUniversalTime();
 

--- a/src/Microsoft.IdentityModel.Tokens/InternalValidators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/InternalValidators.cs
@@ -81,12 +81,12 @@ namespace Microsoft.IdentityModel.Tokens
             }
 
             if (validLifetime && validIssuer)
-                throw LogHelper.LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(
-                    LogHelper.FormatInvariant(TokenLogMessages.IDX10501,
-                    kid,
+                throw LogHelper.LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(LogHelper.FormatInvariant(TokenLogMessages.IDX10501,
+                    LogHelper.MarkAsNonPII(kid),
                     LogHelper.MarkAsNonPII(numKeysInTokenValidationParameters),
                     LogHelper.MarkAsNonPII(numKeysInConfiguration),
-                    exceptionStrings, securityToken)));
+                    exceptionStrings,
+                    securityToken)));
             else
             {
                 var validationFailure = ValidationFailure.None;
@@ -100,11 +100,13 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogExceptionMessage(new SecurityTokenUnableToValidateException(
                     validationFailure,
                     LogHelper.FormatInvariant(TokenLogMessages.IDX10516,
-                    kid,
+                    LogHelper.MarkAsNonPII(kid),
                     LogHelper.MarkAsNonPII(numKeysInTokenValidationParameters),
                     LogHelper.MarkAsNonPII(numKeysInConfiguration),
-                    exceptionStrings, securityToken,
-                    LogHelper.MarkAsNonPII(validLifetime), validIssuer)));
+                    exceptionStrings,
+                    securityToken,
+                    LogHelper.MarkAsNonPII(validLifetime),
+                    LogHelper.MarkAsNonPII(validIssuer))));
             }
         }
 
@@ -156,7 +158,7 @@ namespace Microsoft.IdentityModel.Tokens
 
                 throw LogHelper.LogExceptionMessage(new SecurityTokenUnableToValidateException(
                     validationFailure,
-                    LogHelper.FormatInvariant(TokenLogMessages.IDX10515, keyInfo, exceptionStrings, securityToken, LogHelper.MarkAsNonPII(validLifetime), validIssuer)));
+                    LogHelper.FormatInvariant(TokenLogMessages.IDX10515, keyInfo, exceptionStrings, securityToken, LogHelper.MarkAsNonPII(validLifetime), LogHelper.MarkAsNonPII(validIssuer))));
             }
         }
     }

--- a/src/Microsoft.IdentityModel.Tokens/Validators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validators.cs
@@ -130,7 +130,10 @@ namespace Microsoft.IdentityModel.Tokens
                 return;
 
             throw LogHelper.LogExceptionMessage(
-                new SecurityTokenInvalidAudienceException(LogHelper.FormatInvariant(LogMessages.IDX10214, Utility.SerializeAsSingleCommaDelimitedString(audiences), (validationParameters.ValidAudience ?? "null"), Utility.SerializeAsSingleCommaDelimitedString(validationParameters.ValidAudiences)))
+                new SecurityTokenInvalidAudienceException(LogHelper.FormatInvariant(LogMessages.IDX10214,
+                LogHelper.MarkAsNonPII(Utility.SerializeAsSingleCommaDelimitedString(audiences)),
+                LogHelper.MarkAsNonPII(validationParameters.ValidAudience ?? "null"),
+                LogHelper.MarkAsNonPII(Utility.SerializeAsSingleCommaDelimitedString(validationParameters.ValidAudiences))))
                 { InvalidAudience = Utility.SerializeAsSingleCommaDelimitedString(audiences) });
         }
 
@@ -148,7 +151,7 @@ namespace Microsoft.IdentityModel.Tokens
 
                     if (AudiencesMatch(validationParameters, tokenAudience, validAudience))
                     {
-                        LogHelper.LogInformation(LogMessages.IDX10234, tokenAudience);
+                        LogHelper.LogInformation(LogMessages.IDX10234, LogHelper.MarkAsNonPII(tokenAudience));
                         return true;
                     }
                 }
@@ -185,7 +188,7 @@ namespace Microsoft.IdentityModel.Tokens
 
             if (string.CompareOrdinal(validAudience, 0, tokenAudience, 0, length) == 0)
             {
-                LogHelper.LogInformation(LogMessages.IDX10234, tokenAudience);
+                LogHelper.LogInformation(LogMessages.IDX10234, LogHelper.MarkAsNonPII(tokenAudience));
                 return true;
             }
 
@@ -260,7 +263,7 @@ namespace Microsoft.IdentityModel.Tokens
 
             if (string.Equals(validationParameters.ValidIssuer, issuer))
             {
-                LogHelper.LogInformation(LogMessages.IDX10236, issuer);
+                LogHelper.LogInformation(LogMessages.IDX10236, LogHelper.MarkAsNonPII(issuer));
                 return issuer;
             }
 
@@ -276,15 +279,18 @@ namespace Microsoft.IdentityModel.Tokens
 
                     if (string.Equals(str, issuer))
                     {
-                        LogHelper.LogInformation(LogMessages.IDX10236, issuer);
+                        LogHelper.LogInformation(LogMessages.IDX10236, LogHelper.MarkAsNonPII(issuer));
                         return issuer;
                     }
                 }
             }
 
             throw LogHelper.LogExceptionMessage(
-                new SecurityTokenInvalidIssuerException(LogHelper.FormatInvariant(LogMessages.IDX10205, issuer, (validationParameters.ValidIssuer ?? "null"), Utility.SerializeAsSingleCommaDelimitedString(validationParameters.ValidIssuers), configuration?.Issuer))
-                { InvalidIssuer = issuer });
+                new SecurityTokenInvalidIssuerException(LogHelper.FormatInvariant(LogMessages.IDX10205,
+                LogHelper.MarkAsNonPII(issuer),
+                LogHelper.MarkAsNonPII(validationParameters.ValidIssuer ?? "null"),
+                LogHelper.MarkAsNonPII(Utility.SerializeAsSingleCommaDelimitedString(validationParameters.ValidIssuers)),
+                LogHelper.MarkAsNonPII(configuration?.Issuer))) { InvalidIssuer = issuer });
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -194,11 +194,11 @@ namespace Microsoft.IdentityModel.Validators
             }
             catch (Exception ex)
             {
-                throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidIssuerException(LogHelper.FormatInvariant(LogMessages.IDX40001, issuer), ex));
+                throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidIssuerException(LogHelper.FormatInvariant(LogMessages.IDX40001, LogHelper.MarkAsNonPII(issuer)), ex));
             }
 
             // If a valid issuer is not found, throw
-            throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidIssuerException(LogHelper.FormatInvariant(LogMessages.IDX40001, issuer)));
+            throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidIssuerException(LogHelper.FormatInvariant(LogMessages.IDX40001, LogHelper.MarkAsNonPII(issuer))));
         }
 
         /// <summary>

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -664,7 +664,7 @@ namespace System.IdentityModel.Tokens.Jwt
                     notBefore = now;
             }
 
-            LogHelper.LogVerbose(LogMessages.IDX12721, (audience ?? "null"), (issuer ?? "null"));
+            LogHelper.LogVerbose(LogMessages.IDX12721, LogHelper.MarkAsNonPII(audience ?? "null"), LogHelper.MarkAsNonPII(issuer ?? "null"));
             JwtPayload payload = new JwtPayload(issuer, audience, (subject == null ? null : OutboundClaimTypeTransform(subject.Claims)), (claimCollection == null ? null : OutboundClaimTypeTransform(claimCollection)), notBefore, expires, issuedAt);
             JwtHeader header = new JwtHeader(signingCredentials, OutboundAlgorithmMap, tokenType, additionalInnerHeaderClaims);
 
@@ -1387,12 +1387,14 @@ namespace System.IdentityModel.Tokens.Jwt
                 {
                     var isKidInTVP = keysInTokenValidationParameters.Any(x => x.KeyId.Equals(jwtToken.Header.Kid));
                     var keyLocation = isKidInTVP ? "TokenValidationParameters" : "Configuration";
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(
-                        LogHelper.FormatInvariant(TokenLogMessages.IDX10511,
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10511,
                         keysAttempted,
                         LogHelper.MarkAsNonPII(numKeysInTokenValidationParameters),
-                        LogHelper.MarkAsNonPII(numKeysInConfiguration), LogHelper.MarkAsNonPII(keyLocation),
-                        jwtToken.Header.Kid, exceptionStrings, jwtToken)));
+                        LogHelper.MarkAsNonPII(numKeysInConfiguration),
+                        LogHelper.MarkAsNonPII(keyLocation),
+                        LogHelper.MarkAsNonPII(jwtToken.Header.Kid),
+                        exceptionStrings,
+                        jwtToken)));
                 }
 
                 DateTime? expires = (jwtToken.Payload.Exp == null) ? null : new DateTime?(jwtToken.ValidTo);
@@ -1411,12 +1413,12 @@ namespace System.IdentityModel.Tokens.Jwt
             }
 
             if (keysAttempted.Length > 0)
-                throw LogHelper.LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(
-                    LogHelper.FormatInvariant(TokenLogMessages.IDX10503,
+                throw LogHelper.LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(LogHelper.FormatInvariant(TokenLogMessages.IDX10503,
                     keysAttempted,
                     LogHelper.MarkAsNonPII(numKeysInTokenValidationParameters),
                     LogHelper.MarkAsNonPII(numKeysInConfiguration),
-                    exceptionStrings, jwtToken)));
+                    exceptionStrings,
+                    jwtToken)));
 
             throw LogHelper.LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(TokenLogMessages.IDX10500));
         }
@@ -1449,7 +1451,7 @@ namespace System.IdentityModel.Tokens.Jwt
             var actualIssuer = issuer;
             if (string.IsNullOrWhiteSpace(issuer))
             {
-                LogHelper.LogVerbose(TokenLogMessages.IDX10244, ClaimsIdentity.DefaultIssuer);
+                LogHelper.LogVerbose(TokenLogMessages.IDX10244, LogHelper.MarkAsNonPII(ClaimsIdentity.DefaultIssuer));
                 actualIssuer = ClaimsIdentity.DefaultIssuer;
             }
             

--- a/test/Microsoft.IdentityModel.Logging.Tests/LoggerTests.cs
+++ b/test/Microsoft.IdentityModel.Logging.Tests/LoggerTests.cs
@@ -44,6 +44,7 @@ namespace Microsoft.IdentityModel.Logging.Tests
         {
             var logger = new TestLogger();
             LogHelper.Logger = logger;
+            LogHelper.HeaderWritten = false;
 
             var arg = "Test argument.";
             var guid = Guid.NewGuid().ToString();
@@ -53,12 +54,15 @@ namespace Microsoft.IdentityModel.Logging.Tests
             var warnMessage = "Warn Message. {0}";
 
             LogHelper.LogExceptionMessage(EventLevel.Error, new ArgumentException(errorMessage));
+            Assert.True(logger.LogStartsWith("Microsoft.IdentityModel Version:", EventLogLevel.Error));
+            Assert.True(logger.ContainsLogOfSpecificLevel(errorMessage, EventLogLevel.Error));
+            Assert.True(LogHelper.HeaderWritten);
+
             LogHelper.LogArgumentNullException(guid);
             LogHelper.LogInformation(infoMessage, LogHelper.MarkAsNonPII(arg));
             LogHelper.LogVerbose(verboseMessage, LogHelper.MarkAsNonPII(arg));
             LogHelper.LogWarning(warnMessage, LogHelper.MarkAsNonPII(arg));
-
-            Assert.True(logger.ContainsLogOfSpecificLevel(errorMessage, EventLogLevel.Error));
+           
             Assert.True(logger.ContainsLogOfSpecificLevel("IDX10000:", EventLogLevel.Error));
             Assert.True(logger.ContainsLogOfSpecificLevel(string.Format(infoMessage, arg), EventLogLevel.Informational));
             Assert.True(logger.ContainsLogOfSpecificLevel(string.Format(verboseMessage, arg), EventLogLevel.Verbose));

--- a/test/Microsoft.IdentityModel.Logging.Tests/TestLogger.cs
+++ b/test/Microsoft.IdentityModel.Logging.Tests/TestLogger.cs
@@ -21,6 +21,14 @@ namespace Microsoft.IdentityModel.Logging.Tests
             _logs.Add(new Tuple<string, EventLogLevel>(entry.Message, entry.EventLogLevel));
         }
 
+        public bool LogStartsWith(string prefix, EventLogLevel logLevel)
+        {
+            if (string.IsNullOrEmpty(prefix))
+                return true;
+
+            return _logs.Any(x => x.Item1.StartsWith(prefix) && x.Item2 == logLevel);
+        }
+
         public bool ContainsLog(string substring)
         {
             if (string.IsNullOrEmpty(substring))


### PR DESCRIPTION
Header is logged as a fatal message and logging improvements -
Wilson header information (version, PII ON/OFF message, Date/Time) is being displayed as a fatal message because LogAlways EventLogLevel is mapped to Critical log level. Critical log level choice for header caused confusion in customers. 
According to [LogLevel](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loglevel?view=dotnet-plat-ext-6.0) Trace contains the most detailed information and mapping LogAlways to Trace seemes appropriate.

What this means for customers -
1. Header information will be prefixed to the first log message logged by Wilson. 
Header and the message will be separated by newline for added clarity. 
2. Properties like audience, issuer and kid that were previously marked as PII will be unmasked and displayed as clear text to improve legibility of logs