### PR TITLE
Remove  use of exception SecurityTokenUnableToValidateException

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -1542,16 +1542,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
                 if (!validationParameters.ValidateSignatureLast)
                 {
-                    InternalValidators.ValidateLifetimeAndIssuerAfterSignatureNotValidatedJwt(
+                    InternalValidators.ValidateAfterSignatureFailed(
                         jwtToken,
                         notBefore,
                         expires,
-                        jwtToken.Kid,
+                        jwtToken.Audiences,
                         validationParameters,
-                        configuration,
-                        exceptionStrings,
-                        numKeysInTokenValidationParameters,
-                        numKeysInConfiguration);
+                        configuration);
                 }
             }
 

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -1084,14 +1084,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 if (keyMatched)
                     throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10514, keysAttempted, samlToken.Assertion.Signature.KeyInfo, exceptionStrings, samlToken)));
 
-                if (samlToken.Assertion.Conditions != null)
-                    InternalValidators.ValidateLifetimeAndIssuerAfterSignatureNotValidatedSaml(
-                        samlToken,
-                        samlToken.Assertion.Conditions.NotBefore,
-                        samlToken.Assertion.Conditions.NotOnOrAfter,
-                        samlToken.Assertion.Signature.KeyInfo.ToString(),
-                        validationParameters,
-                        exceptionStrings);
+                ValidateIssuer(samlToken.Issuer, samlToken, validationParameters);
+                ValidateConditions(samlToken, validationParameters);
             }
 
             if (keysAttempted.Length > 0)

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -466,14 +466,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                 if (keyMatched)
                     throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10514, keysAttempted, samlToken.Assertion.Signature.KeyInfo, exceptionStrings, samlToken)));
 
-                if (samlToken.Assertion.Conditions != null)
-                    InternalValidators.ValidateLifetimeAndIssuerAfterSignatureNotValidatedSaml(
-                        samlToken,
-                        samlToken.Assertion.Conditions.NotBefore,
-                        samlToken.Assertion.Conditions.NotOnOrAfter,
-                        samlToken.Assertion.Signature.KeyInfo.ToString(),
-                        validationParameters,
-                        exceptionStrings);
+                ValidateIssuer(samlToken.Issuer, samlToken, validationParameters);
+                ValidateConditions(samlToken, validationParameters);
             }
 
             if (keysAttempted.Length > 0)

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -82,7 +82,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         // 10500 - SignatureValidation
         public const string IDX10500 = "IDX10500: Signature validation failed. No security keys were provided to validate the signature.";
-        public const string IDX10501 = "IDX10501: Signature validation failed. Unable to match key: \nkid: '{0}'. \nNumber of keys in TokenValidationParameters: '{1}'. \nNumber of keys in Configuration: '{2}'. \nExceptions caught:\n '{3}'. \ntoken: '{4}'.";
+        //public const string IDX10501 = "IDX10501: Signature validation failed. Unable to match key: \nkid: '{0}'. \nNumber of keys in TokenValidationParameters: '{1}'. \nNumber of keys in Configuration: '{2}'. \nExceptions caught:\n '{3}'. \ntoken: '{4}'.";
         public const string IDX10503 = "IDX10503: Signature validation failed. Token does not have a kid. Keys tried: '{0}'. Number of keys in TokenValidationParameters: '{1}'. \nNumber of keys in Configuration: '{2}'. \nExceptions caught:\n '{3}'.\ntoken: '{4}'. See https://aka.ms/IDX10503 for details.";
         public const string IDX10504 = "IDX10504: Unable to validate signature, token does not have a signature: '{0}'.";
         public const string IDX10505 = "IDX10505: Signature validation failed. The user defined 'Delegate' specified on TokenValidationParameters returned null when validating token: '{0}'.";
@@ -93,10 +93,10 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10510 = "IDX10510: Token validation failed. The user defined 'Delegate' set on TokenValidationParameters.TokenReader returned null when reading token: '{0}'.";
         public const string IDX10511 = "IDX10511: Signature validation failed. Keys tried: '{0}'. \nNumber of keys in TokenValidationParameters: '{1}'. \nNumber of keys in Configuration: '{2}'. \nMatched key was in '{3}'. \nkid: '{4}'. \nExceptions caught:\n '{5}'.\ntoken: '{6}'. See https://aka.ms/IDX10511 for details.";
         public const string IDX10512 = "IDX10512: Signature validation failed. Token does not have KeyInfo. Keys tried: '{0}'.\nExceptions caught:\n '{1}'.\ntoken: '{2}'.";
-        public const string IDX10513 = "IDX10513: Signature validation failed. Unable to match key: \nKeyInfo: '{0}'.\nExceptions caught:\n '{1}'. \ntoken: '{2}'.";
+        //public const string IDX10513 = "IDX10513: Signature validation failed. Unable to match key: \nKeyInfo: '{0}'.\nExceptions caught:\n '{1}'. \ntoken: '{2}'.";
         public const string IDX10514 = "IDX10514: Signature validation failed. Keys tried: '{0}'. \nKeyInfo: '{1}'. \nExceptions caught:\n '{2}'.\ntoken: '{3}'.";
-        public const string IDX10515 = "IDX10515: Signature validation failed. Unable to match key: \nKeyInfo: '{0}'.\nExceptions caught:\n '{1}'. \ntoken: '{2}'. Valid Lifetime: '{3}'. Valid Issuer: '{4}'";
-        public const string IDX10516 = "IDX10516: Signature validation failed. Unable to match key: \nkid: '{0}'. \nNumber of keys in TokenValidationParameters: '{1}'. \nNumber of keys in Configuration: '{2}'. \nExceptions caught:\n '{3}'. \ntoken: '{4}'. Valid Lifetime: '{5}'. Valid Issuer: '{6}'";
+        //public const string IDX10515 = "IDX10515: Signature validation failed. Unable to match key: \nKeyInfo: '{0}'.\nExceptions caught:\n '{1}'. \ntoken: '{2}'. Valid Lifetime: '{3}'. Valid Issuer: '{4}'";
+        //public const string IDX10516 = "IDX10516: Signature validation failed. Unable to match key: \nkid: '{0}'. \nNumber of keys in TokenValidationParameters: '{1}'. \nNumber of keys in Configuration: '{2}'. \nExceptions caught:\n '{3}'. \ntoken: '{4}'. Valid Lifetime: '{5}'. Valid Issuer: '{6}'";
 
         // encryption / decryption
         // public const string IDX10600 = "IDX10600:";

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1398,16 +1398,13 @@ namespace System.IdentityModel.Tokens.Jwt
 
                 if (!validationParameters.ValidateSignatureLast)
                 {
-                    InternalValidators.ValidateLifetimeAndIssuerAfterSignatureNotValidatedJwt(
+                    InternalValidators.ValidateAfterSignatureFailed(
                         jwtToken,
                         notBefore,
                         expires,
-                        jwtToken.Header.Kid,
+                        jwtToken.Audiences,
                         validationParameters,
-                        configuration,
-                        exceptionStrings,
-                        numKeysInConfiguration,
-                        numKeysInTokenValidationParameters);
+                        configuration);
                 }
             }
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -2194,7 +2194,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         Payload = Default.PayloadString,
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         EncryptingCredentials = Default.SymmetricEncryptingCredentials,
-                        ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10516:")
+                        ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX10204:")
                     },
                     new CreateTokenTheoryData()
                     {
@@ -2682,7 +2682,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     new JwtTheoryData("SymmetricJws_RequireSignedTokens_KeyNotFound")
                     {
                         Token = Default.SymmetricJws,
-                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10501"),
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500"),
                         ValidationParameters = new TokenValidationParameters
                         {
                             ValidateIssuerSigningKey = true,
@@ -2707,7 +2707,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     },
                     new JwtTheoryData("SymmetricJws_RequireSignedTokensNullSigningKey")
                     {
-                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10501:"),
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500:"),
                         Token = Default.SymmetricJws,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -3308,7 +3308,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         IssuerSigningKey = Default.SymmetricSigningKey,
                         ValidIssuer = Default.Issuer
                     },
-                    ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10516:")
+                    ExpectedException = ExpectedException.SecurityTokenExpiredException("IDX10223:")
                 },
                 new CreateTokenTheoryData
                 {
@@ -3322,7 +3322,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     {
                         IssuerSigningKey = Default.SymmetricSigningKey,
                     },
-                    ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10516:")
+                    ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX10204:")
                 },
                 new CreateTokenTheoryData
                 {
@@ -3339,7 +3339,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     {
                         IssuerSigningKey = Default.SymmetricSigningKey,
                     },
-                    ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10516:")
+                    ExpectedException = ExpectedException.SecurityTokenExpiredException("IDX10223:")
                 },
                 new CreateTokenTheoryData
                 {
@@ -3353,8 +3353,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     {
                         IssuerSigningKey = Default.SymmetricSigningKey,
                         ValidIssuer = Default.Issuer,
+                        ValidateAudience = false
                     },
-                    ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10501:")
+                    ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10503:")
                 },
             };
         }

--- a/test/Microsoft.IdentityModel.TestUtils/TokenTheoryData.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/TokenTheoryData.cs
@@ -12,7 +12,10 @@ namespace Microsoft.IdentityModel.TestUtils
     {
         public TokenTheoryData()
         {
+        }
 
+        public TokenTheoryData(string testId) : base(testId)
+        {
         }
 
         public TokenTheoryData(TokenTheoryData other)

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/CreateTokenTheoryData.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/CreateTokenTheoryData.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens.Saml2;
+
+#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
+
+namespace Microsoft.IdentityModel.Tokens.Saml.Tests
+{
+    public class CreateTokenTheoryData : TheoryDataBase
+    {
+        public Dictionary<string, object> AdditionalHeaderClaims { get; set; }
+
+        public string Payload { get; set; }
+
+        public string CompressionAlgorithm { get; set; }
+
+        public CompressionProviderFactory CompressionProviderFactory { get; set; }
+
+        public EncryptingCredentials EncryptingCredentials { get; set; }
+
+        public bool IsValid { get; set; } = true;
+
+        public SigningCredentials SigningCredentials { get; set; }
+
+        public SecurityTokenDescriptor TokenDescriptor { get; set; }
+
+        public SamlSecurityTokenHandler SamlSecurityTokenHandler { get; set; }
+
+        public Saml2SecurityTokenHandler Saml2SecurityTokenHandler { get; set; }
+
+        public string SamlToken { get; set; }
+
+        public TokenValidationParameters ValidationParameters { get; set; }
+    }
+}
+
+#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@
 using System;
 using System.Runtime.InteropServices;
 
-[assembly: CLSCompliant(true)]
+[assembly: CLSCompliant(false)]
 [assembly: ComVisible(false)]

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
@@ -10,8 +10,6 @@ using Microsoft.IdentityModel.Tokens.Saml.Tests;
 using Microsoft.IdentityModel.Xml;
 using Xunit;
 
-#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
-
 namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
 {
     public class Saml2SecurityTokenHandlerTests
@@ -596,10 +594,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
 
                 return new TheoryData<Saml2TheoryData>
                 {
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid")
                     {
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_Valid),
                         Token = ReferenceTokens.Saml2Token_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -609,99 +605,75 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("Null_SecurityToken")
                     {
                         ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
-                        First = true,
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = "Null-SecurityToken",
                         Token = null,
                         ValidationParameters = new TokenValidationParameters()
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("NULL_TokenValidationParameters")
                     {
                         ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = "NULL-TokenValidationParameters",
                         Token = "s",
                         ValidationParameters = null,
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("SecurityTokenTooLarge")
                     {
                         ExpectedException = ExpectedException.ArgumentException("IDX10209:"),
                         Handler = new Saml2SecurityTokenHandler { MaximumTokenSizeInBytes = 1 },
-                        TestId = "SecurityTokenTooLarge",
                         Token = "ss",
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_MissingVersion")
                     {
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenReadException), "IDX13106:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_MissingVersion),
                         Token = ReferenceTokens.Saml2Token_MissingVersion,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_VersionNotV20")
                     {
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenReadException), "IDX13137:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_VersionNotV20),
                         Token = ReferenceTokens.Saml2Token_VersionNotV20,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_IdMissing")
                     {
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenReadException), "IDX13106:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_IdMissing),
                         Token = ReferenceTokens.Saml2Token_IdMissing,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_IssueInstantMissing")
                     {
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenReadException), "IDX13106:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_IssueInstantMissing),
                         Token = ReferenceTokens.Saml2Token_IssueInstantMissing,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_IssueInstantFormatError")
                     {
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenReadException), "IDX13102:", typeof(FormatException)),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_IssueInstantFormatError),
                         Token = ReferenceTokens.Saml2Token_IssueInstantFormatError,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_IssuerMissing")
                     {
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenReadException), "IDX13102:", typeof(XmlReadException)),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_IssuerMissing),
                         Token = ReferenceTokens.Saml2Token_IssuerMissing,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_NoSubjectNoStatements")
                     {
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenReadException), "IDX13108:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_NoSubjectNoStatements),
                         Token = ReferenceTokens.Saml2Token_NoSubjectNoStatements,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_NoAttributes")
                     {
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenReadException), "IDX13138:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_NoAttributes),
                         Token = ReferenceTokens.Saml2Token_NoAttributes,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_IssuerSigningKey_set")
                     {
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)} IssuerSigningKey set",
                         Token = ReferenceTokens.Saml2Token_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -711,10 +683,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_Spaces_Added")
                     {
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_Valid_Spaces_Added),
                         Token = ReferenceTokens.Saml2Token_Valid_Spaces_Added,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -724,21 +694,17 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Formated")
                     {
                         ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10514:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_Formated),
                         Token = ReferenceTokens.Saml2Token_Formated,
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_IssuerSigningKey_Rsa")
                     {
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)} IssuerSigningKey Rsa",
                         Token = ReferenceTokens.Saml2Token_Valid_WithRsaKeyValue,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -748,10 +714,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_IssuerSigningKey_JsonWithCertificate")
                     {
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)} IssuerSigningKey JsonWithCertificate",
                         Token = ReferenceTokens.Saml2Token_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -761,10 +725,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_IssuerSigningKey_JsonWithParameters")
                     {
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)} IssuerSigningKey JsonWithParameters",
                         Token = ReferenceTokens.Saml2Token_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -774,22 +736,18 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_AttributeTampered")
                     {
                         ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10514:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_AttributeTampered),
                         Token = ReferenceTokens.Saml2Token_AttributeTampered,
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_DigestTampered")
                     {
                         ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10514:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_DigestTampered),
                         Token = ReferenceTokens.Saml2Token_DigestTampered,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -797,32 +755,26 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                         }
                     },
                     // Removed until we have a way of matching a SecurityKey with a KeyInfo.
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_AttributeTampered_NoKeyMatch")
                     {
-                        ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10515:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_AttributeTampered_NoKeyMatch),
+                        ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX10204:"),
                         Token = ReferenceTokens.Saml2Token_AttributeTampered_NoKeyMatch,
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_SignatureTampered")
                     {
                         ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10514:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_SignatureTampered),
                         Token = ReferenceTokens.Saml2Token_SignatureTampered,
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_SignatureMissing")
                     {
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.Saml2Token_SignatureMissing),
                         Token = ReferenceTokens.Saml2Token_SignatureMissing,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -833,10 +785,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             RequireSignedTokens = false,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_Issuer_SigningKeyResolver")
                     {
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}IssuerSigningKeyResolver",
                         Token = ReferenceTokens.Saml2Token_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -846,10 +796,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             IssuerSigningKeyResolver = (token, securityToken, keyIdentifier, tvp) => { return new List<SecurityKey> { KeyingMaterial.DefaultAADSigningKey }; },
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_RequireSignedTokens")
                     {
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}RequireSignedTokens",
                         Token = ReferenceTokens.Saml2Token_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -861,11 +809,9 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_RequireSignedTokensNullSigningKey")
                     {
-                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10513:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}RequireSignedTokensNullSigningKey",
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500:"),
                         Token = ReferenceTokens.Saml2Token_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -877,10 +823,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_DontRequireSignedTokens")
                     {
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}DontRequireSignedTokens",
                         Token = ReferenceTokens.Saml2Token_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -892,10 +836,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_SignatureMissing_DontRequireSignedTokensNullSigningKey")
                     {
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_SignatureMissing)}DontRequireSignedTokensNullSigningKey",
                         Token = ReferenceTokens.Saml2Token_SignatureMissing,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -907,12 +849,11 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidateLifetime = false,
                         }
                     },
-                     new Saml2TheoryData
+                     new Saml2TheoryData("ReferenceTokens_Saml2Token_NoAudienceRestrictions_NoSignature_RequireAudienceTrue")
                      {
                         Audiences = new List<string>(),
                         Token = ReferenceTokens.Saml2Token_NoAudienceRestrictions_NoSignature,
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenException), "IDX13002:"),
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_NoAudienceRestrictions_NoSignature)}RequireAudienceTrue",
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
@@ -922,11 +863,10 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             RequireSignedTokens = false
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_NoAudienceRestrictions_NoSignature_RequireAudienceFalse")
                     {
                         Audiences = new List<string>(),
                         Token = ReferenceTokens.Saml2Token_NoAudienceRestrictions_NoSignature,
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_NoAudienceRestrictions_NoSignature)}RequireAudienceFalse",
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
@@ -937,12 +877,11 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             RequireSignedTokens = false
                         },
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_NoAudienceRestrictions_NoSignature_RequireAudienceFalseValidateLifetimeTrue")
                     {
                         Audiences = new List<string>(),
                         Token = ReferenceTokens.Saml2Token_NoAudienceRestrictions_NoSignature,
                         ExpectedException = new ExpectedException(typeof(SecurityTokenExpiredException), "IDX10223:"),
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_NoAudienceRestrictions_NoSignature)}RequireAudienceFalseValidateLifetimeTrue",
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
@@ -953,12 +892,11 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             RequireSignedTokens = false
                         },
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_NoConditions_NoSignature_RequireAudienceTrue")
                     {
                         Audiences = new List<string>(),
                         Token = ReferenceTokens.Saml2Token_NoConditions_NoSignature,
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenException), "IDX13002:"),
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_NoConditions_NoSignature)}RequireAudienceTrue",
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
@@ -968,11 +906,10 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             RequireSignedTokens = false
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_NoConditions_NoSignature_RequireAudienceFalse")
                     {
                         Audiences = new List<string>(),
                         Token = ReferenceTokens.Saml2Token_NoConditions_NoSignature,
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_NoConditions_NoSignature)}RequireAudienceFalse",
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
@@ -983,11 +920,9 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             RequireSignedTokens = false
                         },
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_AttributeTampered_NoKeyMatch_NotTryAllIssuerSigningKeys")
                     {
-                        ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10515:"),
-                        Handler = new Saml2SecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_AttributeTampered_NoKeyMatch)}NotTryAllIssuerSigningKeys",
+                        ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX10204:"),
                         Token = ReferenceTokens.Saml2Token_AttributeTampered_NoKeyMatch,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -995,9 +930,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             TryAllIssuerSigningKeys = false
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_SpecifyAlgorithm_AlgorithnInList")
                     {
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}_SpecifyAlgorithm_AlgorithnInList",
                         Token = ReferenceTokens.Saml2Token_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -1008,9 +942,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidAlgorithms = new List<string> { SecurityAlgorithms.RsaSha256Signature }
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_SpecifyAlgorithm_EmptyList")
                     {
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}_SpecifyAlgorithm_EmptyList",
                         Token = ReferenceTokens.Saml2Token_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -1021,9 +954,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             ValidAlgorithms = new List<string>()
                         }
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_SpecifyAlgorithm_AlgorithnNotList")
                     {
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}_SpecifyAlgorithm_AlgorithnNotList",
                         Token = ReferenceTokens.Saml2Token_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -1035,9 +967,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                         },
                         ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10514")
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_SpecifyAlgorithm_AlgorithmValidationFails")
                     {
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}_SpecifyAlgorithm_AlgorithmValidationFails",
                         Token = ReferenceTokens.Saml2Token_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -1049,9 +980,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                         },
                         ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10514")
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_SpecifyAlgorithm_AlgorithmValidationValidates")
                     {
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid)}_SpecifyAlgorithm_AlgorithmValidationValidates",
                         Token = ReferenceTokens.Saml2Token_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -1062,9 +992,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             AlgorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(true)
                         },
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_WithNoKeyInfo_NullSigningKey")
                     {
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid_WithNoKeyInfo)}NullSigningKey",
                         Token = ReferenceTokens.Saml2Token_Valid_WithNoKeyInfo,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -1077,9 +1006,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                         },
                         ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500:")
                     },
-                    new Saml2TheoryData
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_WithNoKeyInfo_NotNullSigningKey")
                     {
-                        TestId = $"{nameof(ReferenceTokens.Saml2Token_Valid_WithNoKeyInfo)}NotNullSigningKey",
                         Token = ReferenceTokens.Saml2Token_Valid_WithNoKeyInfo,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -1326,7 +1254,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             {
                 var handler = new Saml2SecurityTokenHandler();
                 var token = handler.CreateToken(theoryData.TokenDescriptor);
-                handler.ValidateToken(handler.WriteToken(token), theoryData.ValidationParameters, out var validationResult);
+                string samlToken = handler.WriteToken(token);
+                handler.ValidateToken(samlToken, theoryData.ValidationParameters, out var validationResult);
             }
             catch (Exception ex)
             {
@@ -1338,78 +1267,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
 
         public static TheoryData<CreateTokenTheoryData> SecurityKeyNotFoundExceptionTestTheoryData()
         {
-            return new TheoryData<CreateTokenTheoryData>()
-            {
-                new CreateTokenTheoryData
-                {
-                    First = true,
-                    TestId = "TokenExpired",
-                    TokenDescriptor = new SecurityTokenDescriptor
-                    {
-                        Subject = new ClaimsIdentity(Default.SamlClaims),
-                        Expires = DateTime.UtcNow.Subtract(new TimeSpan(0, 10, 0)),
-                        IssuedAt = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
-                        NotBefore = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
-                        SigningCredentials = Default.AsymmetricSigningCredentials,
-                        Issuer = Default.Issuer,
-                     },
-                     ValidationParameters = new TokenValidationParameters
-                     {
-                        IssuerSigningKey = Default.SymmetricSigningKey,
-                        ValidIssuer = Default.Issuer,
-                     },
-                     ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10515:")
-                },
-                new CreateTokenTheoryData
-                {
-                    TestId = "InvalidIssuer",
-                    TokenDescriptor = new SecurityTokenDescriptor
-                    {
-                        Subject = new ClaimsIdentity(Default.SamlClaims),
-                        SigningCredentials = Default.AsymmetricSigningCredentials,
-                        Issuer = Default.Issuer,
-                    },
-                    ValidationParameters = new TokenValidationParameters
-                    {
-                        IssuerSigningKey = Default.SymmetricSigningKey,
-                    },
-                    ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10515:")
-                },
-                new CreateTokenTheoryData
-                {
-                    TestId = "ExpiredAndInvalidIssuer",
-                    TokenDescriptor = new SecurityTokenDescriptor
-                    {
-                        Subject = new ClaimsIdentity(Default.SamlClaims),
-                        Expires = DateTime.UtcNow.Subtract(new TimeSpan(0, 10, 0)),
-                        IssuedAt = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
-                        NotBefore = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
-                        SigningCredentials = Default.AsymmetricSigningCredentials,
-                        Issuer = Default.Issuer,
-                    },
-                    ValidationParameters = new TokenValidationParameters
-                    {
-                        IssuerSigningKey = Default.SymmetricSigningKey,
-                    },
-                    ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10515:")
-                },
-                new CreateTokenTheoryData
-                {
-                    TestId = "KeysDontMatchValidLifetimeAndIssuer",
-                    TokenDescriptor = new SecurityTokenDescriptor
-                    {
-                        Subject = new ClaimsIdentity(Default.SamlClaims),
-                        SigningCredentials = Default.AsymmetricSigningCredentials,
-                        Issuer = Default.Issuer,
-                    },
-                    ValidationParameters = new TokenValidationParameters
-                    {
-                        IssuerSigningKey = Default.SymmetricSigningKey,
-                        ValidIssuer = Default.Issuer,
-                    },
-                    ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10513:")
-                }
-            };
+            return SamlTestData.SecurityKeyNotFoundExceptionTestTheoryData();
         }
     }
 
@@ -1448,31 +1306,4 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
         {
         }
     }
-
-    public class CreateTokenTheoryData : TheoryDataBase
-    {
-        public Dictionary<string, object> AdditionalHeaderClaims { get; set; }
-
-        public string Payload { get; set; }
-
-        public string CompressionAlgorithm { get; set; }
-
-        public CompressionProviderFactory CompressionProviderFactory { get; set; }
-
-        public EncryptingCredentials EncryptingCredentials { get; set; }
-
-        public bool IsValid { get; set; } = true;
-
-        public SigningCredentials SigningCredentials { get; set; }
-
-        public SecurityTokenDescriptor TokenDescriptor { get; set; }
-
-        public Saml2SecurityTokenHandler Saml2SecurityTokenHandler { get; set; }
-
-        public string SamlToken { get; set; }
-
-        public TokenValidationParameters ValidationParameters { get; set; }
-    }
 }
-
-#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2TheoryData.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2TheoryData.cs
@@ -13,6 +13,10 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
         {
         }
 
+        public Saml2TheoryData(string testId) : base(testId)
+        {
+        }
+
         public Saml2TheoryData(TokenTheoryData tokenTheoryData)
             : base(tokenTheoryData)
         {

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.IO;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Xml;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Xml;
@@ -327,139 +328,107 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
 
                 return new TheoryData<SamlTheoryData>
                 {
-                    new SamlTheoryData
+                    new SamlTheoryData("Null_SecurityToken")
                     {
                         ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
                         First = true,
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = "Null-SecurityToken",
                         Token = null,
                         ValidationParameters = new TokenValidationParameters()
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("NULL_TokenValidationParameters")
                     {
                         ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = "NULL-TokenValidationParameters",
+                        Handler = new SamlSecurityTokenHandler { MaximumTokenSizeInBytes = 1 },
                         Token = "s",
                         ValidationParameters = null,
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("SecurityTokenTooLarge")
                     {
                         ExpectedException = ExpectedException.ArgumentException("IDX10209:"),
                         Handler = new SamlSecurityTokenHandler { MaximumTokenSizeInBytes = 1 },
-                        TestId = "SecurityTokenTooLarge",
                         Token = "ss",
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_MissingMajorVersion")
                     {
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenReadException), "IDX11115:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_MissingMajorVersion),
                         Token = ReferenceTokens.SamlToken_MissingMajorVersion,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_MissingMinorVersion")
                     {
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenReadException), "IDX11115:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_MissingMinorVersion),
                         Token = ReferenceTokens.SamlToken_MissingMinorVersion,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_MajorVersionNotV1")
                     {
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenReadException), "IDX11116:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_MajorVersionNotV1),
                         Token = ReferenceTokens.SamlToken_MajorVersionNotV1,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_MinorVersionNotV1")
                     {
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenReadException), "IDX11117:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_MinorVersionNotV1),
                         Token = ReferenceTokens.SamlToken_MinorVersionNotV1,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_IdMissing")
                     {
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenReadException), "IDX11115:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_IdMissing),
                         Token = ReferenceTokens.SamlToken_IdMissing,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_IdFormatError")
                     {
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenReadException), "IDX11121:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_IdFormatError),
                         Token = ReferenceTokens.SamlToken_IdFormatError,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_IssuerMissing")
                     {
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenReadException), "IDX11115:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_IssuerMissing),
                         Token = ReferenceTokens.SamlToken_IssuerMissing,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_IssueInstantMissing")
                     {
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenReadException), "IDX11115:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_IssueInstantMissing),
                         Token = ReferenceTokens.SamlToken_IssueInstantMissing,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_IssueInstantFormatError")
                     {
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenReadException), "IDX11122:", typeof(FormatException)),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_IssueInstantFormatError),
                         Token = ReferenceTokens.SamlToken_IssueInstantFormatError,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_AudienceMissing")
                     {
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenReadException), "IDX11120:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_AudienceMissing),
                         Token = ReferenceTokens.SamlToken_AudienceMissing,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_NoStatements")
                     {
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenReadException), "IDX11130:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_NoStatements),
                         Token = ReferenceTokens.SamlToken_NoStatements,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_NoSubject")
                     {
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenReadException), "IDX11112:", typeof(XmlReadException)),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_NoSubject),
                         Token = ReferenceTokens.SamlToken_NoSubject,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_NoAttributes")
                     {
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenReadException), "IDX11131:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_NoAttributes),
                         Token = ReferenceTokens.SamlToken_NoAttributes,
                         ValidationParameters = new TokenValidationParameters(),
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_IssuerSigningKey_Set")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)} IssuerSigningKey set",
                         Token = ReferenceTokens.SamlToken_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -469,10 +438,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_IssuerSigningKey_Rsa")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)} IssuerSigningKey Rsa",
                         Token = ReferenceTokens.SamlToken_Valid_WithRsaKeyValue,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -482,10 +449,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_IssuerSigningKey_JsonWithCertificate")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)} IssuerSigningKey JsonWithCertificate",
                         Token = ReferenceTokens.SamlToken_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -495,10 +460,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_IssuerSigningKey_JsonWithParameters")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)} IssuerSigningKey JsonWithParameters",
                         Token = ReferenceTokens.SamlToken_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -508,10 +471,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_Spaces_Added")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_Valid_Spaces_Added),
                         Token = ReferenceTokens.SamlToken_Valid_Spaces_Added,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -521,22 +482,18 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_AttributeTampered")
                     {
                         ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10514:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_AttributeTampered),
                         Token = ReferenceTokens.SamlToken_AttributeTampered,
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2.Key,
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_DigestTampered")
                     {
                         ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10514:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_DigestTampered),
                         Token = ReferenceTokens.SamlToken_DigestTampered,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -544,32 +501,26 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                         }
                     },
                     // Removed until we have a way of matching a KeyInfo with a SecurityKey.
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid")
                     {
-                        ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10515:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_Valid),
+                        ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX10204:"),
                         Token = ReferenceTokens.SamlToken_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_SignatureTampered")
                     {
                         ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10514:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = nameof(ReferenceTokens.SamlToken_SignatureTampered),
                         Token = ReferenceTokens.SamlToken_SignatureTampered,
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2.Key,
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_IssuerSigningKeyResolver")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}IssuerSigningKeyResolver",
                         Token = ReferenceTokens.SamlToken_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -579,10 +530,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             IssuerSigningKeyResolver = (token, securityToken, keyIdentifier, tvp) => { return new List<SecurityKey> { KeyingMaterial.DefaultJsonWebKeyWithCertificate1 }; },
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_RequireSignedTokens")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}RequireSignedTokens",
                         Token = ReferenceTokens.SamlToken_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -594,11 +543,9 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_RequireSignedTokensNullSigningKey")
                     {
-                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10513:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}RequireSignedTokensNullSigningKey",
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500:"),
                         Token = ReferenceTokens.SamlToken_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -610,10 +557,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_DontRequireSignedTokens")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}DontRequireSignedTokens",
                         Token = ReferenceTokens.SamlToken_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -625,10 +570,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_SignatureMissing_DontRequireSignedTokensNullSigningKey")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_SignatureMissing)}DontRequireSignedTokensNullSigningKey",
                         Token = ReferenceTokens.SamlToken_SignatureMissing,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -640,12 +583,11 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidateLifetime = false,
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_NoAudienceRestrictions_NoSignature_RequireAudienceTrue")
                     {
                         Audiences = new List<string>(),
                         Token = ReferenceTokens.SamlToken_NoAudienceRestrictions_NoSignature,
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenException), "IDX11401:"),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_NoAudienceRestrictions_NoSignature)}RequireAudienceTrue",
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
@@ -655,11 +597,10 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             RequireSignedTokens = false
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_NoAudienceRestrictions_NoSignature_RequireAudienceFalse")
                     {
                         Audiences = new List<string>(),
                         Token = ReferenceTokens.SamlToken_NoAudienceRestrictions_NoSignature,
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_NoAudienceRestrictions_NoSignature)}RequireAudienceFalse",
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
@@ -670,12 +611,11 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             RequireSignedTokens = false
                         },
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_NoAudienceRestrictions_NoSignature_RequireAudienceFalseValidateLifetimeTrue")
                     {
                         Audiences = new List<string>(),
                         Token = ReferenceTokens.SamlToken_NoAudienceRestrictions_NoSignature,
                         ExpectedException = new ExpectedException(typeof(SecurityTokenExpiredException), "IDX10223:"),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_NoAudienceRestrictions_NoSignature)}RequireAudienceFalseValidateLifetimeTrue",
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
@@ -686,12 +626,11 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             RequireSignedTokens = false
                         },
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_NoConditions_NoSignature_RequireAudienceTrue")
                     {
                         Audiences = new List<string>(),
                         Token = ReferenceTokens.SamlToken_NoConditions_NoSignature,
                         ExpectedException = new ExpectedException(typeof(SamlSecurityTokenException), "IDX11401:"),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_NoConditions_NoSignature)}RequireAudienceTrue",
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
@@ -701,11 +640,10 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             RequireSignedTokens = false
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_NoConditions_NoSignature_RequireAudienceFalse")
                     {
                         Audiences = new List<string>(),
                         Token = ReferenceTokens.SamlToken_NoConditions_NoSignature,
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_NoConditions_NoSignature)}RequireAudienceFalse",
                         ValidationParameters = new TokenValidationParameters
                         {
                             IssuerSigningKey = KeyingMaterial.DefaultAADSigningKey,
@@ -716,11 +654,9 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             RequireSignedTokens = false
                         },
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_NotTryAllIssuerSigningKeys")
                     {
-                        ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10515:"),
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}NotTryAllIssuerSigningKeys",
+                        ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX10204:"),
                         Token = ReferenceTokens.SamlToken_Valid,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -728,10 +664,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             TryAllIssuerSigningKeys = false
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_SpecifyAlgorithm_AlgorithmInList")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}_SpecifyAlgorithm_AlgorithnInList",
                         Token = ReferenceTokens.SamlToken_Valid_WithRsaKeyValue,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -742,10 +676,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidAlgorithms = new List<string> { SecurityAlgorithms.RsaSha256Signature }
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_SpecifyAlgorithm_EmptyList")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}_SpecifyAlgorithm_EmptyList",
                         Token = ReferenceTokens.SamlToken_Valid_WithRsaKeyValue,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -756,10 +688,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidAlgorithms = new List<string>(),
                         }
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_SpecifyAlgorithm_AlgorithnNotList")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}_SpecifyAlgorithm_AlgorithnNotList",
                         Token = ReferenceTokens.SamlToken_Valid_WithRsaKeyValue,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -769,12 +699,10 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidateLifetime = false,
                             ValidAlgorithms = new List<string> { SecurityAlgorithms.RsaSha512Signature }
                         },
-                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10513")
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10512")
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_SpecifyAlgorithm_AlgorithmValidationFails")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}_SpecifyAlgorithm_AlgorithmValidationFails",
                         Token = ReferenceTokens.SamlToken_Valid_WithRsaKeyValue,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -784,12 +712,10 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             ValidateLifetime = false,
                             AlgorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(false)
                         },
-                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10513")
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10512")
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_SpecifyAlgorithm_AlgorithmValidationValidates")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid)}_SpecifyAlgorithm_AlgorithmValidationValidates",
                         Token = ReferenceTokens.SamlToken_Valid_WithRsaKeyValue,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -800,10 +726,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             AlgorithmValidator = ValidationDelegates.AlgorithmValidatorBuilder(true)
                         },
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_WithNoKeyInfo_NullSigningKey")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid_WithNoKeyInfo)}NullSigningKey",
                         Token = ReferenceTokens.SamlToken_Valid_WithNoKeyInfo,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -816,10 +740,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                         },
                         ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500:")
                     },
-                    new SamlTheoryData
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_WithNoKeyInfo_NotNullSigningKey")
                     {
-                        Handler = new SamlSecurityTokenHandler(),
-                        TestId = $"{nameof(ReferenceTokens.SamlToken_Valid_WithNoKeyInfo)}NotNullSigningKey",
                         Token = ReferenceTokens.SamlToken_Valid_WithNoKeyInfo,
                         ValidationParameters = new TokenValidationParameters
                         {
@@ -1148,7 +1070,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                         ValidationParameters = validationParameters
                     },
                     new CreateTokenTheoryData
-                    { 
+                    {
                         TestId = "OnlySubjectClaims",
                         TokenDescriptor =  new SecurityTokenDescriptor
                         {
@@ -1270,7 +1192,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             {
                 var handler = new SamlSecurityTokenHandler();
                 var token = handler.CreateToken(theoryData.TokenDescriptor);
-                handler.ValidateToken(handler.WriteToken(token), theoryData.ValidationParameters, out var validationResult);
+                string samlToken = handler.WriteToken(token);
+                handler.ValidateToken(samlToken, theoryData.ValidationParameters, out var validationResult);
             }
             catch (Exception ex)
             {
@@ -1282,78 +1205,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
 
         public static TheoryData<CreateTokenTheoryData> SecurityKeyNotFoundExceptionTestTheoryData()
         {
-            return new TheoryData<CreateTokenTheoryData>()
-            {
-                new CreateTokenTheoryData
-                {
-                    First = true,
-                    TestId = "TokenExpired",
-                    TokenDescriptor = new SecurityTokenDescriptor
-                    {
-                        Subject = new ClaimsIdentity(Default.SamlClaims),
-                        Expires = DateTime.UtcNow.Subtract(new TimeSpan(0, 10, 0)),
-                        IssuedAt = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
-                        NotBefore = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
-                        SigningCredentials = Default.AsymmetricSigningCredentials,
-                        Issuer = Default.Issuer,
-                     },
-                     ValidationParameters = new TokenValidationParameters
-                     {
-                        IssuerSigningKey = Default.SymmetricSigningKey,
-                        ValidIssuer = Default.Issuer,
-                     },
-                     ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10515:")
-                },
-                new CreateTokenTheoryData
-                {
-                    TestId = "InvalidIssuer",
-                    TokenDescriptor = new SecurityTokenDescriptor
-                    {
-                        Subject = new ClaimsIdentity(Default.SamlClaims),
-                        SigningCredentials = Default.AsymmetricSigningCredentials,
-                        Issuer = Default.Issuer,
-                    },
-                    ValidationParameters = new TokenValidationParameters
-                    {
-                        IssuerSigningKey = Default.SymmetricSigningKey,
-                    },
-                    ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10515:")
-                },
-                new CreateTokenTheoryData
-                {
-                    TestId = "ExpiredAndInvalidIssuer",
-                    TokenDescriptor = new SecurityTokenDescriptor
-                    {
-                        Subject = new ClaimsIdentity(Default.SamlClaims),
-                        Expires = DateTime.UtcNow.Subtract(new TimeSpan(0, 10, 0)),
-                        IssuedAt = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
-                        NotBefore = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
-                        SigningCredentials = Default.AsymmetricSigningCredentials,
-                        Issuer = Default.Issuer,
-                    },
-                    ValidationParameters = new TokenValidationParameters
-                    {
-                        IssuerSigningKey = Default.SymmetricSigningKey,
-                    },
-                    ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10515:")
-                },
-                new CreateTokenTheoryData
-                {
-                    TestId = "KeysDontMatchValidLifetimeAndIssuer",
-                    TokenDescriptor = new SecurityTokenDescriptor
-                    {
-                        Subject = new ClaimsIdentity(Default.SamlClaims),
-                        SigningCredentials = Default.AsymmetricSigningCredentials,
-                        Issuer = Default.Issuer,
-                    },
-                    ValidationParameters = new TokenValidationParameters
-                    {
-                        IssuerSigningKey = Default.SymmetricSigningKey,
-                        ValidIssuer = Default.Issuer,
-                    },
-                    ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10513:")
-                }
-            };
+            return SamlTestData.SecurityKeyNotFoundExceptionTestTheoryData();
         }
 
         private class SamlSecurityTokenHandlerPublic : SamlSecurityTokenHandler
@@ -1372,31 +1224,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             {
                 return base.ValidateIssuer(issuer, token, validationParameters);
             }
-        }
-
-        public class CreateTokenTheoryData : TheoryDataBase
-        {
-            public Dictionary<string, object> AdditionalHeaderClaims { get; set; }
-
-            public string Payload { get; set; }
-
-            public string CompressionAlgorithm { get; set; }
-
-            public CompressionProviderFactory CompressionProviderFactory { get; set; }
-
-            public EncryptingCredentials EncryptingCredentials { get; set; }
-
-            public bool IsValid { get; set; } = true;
-
-            public SigningCredentials SigningCredentials { get; set; }
-
-            public SecurityTokenDescriptor TokenDescriptor { get; set; }
-
-            public SamlSecurityTokenHandler SamlSecurityTokenHandler { get; set; }
-
-            public string SamlToken { get; set; }
-
-            public TokenValidationParameters ValidationParameters { get; set; }
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenTests.cs
@@ -28,11 +28,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             if (!token.Assertion.Issuer.Equals(ClaimsIdentity.DefaultIssuer))
                 context.Diffs.Add("token.Assertion.Issuer.Equals(ClaimsIdentity.DefaultIssuer)");
 
-            // It's possible that DateTime.UtcNow will be slightly different from token.Assertion.IssueInstant, so we can't compare them directly. 
-            var timeDiff = DateTime.UtcNow.Subtract(token.Assertion.IssueInstant).TotalMilliseconds;
-            if (Math.Abs(timeDiff) >= 100)
-                context.Diffs.Add("Math.Abs(DateTime.UtcNow.Subtract(token.Assertion.IssueInstant).TotalMilliseconds) >= 100");
-
             if (token.Assertion.Conditions == null)
                 context.Diffs.Add("token.Assertion.Conditions == null");
 

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlTestData.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlTestData.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Security.Claims;
+using Microsoft.IdentityModel.TestUtils;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Tokens.Saml.Tests
+{
+    public class SamlTestData
+    {
+        public static TheoryData<CreateTokenTheoryData> SecurityKeyNotFoundExceptionTestTheoryData()
+        {
+            return new TheoryData<CreateTokenTheoryData>()
+            {
+                new CreateTokenTheoryData
+                {
+                    First = true,
+                    TestId = "TokenExpired",
+                    TokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(Default.SamlClaims),
+                        Expires = DateTime.UtcNow.Subtract(new TimeSpan(0, 10, 0)),
+                        IssuedAt = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
+                        NotBefore = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                        Issuer = Default.Issuer,
+                     },
+                     ValidationParameters = new TokenValidationParameters
+                     {
+                        IssuerSigningKey = Default.SymmetricSigningKey,
+                        ValidIssuer = Default.Issuer,
+                     },
+                     ExpectedException = ExpectedException.SecurityTokenExpiredException("IDX10223:")
+                },
+                new CreateTokenTheoryData
+                {
+                    TestId = "InvalidIssuer",
+                    TokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(Default.SamlClaims),
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                        Issuer = Default.Issuer,
+                    },
+                    ValidationParameters = new TokenValidationParameters
+                    {
+                        IssuerSigningKey = Default.SymmetricSigningKey,
+                    },
+                    ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX10204:")
+                },
+                new CreateTokenTheoryData
+                {
+                    TestId = "ExpiredAndInvalidIssuer",
+                    TokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(Default.SamlClaims),
+                        Expires = DateTime.UtcNow.Subtract(new TimeSpan(0, 10, 0)),
+                        IssuedAt = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
+                        NotBefore = DateTime.UtcNow.Subtract(new TimeSpan(1, 0, 0)),
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                        Issuer = Default.Issuer,
+                    },
+                    ValidationParameters = new TokenValidationParameters
+                    {
+                        IssuerSigningKey = Default.SymmetricSigningKey,
+                        ValidateIssuer = false,
+                        ValidateAudience = false
+                    },
+                    ExpectedException = ExpectedException.SecurityTokenExpiredException("IDX10223:")
+                },
+                new CreateTokenTheoryData
+                {
+                    TestId = "KeysDontMatchValidLifetimeAndIssuer",
+                    TokenDescriptor = new SecurityTokenDescriptor
+                    {
+                        Subject = new ClaimsIdentity(Default.SamlClaims),
+                        SigningCredentials = Default.AsymmetricSigningCredentials,
+                        Issuer = Default.Issuer,
+                    },
+                    ValidationParameters = new TokenValidationParameters
+                    {
+                        IssuerSigningKey = KeyingMaterial.X509SecurityKey_AAD_Public,
+                        ValidIssuer = Default.Issuer,
+                        ValidateIssuer = false,
+                        ValidateAudience = false,
+                        RequireAudience = false,
+                        ValidateLifetime = false
+                    },
+                    ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10512:")
+                }
+            };
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlTheoryData.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlTheoryData.cs
@@ -12,6 +12,10 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
         {
         }
 
+        public SamlTheoryData(string testId) : base(testId)
+        {
+        }
+
         public SamlTheoryData(TokenTheoryData tokenTheoryData)
             : base(tokenTheoryData)
         {

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
@@ -836,7 +836,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     IssuerSigningKey = NotDefault.SymmetricSigningKey256,
                     TokenDecryptionKey = Default.SymmetricEncryptionKey256,
                 },
-                ExpectedException.SecurityTokenUnableToValidateException("IDX10516:")
+                ExpectedException.SecurityTokenInvalidIssuerException("IDX10204:")
             );
 
             // encryption key not found
@@ -956,7 +956,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     ValidateLifetime = false
                 },
                 expectedPayload,
-                ExpectedException.SecurityTokenUnableToValidateException("IDX10516:")
+                ExpectedException.SecurityTokenInvalidIssuerException("IDX10204:")
             );
 
             theoryData.Add(

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -453,7 +453,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     new JwtTheoryData
                     {
                         TestId = "ActorValidationUsingActorTVP - ExceptionExpected",
-                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10501"),
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10503"),
                         Token = handler.CreateEncodedJwt(Default.Issuer, Default.Audience, claimsIdentity, null, null, null, Default.AsymmetricSigningCredentials),
                         TokenHandler = handler,
                         ValidationParameters = validationParameters
@@ -472,7 +472,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     new JwtTheoryData
                     {
                         TestId = "ActorValidationUsingTVP - ExceptionExpected",
-                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10501"),
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10503"),
                         Token = handler.CreateEncodedJwt(Default.Issuer, Default.Audience, claimsIdentity, null, null, null, Default.AsymmetricSigningCredentials),
                         TokenHandler = handler,
                         ValidationParameters = validationParameters
@@ -493,7 +493,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     new JwtTheoryData
                     {
                         TestId = "ActorValidationUsingTVP - NotTryingAllIssuerSigningKeys - ExceptionExpected",
-                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10501"),
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500"),
                         Token = handler.CreateEncodedJwt(Default.Issuer, Default.Audience, claimsIdentity, null, null, null, Default.AsymmetricSigningCredentials),
                         TokenHandler = handler,
                         ValidationParameters = validationParameters
@@ -2228,7 +2228,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     },
                     new JwtTheoryData
                     {
-                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10501:"),
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500:"),
                         TestId = nameof(Default.SymmetricJws) + "_" + "RequireSignedTokensNullSigningKey",
                         Token = Default.SymmetricJws,
                         ValidationParameters = new TokenValidationParameters
@@ -2794,7 +2794,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                         IssuerSigningKey = Default.SymmetricSigningKey,
                         ValidIssuer = Default.Issuer
                     },
-                    ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10516:")
+                    ExpectedException = ExpectedException.SecurityTokenExpiredException("IDX10223:")
                 },
                 new CreateTokenTheoryData
                 {
@@ -2808,7 +2808,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     {
                         IssuerSigningKey = Default.SymmetricSigningKey,
                     },
-                    ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10516:")
+                    ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX10204:")
                 },
                 new CreateTokenTheoryData
                 {
@@ -2825,7 +2825,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     {
                         IssuerSigningKey = Default.SymmetricSigningKey,
                     },
-                    ExpectedException = ExpectedException.SecurityTokenUnableToValidateException("IDX10516:")
+                    ExpectedException = ExpectedException.SecurityTokenExpiredException("IDX10223:")
                 },
                 new CreateTokenTheoryData
                 {
@@ -2840,7 +2840,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                         IssuerSigningKey = Default.SymmetricSigningKey,
                         ValidIssuer = Default.Issuer,
                     },
-                    ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10501:")
+                    ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208:")
                 },
             };
         }

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtTestDatasets.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtTestDatasets.cs
@@ -143,7 +143,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                             ValidateAudience = false,
                             ValidateLifetime = false,
                         },
-                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10501: "),
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10503: "),
                     },
                     new JwtTheoryData
                     {
@@ -205,7 +205,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                             ValidateAudience = false,
                             ValidateLifetime = false,
                         },
-                        ExpectedException = new ExpectedException(typeof(SecurityTokenUnableToValidateException), "IDX10516: ")
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidIssuerException), "IDX10204: ")
                     },
                     new JwtTheoryData
                     {
@@ -454,7 +454,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                             ValidateAudience = false,
                             ValidateLifetime = false,
                         },
-                        ExpectedException = new ExpectedException(typeof(SecurityTokenUnableToValidateException))
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidIssuerException))
                     },
                     new JwtTheoryData
                     {
@@ -550,7 +550,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                             ValidateAudience = false,
                             ValidateLifetime = true,
                         },
-                        ExpectedException = new ExpectedException(typeof(SecurityTokenUnableToValidateException))
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenNotYetValidException))
                     },
                     new JwtTheoryData
                     {
@@ -597,7 +597,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                             ValidateAudience = false,
                             ValidateLifetime = false,
                         },
-                        ExpectedException = new ExpectedException(typeof(SecurityTokenUnableToValidateException))
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidIssuerException))
                     },
                     new JwtTheoryData
                     {
@@ -854,7 +854,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                             ValidateLifetime = false,
                             TokenDecryptionKey = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes128_Sha2.Key
                         },
-                        ExpectedException = new ExpectedException(typeof(SecurityTokenUnableToValidateException))
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidIssuerException))
                     },
                     new JwtTheoryData
                     {
@@ -956,7 +956,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                             ValidateLifetime = true,
                             TokenDecryptionKey = Default.SymmetricEncryptingCredentials.Key
                         },
-                        ExpectedException = new ExpectedException(typeof(SecurityTokenUnableToValidateException))
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenNotYetValidException))
                     },
                     new JwtTheoryData
                     {
@@ -1006,7 +1006,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                             ValidateLifetime = false,
                             TokenDecryptionKey = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes128_Sha2.Key
                         },
-                        ExpectedException = new ExpectedException(typeof(SecurityTokenUnableToValidateException))
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenInvalidIssuerException))
                     },
                     new JwtTheoryData
                     {


### PR DESCRIPTION
The basic change is to stop using the exception SecurityTokenUnableToValidateException. Instead throw exception that would have been thrown, SecurityTokenInvalidIssuerException, SecurityTokenInvalidLifetimeException, SecurityTokenInvalidAudienceException. None of these three will result in requesting new metadata which is what we want.

The other change is to simplify the logic when a validation fails.

