### PR TITLE
IdentityComparer was not ignoring the claims to be ignored

### DIFF
--- a/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
@@ -638,6 +638,9 @@ namespace Microsoft.IdentityModel.TestUtils
             int numMatched = 0;
             foreach (string key in dictionary1.Keys)
             {
+                if (context.ClaimTypesToIgnoreWhenComparing.Contains(key))
+                    continue;
+
                 if (dictionary2.ContainsKey(key))
                 {
                     if (dictionary1[key].GetType() != dictionary2[key].GetType())


### PR DESCRIPTION
Adding the use of ClaimTypesToIgnoreWhenComparing in AreObjectDictionariesEqual so that exp, iat and cnf are correctly ignored when doing unit tests.

A unit test was creating two tokens back-to-back, this is creating a race condition where it would fail depending on the values determined in runtime for these claims. Hence the unit test failures from time to time in the build server.

#1918 