### PR TITLE
JsonWebTokenHandler to return the JsonWebToken on validation failure

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -1319,7 +1319,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 return new TokenValidationResult
                 {
                     Exception = ex,
-                    IsValid = false
+                    IsValid = false,
+                    TokenOnFailedValidation = validationParameters.IncludeTokenOnFailedValidation ? jsonWebToken : null
                 };
             }
         }
@@ -1354,7 +1355,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 return new TokenValidationResult
                 {
                     Exception = ex,
-                    IsValid = false
+                    IsValid = false,
+                    TokenOnFailedValidation = validationParameters.IncludeTokenOnFailedValidation ? jwtToken : null
                 };
             }
         }

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -427,6 +427,10 @@ namespace Microsoft.IdentityModel.Tokens
         [DefaultValue(true)]
         public bool IgnoreTrailingSlashWhenValidatingAudience { get; set; } = true;
 
+        /// <summary>
+        /// Gets or sets the flag that indicates whether to include the <see cref="SecurityToken"/> when the validation fails.
+        /// </summary>
+        public bool IncludeTokenOnFailedValidation { get; set; } = false;
 
         /// <summary>
         /// Gets or sets a delegate for validating the <see cref="SecurityKey"/> that signed the token.
@@ -865,10 +869,5 @@ namespace Microsoft.IdentityModel.Tokens
         /// The default is <c>null</c>.
         /// </summary>
         public IEnumerable<string> ValidTypes { get; set; }
-
-        /// <summary>
-        /// Gets or sets the flag that indicates whether to include the <see cref="SecurityToken"/> when the validation fails.
-        /// </summary>
-        public bool IncludeTokenOnFailedValidation { get; set; } = false;
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -211,6 +211,7 @@ namespace Microsoft.IdentityModel.Tokens
             ConfigurationManager = other.ConfigurationManager;
             CryptoProviderFactory = other.CryptoProviderFactory;
             DebugId = other.DebugId;
+            IncludeTokenOnFailedValidation = other.IncludeTokenOnFailedValidation;
             IgnoreTrailingSlashWhenValidatingAudience = other.IgnoreTrailingSlashWhenValidatingAudience;
             IssuerSigningKey = other.IssuerSigningKey;
             IssuerSigningKeyResolver = other.IssuerSigningKeyResolver;

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -865,5 +865,10 @@ namespace Microsoft.IdentityModel.Tokens
         /// The default is <c>null</c>.
         /// </summary>
         public IEnumerable<string> ValidTypes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag that indicates whether to include the <see cref="SecurityToken"/> when the validation fails.
+        /// </summary>
+        public bool IncludeTokenOnFailedValidation { get; set; } = false;
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
@@ -23,11 +23,6 @@ namespace Microsoft.IdentityModel.Tokens
         private TokenHandler _tokenHandler;
 
         /// <summary>
-        /// The <see cref="SecurityToken"/> to be returned when a validation fails.
-        /// </summary>
-        public SecurityToken TokenOnFailedValidation { get; internal set; }
-
-        /// <summary>
         /// Creates an instance of <see cref="TokenValidationResult"/>
         /// </summary>
         public TokenValidationResult()
@@ -146,6 +141,11 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets or sets the <see cref="SecurityToken"/> that was validated.
         /// </summary>
         public SecurityToken SecurityToken { get; set; }
+
+        /// <summary>
+        /// The <see cref="SecurityToken"/> to be returned when validation fails.
+        /// </summary>
+        public SecurityToken TokenOnFailedValidation { get; internal set; }
 
         /// <summary>
         /// Gets or sets the <see cref="CallContext"/> that contains call information.

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
@@ -23,6 +23,11 @@ namespace Microsoft.IdentityModel.Tokens
         private TokenHandler _tokenHandler;
 
         /// <summary>
+        /// The <see cref="SecurityToken"/> to be returned when a validation fails.
+        /// </summary>
+        public SecurityToken TokenOnFailedValidation { get; internal set; }
+
+        /// <summary>
         /// Creates an instance of <see cref="TokenValidationResult"/>
         /// </summary>
         public TokenValidationResult()

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -3358,6 +3358,77 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 },
             };
         }
+
+        [Theory, MemberData(nameof(IncludeSecurityTokenOnFailureTestTheoryData))]
+        public void IncludeSecurityTokenOnFailedValidationTest(CreateTokenTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.IncludeSecurityTokenOnFailedValidationTest", theoryData);
+
+            try
+            {
+                var handler = new JsonWebTokenHandler();
+                var token = handler.CreateToken(theoryData.TokenDescriptor);
+                var validationResult = handler.ValidateToken(token, theoryData.ValidationParameters);
+                if (theoryData.ValidationParameters.IncludeTokenOnFailedValidation)
+                {
+                    Assert.NotNull(validationResult.TokenOnFailedValidation);
+                }
+                else
+                {
+                    Assert.Null(validationResult.TokenOnFailedValidation);
+                }
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<CreateTokenTheoryData> IncludeSecurityTokenOnFailureTestTheoryData()
+        {
+            return new TheoryData<CreateTokenTheoryData>()
+            {
+                new CreateTokenTheoryData
+                {
+                    First = true,
+                    TestId = "TokenExpiredIncludeTokenOnFailedValidation",
+                    TokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(Default.PayloadClaimsExpired),
+                        Expires = DateTime.UtcNow.Subtract(new TimeSpan(0, 10, 0)),
+                        IssuedAt = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
+                        NotBefore = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                    },
+                    ValidationParameters = new TokenValidationParameters
+                    {
+                        IssuerSigningKey = Default.SymmetricSigningKey,
+                        ValidIssuer = Default.Issuer,
+                        IncludeTokenOnFailedValidation = true
+                    }
+                },
+                new CreateTokenTheoryData
+                {
+                    First = true,
+                    TestId = "TokenExpiredNotIncludeTokenOnFailedValidation",
+                    TokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(Default.PayloadClaimsExpired),
+                        Expires = DateTime.UtcNow.Subtract(new TimeSpan(0, 10, 0)),
+                        IssuedAt = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
+                        NotBefore = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                    },
+                    ValidationParameters = new TokenValidationParameters
+                    {
+                        IssuerSigningKey = Default.SymmetricSigningKey,
+                        ValidIssuer = Default.Issuer,
+                    }
+                },
+            };
+        }
     }
 
     public class CreateTokenTheoryData : TheoryDataBase

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
@@ -16,14 +16,16 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class TokenValidationParametersTests
     {
+        int ExpectedPropertyCount = 57;
+
         [Fact]
         public void Publics()
         {
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 57)
-                Assert.True(false, "Number of properties has changed from 57 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != ExpectedPropertyCount)
+                Assert.True(false, $"Number of properties has changed from {ExpectedPropertyCount} to: " + properties.Length + ", adjust tests");
 
             TokenValidationParameters actorValidationParameters = new TokenValidationParameters();
             SecurityKey issuerSigningKey = KeyingMaterial.DefaultX509Key_2048_Public;
@@ -157,8 +159,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 57)
-                Assert.True(false, "Number of public fields has changed from 57 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != ExpectedPropertyCount)
+                Assert.True(false, $"Number of public fields has changed from {ExpectedPropertyCount} to: " + properties.Length + ", adjust tests");
 
             GetSetContext context =
                 new GetSetContext

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
@@ -22,8 +22,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 56)
-                Assert.True(false, "Number of properties has changed from 56 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 57)
+                Assert.True(false, "Number of properties has changed from 57 to: " + properties.Length + ", adjust tests");
 
             TokenValidationParameters actorValidationParameters = new TokenValidationParameters();
             SecurityKey issuerSigningKey = KeyingMaterial.DefaultX509Key_2048_Public;
@@ -157,8 +157,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationParameters validationParameters = new TokenValidationParameters();
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 56)
-                Assert.True(false, "Number of public fields has changed from 56 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 57)
+                Assert.True(false, "Number of public fields has changed from 57 to: " + properties.Length + ", adjust tests");
 
             GetSetContext context =
                 new GetSetContext

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationResultTests.cs
@@ -21,8 +21,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TokenValidationResult tokenValidationResult = new TokenValidationResult();
             Type type = typeof(TokenValidationResult);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 9)
-                Assert.True(false, "Number of public fields has changed from 9 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 10)
+                Assert.True(false, "Number of public fields has changed from 10 to: " + properties.Length + ", adjust tests");
 
             GetSetContext context =
                 new GetSetContext


### PR DESCRIPTION
When a validation fails, the JsonWebTokenHandler should return the JsonWebToken so the caller can check the claims and log details if needed.