### PR TITLE
Validate size of signature against algorithm considering JWE

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Encryption/AuthenticatedEncryptionProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/AuthenticatedEncryptionProvider.cs
@@ -170,7 +170,7 @@ namespace Microsoft.IdentityModel.Tokens
             Array.Copy(iv, 0, macBytes, authenticatedData.Length, iv.Length);
             Array.Copy(ciphertext, 0, macBytes, authenticatedData.Length + iv.Length, ciphertext.Length);
             Array.Copy(al, 0, macBytes, authenticatedData.Length + iv.Length + ciphertext.Length, al.Length);
-            if (!_symmetricSignatureProvider.Value.Verify(macBytes, authenticationTag, _authenticatedkeys.Value.HmacKey.Key.Length))
+            if (!_symmetricSignatureProvider.Value.Verify(macBytes, 0, macBytes.Length, authenticationTag, 0, _authenticatedkeys.Value.HmacKey.Key.Length, Algorithm))
                 throw LogHelper.LogExceptionMessage(new SecurityTokenDecryptionFailedException(LogHelper.FormatInvariant(LogMessages.IDX10650, Base64UrlEncoder.Encode(authenticatedData), Base64UrlEncoder.Encode(iv), Base64UrlEncoder.Encode(authenticationTag))));
 
             using Aes aes = Aes.Create();
@@ -383,13 +383,13 @@ namespace Microsoft.IdentityModel.Tokens
         private static string GetHmacAlgorithm(string algorithm)
         {
             if (SecurityAlgorithms.Aes128CbcHmacSha256.Equals(algorithm))
-                    return SecurityAlgorithms.HmacSha256;
+                return SecurityAlgorithms.HmacSha256;
 
             if (SecurityAlgorithms.Aes192CbcHmacSha384.Equals(algorithm))
                 return SecurityAlgorithms.HmacSha384;
 
             if (SecurityAlgorithms.Aes256CbcHmacSha512.Equals(algorithm))
-                    return SecurityAlgorithms.HmacSha512;
+                return SecurityAlgorithms.HmacSha512;
 
             throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10652, LogHelper.MarkAsNonPII(algorithm)), nameof(algorithm)));
         }

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -219,6 +219,8 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10715 = "IDX10715: Encryption using algorithm: '{0}' is not supported.";
         public const string IDX10716 = "IDX10716: '{0}' must be greater than 0, was: '{1}'";
         public const string IDX10717 = "IDX10717: '{0} + {1}' must not be greater than {2}, '{3} + {4} > {5}'.";
+        public const string IDX10718 = "IDX10718: AlgorithmToValidate is not supported: '{0}'. Algorithm '{1}'.";
+        public const string IDX10719 = "IDX10719: SignatureSize (in bytes) was expected to be '{0}', was '{1}'.";
 
         // Json specific errors
         //public const string IDX10801 = "IDX10801:"

--- a/src/Microsoft.IdentityModel.Tokens/SignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SignatureProvider.cs
@@ -110,8 +110,8 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="inputOffset">offset in to input bytes to caculate hash.</param>
         /// <param name="inputLength">number of bytes of signature to use.</param>
         /// <param name="signature">signature to compare against.</param>
-        /// <param name="signatureOffset"></param>
-        /// <param name="signatureLength"></param>
+        /// <param name="signatureOffset">offset into signature array.</param>
+        /// <param name="signatureLength">how many bytes to verfiy.</param>
         /// <returns>true if computed signature matches the signature parameter, false otherwise.</returns>
         /// <exception cref="ArgumentNullException">'input' is null.</exception>
         /// <exception cref="ArgumentNullException">'signature' is null.</exception>

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Properties/AssemblyInfo.cs
@@ -5,6 +5,6 @@ using System;
 using System.Runtime.InteropServices;
 using Xunit;
 
-[assembly: CLSCompliant(true)]
+[assembly: CLSCompliant(false)]
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]
 [assembly: ComVisible(false)]

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -549,6 +549,151 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
+        [Theory, MemberData(nameof(SymmetricVerifySingatureSizeTheoryData))]
+        public void SymmetricVerify1Tests(SignatureProviderTheoryData theoryData)
+        {
+            // verifies: public bool Verify(byte[] input, byte[] signature)
+            var context = TestUtilities.WriteHeader($"{this}.SymmetricVerify1Tests", theoryData);
+            try
+            {
+                if (theoryData.SigningSignatureProvider.Verify(theoryData.RawBytes, theoryData.Signature))
+                    context.Diffs.Add("SigningSignatureProvider.Verify should not have succeeded");
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Theory, MemberData(nameof(SymmetricVerifySingatureSizeTheoryData))]
+        public void SymmetricVerify2Tests(SignatureProviderTheoryData theoryData)
+        {
+            // verifies: public bool Verify(byte[] input, byte[] signature, int length)
+            var context = TestUtilities.WriteHeader($"{this}.SymmetricVerify2Tests", theoryData);
+            try
+            {
+                ((SymmetricSignatureProvider)theoryData.SigningSignatureProvider).Verify(theoryData.RawBytes, theoryData.Signature, theoryData.Signature.Length);
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Theory, MemberData(nameof(SymmetricVerifySingatureSizeTheoryData))]
+        public void SymmetricVerify3Tests(SignatureProviderTheoryData theoryData)
+        {
+            // verifies: public override bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength)
+            var context = TestUtilities.WriteHeader($"{this}.SymmetricVerify3Tests", theoryData);
+            try
+            {
+                theoryData.SigningSignatureProvider.Verify(theoryData.RawBytes, 0, theoryData.RawBytes.Length, theoryData.Signature, 0, theoryData.Signature.Length);
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<SignatureProviderTheoryData> SymmetricVerifySingatureSizeTheoryData
+        {
+            get
+            {
+                return new TheoryData<SignatureProviderTheoryData>
+                {
+                    new SignatureProviderTheoryData("HmacSha256")
+                    {
+                        ExpectedException = EE.ArgumentException("IDX10719:"),
+                        RawBytes= new byte[16],
+                        Signature = new byte[16],
+                        SigningSignatureProvider = new SymmetricSignatureProvider(KEY.SymmetricSecurityKey2_256, ALG.HmacSha256),
+                    },
+                    new SignatureProviderTheoryData("HmacSha384")
+                    {
+                        ExpectedException = EE.ArgumentException("IDX10719:"),
+                        RawBytes= new byte[32],
+                        Signature = new byte[32],
+                        SigningSignatureProvider = new SymmetricSignatureProvider(KEY.SymmetricSecurityKey2_256, ALG.HmacSha384),
+                    },
+                    new SignatureProviderTheoryData("HmacSha512")
+                    {
+                        ExpectedException = EE.ArgumentException("IDX10719:"),
+                        RawBytes= new byte[48],
+                        Signature = new byte[48],
+                        SigningSignatureProvider = new SymmetricSignatureProvider(KEY.SymmetricSecurityKey2_256, ALG.HmacSha512),
+                    }
+                };
+            }
+        }
+
+        [Theory, MemberData(nameof(SymmetricVerifySingatureSizeInternalTheoryData))]
+        public void SymmetricVerify4Tests(SignatureProviderTheoryData theoryData)
+        {
+            // verifies: internal bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength, string algorithm)
+            var context = TestUtilities.WriteHeader($"{this}.SymmetricVerify4Tests", theoryData);
+            try
+            {
+                ((SymmetricSignatureProvider)theoryData.SigningSignatureProvider).Verify(theoryData.RawBytes, 0, theoryData.RawBytes.Length, theoryData.Signature, 0, theoryData.Signature.Length, theoryData.VerifyAlgorithm);
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+        
+        public static TheoryData<SignatureProviderTheoryData> SymmetricVerifySingatureSizeInternalTheoryData
+        {
+            get
+            {
+                return new TheoryData<SignatureProviderTheoryData>
+                {
+                    new SignatureProviderTheoryData("UnknownAlgorithm")
+                    {
+                        ExpectedException = EE.ArgumentException("IDX10718:"),
+                        RawBytes= new byte[10],
+                        Signature = new byte[10],
+                        SigningSignatureProvider = new SymmetricSignatureProvider(KEY.SymmetricSecurityKey2_256, ALG.HmacSha256),
+                        VerifyAlgorithm = "ALG.Aes128CbcHmacSha256"
+                    },
+                    new SignatureProviderTheoryData("HmacSha256_HmacSha384")
+                    {
+                        ExpectedException = EE.ArgumentException("IDX10719:"),
+                        RawBytes= new byte[32],
+                        Signature = new byte[32],
+                        SigningSignatureProvider = new SymmetricSignatureProvider(KEY.SymmetricSecurityKey2_256, ALG.HmacSha256),
+                        VerifyAlgorithm = ALG.HmacSha384
+                    },
+                    new SignatureProviderTheoryData("HmacSha384_HmacSha256")
+                    {
+                        ExpectedException = EE.ArgumentException("IDX10719:"),
+                        RawBytes= new byte[384],
+                        Signature = new byte[384],
+                        SigningSignatureProvider = new SymmetricSignatureProvider(KEY.SymmetricSecurityKey2_256, ALG.HmacSha384),
+                        VerifyAlgorithm = ALG.HmacSha256
+                    },
+                    new SignatureProviderTheoryData("HmacSha512_HmacSha384")
+                    {
+                        ExpectedException = EE.ArgumentException("IDX10719:"),
+                        RawBytes= new byte[512],
+                        Signature = new byte[512],
+                        SigningSignatureProvider = new SymmetricSignatureProvider(KEY.SymmetricSecurityKey2_256, ALG.HmacSha512),
+                        VerifyAlgorithm = ALG.HmacSha384
+                    }
+                };
+            }
+        }
+
         [Fact]
         public void SymmetricSignatureProvider_SupportedAlgorithms()
         {
@@ -825,14 +970,15 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     public class CryptoProviderFactoryTheoryData : TheoryDataBase, IDisposable
     {
         public CryptoProviderFactoryTheoryData() { }
+        public CryptoProviderFactoryTheoryData(string testId) : base(testId) { }
 
         public CryptoProviderFactoryTheoryData(string testId, string algorithm, SecurityKey signingKey, SecurityKey verifyKey, EE expectedException = null)
+            : base(testId)
         {
             SigningAlgorithm = algorithm;
             SigningKey = signingKey;
             VerifyKey = verifyKey;
             ExpectedException = expectedException ?? EE.NoExceptionExpected;
-            TestId = testId;
         }
 
         public CryptoProviderFactory CryptoProviderFactory { get; set; } = new CryptoProviderFactory(CryptoProviderCacheTests.CreateCacheForTesting())
@@ -885,6 +1031,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     public class SignatureProviderTheoryData : CryptoProviderFactoryTheoryData
     {
         public SignatureProviderTheoryData() { }
+
+        public SignatureProviderTheoryData(string testId) : base(testId) { }
 
         public SignatureProviderTheoryData(string testId, string signingAlgorithm, string verifyAlgorithm, SecurityKey signingKey, SecurityKey verifyKey, EE expectedException = null, bool isValid = true)
         {

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TamperedTokenTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TamperedTokenTests.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.TestUtils;
+using Xunit;
+
+using JwtRegisteredClaimNames = Microsoft.IdentityModel.JsonWebTokens.JwtRegisteredClaimNames;
+
+namespace Microsoft.IdentityModel.Tokens.Tests
+{
+    public class TamperedTokenTests
+    {
+        [Theory, MemberData(nameof(JwtSignatureTruncationTheoryData))]
+        public async Task JwtSignatureTruncation(ValidateTokenTheoryData theoryData)
+        {
+            CompareContext compareContext = TestUtilities.WriteHeader($"{this}.JwtSignatureTruncation", theoryData);
+            JsonWebToken jsonWebToken = new JsonWebToken(theoryData.JsonWebToken);
+            JsonWebTokenHandler jsonWebTokenHandler = new JsonWebTokenHandler();
+            JwtSecurityTokenHandler jwtSecurityTokenHandler = new JwtSecurityTokenHandler();
+            TokenValidationResult tokenValidationResult;
+
+            try
+            {
+                tokenValidationResult = await jsonWebTokenHandler.ValidateTokenAsync(theoryData.JsonWebToken, theoryData.ValidationParameters);
+                if (!tokenValidationResult.IsValid)
+                    compareContext.AddDiff($"JsonWebTokenHandler.ValidateTokenAsync IS NOT VALID with untampered token. The token should have validated");
+
+                tokenValidationResult = await jwtSecurityTokenHandler.ValidateTokenAsync(theoryData.JsonWebToken, theoryData.ValidationParameters);
+                if (!tokenValidationResult.IsValid)
+                    compareContext.AddDiff($"JwtSecurityTokenHandler.ValidateTokenAsync IS NOT VALID with untampered token. The token should have validated");
+
+                theoryData.ExpectedException.ProcessNoException(compareContext);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, compareContext);
+            }
+
+            for (int i = 1; i < jsonWebToken.EncodedSignature.Length; i++)
+            {
+                try
+                {
+                    string token = theoryData.JsonWebToken.Substring(0, theoryData.JsonWebToken.Length - i);
+                    tokenValidationResult = await jsonWebTokenHandler.ValidateTokenAsync(token, theoryData.ValidationParameters);
+                    if (tokenValidationResult.IsValid)
+                        compareContext.AddDiff($"jsonWebTokenHandler.ValidateTokenAsync, tokenValidationResult.IsValid, index:'{i}'.");
+
+                    tokenValidationResult = await jwtSecurityTokenHandler.ValidateTokenAsync(token, theoryData.ValidationParameters);
+                    if (tokenValidationResult.IsValid)
+                        compareContext.AddDiff($"jwtSecurityTokenHandler.ValidateTokenAsync, tokenValidationResult.IsValid, index:'{i}'.");
+
+                    theoryData.ExpectedException.ProcessNoException(compareContext);
+                }
+                catch (Exception ex)
+                {
+                    theoryData.ExpectedException.ProcessException(ex, compareContext);
+                }
+            }
+
+            TestUtilities.AssertFailIfErrors(compareContext);
+        }
+
+        public static TheoryData<ValidateTokenTheoryData> JwtSignatureTruncationTheoryData()
+        {
+            var theoryData = new TheoryData<ValidateTokenTheoryData>();
+
+            JsonWebTokenHandler jsonWebTokenHandler = new JsonWebTokenHandler();
+            SecurityTokenDescriptor securityTokenDescriptor = new SecurityTokenDescriptor
+            {
+                Issuer = "https://idp.com",
+                Claims = new Dictionary<string, object>
+                {
+                    { JwtRegisteredClaimNames.Aud, "https://relyingparty.com" },
+                    { JwtRegisteredClaimNames.Email, "bob@contoso.com" },
+                    { JwtRegisteredClaimNames.GivenName, "bob" },
+                    { JwtRegisteredClaimNames.Sub, "123456789" }
+                }
+            };
+
+            // ECD - Key - 256
+            theoryData.Add(BuildTestCase("ES256_Key256", KeyingMaterial.Ecdsa256Key, SecurityAlgorithms.EcdsaSha256, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("ES384_Key256", KeyingMaterial.Ecdsa256Key, SecurityAlgorithms.EcdsaSha384, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("ES512_Key256", KeyingMaterial.Ecdsa256Key, SecurityAlgorithms.EcdsaSha512, securityTokenDescriptor, jsonWebTokenHandler));
+
+            // ECD - Key - 384
+            theoryData.Add(BuildTestCase("ES256_Key384", KeyingMaterial.Ecdsa384Key, SecurityAlgorithms.EcdsaSha256, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("ES384_Key384", KeyingMaterial.Ecdsa384Key, SecurityAlgorithms.EcdsaSha384, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("ES512_Key384", KeyingMaterial.Ecdsa384Key, SecurityAlgorithms.EcdsaSha512, securityTokenDescriptor, jsonWebTokenHandler));
+
+            // ECD - Key - 521
+            theoryData.Add(BuildTestCase("ES256_Key521", KeyingMaterial.Ecdsa521Key, SecurityAlgorithms.EcdsaSha256, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("ES384_Key521", KeyingMaterial.Ecdsa521Key, SecurityAlgorithms.EcdsaSha384, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("ES512_Key521", KeyingMaterial.Ecdsa521Key, SecurityAlgorithms.EcdsaSha512, securityTokenDescriptor, jsonWebTokenHandler));
+
+            // RSA - Key - 2048
+            theoryData.Add(BuildTestCase("RS256_Key2048", KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaSha256, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("RS384_Key2048", KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaSha384, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("RS512_Key2048", KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaSha512, securityTokenDescriptor, jsonWebTokenHandler));
+
+            // RSA - Key - 4096
+            theoryData.Add(BuildTestCase("RS256_Key4096", KeyingMaterial.RsaSecurityKey_4096, SecurityAlgorithms.RsaSha256, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("RS384_Key4096", KeyingMaterial.RsaSecurityKey_4096, SecurityAlgorithms.RsaSha384, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("RS512_Key4096", KeyingMaterial.RsaSecurityKey_4096, SecurityAlgorithms.RsaSha512, securityTokenDescriptor, jsonWebTokenHandler));
+
+            // Symmetric - Key - 256
+            theoryData.Add(BuildTestCase("Hmac256_Key256", KeyingMaterial.SymmetricSecurityKey2_256, SecurityAlgorithms.HmacSha256, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("Hmac384_Key256", KeyingMaterial.SymmetricSecurityKey2_256, SecurityAlgorithms.HmacSha384, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("Hmac512_Key256", KeyingMaterial.SymmetricSecurityKey2_256, SecurityAlgorithms.HmacSha512, securityTokenDescriptor, jsonWebTokenHandler));
+
+            // Symmetric - Key - 384
+            theoryData.Add(BuildTestCase("Hmac256_Key384", KeyingMaterial.SymmetricSecurityKey2_384, SecurityAlgorithms.HmacSha256, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("Hmac384_Key384", KeyingMaterial.SymmetricSecurityKey2_384, SecurityAlgorithms.HmacSha384, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("Hmac512_Key384", KeyingMaterial.SymmetricSecurityKey2_384, SecurityAlgorithms.HmacSha512, securityTokenDescriptor, jsonWebTokenHandler));
+
+            // Symmetric - Key - 512
+            theoryData.Add(BuildTestCase("Hmac256_Key512", KeyingMaterial.SymmetricSecurityKey2_512, SecurityAlgorithms.HmacSha256, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("Hmac384_Key512", KeyingMaterial.SymmetricSecurityKey2_512, SecurityAlgorithms.HmacSha384, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("Hmac512_Key512", KeyingMaterial.SymmetricSecurityKey2_512, SecurityAlgorithms.HmacSha512, securityTokenDescriptor, jsonWebTokenHandler));
+
+            return theoryData;
+        }
+
+        private static ValidateTokenTheoryData BuildTestCase(string testId, SecurityKey securityKey, string securityAlgorithm, SecurityTokenDescriptor securityTokenDescriptor, JsonWebTokenHandler jsonWebTokenHandler)
+        {
+            securityTokenDescriptor.SigningCredentials = new SigningCredentials(securityKey, securityAlgorithm);
+            return new ValidateTokenTheoryData(testId)
+            {
+                JsonWebToken = jsonWebTokenHandler.CreateToken(securityTokenDescriptor),
+                ValidationParameters = new TokenValidationParameters
+                {
+                    IssuerSigningKey = securityKey,
+                    ValidateIssuer = false,
+                    ValidateAudience = false
+                }
+            };
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ValidateTokenTheoryData.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ValidateTokenTheoryData.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.IdentityModel.Tokens.Tests
+{
+    public class ValidateTokenTheoryData : TheoryDataBase
+    {
+        public ValidateTokenTheoryData(string testId) : base(testId)
+        { }
+
+        public TokenValidationParameters ValidationParameters { get; set; }
+
+        public TokenHandler TokenHandler { get; set; }
+
+        public string JsonWebToken { get; set; }
+    }
+}


### PR DESCRIPTION
SymmetricSignatures are now ensuring the size of the signature matches the algorithm.
Authenticated Encryption needed special processing as only the first half of the signature is considered for Aes128CbcHmacSha256, Aes128CbcHmacSha384 and Aes128CbcHmacSha512.