### PR TITLE
Bundling the exception as an inner exception of the ArgumentException.

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -1174,11 +1174,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 {
                     jsonWebToken = new JsonWebToken(token);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
                     return new TokenValidationResult
                     {
-                        Exception = LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14100, token))),
+                        Exception = LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14100, token, ex))),
                         IsValid = false
                     };
                 }


### PR DESCRIPTION
This will embed the exception caught from the constructor as an inner exception of the ArgumentException logged by ReadToken as suggested in the issue.

Fixes https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1965.

Unfortunately I'm having trouble building the projet locally and running the tests (the build process mention not finding Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests\obj\Debug\netcoreapp2.1\Microsoft.I
dentityModel.Protocols.SignedHttpRequest.Tests.GeneratedMSBuildEditorConfig.editorconfig for instance). So I'm having trouble figuring out if I need to fix the test or add a new one to make the PR work.