### PR TITLE
First Round of Trimming Analysis

### DIFF
--- a/Wilson.sln
+++ b/Wilson.sln
@@ -99,8 +99,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.IdentityModel.Sam
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.IdentityModel.Abstractions", "src\Microsoft.IdentityModel.Abstractions\Microsoft.IdentityModel.Abstractions.csproj", "{8057C69A-3D1E-46A3-86E4-E6B26249DD25}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.IdentityModel.LoggingExtensions", "src\Microsoft.IdentityModel.LoggingExtensions\Microsoft.IdentityModel.LoggingExtensions.csproj", "{C1F5A997-FAA9-45E5-8D28-D4E92D4A034D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.IdentityModel.LoggingExtensions", "src\Microsoft.IdentityModel.LoggingExtensions\Microsoft.IdentityModel.LoggingExtensions.csproj", "{C1F5A997-FAA9-45E5-8D28-D4E92D4A034D}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.IdentityModel.Abstractions.Tests", "test\Microsoft.IdentityModel.Abstractions.Tests\Microsoft.IdentityModel.Abstractions.Tests.csproj", "{EF9A4431-6D2C-4DD1-BF6B-6F2CC619DEE1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.IdentityModel.AotCompatibility.TestApp", "test\Microsoft.IdentityModel.AotCompatibility.TestApp\Microsoft.IdentityModel.AotCompatibility.TestApp.csproj", "{8105289F-3D54-4054-9738-5985F3B6CF2C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.IdentityModel.AotCompatibility.Tests", "test\Microsoft.IdentityModel.AotCompatibility.Tests\Microsoft.IdentityModel.AotCompatibility.Tests.csproj", "{CD0EEF56-7221-4420-8181-48EE82E91306}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -244,6 +249,14 @@ Global
 		{EF9A4431-6D2C-4DD1-BF6B-6F2CC619DEE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EF9A4431-6D2C-4DD1-BF6B-6F2CC619DEE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EF9A4431-6D2C-4DD1-BF6B-6F2CC619DEE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8105289F-3D54-4054-9738-5985F3B6CF2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8105289F-3D54-4054-9738-5985F3B6CF2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8105289F-3D54-4054-9738-5985F3B6CF2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8105289F-3D54-4054-9738-5985F3B6CF2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD0EEF56-7221-4420-8181-48EE82E91306}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD0EEF56-7221-4420-8181-48EE82E91306}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD0EEF56-7221-4420-8181-48EE82E91306}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD0EEF56-7221-4420-8181-48EE82E91306}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -286,6 +299,8 @@ Global
 		{8057C69A-3D1E-46A3-86E4-E6B26249DD25} = {BD2706C5-6C57-484D-89C8-A0CF5F8E3D19}
 		{C1F5A997-FAA9-45E5-8D28-D4E92D4A034D} = {EB14B99B-2255-45BC-BF14-E488DCD4A4BA}
 		{EF9A4431-6D2C-4DD1-BF6B-6F2CC619DEE1} = {8905D2E3-4499-4A86-BF3E-F098F228DD59}
+		{8105289F-3D54-4054-9738-5985F3B6CF2C} = {8905D2E3-4499-4A86-BF3E-F098F228DD59}
+		{CD0EEF56-7221-4420-8181-48EE82E91306} = {8905D2E3-4499-4A86-BF3E-F098F228DD59}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2F681326-7ED4-45F6-BD1D-1119EA388F42}

--- a/buildConfiguration.xml
+++ b/buildConfiguration.xml
@@ -40,6 +40,7 @@
       <project name="Microsoft.IdentityModel.KeyVaultExtensions.Tests" test="yes" />
       <project name="Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.Tests" test="yes" />
       <project name="Microsoft.IdentityModel.Validators.Tests" test="yes" />
+      <project name="Microsoft.IdentityModel.AotCompatibility.Tests" test="yes" />
     </test>
   </projects>
 </root>

--- a/src/Common/TrimmingAttributes.cs
+++ b/src/Common/TrimmingAttributes.cs
@@ -1,0 +1,234 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that the specified method requires dynamic access to code that is not referenced
+    /// statically, for example through <see cref="System.Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which methods are unsafe to call when removing unreferenced
+    /// code from an application.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class, Inherited = false)]
+    internal sealed class RequiresUnreferencedCodeAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequiresUnreferencedCodeAttribute"/> class
+        /// with the specified message.
+        /// </summary>
+        /// <param name="message">
+        /// A message that contains information about the usage of unreferenced code.
+        /// </param>
+        public RequiresUnreferencedCodeAttribute(string message)
+        {
+            Message = message;
+        }
+
+        /// <summary>
+        /// Gets a message that contains information about the usage of unreferenced code.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// Gets or sets an optional URL that contains more information about the method,
+        /// why it requires unreferenced code, and what options a consumer has to deal with it.
+        /// </summary>
+        public string Url { get; set; }
+    }
+
+    /// <summary>
+    /// Suppresses reporting of a specific rule violation, allowing multiple suppressions on a
+    /// single code artifact.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="UnconditionalSuppressMessageAttribute"/> is different than
+    /// <see cref="SuppressMessageAttribute"/> in that it doesn't have a
+    /// <see cref="ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    internal sealed class UnconditionalSuppressMessageAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>
+        /// class, specifying the category of the tool and the identifier for an analysis rule.
+        /// </summary>
+        /// <param name="category">The category for the attribute.</param>
+        /// <param name="checkId">The identifier of the analysis rule the attribute applies to.</param>
+        public UnconditionalSuppressMessageAttribute(string category, string checkId)
+        {
+            Category = category;
+            CheckId = checkId;
+        }
+
+        /// <summary>
+        /// Gets the category identifying the classification of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Category"/> property describes the tool or tool analysis category
+        /// for which a message suppression attribute applies.
+        /// </remarks>
+        public string Category { get; }
+
+        /// <summary>
+        /// Gets the identifier of the analysis tool rule to be suppressed.
+        /// </summary>
+        /// <remarks>
+        /// Concatenated together, the <see cref="Category"/> and <see cref="CheckId"/>
+        /// properties form a unique check identifier.
+        /// </remarks>
+        public string CheckId { get; }
+
+        /// <summary>
+        /// Gets or sets the scope of the code that is relevant for the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The Scope property is an optional argument that specifies the metadata scope for which
+        /// the attribute is relevant.
+        /// </remarks>
+        public string Scope { get; set; }
+
+        /// <summary>
+        /// Gets or sets a fully qualified path that represents the target of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Target"/> property is an optional argument identifying the analysis target
+        /// of the attribute. An example value is "System.IO.Stream.ctor():System.Void".
+        /// Because it is fully qualified, it can be long, particularly for targets such as parameters.
+        /// The analysis tool user interface should be capable of automatically formatting the parameter.
+        /// </remarks>
+        public string Target { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional argument expanding on exclusion criteria.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="MessageId "/> property is an optional argument that specifies additional
+        /// exclusion where the literal metadata target is not sufficiently precise. For example,
+        /// the <see cref="UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
+        /// and it may be desirable to suppress a violation against a statement in the method that will
+        /// give a rule violation, but not against all statements in the method.
+        /// </remarks>
+        public string MessageId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the justification for suppressing the code analysis message.
+        /// </summary>
+        public string Justification { get; set; }
+    }
+
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method |
+        AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+        Inherited = false)]
+    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// with the specified member types.
+        /// </summary>
+        /// <param name="memberTypes">The types of members dynamically accessed.</param>
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members dynamically accessed.
+        /// </summary>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+
+    /// <summary>
+    /// Specifies the types of members that are dynamically accessed.
+    ///
+    /// This enumeration has a <see cref="FlagsAttribute"/> attribute that allows a
+    /// bitwise combination of its member values.
+    /// </summary>
+    [Flags]
+    internal enum DynamicallyAccessedMemberTypes
+    {
+        /// <summary>
+        /// Specifies no members.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Specifies the default, parameterless public constructor.
+        /// </summary>
+        PublicParameterlessConstructor = 0x0001,
+
+        /// <summary>
+        /// Specifies all public constructors.
+        /// </summary>
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+
+        /// <summary>
+        /// Specifies all non-public constructors.
+        /// </summary>
+        NonPublicConstructors = 0x0004,
+
+        /// <summary>
+        /// Specifies all public methods.
+        /// </summary>
+        PublicMethods = 0x0008,
+
+        /// <summary>
+        /// Specifies all non-public methods.
+        /// </summary>
+        NonPublicMethods = 0x0010,
+
+        /// <summary>
+        /// Specifies all public fields.
+        /// </summary>
+        PublicFields = 0x0020,
+
+        /// <summary>
+        /// Specifies all non-public fields.
+        /// </summary>
+        NonPublicFields = 0x0040,
+
+        /// <summary>
+        /// Specifies all public nested types.
+        /// </summary>
+        PublicNestedTypes = 0x0080,
+
+        /// <summary>
+        /// Specifies all non-public nested types.
+        /// </summary>
+        NonPublicNestedTypes = 0x0100,
+
+        /// <summary>
+        /// Specifies all public properties.
+        /// </summary>
+        PublicProperties = 0x0200,
+
+        /// <summary>
+        /// Specifies all non-public properties.
+        /// </summary>
+        NonPublicProperties = 0x0400,
+
+        /// <summary>
+        /// Specifies all public events.
+        /// </summary>
+        PublicEvents = 0x0800,
+
+        /// <summary>
+        /// Specifies all non-public events.
+        /// </summary>
+        NonPublicEvents = 0x1000,
+
+        /// <summary>
+        /// Specifies all interfaces implemented by the type.
+        /// </summary>
+        Interfaces = 0x2000,
+
+        /// <summary>
+        /// Specifies all members.
+        /// </summary>
+        All = ~None
+    }
+}

--- a/src/Microsoft.IdentityModel.Abstractions/Microsoft.IdentityModel.Abstractions.csproj
+++ b/src/Microsoft.IdentityModel.Abstractions/Microsoft.IdentityModel.Abstractions.csproj
@@ -8,6 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Microsoft.IdentityModel.Abstractions</PackageId>
     <PackageTags>.NET;Windows;Authentication;Identity;Abstractions</PackageTags>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Microsoft.IdentityModel.Logging/LogHelper.cs
+++ b/src/Microsoft.IdentityModel.Logging/LogHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.Linq;
@@ -56,7 +57,7 @@ namespace Microsoft.IdentityModel.Logging
         /// </summary>
         /// <param name="message">message to log.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogException<T>(string message) where T : Exception
+        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string message) where T : Exception
         {
             return LogException<T>(EventLevel.Error, null, message, null);
         }
@@ -67,11 +68,10 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
         /// <param name="message">message to log.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogArgumentException<T>(string argumentName, string message) where T : ArgumentException
+        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string argumentName, string message) where T : ArgumentException
         {
             return LogArgumentException<T>(EventLevel.Error, argumentName, null, message, null);
         }
-
 
         /// <summary>
         /// Logs an exception using the event source logger and returns new typed exception.
@@ -79,7 +79,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogException<T>(string format, params object[] args) where T : Exception
+        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string format, params object[] args) where T : Exception
         {
             return LogException<T>(EventLevel.Error, null, format, args);
         }
@@ -91,7 +91,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogArgumentException<T>(string argumentName, string format, params object[] args) where T : ArgumentException
+        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string argumentName, string format, params object[] args) where T : ArgumentException
         {
             return LogArgumentException<T>(EventLevel.Error, argumentName, null, format, args);
         }
@@ -102,7 +102,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="message">message to log.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogException<T>(Exception innerException, string message) where T : Exception
+        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Exception innerException, string message) where T : Exception
         {
             return LogException<T>(EventLevel.Error, innerException, message, null);
         }
@@ -114,7 +114,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="message">message to log.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogArgumentException<T>(string argumentName, Exception innerException, string message) where T : ArgumentException
+        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string argumentName, Exception innerException, string message) where T : ArgumentException
         {
             return LogArgumentException<T>(EventLevel.Error, argumentName, innerException, message, null);
         }
@@ -126,7 +126,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogException<T>(Exception innerException, string format, params object[] args) where T : Exception
+        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Exception innerException, string format, params object[] args) where T : Exception
         {
             return LogException<T>(EventLevel.Error, innerException, format, args);
         }
@@ -139,7 +139,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogArgumentException<T>(string argumentName, Exception innerException, string format, params object[] args) where T : ArgumentException
+        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string argumentName, Exception innerException, string format, params object[] args) where T : ArgumentException
         {
             return LogArgumentException<T>(EventLevel.Error, argumentName, innerException, format, args);
         }
@@ -149,7 +149,7 @@ namespace Microsoft.IdentityModel.Logging
         /// </summary>
         /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
         /// <param name="message">message to log.</param>
-        public static T LogException<T>(EventLevel eventLevel, string message) where T : Exception
+        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string message) where T : Exception
         {
             return LogException<T>(eventLevel, null, message, null);
         }
@@ -160,7 +160,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
         /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
         /// <param name="message">message to log.</param>
-        public static T LogArgumentException<T>(EventLevel eventLevel, string argumentName, string message) where T : ArgumentException
+        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string argumentName, string message) where T : ArgumentException
         {
             return LogArgumentException<T>(eventLevel, argumentName, null, message, null);
         }
@@ -171,7 +171,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public static T LogException<T>(EventLevel eventLevel, string format, params object[] args) where T : Exception
+        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string format, params object[] args) where T : Exception
         {
             return LogException<T>(eventLevel, null, format, args);
         }
@@ -183,7 +183,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public static T LogArgumentException<T>(EventLevel eventLevel, string argumentName, string format, params object[] args) where T : ArgumentException
+        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string argumentName, string format, params object[] args) where T : ArgumentException
         {
             return LogArgumentException<T>(eventLevel, argumentName, null, format, args);
         }
@@ -194,7 +194,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="message">message to log.</param>
-        public static T LogException<T>(EventLevel eventLevel, Exception innerException, string message) where T : Exception
+        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, Exception innerException, string message) where T : Exception
         {
             return LogException<T>(eventLevel, innerException, message, null);
         }
@@ -206,7 +206,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="message">message to log.</param>
-        public static T LogArgumentException<T>(EventLevel eventLevel, string argumentName, Exception innerException, string message) where T : ArgumentException
+        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string argumentName, Exception innerException, string message) where T : ArgumentException
         {
             return LogArgumentException<T>(eventLevel, argumentName, innerException, message, null);
         }
@@ -218,7 +218,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public static T LogException<T>(EventLevel eventLevel, Exception innerException, string format, params object[] args) where T : Exception
+        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, Exception innerException, string format, params object[] args) where T : Exception
         {
             return LogExceptionImpl<T>(eventLevel, null, innerException, format, args);
         }
@@ -231,7 +231,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public static T LogArgumentException<T>(EventLevel eventLevel, string argumentName, Exception innerException, string format, params object[] args) where T : ArgumentException
+        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string argumentName, Exception innerException, string format, params object[] args) where T : ArgumentException
         {
             return LogExceptionImpl<T>(eventLevel, argumentName, innerException, format, args);
         }
@@ -315,7 +315,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        private static T LogExceptionImpl<T>(EventLevel eventLevel, string argumentName, Exception innerException, string format, params object[] args) where T : Exception 
+        private static T LogExceptionImpl<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string argumentName, Exception innerException, string format, params object[] args) where T : Exception 
         {
             string message = null;
 

--- a/src/Microsoft.IdentityModel.Logging/Microsoft.IdentityModel.Logging.csproj
+++ b/src/Microsoft.IdentityModel.Logging/Microsoft.IdentityModel.Logging.csproj
@@ -8,6 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Microsoft.IdentityModel.Logging</PackageId>
     <PackageTags>.NET;Windows;Authentication;Identity;Logging</PackageTags>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -15,6 +16,11 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Common\TrimmingAttributes.cs" LinkBase="Common"
+             Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
+  </ItemGroup>
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/test/Microsoft.IdentityModel.AotCompatibility.TestApp/Microsoft.IdentityModel.AotCompatibility.TestApp.csproj
+++ b/test/Microsoft.IdentityModel.AotCompatibility.TestApp/Microsoft.IdentityModel.AotCompatibility.TestApp.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <ILLinkTreatWarningsAsErrors>true</ILLinkTreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- List of the assemblies to analyze.
+
+      FullAnalyze indicates whether to analyze the whole assembly (i.e. TrimmerRootAssembly).
+      Other referenced assemblies will only have code referenced from Program.cs analyzed.
+    -->
+    <CompatibleReference Include="Microsoft.IdentityModel.Abstractions" FullAnalyze="true" />
+    <CompatibleReference Include="Microsoft.IdentityModel.Logging" FullAnalyze="true" />
+    <CompatibleReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+    
+    <CompatibleReference Update="@(CompatibleReference)" Path="..\..\src\%(Identity)\%(Identity).csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="@(CompatibleReference->'%(Path)')" />
+
+    <TrimmerRootAssembly Include="@(CompatibleReference->WithMetadataValue('FullAnalyze','true'))"/>
+  </ItemGroup>
+
+</Project>

--- a/test/Microsoft.IdentityModel.AotCompatibility.TestApp/Program.cs
+++ b/test/Microsoft.IdentityModel.AotCompatibility.TestApp/Program.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.IdentityModel.JsonWebTokens;
+
+internal sealed class Program
+{
+    // The code in this program is expected to be trim and AOT compatible
+    private static int Main()
+    {
+        const string token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjbGFpbV9hc19kYXRldGltZSI6IjIwMTktMTEtMTVUMTQ6MzE6MjEuNjEwMTMyNloifQ.yYcHSl-rNT2nHe8Nb0aWe6Qu3E0ZOn2_OUidpxuw0wk";
+
+        JsonWebToken t = new JsonWebToken(token);
+        if (t.Claims.Count() != 1)
+        {
+            return -1;
+        }
+
+        Claim dateClaim = t.GetClaim("claim_as_datetime");
+        if (dateClaim.Value != "2019-11-15T14:31:21.6101326Z")
+        {
+            return -2;
+        }
+
+        return 100;
+    }
+}

--- a/test/Microsoft.IdentityModel.AotCompatibility.Tests/AotCompatibilityTests.cs
+++ b/test/Microsoft.IdentityModel.AotCompatibility.Tests/AotCompatibilityTests.cs
@@ -45,21 +45,21 @@ namespace Microsoft.IdentityModel.AotCompatibility.Tests
                 testObjDir.Delete(recursive: true);
             }
 
-            var startInfo = new ProcessStartInfo("dotnet", $"publish --self-contained {testAppProject}")
+            var process = new Process();
+            process.StartInfo = new ProcessStartInfo("dotnet", $"publish --self-contained {testAppProject}")
             {
                 RedirectStandardOutput = true,
-                RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 WorkingDirectory = testAppPath
             };
+            process.OutputDataReceived += (sender, e) => _testOutputHelper.WriteLine(e.Data);
+            process.Start();
+            process.BeginOutputReadLine();
 
-            Process proc = Process.Start(startInfo);
-            _testOutputHelper.WriteLine(proc.StandardOutput.ReadToEnd());
+            Assert.True(process.WaitForExit(milliseconds: 30_000), "dotnet publish command timed out after 30 seconds.");
 
-            Assert.True(proc.WaitForExit(milliseconds: 30_000), "dotnet publish command timed out after 30 seconds.");
-
-            Assert.True(proc.ExitCode == 0, "Publishing the AotCompatibility app failed. See test output for more details.");
+            Assert.True(process.ExitCode == 0, "Publishing the AotCompatibility app failed. See test output for more details.");
         }
     }
 }

--- a/test/Microsoft.IdentityModel.AotCompatibility.Tests/AotCompatibilityTests.cs
+++ b/test/Microsoft.IdentityModel.AotCompatibility.Tests/AotCompatibilityTests.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics;
+using System.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.IdentityModel.AotCompatibility.Tests
+{
+    public class AotCompatibilityTests
+    {
+        private ITestOutputHelper _testOutputHelper;
+
+        public AotCompatibilityTests(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        /// <summary>
+        /// This test ensures that the intended APIs of the Microsoft.IdentityModel libraries are
+        /// trimming and NativeAOT compatible.
+        ///
+        /// This test follows the instructions in https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming#show-all-warnings-with-sample-application
+        ///
+        /// If this test fails, it is due to adding trimming and/or AOT incompatible changes
+        /// to code that is supposed to be compatible.
+        /// 
+        /// To diagnose the problem, inspect the test output which will contain the trimming and AOT errors. For example:
+        ///
+        /// error IL2091: 'T' generic argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors'
+        ///
+        /// You can also 'dotnet publish' the 'Microsoft.IdentityModel.AotCompatibility.TestApp.csproj' as well to get the errors.
+        /// </summary>
+        [Fact]
+        public void EnsureAotCompatibility()
+        {
+            string testAppPath = @"..\..\..\..\Microsoft.IdentityModel.AotCompatibility.TestApp";
+            string testAppProject = "Microsoft.IdentityModel.AotCompatibility.TestApp.csproj";
+
+            // ensure we run a clean publish every time
+            DirectoryInfo testObjDir = new DirectoryInfo(Path.Combine(testAppPath, "obj"));
+            if (testObjDir.Exists)
+            {
+                testObjDir.Delete(recursive: true);
+            }
+
+            var startInfo = new ProcessStartInfo("dotnet", $"publish --self-contained {testAppProject}")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = testAppPath
+            };
+
+            Process proc = Process.Start(startInfo);
+            _testOutputHelper.WriteLine(proc.StandardOutput.ReadToEnd());
+
+            Assert.True(proc.WaitForExit(milliseconds: 30_000), "dotnet publish command timed out after 30 seconds.");
+
+            Assert.True(proc.ExitCode == 0, "Publishing the AotCompatibility app failed. See test output for more details.");
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.AotCompatibility.Tests/Microsoft.IdentityModel.AotCompatibility.Tests.csproj
+++ b/test/Microsoft.IdentityModel.AotCompatibility.Tests/Microsoft.IdentityModel.AotCompatibility.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\..\build\commonTest.props" />
+
+  <PropertyGroup>
+    <!-- This test only needs to run on .NET -->
+    <TargetFrameworks>net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This enables trimming analysis on a subset of core assemblies:

* Microsoft.IdentityModel.Abstractions
* Microsoft.IdentityModel.Logging

It also enables trimming analysis for the JsonWebToken constructor. More scenarios will be analyzed in the future, as we enable more scenarios for trimming.

Contributes to #2035

See https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming for more information on how to prepare libraries for trimming. Being "trim compatible" is the first step to being "NativeAOT compatible".

This addresses the first bullet in #2035.

cc @brentschmaltz 