### PR TITLE
Handle escaped datetime conversion.

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
@@ -78,10 +78,17 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             // Json.net recognized DateTime by default.
             if (jsonElement.ValueKind == JsonValueKind.String)
             {
-                if (jsonElement.TryGetDateTime(out DateTime dateTimeValue))
-                    return new Claim(key, dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), ClaimValueTypes.DateTime, issuer, issuer);
-                else
+                try
+                {
+                    if (jsonElement.TryGetDateTime(out DateTime dateTimeValue))
+                        return new Claim(key, dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), ClaimValueTypes.DateTime, issuer, issuer);
+                    else
+                        return new Claim(key, jsonElement.ToString(), ClaimValueTypes.String, issuer, issuer);
+                }
+                catch(IndexOutOfRangeException)
+                {
                     return new Claim(key, jsonElement.ToString(), ClaimValueTypes.String, issuer, issuer);
+                }
             }
             else if (jsonElement.ValueKind == JsonValueKind.Null)
                 return new Claim(key, string.Empty, JsonClaimValueTypes.JsonNull, issuer, issuer);

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
@@ -1,40 +1,17 @@
-//------------------------------------------------------------------------------
-//
-// Copyright (c) Microsoft Corporation.
-// All rights reserved.
-//
-// This code is licensed under the MIT License.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files(the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions :
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-//
-//------------------------------------------------------------------------------
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Security.Claims;
-using Microsoft.IdentityModel.Json.Linq;
 using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
 using Xunit;
 
 #if NET452
+using Microsoft.IdentityModel.Json.Linq;
 using JsonClaimSet = Microsoft.IdentityModel.JsonWebTokens.JsonClaimSet45;
 #endif
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -572,6 +572,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             Assert.True(string.Equals(claimA.ValueType, ClaimValueTypes.DateTime), "ClaimValueType is not DateTime.");
             // claim value shouldn't contain any quotes
             Assert.DoesNotContain("\"", claimA.Value);
+        }
+
+        [Fact]
+        public void EscapedClaims()
+        {
+            string json = @"{""family_name"":""\u0027\u0027"",""given_name"":""\u0027\u0027"",""name"":""謝京螢""}";
+            string jsonEncoded = Base64UrlEncoder.Encode("{}") + "." + Base64UrlEncoder.Encode(json) + ".";
+            JsonWebToken encodedToken = new JsonWebToken(jsonEncoded);
+            _ = encodedToken.Claims;
         }
     }
 


### PR DESCRIPTION
.net 6.0 can throw IndexOutOfRangeException exceptions when calling TryGetDateTime.
In this case, catch the exception and return the claim as a string.