### PR TITLE
corrected links to datatracker.ietf.org

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -362,7 +362,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// Gets the Initialization Vector used when encrypting the plaintext.
         /// </summary>
         /// <remarks>
-        /// see: https://datatracker.ietf.org/doc/html/rfc7516#appendix-A.1.4
+        /// see: https://datatracker.ietf.org/doc/html/rfc7516#appendix-A-1-4
         /// <para>
         /// Some algorithms may not use an Initialization Vector.
         /// If not found an empty string is returned.
@@ -610,7 +610,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <remarks>
         /// Identifies the cryptographic algorithm used to encrypt or determine the value of the Content Encryption Key.
         /// Applicable to an encrypted JWT {JWE}.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.1
+        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4-1-1
         /// <para>
         /// If the 'alg' claim is not found, an empty string is returned.
         /// </para>
@@ -631,7 +631,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </summary>
         /// <remarks>
         /// Identifies the recipients that the JWT is intended for.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4-1-3
         /// <para>
         /// If the 'aud' claim is not found, enumeration will be empty.
         /// </para>
@@ -695,8 +695,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </summary>
         /// <remarks>
         /// Used by JWS applications to declare the media type[IANA.MediaTypes] of the secured content (the payload).
-        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.12 (JWE)
-        /// see: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.10 (JWS)
+        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4-1-12 (JWE)
+        /// see: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-10 (JWS)
         /// <para>
         /// If the 'cty' claim is not found, an empty string is returned.
         /// </para>
@@ -718,7 +718,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <remarks>
         /// Identifies the content encryption algorithm used to perform authenticated encryption
         /// on the plaintext to produce the ciphertext and the Authentication Tag.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.2
+        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4-1-2
         /// </remarks>
         public string Enc
         {
@@ -790,7 +790,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </summary>
         /// <remarks>
         /// Provides a unique identifier for the JWT.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4-1-7
         /// <para>
         /// If the 'jti' claim is not found, an empty string is returned.
         /// </para>
@@ -811,7 +811,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </summary>
         /// <remarks>
         /// Identifies the time at which the JWT was issued.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4-1-6
         /// <para>
         /// If the 'iat' claim is not found, then <see cref="DateTime.MinValue"/> is returned.
         /// </para>
@@ -832,7 +832,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </summary>
         /// <remarks>
         /// Identifies the principal that issued the JWT.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4-1-1
         /// <para>
         /// If the 'iss' claim is not found, an empty string is returned.
         /// </para>
@@ -853,8 +853,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </summary>
         /// <remarks>
         /// 'kid'is a hint indicating which key was used to secure the JWS.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4 (JWS)
-        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.6 (JWE)
+        /// see: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-4 (JWS)
+        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4-1-6 (JWE)
         /// <para>
         /// If the 'kid' claim is not found, an empty string is returned.
         /// </para>
@@ -874,7 +874,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// Gets the 'value' of the 'sub' claim from the payload.
         /// </summary>
         /// <remarks>
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4-1-2
         /// Identifies the principal that is the subject of the JWT.
         /// <para>
         /// If the 'sub' claim is not found, an empty string is returned.
@@ -975,7 +975,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </summary>
         /// <remarks>
         /// Is used by JWT applications to declare the media type.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-5.1
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-5-1
         /// <para>
         /// If the 'typ' claim is not found, an empty string is returned.
         /// </para>
@@ -996,7 +996,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </summary>
         /// <remarks>
         /// Is the base64url-encoded SHA-1 thumbprint(a.k.a.digest) of the DER encoding of the X.509 certificate used to sign this token.
-        /// see : https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.7
+        /// see : https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-7
         /// <para>
         /// If the 'x5t' claim is not found, an empty string is returned.
         /// </para>
@@ -1017,7 +1017,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </summary>
         /// <remarks>
         /// Identifies the time before which the JWT MUST NOT be accepted for processing.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4-1-5
         /// <para>
         /// If the 'nbf' claim is not found, then <see cref="DateTime.MinValue"/> is returned.
         /// </para>
@@ -1038,7 +1038,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </summary>
         /// <remarks>
         /// Identifies the expiration time on or after which the JWT MUST NOT be accepted for processing.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4-1-4
         /// <para>
         /// If the 'exp' claim is not found, then <see cref="DateTime.MinValue"/> is returned.
         /// </para>
@@ -1059,7 +1059,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </summary>
         /// <remarks>
         /// The "zip" (compression algorithm) applied to the plaintext before encryption, if any.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.3
+        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4-1-3
         /// <para>
         /// If the 'zip' claim is not found, an empty string is returned.
         /// </para>

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtHeaderParameterNames.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtHeaderParameterNames.cs
@@ -9,49 +9,49 @@ namespace Microsoft.IdentityModel.JsonWebTokens
     public struct JwtHeaderParameterNames
     {
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.1
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-1
         /// </summary>
         public const string Alg = "alg";
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.10
-        /// Also: https://datatracker.ietf.org/doc/html/rfc7519#section-5.2
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-10
+        /// Also: https://datatracker.ietf.org/doc/html/rfc7519#section-5-2
         /// </summary>
         public const string Cty = "cty";
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.2
+        /// See: https://datatracker.ietf.org/doc/html/rfc7516#section-4-1-2
         /// </summary>
         public const string Enc = "enc";
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4.7.1.1
+        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4-7-1-1
         /// </summary>
         public const string IV = "iv";
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.2
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-2
         /// </summary>
         public const string Jku = "jku";
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.3
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-3
         /// </summary>
         public const string Jwk = "jwk";
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-4
         /// </summary>
         public const string Kid = "kid";
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.9
-        /// Also: https://datatracker.ietf.org/doc/html/rfc7519#section-5.1
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-9
+        /// Also: https://datatracker.ietf.org/doc/html/rfc7519#section-5-1
         /// </summary>
         public const string Typ = "typ";
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.6
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-6
         /// </summary>
         public const string X5c = "x5c";
 
@@ -61,27 +61,27 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         public const string X5t = "x5t";
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.5
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-5
         /// </summary>
         public const string X5u = "x5u";
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.3
+        /// See: https://datatracker.ietf.org/doc/html/rfc7516#section-4-1-3
         /// </summary>
         public const string Zip = "zip";
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.1.1
+        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4-6-1-1
         /// </summary>
         public const string Epk = "epk";
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.1.2
+        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4-6-1-2
         /// </summary>
         public const string Apu = "apu";
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.1.3
+        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4-6-1-3
         /// </summary>
         public const string Apv = "apv";
     }

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -230,7 +230,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             if (validationContext.ValidatedIdToken == null)
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21332));
 
-            // 'refresh_token' should not be returned from 'authorization_endpoint'. https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.2.
+            // 'refresh_token' should not be returned from 'authorization_endpoint'. https://datatracker.ietf.org/doc/html/rfc6749#section-4-2-2.
             if (!string.IsNullOrEmpty(validationContext.ProtocolMessage.RefreshToken))
                 throw LogHelper.LogExceptionMessage(new OpenIdConnectProtocolException(LogMessages.IDX21335));
 

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectResponseType.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectResponseType.cs
@@ -55,7 +55,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 
         /// <summary>
         /// Defined in OAuth 2.0 spec, included for completion.
-        /// See: https://datatracker.ietf.org/doc/html/rfc6749#section-11.3.2.
+        /// See: https://datatracker.ietf.org/doc/html/rfc6749#section-11-3-2.
         /// </summary>
         public const string Token = "token";
     }

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/ConfirmationClaimTypes.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/ConfirmationClaimTypes.cs
@@ -10,27 +10,27 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
     public static class ConfirmationClaimTypes
     {
         /// <summary>
-        /// https://datatracker.ietf.org/doc/html/rfc7800#section-6.1.1
+        /// https://datatracker.ietf.org/doc/html/rfc7800#section-6-1-1
         /// </summary>
         public const string Cnf = "cnf";
 
         /// <summary>
-        /// https://datatracker.ietf.org/doc/html/rfc7800#section-6.2.2
+        /// https://datatracker.ietf.org/doc/html/rfc7800#section-6-2-2
         /// </summary>
         public const string Jwk = "jwk";
 
         /// <summary>
-        /// https://datatracker.ietf.org/doc/html/rfc7800#section-6.2.2
+        /// https://datatracker.ietf.org/doc/html/rfc7800#section-6-2-2
         /// </summary>
         public const string Jwe = "jwe";
 
         /// <summary>
-        /// https://datatracker.ietf.org/doc/html/rfc7800#section-6.2.2
+        /// https://datatracker.ietf.org/doc/html/rfc7800#section-6-2-2
         /// </summary>
         public const string Jku = "jku";
 
         /// <summary>
-        /// https://datatracker.ietf.org/doc/html/rfc7800#section-6.2.2        
+        /// https://datatracker.ietf.org/doc/html/rfc7800#section-6-2-2
         /// </summary>
         public const string Kid = "kid";
     }

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestConstants.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestConstants.cs
@@ -11,19 +11,19 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <summary>
         /// The "Authorization" header string.
         /// </summary>
-        /// <remarks>https://datatracker.ietf.org/doc/html/rfc7235#section-4.2</remarks>
+        /// <remarks>https://datatracker.ietf.org/doc/html/rfc7235#section-4-2</remarks>
         public const string AuthorizationHeader = "Authorization";
 
         /// <summary>
         /// Authorization header scheme name.
         /// </summary>
-        /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-4.1</remarks>
+        /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-4-1</remarks>
         public const string AuthorizationHeaderSchemeName = "PoP";
 
         /// <summary>
         /// SignedHttpRequest token type.
         /// </summary>
-        /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-6.1</remarks> 
+        /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-6-1</remarks>
         public const string TokenType = "pop";
     }
 }

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestDescriptor.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestDescriptor.cs
@@ -40,7 +40,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// </summary>
         /// <remarks>
         /// <paramref name="accessToken"/> has to contain the 'cnf' claim so that PoP key can be resolved on the validation side.
-        /// https://datatracker.ietf.org/doc/html/rfc7800#section-3.1
+        /// https://datatracker.ietf.org/doc/html/rfc7800#section-3-1
         /// Default <see cref="SignedHttpRequestCreationParameters"/> and <see cref="CallContext"/> will be created.
         /// </remarks>
         /// <param name="accessToken">An access token that contains the 'cnf' claim.</param>
@@ -56,7 +56,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// </summary>
         /// <remarks>
         /// <paramref name="accessToken"/> has to contain the 'cnf' claim so that PoP key can be resolved on the validation side.
-        /// https://datatracker.ietf.org/doc/html/rfc7800#section-3.1
+        /// https://datatracker.ietf.org/doc/html/rfc7800#section-3-1
         /// </remarks> 
         /// <param name="accessToken">An access token that contains the 'cnf' claim.</param>
         /// <param name="httpRequestData">A structure that represents an outgoing http request.</param>

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
     /// <remarks>The handler implementation is based on 'A Method for Signing HTTP Requests for OAuth' specification.</remarks>
     public class SignedHttpRequestHandler
     {
-        // (https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-3.2)
+        // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-3-2
         // "Encodes the name and value of the header as "name: value" and appends it to the string buffer separated by a newline "\n" character."
         private readonly string _newlineSeparator = "\n";
 
@@ -95,7 +95,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             }
 
             // set the "typ" header claim to "pop"
-            // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-6.2
+            // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-6-2
             header[JwtHeaderParameterNames.Alg] = signedHttpRequestDescriptor.SigningCredentials.Algorithm;
             header[JwtHeaderParameterNames.Typ] = SignedHttpRequestConstants.TokenType;
 
@@ -758,7 +758,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             if (!signedHttpRequest.TryGetPayloadValue(SignedHttpRequestClaimTypes.U, out string uClaimValue) || uClaimValue == null)
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidUClaimException(LogHelper.FormatInvariant(LogMessages.IDX23003, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.U))));
 
-            // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-3.2
+            // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-3-2
             // u: The HTTP URL host component as a JSON string.
             // This MAY include the port separated from the host by a colon in host:port format.
             var expectedUClaimValue = httpRequestUri.Host;
@@ -1030,7 +1030,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <param name="signedHttpRequestValidationContext">A structure that wraps parameters needed for SignedHttpRequest validation.</param>
         /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
         /// <returns>A resolved PoP <see cref="SecurityKey"/>.</returns>
-        /// <remarks>https://datatracker.ietf.org/doc/html/rfc7800#section-3.1</remarks>
+        /// <remarks>https://datatracker.ietf.org/doc/html/rfc7800#section-3-1</remarks>
         internal virtual async Task<SecurityKey> ResolvePopKeyFromCnfClaimAsync(JObject cnf, JsonWebToken signedHttpRequest, JsonWebToken validatedAccessToken, SignedHttpRequestValidationContext signedHttpRequestValidationContext, CancellationToken cancellationToken)
         {
             if (cnf == null)
@@ -1109,7 +1109,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             }
             // If there are multiple keys in the referenced JWK Set document, a "kid" member MUST also be included
             // with the referenced key's JWK also containing the same "kid" value.
-            // https://datatracker.ietf.org/doc/html/rfc7800#section-3.5
+            // https://datatracker.ietf.org/doc/html/rfc7800#section-3-5
             else if (cnf.TryGetValue(ConfirmationClaimTypes.Kid, StringComparison.Ordinal, out var kid))
             {
                 foreach (var key in popKeys)
@@ -1247,10 +1247,10 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <summary>
         /// Sanitizes the query params to comply with the specification.
         /// </summary>
-        /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-7.5.</remarks>
+        /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-7-5.</remarks>
         private static Dictionary<string, string> SanitizeQueryParams(Uri httpRequestUri)
         {
-            // Remove repeated query params according to the spec: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-7.5.
+            // Remove repeated query params according to the spec: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-7-5
             // "If a header or query parameter is repeated on either the outgoing request from the client or the
             // incoming request to the protected resource, that query parameter or header name MUST NOT be covered by the hash and signature."
             var sanitizedQueryParams = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -1298,12 +1298,12 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// Sanitizes the headers to comply with the specification.
         /// </summary>
         /// <remarks>
-        /// https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-4.1
-        /// https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-7.5
+        /// https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-4-1
+        /// https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-7-5
         /// </remarks>
         private static Dictionary<string, string> SanitizeHeaders(IDictionary<string, IEnumerable<string>> headers)
         {
-            // Remove repeated headers according to the spec: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-7.5.
+            // Remove repeated headers according to the spec: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-7-5
             // "If a header or query parameter is repeated on either the outgoing request from the client or the
             // incoming request to the protected resource, that query parameter or header name MUST NOT be covered by the hash and signature."
             var sanitizedHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -1315,7 +1315,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                 if (string.IsNullOrEmpty(headerName))
                     continue;
 
-                // Don't include the authorization header (https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-4.1).
+                // Don't include the authorization header https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-4-1
                 if (string.Equals(headerName, SignedHttpRequestConstants.AuthorizationHeader, StringComparison.OrdinalIgnoreCase))
                     continue;
 

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestUtilities.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestUtilities.cs
@@ -23,7 +23,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// </summary>
         /// <param name="jsonWebKey">JsonWebKey representation of an asymmetric public key.</param>
         /// <returns>A "jwk" claim as a JSON string.</returns>
-        /// <remarks>https://datatracker.ietf.org/doc/html/rfc7800#section-3.2</remarks>
+        /// <remarks>https://datatracker.ietf.org/doc/html/rfc7800#section-3-2</remarks>
         public static string CreateJwkClaim(JsonWebKey jsonWebKey)
         {
             if (jsonWebKey == null)
@@ -37,7 +37,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// </summary>
         /// <param name="signedHttpRequest">A signed http request.</param>
         /// <returns>A SignedHttpRequest value prefixed with the word "PoP".</returns>
-        /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-4.1</remarks>
+        /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-4-1</remarks>
         public static string CreateSignedHttpRequestHeader(string signedHttpRequest)
         {
             if (string.IsNullOrEmpty(signedHttpRequest))

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestValidationParameters.cs
@@ -45,7 +45,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
     /// <param name="signedHttpRequestValidationContext">A structure that wraps parameters needed for SignedHttpRequest validation.</param>
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns>A resolved <see cref="SecurityKey"/>.</returns>
-    /// <remarks>https://datatracker.ietf.org/doc/html/rfc7800#section-3.4</remarks>
+    /// <remarks>https://datatracker.ietf.org/doc/html/rfc7800#section-3-4</remarks>
     public delegate Task<SecurityKey> PopKeyResolverFromKeyIdAsync(string kid, SecurityToken validatedAccessToken, SecurityToken signedHttpRequest, SignedHttpRequestValidationContext signedHttpRequestValidationContext, CancellationToken cancellationToken);
 
     /// <summary>
@@ -88,13 +88,13 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <summary>
         /// Gets or sets a value indicating whether the unsigned query parameters are accepted or not.
         /// </summary>
-        /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-5.1</remarks>
+        /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-5-1</remarks>
         public bool AcceptUnsignedQueryParameters { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether the unsigned headers are accepted or not. 
         /// </summary>
-        /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-5.1</remarks>
+        /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-5-1</remarks>
         public bool AcceptUnsignedHeaders { get; set; } = true;
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <summary>
         /// Gets or sets the <see cref="HttpClientProvider"/> delegate.
         /// </summary>
-        /// <remarks>https://datatracker.ietf.org/doc/html/rfc7800#section-3.5</remarks>
+        /// <remarks>https://datatracker.ietf.org/doc/html/rfc7800#section-3-5</remarks>
         public HttpClientProvider HttpClientProvider { get; set; }
 
         /// <summary>
@@ -148,7 +148,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <summary>
         /// Gets or sets a value indicating whether TLS is required when obtaining a JWK set using the 'jku' claim.
         /// </summary>
-        /// <remarks>https://datatracker.ietf.org/doc/html/rfc7800#section-3.5</remarks>
+        /// <remarks>https://datatracker.ietf.org/doc/html/rfc7800#section-3-5</remarks>
         public bool RequireHttpsForJkuResourceRetrieval { get; set; } = true;
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/Encryption/EcdhKeyExchangeProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/EcdhKeyExchangeProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns>Returns <see cref="SecurityKey"/> that represents the key generated</returns>
         public SecurityKey GenerateKdf(string apu = null, string apv = null)
         {
-            //The "apu" and "apv" values MUST be distinct when used (per rfc7518 section 4.6.2) https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.2
+            //The "apu" and "apv" values MUST be distinct when used (per rfc7518 section 4.6.2) https://datatracker.ietf.org/doc/html/rfc7518#section-4-6-2
             if (!string.IsNullOrEmpty(apu) && !string.IsNullOrEmpty(apv) && apu.Equals(apv))
                 throw LogHelper.LogArgumentException<ArgumentException>(
                     nameof(apu),
@@ -73,13 +73,13 @@ namespace Microsoft.IdentityModel.Tokens
 
             int kdfLength = KeyDataLen / 8; // number of octets
             // prepend bytes that represent n = ceiling of (keydatalen / hashlen), see section 5.8.1.1: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar2.pdf
-            // hashlen is always 256 for ecdh-es, see: https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.2
+            // hashlen is always 256 for ecdh-es, see: https://datatracker.ietf.org/doc/html/rfc7518#section-4-6-2
             // for supported algorithms it is always '1', for saml might be different
             byte[] prepend = new byte[4] { 0, 0, 0, 1 };
             SetAppendBytes(apu, apv, out byte[] append);
             byte[] kdf = new byte[kdfLength];
 
-            // JWA's spec https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.2 specifies SHA256, saml might be different
+            // JWA's spec https://datatracker.ietf.org/doc/html/rfc7518#section-4-6-2 specifies SHA256, saml might be different
             byte[] derivedKey = _ecdhPrivate.DeriveKeyFromHash(_ecdhPublic.PublicKey, HashAlgorithmName.SHA256, prepend, append);
             Array.Copy(derivedKey, kdf, kdfLength);
 

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebAlgorithmsKeyTypes.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebAlgorithmsKeyTypes.cs
@@ -5,7 +5,7 @@ namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
     /// Constants for JsonWebAlgorithms  "kty" Key Type (sec 6.1)
-    /// https://datatracker.ietf.org/doc/html/rfc7518#section-6.1
+    /// https://datatracker.ietf.org/doc/html/rfc7518#section-6-1
     /// </summary>
     public static class JsonWebAlgorithmsKeyTypes
     {

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
@@ -410,7 +410,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// Creates a JsonWebKey representation of an asymmetric public key.
         /// </summary>
         /// <returns>JsonWebKey representation of an asymmetric public key.</returns>
-        /// <remarks>https://datatracker.ietf.org/doc/html/rfc7800#section-3.2</remarks>
+        /// <remarks>https://datatracker.ietf.org/doc/html/rfc7800#section-3-2</remarks>
         internal string RepresentAsAsymmetricPublicJwk()
         {
             JObject jwk = new JObject();

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeyConverter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeyConverter.cs
@@ -276,7 +276,7 @@ namespace Microsoft.IdentityModel.Tokens
             try
             {
                 // only the first certificate should be used to perform signing operations
-                // https://datatracker.ietf.org/doc/html/rfc7517#section-4.7
+                // https://datatracker.ietf.org/doc/html/rfc7517#section-4-7
                 key = new X509SecurityKey(webKey);
                 return true;
             }

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeyECTypes.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeyECTypes.cs
@@ -5,7 +5,7 @@ namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
     /// Constants for JsonWebKey Elliptical Curve Types
-    /// https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.1.1
+    /// https://datatracker.ietf.org/doc/html/rfc7518#section-6-2-1-1
     /// </summary>
     public static class JsonWebKeyECTypes
     {

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
@@ -98,7 +98,7 @@ namespace Microsoft.IdentityModel.Tokens
             foreach (var webKey in Keys)
             {
                 // skip if "use" (Public Key Use) parameter is not empty or "sig".
-                // https://datatracker.ietf.org/doc/html/rfc7517#section-4.2
+                // https://datatracker.ietf.org/doc/html/rfc7517#section-4-2
                 if (!string.IsNullOrEmpty(webKey.Use) && !webKey.Use.Equals(JsonWebKeyUseNames.Sig))
                 {
                     string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10808, webKey, webKey.Use);

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeyUseNames.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeyUseNames.cs
@@ -5,7 +5,7 @@ namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
     /// Constants for JsonWebKeyUse (sec 4.2)
-    /// https://datatracker.ietf.org/doc/html/rfc7517#section-4.2
+    /// https://datatracker.ietf.org/doc/html/rfc7517#section-4-2
     /// </summary>
     public static class JsonWebKeyUseNames
     {

--- a/src/Microsoft.IdentityModel.Tokens/SecurityAlgorithms.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityAlgorithms.cs
@@ -25,7 +25,7 @@ namespace Microsoft.IdentityModel.Tokens
         // See: https://www.w3.org/TR/xmlenc-core1/#sec-RSA-OAEP
         public const string RsaOaepKeyWrap = "http://www.w3.org/2001/04/xmlenc#rsa-oaep";
 
-        // See: https://datatracker.ietf.org/doc/html/rfc7518#section-4.1
+        // See: https://datatracker.ietf.org/doc/html/rfc7518#section-4-1
         public const string Aes128KW = "A128KW";
         public const string Aes192KW = "A192KW";
         public const string Aes256KW = "A256KW";
@@ -40,7 +40,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string EnvelopedSignature = "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
 
         // See http://www.w3.org/TR/2002/REC-xmlenc-core-20021210/#sec-SHA256
-        // and https://datatracker.ietf.org/doc/html/rfc6931#section-2.1.3
+        // and https://datatracker.ietf.org/doc/html/rfc6931#section-2-1-3
         public const string Sha256Digest = "http://www.w3.org/2001/04/xmlenc#sha256";
         public const string Sha384Digest = "http://www.w3.org/2001/04/xmldsig-more#sha384";
         public const string Sha512Digest = "http://www.w3.org/2001/04/xmlenc#sha512";
@@ -50,22 +50,22 @@ namespace Microsoft.IdentityModel.Tokens
         public const string Sha384 = "SHA384";
         public const string Sha512 = "SHA512";
 
-        // See: https://datatracker.ietf.org/doc/html/rfc6931#section-2.3.6
+        // See: https://datatracker.ietf.org/doc/html/rfc6931#section-2-3-6
         public const string EcdsaSha256Signature = "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256";
         public const string EcdsaSha384Signature = "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384";
         public const string EcdsaSha512Signature = "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512";
 
-        // See: https://datatracker.ietf.org/doc/html/rfc6931#section-2.2.2
+        // See: https://datatracker.ietf.org/doc/html/rfc6931#section-2-2-2
         public const string HmacSha256Signature = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256";
         public const string HmacSha384Signature = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha384";
         public const string HmacSha512Signature = "http://www.w3.org/2001/04/xmldsig-more#hmac-sha512";
 
-        // See: https://datatracker.ietf.org/doc/html/rfc6931#section-2.3.2
+        // See: https://datatracker.ietf.org/doc/html/rfc6931#section-2-3-2
         public const string RsaSha256Signature = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
         public const string RsaSha384Signature = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384";
         public const string RsaSha512Signature = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
 
-        // See: https://datatracker.ietf.org/doc/html/rfc6931#section-2.3.10
+        // See: https://datatracker.ietf.org/doc/html/rfc6931#section-2-3-10
         public const string RsaSsaPssSha256Signature = "http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1";
         public const string RsaSsaPssSha384Signature = "http://www.w3.org/2007/05/xmldsig-more#sha384-rsa-MGF1";
         public const string RsaSsaPssSha512Signature = "http://www.w3.org/2007/05/xmldsig-more#sha512-rsa-MGF1";
@@ -85,7 +85,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string RsaSsaPssSha384 = "PS384";
         public const string RsaSsaPssSha512 = "PS512";
 
-        // See: https://datatracker.ietf.org/doc/html/rfc7518#section-5.1
+        // See: https://datatracker.ietf.org/doc/html/rfc7518#section-5-1
         public const string Aes128CbcHmacSha256 = "A128CBC-HS256";
         public const string Aes192CbcHmacSha384 = "A192CBC-HS384";
         public const string Aes256CbcHmacSha512 = "A256CBC-HS512";
@@ -96,12 +96,12 @@ namespace Microsoft.IdentityModel.Tokens
         internal const string DefaultAsymmetricKeyWrapAlgorithm = RsaOaepKeyWrap;
         internal const string DefaultSymmetricEncryptionAlgorithm = Aes128CbcHmacSha256;
 
-        // See: https://datatracker.ietf.org/doc/html/rfc7518#section-4.6
+        // See: https://datatracker.ietf.org/doc/html/rfc7518#section-4-6
         public const string EcdhEsA128kw = "ECDH-ES+A128KW";
         public const string EcdhEsA192kw = "ECDH-ES+A192KW";
         public const string EcdhEsA256kw = "ECDH-ES+A256KW";
 
-        // See: https://datatracker.ietf.org/doc/html/rfc7518#section-4.6
+        // See: https://datatracker.ietf.org/doc/html/rfc7518#section-4-6
         public const string EcdhEs = "ECDH-ES";
 #pragma warning restore 1591
     }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtHeaderParameterNames.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtHeaderParameterNames.cs
@@ -9,49 +9,49 @@ namespace System.IdentityModel.Tokens.Jwt
     public struct JwtHeaderParameterNames
     {
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.1
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-1
         /// </summary>
         public const string Alg = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.Alg;
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.10
-        /// Also: https://datatracker.ietf.org/doc/html/rfc7519#section-5.2
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-10
+        /// Also: https://datatracker.ietf.org/doc/html/rfc7519#section-5-2
         /// </summary>
         public const string Cty = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.Cty;
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.2
+        /// See: https://datatracker.ietf.org/doc/html/rfc7516#section-4-1-2
         /// </summary>
         public const string Enc = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.Enc;
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4.7.1.1
+        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4-7-1-1
         /// </summary>
         public const string IV = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.IV;
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.2
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-2
         /// </summary>
         public const string Jku = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.Jku;
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.3
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-3
         /// </summary>
         public const string Jwk = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.Jwk;
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-4
         /// </summary>
         public const string Kid = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.Kid;
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.9
-        /// Also: https://datatracker.ietf.org/doc/html/rfc7519#section-5.1
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-9
+        /// Also: https://datatracker.ietf.org/doc/html/rfc7519#section-5-1
         /// </summary>
         public const string Typ = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.Typ;
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.6
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-6
         /// </summary>
         public const string X5c = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.X5c;
 
@@ -61,29 +61,28 @@ namespace System.IdentityModel.Tokens.Jwt
         public const string X5t = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.X5t;
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.5
+        /// See: https://datatracker.ietf.org/doc/html/rfc7515#section-4-1-5
         /// </summary>
         public const string X5u = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.X5u;
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.3
+        /// See: https://datatracker.ietf.org/doc/html/rfc7516#section-4-1-3
         /// </summary>
         public const string Zip = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.Zip;
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.1.1
+        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4-6-1-1
         /// </summary>
         public const string Epk = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.Epk;
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.1.2
+        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4-6-1-2
         /// </summary>
         public const string Apu = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.Apu;
 
         /// <summary>
-        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4.6.1.3
+        /// See: https://datatracker.ietf.org/doc/html/rfc7518#section-4-6-1-3
         /// </summary>
         public const string Apv = Microsoft.IdentityModel.JsonWebTokens.JwtHeaderParameterNames.Apv;
-
     }
 }

--- a/test/CrossVersionTokenValidation.Tests/CrossVersionUtility.cs
+++ b/test/CrossVersionTokenValidation.Tests/CrossVersionUtility.cs
@@ -18,7 +18,7 @@ namespace Microsoft.IdentityModel.Protocols.Extensions.OldVersion
 {
     /// <summary>
     /// Tests for references in specs
-    /// https://datatracker.ietf.org/doc/html/rfc7518#appendix-A.3
+    /// https://datatracker.ietf.org/doc/html/rfc7518#appendix-A-3
     /// </summary>
     public class CrossVersionUtility
     {

--- a/test/Microsoft.IdentityModel.TestUtils/References.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/References.cs
@@ -6,7 +6,7 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.TestUtils
 {
-    // https://datatracker.ietf.org/doc/html/rfc7518#appendix-A.3
+    // https://datatracker.ietf.org/doc/html/rfc7518#appendix-A-3
     // B.1.  Test Cases for AES_128_CBC_HMAC_SHA_256
     public static class AES_128_CBC_HMAC_SHA_256
     {
@@ -116,7 +116,7 @@ namespace Microsoft.IdentityModel.TestUtils
         }
     }
 
-    // https://datatracker.ietf.org/doc/html/rfc7518#appendix-A.3
+    // https://datatracker.ietf.org/doc/html/rfc7518#appendix-A-3
     // B.2.  Test Cases for AES_192_CBC_HMAC_SHA_256
     public static class AES_192_CBC_HMAC_SHA_384
     {
@@ -230,7 +230,7 @@ namespace Microsoft.IdentityModel.TestUtils
         }
     }
   
-    // https://datatracker.ietf.org/doc/html/rfc7518#appendix-A.3
+    // https://datatracker.ietf.org/doc/html/rfc7518#appendix-A-3
     // B.3.  Test Cases for AES_256_CBC_HMAC_SHA_512
     public static class AES_256_CBC_HMAC_SHA_512
     {
@@ -346,7 +346,7 @@ namespace Microsoft.IdentityModel.TestUtils
         }
     }
 
-    // https://datatracker.ietf.org/doc/html/rfc7516#appendix-A.1.4
+    // https://datatracker.ietf.org/doc/html/rfc7516#appendix-A-1-4
     // A.1.4 Content encryption using AES-GCM 256
     public static class AES_256_GCM
     {
@@ -427,7 +427,7 @@ namespace Microsoft.IdentityModel.TestUtils
         }
     }
 
-    // https://datatracker.ietf.org/doc/html/rfc7516#appendix-A.3.3
+    // https://datatracker.ietf.org/doc/html/rfc7516#appendix-A-3-3
     // A.3.3 Key Encryption: Aes128 Key Wrap
     public static class AES128_KeyWrap
     {
@@ -593,7 +593,7 @@ namespace Microsoft.IdentityModel.TestUtils
         public static byte[] Z => new byte[] { 158, 86, 217, 29, 129, 113, 53, 211, 114, 131, 66, 131, 191, 132, 38, 156, 251, 49, 110, 163, 218, 128, 106, 72, 246, 218, 167, 121, 140, 254, 144, 196 };
     }
 
-    // https://datatracker.ietf.org/doc/html/rfc7516#appendix-A.1.3
+    // https://datatracker.ietf.org/doc/html/rfc7516#appendix-A-1-3
     // A.1.3 Key wrap: RSAES-OAEP + JsonWebKey
     public static class RSAES_OAEP_KeyWrap
     {
@@ -662,7 +662,7 @@ namespace Microsoft.IdentityModel.TestUtils
         }
     }
 
-    // https://datatracker.ietf.org/doc/html/rfc7516#appendix-A.2.3
+    // https://datatracker.ietf.org/doc/html/rfc7516#appendix-A-2-3
     // A.2.3 Key wrap: RSAES-PKCS1-v1_5 + JsonWebKey
     public static class RSAES_PKCS1_KeyWrap
     {

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         [Fact]
         public void ComputeJwkThumbprintSpec()
         {
-            // https://datatracker.ietf.org/doc/html/rfc7638#section-3.1
+            // https://datatracker.ietf.org/doc/html/rfc7638#section-3-1
             var context = TestUtilities.WriteHeader($"{this}.ComputeJwkThumbprintSpec", "", true);
 
             var jwk = new JsonWebKey()

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ReferenceTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ReferenceTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     /// <summary>
     /// Tests for references in specs
-    /// https://datatracker.ietf.org/doc/html/rfc7518#appendix-A.3
+    /// https://datatracker.ietf.org/doc/html/rfc7518#appendix-A-3
     /// </summary>
     public class ReferenceTests
     {

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/References.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/References.cs
@@ -18,7 +18,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         #region Keys
 
         // 3.1. EC Public Key
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-3.1
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-3-1
         public static string ECDsaPublicKeyJson
         {
             get
@@ -34,7 +34,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 3.1. EC Public Key
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-3.1
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-3-1
         public static JsonWebKey ECDsaPublicKey
         {
             get
@@ -44,7 +44,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 3.2. EC Private Key Json
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-3.2
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-3-2
         public static string ECDsaPrivateKeyJson
         {
             get
@@ -61,7 +61,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 3.2. EC Private Key
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-3.2
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-3-2
         public static JsonWebKey ECDsaPrivateKey
         {
             get
@@ -71,7 +71,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 3.3.  RSA Public Key Json
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-3.3
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-3-3
         public static string RSASigningPublicKeyJson
         {
             get
@@ -86,7 +86,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 3.3.  RSA Public Key
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-3.3
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-3-3
         public static JsonWebKey RSASigningPublicKey
         {
             get
@@ -96,7 +96,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 3.4.  RSA Private Key Json
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-3.4
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-3-4
         public static string RSASigningPrivateKeyJson
         {
             get
@@ -117,7 +117,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 3.4.  RSA Private Key
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-3.4
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-3-4
         public static JsonWebKey RSASigningPrivateKey
         {
             get
@@ -127,7 +127,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 3.5.  Symmetric Key(MAC Computation)
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-3.5
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-3-5
         public static string SymmetricKeyMacJson
         {
             get
@@ -142,7 +142,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 3.5.  Symmetric Key(MAC Computation)
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-3.5
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-3-5
         public static JsonWebKey SymmetricKeyMac
         {
             get
@@ -159,7 +159,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 3.6.  Symmetric Key(Encryption)
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-3.6
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-3-6
         public static string SymmetricKeyEncJson
         {
             get
@@ -174,7 +174,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 3.6.  Symmetric Key(Encryption)
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-3.6
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-3-6
         public static JsonWebKey SymmetricKeyEnc
         {
             get
@@ -184,7 +184,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 5.1.1  Key Encryption Using RSA v1.5 and AES-HMAC-SHA2
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-5.1.1
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-5-1-1
         public static string RSA_1_5_PrivateKeyJson
         {
             get
@@ -205,7 +205,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 5.1.1  Key Encryption Using RSA v1.5 and AES-HMAC-SHA2
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-5.1.1
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-5-1-1
         public static JsonWebKey RSA_1_5_PrivateKey
         {
             get
@@ -215,7 +215,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 5.2.1.  Key Encryption Using RSA v1.5 and A256GCM
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-5.2.1
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-5-2-1
         public static string RSA_OEAP_PrivateKeyJson
         {
             get
@@ -237,7 +237,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // 5.2.1.  Key Encryption Using RSA v1.5 and A256GCM
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-5.2.1
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-5-2-1
         public static JsonWebKey RSA_OEAP_PrivateKey
         {
             get
@@ -265,7 +265,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         #region 4.1.2
 
         // 4.1.2.  Signing Operation
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-4.1.2
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-4-1-2
         public static string RSAHeaderJson
         {
             get { return @"{""alg"":""RS256"",""kid"":""bilbo.baggins@hobbiton.example""}"; }
@@ -303,7 +303,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         #region 4.3.2
 
         // 4.3.2.  Signing Operation
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-4.3.2
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-4-3-2
 
         public static string ES512HeaderJson
         {
@@ -342,7 +342,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         #region 4.4.2
 
         //4.4.2.  Signing Operation
-        //https://datatracker.ietf.org/doc/html/rfc7520#section-4.4.1
+        //https://datatracker.ietf.org/doc/html/rfc7520#section-4-4-1
         public static string SymmetricEncoded
         {
             get { return SymmetricHeaderEncoded + "." + PayloadEncoded; }
@@ -380,7 +380,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         #region 5.1
 
         // 5.1.2.  Generated Factors
-        // https://datatracker.ietf.org/doc/html/rfc7520#section-5.1.2
+        // https://datatracker.ietf.org/doc/html/rfc7520#section-5-1-2
         public static string RSA_1_5_CEKEncoded
         {
             get { return "3qyTVhIWt5juqZUCpfRqpvauwB956MEJL2Rt-8qXKSo"; }
@@ -602,7 +602,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
     }
 
-    // https://datatracker.ietf.org/doc/html/rfc7516#appendix-A.3
+    // https://datatracker.ietf.org/doc/html/rfc7516#appendix-A-3
     // A.3 JWE Using AES Key Wrap and AES_128_CBC_HMAC_SHA_256
     public static class AESKeyWrap_AES_128_CBC_HMAC_SHA_256
     {


### PR DESCRIPTION
The links to datatracker.ietf.org used '.' instead of '-'.