### PR TITLE
Actually embed the inner exception instead of adding it to the FormatInvariant

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -1178,7 +1178,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 {
                     return new TokenValidationResult
                     {
-                        Exception = LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14100, token, ex))),
+                        Exception = LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14100, token), ex)),
                         IsValid = false
                     };
                 }

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -2846,6 +2846,17 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         },
                         ExpectedException = ExpectedException.SecurityTokenNoExpirationException("IDX10225:")
                     },
+                    new JwtTheoryData("JWS_DotMissingInnerException")
+                    {
+                        Token = "abcde.efgh",
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key,
+                            ValidAudience = Default.Audience,
+                            ValidIssuer = Default.Issuer,
+                        },
+                        ExpectedException = new ExpectedException(typeof(ArgumentException), "IDX14100:", typeof(ArgumentException))
+                    }
                 };
             }
         }


### PR DESCRIPTION
Unit test added to actually cover the use case (which would detect the previous pull request was in fact incorrect).

I have tested the unit test locally and the JsonWebTokens.Test and Tokens.Tests project are all green (save for the not supported Linux exception which i can't recreate on my windows machine).

Fixes #1992 .