### PR TITLE
set default LastKnownGood cache instance.

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
@@ -22,7 +22,12 @@ namespace Microsoft.IdentityModel.Tokens
         private BaseConfiguration _lastKnownGoodConfiguration;
         private DateTime? _lastKnownGoodConfigFirstUse = null;
 
-        internal EventBasedLRUCache<BaseConfiguration, DateTime> _lastKnownGoodConfigurationCache;
+        internal EventBasedLRUCache<BaseConfiguration, DateTime> _lastKnownGoodConfigurationCache =
+             new EventBasedLRUCache<BaseConfiguration, DateTime>(
+                    10,
+                    TaskCreationOptions.None,
+                    new BaseConfigurationComparer(),
+                    true);
 
         /// <summary>
         /// Gets or sets the <see cref="TimeSpan"/> that controls how often an automatic metadata refresh should occur.


### PR DESCRIPTION
Initialize the LastKnownGoodCache as users of BaseConfigurationManager would have no way to do so.