### PR TITLE
Copy the IssuerSigningKeyResolverUsingConfiguration delegate in the Clone() Method

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -229,6 +229,7 @@ namespace Microsoft.IdentityModel.Tokens
             IgnoreTrailingSlashWhenValidatingAudience = other.IgnoreTrailingSlashWhenValidatingAudience;
             IssuerSigningKey = other.IssuerSigningKey;
             IssuerSigningKeyResolver = other.IssuerSigningKeyResolver;
+            IssuerSigningKeyResolverUsingConfiguration = other.IssuerSigningKeyResolverUsingConfiguration;
             IssuerSigningKeys = other.IssuerSigningKeys;
             IssuerSigningKeyValidator = other.IssuerSigningKeyValidator;
             IssuerValidator = other.IssuerValidator;


### PR DESCRIPTION
The TokenValidationParameters.Clone() should copy the IssuerSigningKeyResolverUsingConfiguration delegate.