### PR TITLE
Wrong parameter order when calling ValidateLifetimeAndIssuerAfterSign…

### DIFF
--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1384,8 +1384,8 @@ namespace System.IdentityModel.Tokens.Jwt
                     validationParameters,
                     configuration,
                     exceptionStrings,
-                    numKeysInTokenValidationParameters,
-                    numKeysInConfiguration);
+                    numKeysInConfiguration,
+                    numKeysInTokenValidationParameters);
             }
 
             if (keysAttempted.Length > 0)


### PR DESCRIPTION
Wrong parameter order when calling ValidateLifetimeAndIssuerAfterSignatureNotValidatedJwt