### PR TITLE
Add TVP to check if Token Identifier can be logged

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -220,6 +220,7 @@ namespace Microsoft.IdentityModel.Tokens
             IssuerSigningKeyValidator = other.IssuerSigningKeyValidator;
             IssuerValidator = other.IssuerValidator;
             LifetimeValidator = other.LifetimeValidator;
+            LogTokenId = other.LogTokenId;
             LogValidationExceptions = other.LogValidationExceptions;
             NameClaimType = other.NameClaimType;
             NameClaimTypeRetriever = other.NameClaimTypeRetriever;
@@ -262,6 +263,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>        
         public TokenValidationParameters()
         {
+            LogTokenId = true;
             LogValidationExceptions = true;
             RequireExpirationTime = true;
             RequireSignedTokens = true;
@@ -543,6 +545,13 @@ namespace Microsoft.IdentityModel.Tokens
         /// Even if <see cref="ValidateLifetime"/> is false, this delegate will still be called.
         /// </remarks>
         public LifetimeValidator LifetimeValidator { get; set; }
+
+        /// <summary>
+        /// Gets or sets a <see cref="bool"/> that will decide if the token identifier claim needs to be logged.
+        /// Default value is <c>true</c>.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool LogTokenId { get; set; }
 
         /// <summary>
         /// Gets or sets a <see cref="bool"/> that will decide if validation failure needs to be logged as an error.

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class TokenValidationParametersTests
     {
-        int ExpectedPropertyCount = 57;
+        int ExpectedPropertyCount = 58;
 
         [Fact]
         public void Publics()
@@ -74,6 +74,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 IssuerSigningKeys = issuerSigningKeys,
                 IssuerValidator = ValidationDelegates.IssuerValidatorEcho,
                 LifetimeValidator = ValidationDelegates.LifetimeValidatorReturnsTrue,
+                LogTokenId = true,
                 LogValidationExceptions = true,
                 PropertyBag = propertyBag,
                 SignatureValidator = ValidationDelegates.SignatureValidatorReturnsJwtTokenAsIs,
@@ -112,6 +113,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             validationParametersSets.IssuerSigningKeys = issuerSigningKeysDup;
             validationParametersSets.IssuerValidator = ValidationDelegates.IssuerValidatorEcho;
             validationParametersSets.LifetimeValidator = ValidationDelegates.LifetimeValidatorReturnsTrue;
+            validationParametersSets.LogTokenId = true;
             validationParametersSets.LogValidationExceptions = true;
             validationParametersSets.PropertyBag = propertyBag;
             validationParametersSets.SignatureValidator = ValidationDelegates.SignatureValidatorReturnsJwtTokenAsIs;
@@ -125,7 +127,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             validationParametersSets.ValidIssuer = validIssuer;
             validationParametersSets.ValidIssuers = validIssuers;
             validationParametersSets.ValidTypes = validTypes;
-            
+
             var compareContext = new CompareContext();
             IdentityComparer.AreEqual(validationParametersInline, validationParametersSets, compareContext);
 


### PR DESCRIPTION
What is changing?
Introducing a new boolean TokenValidationParameter LogTokenId. By default, it set to true.
Why?
It will allow the library to log a token identifier if LogTokenId is set to true.

**Note**: Today, no action will be taken in Wilson based on the value of LogTokenId.