### PR TITLE
Update CHANGELOG link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-See the [release notes](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Release-Notes) for details on bug fixes and added features.
+See the [releases](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases) for details on bug fixes and added features.
 
 6.26.1
 =========


### PR DESCRIPTION
Update the releases notes link to not point to the wiki, as the wiki is old content and just points to the GitHub releases. This removes the additional indirection to view the content when users reach it through dependabot pull request notes.

![image](https://user-images.githubusercontent.com/1439341/220301748-40b5ca2d-0df8-4bdb-8c5a-445d898f0e87.png)
