### PR TITLE
Optimize LKG feature for better resilience

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -1224,8 +1224,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             {
                 if (tokenValidationResult.IsValid)
                 {
-                    // Set current configuration as LKG if it exists and has not already been set as the LKG.
-                    if (currentConfiguration != null && !ReferenceEquals(currentConfiguration, validationParameters.ConfigurationManager.LastKnownGoodConfiguration))
+                    // Set current configuration as LKG if it exists.
+                    if (currentConfiguration != null)
                         validationParameters.ConfigurationManager.LastKnownGoodConfiguration = currentConfiguration;
 
                     return tokenValidationResult;

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -1234,15 +1234,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 // we want to make sure that the clause for SecurityTokenUnableToValidateException is hit so that the ValidationFailure is checked
                 else if (TokenUtilities.IsRecoverableException(tokenValidationResult.Exception))
                 {
-                    if (TokenUtilities.IsRecoverableConfiguration(validationParameters, currentConfiguration, out currentConfiguration))
-                    {
-                        validationParameters.ValidateWithLKG = true;
-                        tokenValidationResult = ValidateToken(jsonWebToken, validationParameters, currentConfiguration);
-
-                        if (tokenValidationResult.IsValid)
-                            return tokenValidationResult;
-                    }
-
                     // If we were still unable to validate, attempt to refresh the configuration and validate using it
                     // but ONLY if the currentConfiguration is not null. We want to avoid refreshing the configuration on
                     // retrieval error as this case should have already been hit before. This refresh handles the case
@@ -1257,9 +1248,24 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                         // Only try to re-validate using the newly obtained config if it doesn't reference equal the previously used configuration.
                         if (lastConfig != currentConfiguration)
                         {
-                            validationParameters.ValidateWithLKG = false;
-                            return ValidateToken(jsonWebToken, validationParameters, currentConfiguration);
+                            tokenValidationResult = ValidateToken(jsonWebToken, validationParameters, currentConfiguration);
+
+                            if (tokenValidationResult.IsValid)
+                            {
+                                validationParameters.ConfigurationManager.LastKnownGoodConfiguration = currentConfiguration;
+                                return tokenValidationResult;
+                            }
                         }
+                    }
+
+                    if (TokenUtilities.IsRecoverableConfiguration(validationParameters, currentConfiguration, out currentConfiguration))
+                    {
+                        validationParameters.RefreshBeforeValidation = false;
+                        validationParameters.ValidateWithLKG = true;
+                        tokenValidationResult = ValidateToken(jsonWebToken, validationParameters, currentConfiguration);
+
+                        if (tokenValidationResult.IsValid)
+                            return tokenValidationResult;
                     }
                 }
             }

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -134,7 +134,7 @@ namespace Microsoft.IdentityModel.Protocols
                         // The transport should have it's own timeouts, etc..
                         var configuration = await _configRetriever.GetConfigurationAsync(MetadataAddress, _docRetriever, CancellationToken.None).ConfigureAwait(false);
                         _lastRefresh = now;
-                        // Add 1 hour jitter to avoid spike traffic to ESTS.
+                        // Add 1 hour jitter to avoid spike traffic to IdentityProvider.
                         _syncAfter = DateTimeUtil.Add(now.UtcDateTime, AutomaticRefreshInterval + TimeSpan.FromMinutes(new Random().Next(60)));
                         if (_configValidator != null)
                         {

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -152,11 +152,11 @@ namespace Microsoft.IdentityModel.Protocols
                         if (_currentConfiguration == null) // Throw an exception if there's no configuration to return.
                             throw LogHelper.LogExceptionMessage(
                                 new InvalidOperationException(
-                                    LogHelper.FormatInvariant(LogMessages.IDX20803, LogHelper.MarkAsNonPII(MetadataAddress ?? "null")), ex));
+                                    LogHelper.FormatInvariant(LogMessages.IDX20803, LogHelper.MarkAsNonPII(MetadataAddress ?? "null"), LogHelper.MarkAsNonPII(ex)), ex));
                         else
                             LogHelper.LogExceptionMessage(
                                 new InvalidOperationException(
-                                    LogHelper.FormatInvariant(LogMessages.IDX20806, LogHelper.MarkAsNonPII(MetadataAddress ?? "null")), ex));
+                                    LogHelper.FormatInvariant(LogMessages.IDX20806, LogHelper.MarkAsNonPII(MetadataAddress ?? "null"), LogHelper.MarkAsNonPII(ex)), ex));
                     }
                 }
 

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -134,7 +134,8 @@ namespace Microsoft.IdentityModel.Protocols
                         // The transport should have it's own timeouts, etc..
                         var configuration = await _configRetriever.GetConfigurationAsync(MetadataAddress, _docRetriever, CancellationToken.None).ConfigureAwait(false);
                         _lastRefresh = now;
-                        _syncAfter = DateTimeUtil.Add(now.UtcDateTime, AutomaticRefreshInterval);
+                        // Add 1 hour jitter to avoid spike traffic to ESTS.
+                        _syncAfter = DateTimeUtil.Add(now.UtcDateTime, AutomaticRefreshInterval + TimeSpan.FromMinutes(new Random().Next(60)));
                         if (_configValidator != null)
                         {
                             ConfigurationValidationResult result = _configValidator.Validate(configuration);

--- a/src/Microsoft.IdentityModel.Protocols/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols/LogMessages.cs
@@ -21,10 +21,10 @@ namespace Microsoft.IdentityModel.Protocols
         internal const string IDX20108 = "IDX20108: The address specified '{0}' is not valid as per HTTPS scheme. Please specify an https address for security reasons. If you want to test with http address, set the RequireHttps property  on IDocumentRetriever to false.";
 
         // configuration retrieval errors
-        internal const string IDX20803 = "IDX20803: Unable to obtain configuration from: '{0}'.";
+        internal const string IDX20803 = "IDX20803: Unable to obtain configuration from: '{0}'. Exception: '{1}.";
         internal const string IDX20804 = "IDX20804: Unable to retrieve document from: '{0}'.";
         internal const string IDX20805 = "IDX20805: Obtaining information from metadata endpoint: '{0}'.";
-        internal const string IDX20806 = "IDX20806: Unable to obtain an updated configuration from: '{0}'. Returning the current configuration.";
+        internal const string IDX20806 = "IDX20806: Unable to obtain an updated configuration from: '{0}'. Returning the current configuration. Exception: '{1}.";
         internal const string IDX20807 = "IDX20807: Unable to retrieve document from: '{0}'. HttpResponseMessage: '{1}', HttpResponseMessage.Content: '{2}'.";
         internal const string IDX20808 = "IDX20808: Network error occurred. Status code: '{0}'. \nResponse content: '{1}'. \nAttempting to retrieve document again from: '{2}'.";
         internal const string IDX20809 = "IDX20809: Unable to retrieve document from: '{0}'. Status code: '{1}'. \nResponse content: '{2}'.";

--- a/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
@@ -70,17 +70,12 @@ namespace Microsoft.IdentityModel.Tokens
         {
             get
             {
-                // only set this value the first time the last known good configuration is used for validation
-                // AND if there is actually a LKG set
-                if (_lastKnownGoodConfigFirstUse == null && _lastKnownGoodConfiguration != null)
-                    _lastKnownGoodConfigFirstUse = DateTime.UtcNow;
-
                 return _lastKnownGoodConfiguration;
             }
             set
             {
                 _lastKnownGoodConfiguration = value ?? throw LogHelper.LogArgumentNullException(nameof(value));
-                _lastKnownGoodConfigFirstUse = null; // reset this value as a new last known good configuration was set (and has not been used yet)
+                _lastKnownGoodConfigFirstUse = DateTime.UtcNow;
             }
         }
 

--- a/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
@@ -41,9 +41,9 @@ namespace Microsoft.IdentityModel.Tokens
         public static readonly TimeSpan DefaultAutomaticRefreshInterval = new TimeSpan(0, 12, 0, 0);
 
         /// <summary>
-        /// 1 hour is the default time interval that a last known good configuration will last for.
+        /// 4 hours is the default time interval that a last known good configuration will last for.
         /// </summary>
-        public static readonly TimeSpan DefaultLastKnownGoodConfigurationLifetime = new TimeSpan(0, 1, 0, 0);
+        public static readonly TimeSpan DefaultLastKnownGoodConfigurationLifetime = new TimeSpan(0, 4, 0, 0);
 
         /// <summary>
         /// 5 minutes is the default time interval that must pass for <see cref="RequestRefresh"/> to obtain a new configuration.

--- a/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
@@ -41,9 +41,9 @@ namespace Microsoft.IdentityModel.Tokens
         public static readonly TimeSpan DefaultAutomaticRefreshInterval = new TimeSpan(0, 12, 0, 0);
 
         /// <summary>
-        /// 4 hours is the default time interval that a last known good configuration will last for.
+        /// 1 hour is the default time interval that a last known good configuration will last for.
         /// </summary>
-        public static readonly TimeSpan DefaultLastKnownGoodConfigurationLifetime = new TimeSpan(0, 4, 0, 0);
+        public static readonly TimeSpan DefaultLastKnownGoodConfigurationLifetime = new TimeSpan(0, 1, 0, 0);
 
         /// <summary>
         /// 5 minutes is the default time interval that must pass for <see cref="RequestRefresh"/> to obtain a new configuration.

--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -244,7 +244,7 @@ namespace Microsoft.IdentityModel.Validators
                 new ConfigurationManager<OpenIdConnectConfiguration>(
                     $"{aadAuthority}{AadIssuerValidatorConstants.OidcEndpoint}",
                     new OpenIdConnectConfigurationRetriever())
-                { LastKnownGoodLifetime = new TimeSpan(0, 24, 0, 0) }; ;
+                { LastKnownGoodLifetime = new TimeSpan(0, 24, 0, 0) };
             }
         }
 

--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -20,6 +20,8 @@ namespace Microsoft.IdentityModel.Validators
     /// </summary>
     public class AadIssuerValidator
     {
+        private static readonly TimeSpan LastKnownGoodConfigurationLifetime = new TimeSpan(0, 24, 0, 0);
+
         internal const string V2EndpointSuffix = "/v2.0";
         internal const string TenantidTemplate = "{tenantid}";
 
@@ -236,7 +238,7 @@ namespace Microsoft.IdentityModel.Validators
                      $"{aadAuthority}{AadIssuerValidatorConstants.OidcEndpoint}",
                      new OpenIdConnectConfigurationRetriever(),
                      HttpClient)
-                 { LastKnownGoodLifetime = new TimeSpan(0, 24, 0, 0) };
+                 { LastKnownGoodLifetime = LastKnownGoodConfigurationLifetime };
             }
             else
             {
@@ -244,7 +246,7 @@ namespace Microsoft.IdentityModel.Validators
                 new ConfigurationManager<OpenIdConnectConfiguration>(
                     $"{aadAuthority}{AadIssuerValidatorConstants.OidcEndpoint}",
                     new OpenIdConnectConfigurationRetriever())
-                { LastKnownGoodLifetime = new TimeSpan(0, 24, 0, 0) };
+                { LastKnownGoodLifetime = LastKnownGoodConfigurationLifetime };
             }
         }
 

--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -235,14 +235,16 @@ namespace Microsoft.IdentityModel.Validators
                  new ConfigurationManager<OpenIdConnectConfiguration>(
                      $"{aadAuthority}{AadIssuerValidatorConstants.OidcEndpoint}",
                      new OpenIdConnectConfigurationRetriever(),
-                     HttpClient);
+                     HttpClient)
+                 { LastKnownGoodLifetime = new TimeSpan(0, 24, 0, 0) };
             }
             else
             {
                 return
                 new ConfigurationManager<OpenIdConnectConfiguration>(
                     $"{aadAuthority}{AadIssuerValidatorConstants.OidcEndpoint}",
-                    new OpenIdConnectConfigurationRetriever());
+                    new OpenIdConnectConfigurationRetriever())
+                { LastKnownGoodLifetime = new TimeSpan(0, 24, 0, 0) }; ;
             }
         }
 

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -896,8 +896,8 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 if (claimsPrincipal != null)
                 {
-                    // Set current configuration as LKG if it exists and has not already been set as the LKG.
-                    if (currentConfiguration != null && !ReferenceEquals(currentConfiguration, validationParameters.ConfigurationManager.LastKnownGoodConfiguration))
+                    // Set current configuration as LKG if it exists.
+                    if (currentConfiguration != null)
                         validationParameters.ConfigurationManager.LastKnownGoodConfiguration = currentConfiguration;
 
                     return claimsPrincipal;

--- a/test/Microsoft.IdentityModel.SampleTests/SampleTokenValidationClassTests.cs
+++ b/test/Microsoft.IdentityModel.SampleTests/SampleTokenValidationClassTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.IdentityModel.SampleTests
             TestWithGeneratedToken(
                 () => "InvalidToken",
                 typeof(ArgumentException),
-                "IDX14111");
+                "IDX14100");
         }
 
         /// <summary>

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtTestDatasets.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtTestDatasets.cs
@@ -304,6 +304,9 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 expiredSecurityTokenDescriptor.Expires = DateTime.UtcNow + System.TimeSpan.FromDays(2);
                 var expiredJws = Default.Jwt(expiredSecurityTokenDescriptor);
 
+                AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).ConfigurationManagerV1 =
+                    new MockConfigurationManager<OpenIdConnectConfiguration>(invalidIssuerConfig, validConfig, validConfig) as BaseConfigurationManager;
+
                 return new TheoryData<JwtTheoryData>
                 {
                     new JwtTheoryData
@@ -484,11 +487,11 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     },
                     new JwtTheoryData
                     {
-                        TestId = nameof(Default.AsymmetricJws) + "_ConfigInvalid_ConfigKeyInvalid_LKGIssuerInvalid_RefreshedConfigKeyInvalid",
+                        TestId = nameof(Default.AsymmetricJws) + "_ConfigInvalid_ConfigKeyInvalid_LKGConfigKeyInvalid_RefreshedIssuerInvalid",
                         Token = Default.AsymmetricJws,
                         ValidationParameters = new TokenValidationParameters
                         {
-                            ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(incorrectSigningKeysConfig, invalidIssuerConfig, incorrectSigningKeysConfig),
+                            ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(incorrectSigningKeysConfig, incorrectSigningKeysConfig, invalidIssuerConfig),
                             ValidateIssuerSigningKey = true,
                             RequireSignedTokens = true,
                             ValidateIssuer = true,
@@ -570,7 +573,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                             ValidateAudience = false,
                             ValidateLifetime = false,
                         },
-                        ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidIssuerException))
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenUnableToValidateException))
                     },
                     new JwtTheoryData
                     {
@@ -595,6 +598,21 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                         ValidationParameters = new TokenValidationParameters
                         {
                             ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(invalidIssuerConfig, incorrectSigningKeysConfig, validConfig),
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = true,
+                            ValidateIssuer = true,
+                            IssuerValidator = AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).Validate,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                        },
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = nameof(Default.AsymmetricJws) + "_ConfigInvalid_AadIssuerValidatorThrow_LKGSucceeds_RequestRefreshIssuerInvalid",
+                        Token = Default.AadAsymmetricJws,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(invalidIssuerConfig, validConfig, invalidIssuerConfig),
                             ValidateIssuerSigningKey = true,
                             RequireSignedTokens = true,
                             ValidateIssuer = true,
@@ -669,7 +687,8 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                             ValidateIssuer = true,
                             ValidateAudience = false,
                             ValidateLifetime = false,
-                            TokenDecryptionKey = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes128_Sha2.Key                        }
+                            TokenDecryptionKey = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes128_Sha2.Key
+                        }
                     },
                     new JwtTheoryData
                     {
@@ -829,11 +848,11 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     },
                     new JwtTheoryData
                     {
-                        TestId = nameof(jwe) + "_ConfigKeyInvalid_LKGIssuerInvalid_RefreshedConfigKeyInvalid",
+                        TestId = nameof(jwe) + "_ConfigKeyInvalid_LKGConfigKeyInvalid_RefreshedIssuerInvalid",
                         Token = jwe,
                         ValidationParameters = new TokenValidationParameters
                         {
-                            ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(incorrectSigningKeysConfig, invalidIssuerConfig, incorrectSigningKeysConfig),
+                            ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(incorrectSigningKeysConfig, incorrectSigningKeysConfig, invalidIssuerConfig),
                             ValidateIssuerSigningKey = true,
                             RequireSignedTokens = true,
                             ValidateIssuer = true,
@@ -922,7 +941,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                             TokenDecryptionKey = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes128_Sha2.Key
 
                         },
-                        ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidIssuerException))
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenUnableToValidateException))
                     },
                     new JwtTheoryData
                     {
@@ -941,6 +960,22 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
                         },
                         ExpectedException = new ExpectedException(typeof(SecurityTokenSignatureKeyNotFoundException))
+                    },
+                    new JwtTheoryData
+                    {
+                        TestId = nameof(aadJwe) + "_ConfigInvalid_AadIssuerValidatorThrow_LKGSucceeds_RequestRefreshIssuerInvalid",
+                        Token = aadJwe,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(invalidIssuerConfig, validConfig, invalidIssuerConfig),
+                            ValidateIssuerSigningKey = true,
+                            RequireSignedTokens = true,
+                            ValidateIssuer = true,
+                            IssuerValidator = AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).Validate,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                            TokenDecryptionKey = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes128_Sha2.Key
+                        },
                     },
                     new JwtTheoryData
                     {


### PR DESCRIPTION
Add jitter for metadata refresh to avoid spike traffic.
Update default to 24H for LKG lifetime in AadIssuerValidator for 1P.
Update LKG logic: refresh metadata before validate with LKG.
Mark the exception when fetching the metadata as non-PII.