### PR TITLE
Added net462 target

### DIFF
--- a/build/targets.props
+++ b/build/targets.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <SrcTargets>net45;net461;net472;netstandard2.0;net6.0</SrcTargets>
+    <SrcTargets>net45;net461;net462;net472;netstandard2.0;net6.0</SrcTargets>
     <SrcStandardTargets>netstandard2.0</SrcStandardTargets>
   </PropertyGroup>
 </Project>

--- a/build/targetsTest.props
+++ b/build/targetsTest.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TestTargets>net452;net461;net472;netcoreapp2.1;net6.0</TestTargets>
+    <TestTargets>net452;net461;net462;net472;netcoreapp2.1;net6.0</TestTargets>
     <TestOnlyCoreTargets>netcoreapp2.1</TestOnlyCoreTargets>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.IdentityModel.JsonWebTokens/Microsoft.IdentityModel.JsonWebTokens.csproj
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Microsoft.IdentityModel.JsonWebTokens.csproj
@@ -27,13 +27,13 @@
     <ProjectReference Include="..\Microsoft.IdentityModel.Tokens\Microsoft.IdentityModel.Tokens.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="System.Text.Encoding" Version="$(SystemTextEncoding)" />
 	<PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWeb)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJson)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 

--- a/src/Microsoft.IdentityModel.Logging/IdentityModelTelemetryUtil.cs
+++ b/src/Microsoft.IdentityModel.Logging/IdentityModelTelemetryUtil.cs
@@ -31,6 +31,8 @@ namespace Microsoft.IdentityModel.Logging
             "ID_NET45";
 #elif NET461
             "ID_NET461";
+#elif NET462
+            "ID_NET462";
 #elif NET472
             "ID_NET472";
 #elif NETSTANDARD2_0

--- a/src/Microsoft.IdentityModel.Logging/Microsoft.IdentityModel.Logging.csproj
+++ b/src/Microsoft.IdentityModel.Logging/Microsoft.IdentityModel.Logging.csproj
@@ -15,7 +15,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Microsoft.IdentityModel.Protocols.OpenIdConnect.csproj
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Microsoft.IdentityModel.Protocols.OpenIdConnect.csproj
@@ -27,13 +27,13 @@
     <ProjectReference Include="..\System.IdentityModel.Tokens.Jwt\System.IdentityModel.Tokens.Jwt.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472' Or  '$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or  '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Encoding" Version="$(SystemTextEncoding)" />
 	<PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWeb)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJson)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/Microsoft.IdentityModel.Protocols.SignedHttpRequest.csproj
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/Microsoft.IdentityModel.Protocols.SignedHttpRequest.csproj
@@ -27,11 +27,11 @@
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.Protocols\Microsoft.IdentityModel.Protocols.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472' Or  '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or  '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="System.Text.Encoding" Version="$(SystemTextEncoding)" />
 	<PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWeb)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJson)" />

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/Microsoft.IdentityModel.Protocols.WsFederation.csproj
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/Microsoft.IdentityModel.Protocols.WsFederation.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="System.Xml.XmlDocument" Version="$(SystemXmlXmlDocumentVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/src/Microsoft.IdentityModel.Protocols/Microsoft.IdentityModel.Protocols.csproj
+++ b/src/Microsoft.IdentityModel.Protocols/Microsoft.IdentityModel.Protocols.csproj
@@ -27,7 +27,7 @@
     <ProjectReference Include="..\Microsoft.IdentityModel.Tokens\Microsoft.IdentityModel.Tokens.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/src/Microsoft.IdentityModel.TestExtensions/Microsoft.IdentityModel.TestExtensions.csproj
+++ b/src/Microsoft.IdentityModel.TestExtensions/Microsoft.IdentityModel.TestExtensions.csproj
@@ -18,7 +18,7 @@
     <ProjectReference Include="..\System.IdentityModel.Tokens.Jwt\System.IdentityModel.Tokens.Jwt.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -9,7 +9,7 @@ using Microsoft.IdentityModel.Logging;
 using System.Reflection;
 #endif
 
-#if NET461 || NET472 || NETSTANDARD2_0 || NET6_0
+#if NET461 || NET462 || NET472 || NETSTANDARD2_0 || NET6_0
 using System.Security.Cryptography.X509Certificates;
 #endif
 
@@ -215,7 +215,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
 #endif
 
-#if NET461 || NET472 || NETSTANDARD2_0 || NET6_0
+#if NET461 || NET462 || NET472 || NETSTANDARD2_0 || NET6_0
             if (algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha256) ||
                 algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha256Signature) ||
                 algorithm.Equals(SecurityAlgorithms.RsaSsaPssSha384) ||
@@ -321,7 +321,7 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
 #region NET61+ related code
-#if NET461 || NET472 || NETSTANDARD2_0 || NET6_0
+#if NET461 || NET462 || NET472 || NETSTANDARD2_0 || NET6_0
 
         // HasAlgorithmName was introduced into Net46
         internal AsymmetricAdapter(SecurityKey key, string algorithm, HashAlgorithm hashAlgorithm, HashAlgorithmName hashAlgorithmName, bool requirePrivateKey)

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -162,7 +162,7 @@ namespace Microsoft.IdentityModel.Tokens
             return PrivateKeyStatus.Unknown;
         }
 
-#if NET461 || NET472 || NETSTANDARD2_0 || NET6_0
+#if NET461 || NET462 || NET472 || NETSTANDARD2_0 || NET6_0
         /// <summary>
         /// Creating a Signature requires the use of a <see cref="HashAlgorithm"/>.
         /// This method returns the <see cref="HashAlgorithmName"/>

--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -318,7 +318,7 @@ namespace Microsoft.IdentityModel.Tokens
             return CreateSignatureProvider(key, algorithm, false, cacheProvider);
         }
 
-#if NET461 || NET472 || NETSTANDARD2_0 || NET6_0
+#if NET461 || NET462 || NET472 || NETSTANDARD2_0 || NET6_0
         /// <summary>
         /// Creates a <see cref="HashAlgorithm"/> for a specific algorithm.
         /// </summary>

--- a/src/Microsoft.IdentityModel.Tokens/ECDsaAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ECDsaAdapter.cs
@@ -51,7 +51,7 @@ namespace Microsoft.IdentityModel.Tokens
             return CreateECDsaFunction(jsonWebKey, usePrivateKey);
         }
 
-#if NET45 || NET461 || NETSTANDARD2_0
+#if NET45 || NET461 || NET462 || NETSTANDARD2_0
         /// <summary>
         /// Creates an ECDsa object using the <paramref name="jsonWebKey"/> and <paramref name="usePrivateKey"/>.
         /// 'ECParameters' structure is available in .NET Framework 4.7+, .NET Standard 1.6+, and .NET Core 1.0+.

--- a/src/Microsoft.IdentityModel.Tokens/Microsoft.IdentityModel.Tokens.csproj
+++ b/src/Microsoft.IdentityModel.Tokens/Microsoft.IdentityModel.Tokens.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\build\common.props" />
 
@@ -12,7 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <DefineConstants>$(DefineConstants);TRACE;DESKTOP;HAVE_ADO_NET;HAVE_APP_DOMAIN;HAVE_ASYNC;HAVE_BIG_INTEGER;HAVE_BINARY_FORMATTER;HAVE_BINARY_SERIALIZATION;HAVE_BINARY_EXCEPTION_SERIALIZATION;HAVE_CAS;HAVE_CHAR_TO_LOWER_WITH_CULTURE;HAVE_CHAR_TO_STRING_WITH_CULTURE;HAVE_COM_ATTRIBUTES;HAVE_COMPONENT_MODEL;HAVE_CONCURRENT_COLLECTIONS;HAVE_COVARIANT_GENERICS;HAVE_DATA_CONTRACTS;HAVE_DATE_TIME_OFFSET;HAVE_DB_NULL_TYPE_CODE;HAVE_DYNAMIC;HAVE_EMPTY_TYPES;HAVE_ENTITY_FRAMEWORK;HAVE_EXPRESSIONS;HAVE_FAST_REVERSE;HAVE_FSHARP_TYPES;HAVE_FULL_REFLECTION;HAVE_GUID_TRY_PARSE;HAVE_HASH_SET;HAVE_ICLONEABLE;HAVE_ICONVERTIBLE;HAVE_IGNORE_DATA_MEMBER_ATTRIBUTE;HAVE_INOTIFY_COLLECTION_CHANGED;HAVE_INOTIFY_PROPERTY_CHANGING;HAVE_ISET;HAVE_LINQ;HAVE_MEMORY_BARRIER;HAVE_METHOD_IMPL_ATTRIBUTE;HAVE_NON_SERIALIZED_ATTRIBUTE;HAVE_READ_ONLY_COLLECTIONS;HAVE_REFLECTION_EMIT;HAVE_REGEX_TIMEOUTS;HAVE_SECURITY_SAFE_CRITICAL_ATTRIBUTE;HAVE_SERIALIZATION_BINDER_BIND_TO_NAME;HAVE_STREAM_READER_WRITER_CLOSE;HAVE_STRING_JOIN_WITH_ENUMERABLE;HAVE_TIME_SPAN_PARSE_WITH_CULTURE;HAVE_TIME_SPAN_TO_STRING_WITH_CULTURE;HAVE_TIME_ZONE_INFO;HAVE_TRACE_WRITER;HAVE_TYPE_DESCRIPTOR;HAVE_UNICODE_SURROGATE_DETECTION;HAVE_VARIANT_TYPE_PARAMETERS;HAVE_VERSION_TRY_PARSE;HAVE_XLINQ;HAVE_XML_DOCUMENT;HAVE_XML_DOCUMENT_TYPE;HAVE_CONCURRENT_DICTIONARY;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
 
@@ -39,13 +39,13 @@
     <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCngVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472' Or  '$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or  '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Encoding" Version="$(SystemTextEncoding)" />
 	<PackageReference Include="System.Text.Encodings.Web" Version="$(SystemTextEncodingsWeb)" />
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJson)" />

--- a/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaCryptoServiceProviderProxy.cs
@@ -195,7 +195,7 @@ namespace Microsoft.IdentityModel.Tokens
             return _rsa.VerifyData(input, hash, signature);
         }
 
-#if NET461 || NET472 || NETSTANDARD2_0
+#if NET461 || NET462 || NET472 || NETSTANDARD2_0
         /// <summary>
         /// Verifies that a digital signature is valid by determining the hash value in the signature using the provided public key and comparing it to the hash value of the provided data.
         /// </summary>

--- a/src/Microsoft.IdentityModel.Tokens/RsaSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaSecurityKey.cs
@@ -76,7 +76,7 @@ namespace Microsoft.IdentityModel.Tokens
                     {
                         // imitate signing
                         byte[] hash = new byte[20];
-#if NET461 || NET472 || NETSTANDARD2_0 || NET6_0
+#if NET461 || NET462 || NET472 || NETSTANDARD2_0 || NET6_0
                         Rsa.SignData(hash, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
 #else
                         if (Rsa is RSACryptoServiceProvider rsaCryptoServiceProvider)

--- a/src/Microsoft.IdentityModel.Tokens/SupportedAlgorithms.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SupportedAlgorithms.cs
@@ -104,7 +104,7 @@ namespace Microsoft.IdentityModel.Tokens
             SecurityAlgorithms.EcdhEsA256kw
         };
 
-#if NET461 || NET472 || NETSTANDARD2_0 || NET6_0
+#if NET461 || NET462 || NET472 || NETSTANDARD2_0 || NET6_0
         /// <summary>
         /// Creating a Signature requires the use of a <see cref="HashAlgorithm"/>.
         /// This method returns the <see cref="HashAlgorithmName"/>
@@ -339,7 +339,7 @@ namespace Microsoft.IdentityModel.Tokens
             // RSA-PSS is not available on .NET 4.5
             LogHelper.LogInformation(LogMessages.IDX10692);
             return false;
-#elif NET461 || NET472 || NETSTANDARD2_0 || NET6_0
+#elif NET461 || NET462 || NET472 || NETSTANDARD2_0 || NET6_0
             // RSACryptoServiceProvider doesn't support RSA-PSS
             if (key is RsaSecurityKey rsa && rsa.Rsa is RSACryptoServiceProvider)
             {

--- a/src/Microsoft.IdentityModel.Tokens/Utility.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Utility.cs
@@ -113,7 +113,7 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 return false;
             }
-#if NET461 
+#if NET461 || NET462
             return uri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase); //Uri.UriSchemeHttps is internal in dnxcore
 #else
             return uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);

--- a/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
@@ -78,7 +78,7 @@ namespace Microsoft.IdentityModel.Tokens
                     {
                         if (!_privateKeyAvailabilityDetermined)
                         {
-#if NET461 || NET472 || NETSTANDARD2_0 || NET6_0
+#if NET461 || NET462 || NET472 || NETSTANDARD2_0 || NET6_0
                             _privateKey = RSACertificateExtensions.GetRSAPrivateKey(Certificate);
 #else
                             _privateKey = Certificate.PrivateKey;
@@ -105,7 +105,7 @@ namespace Microsoft.IdentityModel.Tokens
                     {
                         if (_publicKey == null)
                         {
-#if NET461 || NET472 || NETSTANDARD2_0 || NET6_0
+#if NET461 || NET462 || NET472 || NETSTANDARD2_0 || NET6_0
                             _publicKey = RSACertificateExtensions.GetRSAPublicKey(Certificate);
 #else
                             _publicKey = Certificate.PublicKey.Key;

--- a/src/Microsoft.IdentityModel.Validators/Microsoft.IdentityModel.Validators.csproj
+++ b/src/Microsoft.IdentityModel.Validators/Microsoft.IdentityModel.Validators.csproj
@@ -28,9 +28,9 @@
     <ProjectReference Include="..\System.IdentityModel.Tokens.Jwt\System.IdentityModel.Tokens.Jwt.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />    
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.IdentityModel.Abstractions.Tests/Microsoft.IdentityModel.Abstractions.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Abstractions.Tests/Microsoft.IdentityModel.Abstractions.Tests.csproj
@@ -20,7 +20,7 @@
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.Abstractions\Microsoft.IdentityModel.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461'  Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -2029,7 +2029,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         },
                         ExpectedException = ExpectedException.SecurityTokenException("IDX14116:")
                     },
- #if NET461 || NET472 || NET_CORE
+ #if NET461 || NET462 || NET472 || NET_CORE
                     // RsaPss is not supported on .NET < 4.6
                     new CreateTokenTheoryData
                     {

--- a/test/Microsoft.IdentityModel.Logging.Tests/Microsoft.IdentityModel.Logging.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Logging.Tests/Microsoft.IdentityModel.Logging.Tests.csproj
@@ -22,7 +22,7 @@
     <ProjectReference Include="..\Microsoft.IdentityModel.TestUtils\Microsoft.IdentityModel.TestUtils.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461'  Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests.csproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\Microsoft.IdentityModel.Tokens.Tests\Microsoft.IdentityModel.Tokens.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461'  Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
@@ -224,6 +224,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 #elif NET461
             if (!message.SkuTelemetryValue.Equals("ID_NET461"))
                 context.Diffs.Add($"{message.SkuTelemetryValue} != ID_NET461");
+#elif NET462
+            if (!message.SkuTelemetryValue.Equals("ID_NET462"))
+                context.Diffs.Add($"{message.SkuTelemetryValue} != ID_NET462");
 #elif NET472
             if (!message.SkuTelemetryValue.Equals("ID_NET472"))
                 context.Diffs.Add($"{message.SkuTelemetryValue} != ID_NET472");

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests.csproj
@@ -19,7 +19,7 @@
     <ProjectReference Include="..\Microsoft.IdentityModel.TestUtils\Microsoft.IdentityModel.TestUtils.csproj" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461'  Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestTestUtils.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestTestUtils.cs
@@ -81,7 +81,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             { JwtHeaderParameterNames.Kid, Base64UrlEncoder.Encode(new JsonWebKey(DefaultJwkEcdsa.ToString(Formatting.None)).ComputeJwkThumbprint()) },
         };
 
-#if NET452 || NET461
+#if NET452 || NET461 || NET462
         internal static JObject DefaultJwkEcdsa => new JObject
         {
             { "kty", "EC" },

--- a/test/Microsoft.IdentityModel.Protocols.Tests/Microsoft.IdentityModel.Protocols.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/Microsoft.IdentityModel.Protocols.Tests.csproj
@@ -29,7 +29,7 @@
     <ProjectReference Include="..\Microsoft.IdentityModel.TestUtils\Microsoft.IdentityModel.TestUtils.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/test/Microsoft.IdentityModel.SampleTests/Microsoft.IdentityModel.SampleTests.csproj
+++ b/test/Microsoft.IdentityModel.SampleTests/Microsoft.IdentityModel.SampleTests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Azure.KeyVault.Cryptography" Version="$(MicrosoftAzureKeyVaultCryptographyVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 

--- a/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/KeyingMaterial.cs
@@ -11,7 +11,7 @@ namespace Microsoft.IdentityModel.TestUtils
 {
     static public class KeyingMaterial
     {
-#if NET452 || NET461 || NET472
+#if NET452 || NET461 || NET462 || NET472
         static Type _rsaCngType = typeof(CngKey).Assembly.GetType("System.Security.Cryptography.RSACng", false);
         private static Lazy<object> _rsaCng = new Lazy<object>(CreateRSACng2048);
 #endif
@@ -460,7 +460,7 @@ namespace Microsoft.IdentityModel.TestUtils
             RsaSigningCreds_4096 = new SigningCredentials(RsaSecurityKey_2048, SecurityAlgorithms.RsaSha256Signature, SecurityAlgorithms.Sha256);
             RsaSigningCreds_4096_Public = new SigningCredentials(RsaSecurityKey_2048_Public, SecurityAlgorithms.RsaSha256Signature);
 
-#if NET452 || NET461
+#if NET452 || NET461 || NET462
             //ecdsa
             byte[] ecdsa256KeyBlob = TestUtilities.HexToByteArray("454353322000000096e476f7473cb17c5b38684daae437277ae1efadceb380fad3d7072be2ffe5f0b54a94c2d6951f073bfc25e7b81ac2a4c41317904929d167c3dfc99122175a9438e5fb3e7625493138d4149c9438f91a2fecc7f48f804a92b6363776892ee134");
             byte[] ecdsa384KeyBlob = TestUtilities.HexToByteArray("45435334300000009dc6bb9cdc8dac31e3db6e6b5f58f8e3a304e5c08e632705ca9a236f1134646dca526b89f7ea98653962f4a781f2fc9bf479a2d627561b1269548050e6d2c388018b837f4ceba8ee7fe2eefea67c8418ad1e84f60c1309385e573ea5183e9ae8b6d5308a78da207c6e556af2053983321a5f8ac057b787089ee783c99093b9f2afb2f9a1e9a560ad3095b9667aa699fa");
@@ -506,7 +506,7 @@ namespace Microsoft.IdentityModel.TestUtils
 
         }
 
-#if NET45 || NET452 || NET461
+#if NET45 || NET452 || NET461 || NET462
         public static RsaSecurityKey RsaSecurityKeyWithCspProvider_2048
         {
             get
@@ -548,7 +548,7 @@ namespace Microsoft.IdentityModel.TestUtils
         }
 #endif
 
-#if NET461
+#if NET461 || NET462
         public static RsaSecurityKey RsaSecurityKeyWithCngProvider_2048
         {
             get
@@ -596,7 +596,7 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static RsaSecurityKey RsaSecurityKey_2048 => new RsaSecurityKey(RsaParameters_2048) { KeyId = "RsaSecurityKey_2048" };
 
-#if NET452 || NET461 || NET472
+#if NET452 || NET461 || NET462 || NET472
         public static RsaSecurityKey RsaSecurityKeyCng_2048 => new RsaSecurityKey(_rsaCng.Value as RSA) { KeyId = "RsaSecurityKeyRsaCng_2048" };
 
         private static object CreateRSACng2048()
@@ -609,7 +609,7 @@ namespace Microsoft.IdentityModel.TestUtils
             get
             {
                 AsymmetricAlgorithm publicKey;
-#if NET472 || NET_CORE
+#if NET462 || NET472 || NET_CORE
                 publicKey = RSACertificateExtensions.GetRSAPublicKey(DefaultCert_2048);
 #else
                 publicKey = DefaultCert_2048.PublicKey.Key;
@@ -627,7 +627,7 @@ namespace Microsoft.IdentityModel.TestUtils
                 var certData = "MIIDBTCCAe2gAwIBAgIQY4RNIR0dX6dBZggnkhCRoDANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE3MDIxMzAwMDAwMFoXDTE5MDIxNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMBEizU1OJms31S/ry7iav/IICYVtQ2MRPhHhYknHImtU03sgVk1Xxub4GD7R15i9UWIGbzYSGKaUtGU9lP55wrfLpDjQjEgaXi4fE6mcZBwa9qc22is23B6R67KMcVyxyDWei+IP3sKmCcMX7Ibsg+ubZUpvKGxXZ27YgqFTPqCT2znD7K81YKfy+SVg3uW6epW114yZzClTQlarptYuE2mujxjZtx7ZUlwc9AhVi8CeiLwGO1wzTmpd/uctpner6oc335rvdJikNmc1cFKCK+2irew1bgUJHuN+LJA0y5iVXKvojiKZ2Ii7QKXn19Ssg1FoJ3x2NWA06wc0CnruLsCAwEAAaMhMB8wHQYDVR0OBBYEFDAr/HCMaGqmcDJa5oualVdWAEBEMA0GCSqGSIb3DQEBCwUAA4IBAQAiUke5mA86R/X4visjceUlv5jVzCn/SIq6Gm9/wCqtSxYvifRXxwNpQTOyvHhrY/IJLRUp2g9/fDELYd65t9Dp+N8SznhfB6/Cl7P7FRo99rIlj/q7JXa8UB/vLJPDlr+NREvAkMwUs1sDhL3kSuNBoxrbLC5Jo4es+juQLXd9HcRraE4U3UZVhUS2xqjFOfaGsCbJEqqkjihssruofaxdKT1CPzPMANfREFJznNzkpJt4H0aMDgVzq69NxZ7t1JiIuc43xRjeiixQMRGMi1mAB75fTyfFJ/rWQ5J/9kh0HMZVtHsqICBF1tHMTMIK5rwoweY0cuCIpN7A/zMOQtoD";
                 var cert = new X509Certificate2(Convert.FromBase64String(certData));
                 AsymmetricAlgorithm publicKey;
-#if NET472 || NET_CORE
+#if NET462 || NET472 || NET_CORE
                 publicKey = RSACertificateExtensions.GetRSAPublicKey(cert);
 #else
                 publicKey = cert.PublicKey.Key;
@@ -646,7 +646,7 @@ namespace Microsoft.IdentityModel.TestUtils
                 jsonWebKey.X5c.Add("MIIDJTCCAg2gAwIBAgIQGzlg2gNmfKRKBa6dqqZXxzANBgkqhkiG9w0BAQQFADAiMSAwHgYDVQQDExdLZXlTdG9yZVRlc3RDZXJ0aWZpY2F0ZTAeFw0xMTExMDkxODE5MDZaFw0zOTEyMzEyMzU5NTlaMCIxIDAeBgNVBAMTF0tleVN0b3JlVGVzdENlcnRpZmljYXRlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAns1cm8RU1hKZILPI6pB5Zoxn9mW2tSS0atV+o9FCn9NyeOktEOj1kEXOeIz0KfnqxgPMF1GpshuZBAhgjkyy2kNGE6Zx50CCJgq6XUatvVVJpMp8/FV18ynPf+/TRlF8V2HO3IVJ0XqRJ9fGA2f5xpOweWsdLYitdHbaDCl6IBNSXo52iNuqWAcB1k7jBlsnlXpuvslhLIzj60dnghAVA4ltS3NlFyw1Tz3pGlZQDt7x83IBHe7DA9bV3aJs1trkm1NzI1HoRS4vOqU3n4fn+DlfAE2vYKNkSi/PjuAX+1YQCq6e5uN/hOeSEqji8SsWC2nk/bMTKPwD67rn3jNC9wIDAQABo1cwVTBTBgNVHQEETDBKgBA3gSuALjvEuAVmF/x8knXvoSQwIjEgMB4GA1UEAxMXS2V5U3RvcmVUZXN0Q2VydGlmaWNhdGWCEBs5YNoDZnykSgWunaqmV8cwDQYJKoZIhvcNAQEEBQADggEBAFZvDA7PBh/vvFZb/QCBelTyD2Yqij16v3tk30A3Akli6UIILdbbOcA5BiPktT1kJxcsgSXNHUODlfG2Fy9HTqwunr8G7FYniOUXPVrRL+HwhKOzRFDMUS3+On+ZDzum7rbpm3SYlnJDyNb8wynPw/bXQw72jGjt63uh6OnkYE8fJ8iPfVWOenZkP/IXPIXK/bBwLMDJ1y77ZauPYbp7oiQ/991pn0c7F4ugT9LYmbAdJKhiainOaoBTvIHN8/lMZ8gHUuxvOJhPrbgo3NTqvT1/3kfD0AISP4R3pH0QL/0m7cO34nK4rFFLZs1sFUguYUJhfkyq1N8MiyyAqRmrvBQ=");
                 jsonWebKey.Kty = JsonWebAlgorithmsKeyTypes.RSA;
                 AsymmetricAlgorithm publicKey;
-#if NET472 || NET_CORE
+#if NET462 || NET472 || NET_CORE
                 publicKey = RSACertificateExtensions.GetRSAPublicKey(DefaultCert_2048);
 #else
                 publicKey = DefaultCert_2048.PublicKey.Key;
@@ -669,7 +669,7 @@ namespace Microsoft.IdentityModel.TestUtils
                 jsonWebKey.Kty = JsonWebAlgorithmsKeyTypes.RSA;
                 var cert = new X509Certificate2(Convert.FromBase64String(certData));
                 AsymmetricAlgorithm publicKey;
-#if NET472 || NET_CORE
+#if NET462 || NET472 || NET_CORE
                 publicKey = RSACertificateExtensions.GetRSAPublicKey(cert);
 #else
                 publicKey = cert.PublicKey.Key;
@@ -687,7 +687,7 @@ namespace Microsoft.IdentityModel.TestUtils
             get
             {
                 AsymmetricAlgorithm publicKey;
-#if NET472 || NET_CORE
+#if NET462 || NET472 || NET_CORE
                 publicKey = RSACertificateExtensions.GetRSAPublicKey(DefaultCert_2048);
 #else
                 publicKey = DefaultCert_2048.PublicKey.Key;
@@ -709,7 +709,7 @@ namespace Microsoft.IdentityModel.TestUtils
                 var certData = "MIIDBTCCAe2gAwIBAgIQY4RNIR0dX6dBZggnkhCRoDANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE3MDIxMzAwMDAwMFoXDTE5MDIxNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMBEizU1OJms31S/ry7iav/IICYVtQ2MRPhHhYknHImtU03sgVk1Xxub4GD7R15i9UWIGbzYSGKaUtGU9lP55wrfLpDjQjEgaXi4fE6mcZBwa9qc22is23B6R67KMcVyxyDWei+IP3sKmCcMX7Ibsg+ubZUpvKGxXZ27YgqFTPqCT2znD7K81YKfy+SVg3uW6epW114yZzClTQlarptYuE2mujxjZtx7ZUlwc9AhVi8CeiLwGO1wzTmpd/uctpner6oc335rvdJikNmc1cFKCK+2irew1bgUJHuN+LJA0y5iVXKvojiKZ2Ii7QKXn19Ssg1FoJ3x2NWA06wc0CnruLsCAwEAAaMhMB8wHQYDVR0OBBYEFDAr/HCMaGqmcDJa5oualVdWAEBEMA0GCSqGSIb3DQEBCwUAA4IBAQAiUke5mA86R/X4visjceUlv5jVzCn/SIq6Gm9/wCqtSxYvifRXxwNpQTOyvHhrY/IJLRUp2g9/fDELYd65t9Dp+N8SznhfB6/Cl7P7FRo99rIlj/q7JXa8UB/vLJPDlr+NREvAkMwUs1sDhL3kSuNBoxrbLC5Jo4es+juQLXd9HcRraE4U3UZVhUS2xqjFOfaGsCbJEqqkjihssruofaxdKT1CPzPMANfREFJznNzkpJt4H0aMDgVzq69NxZ7t1JiIuc43xRjeiixQMRGMi1mAB75fTyfFJ/rWQ5J/9kh0HMZVtHsqICBF1tHMTMIK5rwoweY0cuCIpN7A/zMOQtoD";
                 var cert = new X509Certificate2(Convert.FromBase64String(certData));
                 AsymmetricAlgorithm publicKey;
-#if NET472 || NET_CORE
+#if NET462 || NET472 || NET_CORE
                 publicKey = RSACertificateExtensions.GetRSAPublicKey(cert);
 #else
                 publicKey = cert.PublicKey.Key;

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricAdapterTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricAdapterTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
             try
             {
-#if NET461 || NET472 || NETCOREAPP2_1 || NET6_0
+#if NET461 || NET462 || NET472 || NETCOREAPP2_1 || NET6_0
                 AsymmetricAdapter asymmetricdapter = new AsymmetricAdapter(theoryData.SecurityKey, theoryData.Algorithm, hashAlgorithm, SupportedAlgorithms.GetHashAlgorithmName(theoryData.Algorithm), true);
 #else
                 AsymmetricAdapter asymmetricdapter = new AsymmetricAdapter(theoryData.SecurityKey, theoryData.Algorithm, hashAlgorithm, true);
@@ -59,7 +59,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
                 // RSA
                 // RSACertificateExtensions.GetRSAPrivateKey - this results in 
-                #if NET461 || NET472 || NETCOREAPP2_1 || NET6_0
+                #if NET461 || NET462 || NET472 || NETCOREAPP2_1 || NET6_0
                 new AsymmetricAdapterTheoryData
                 {
                     Algorithm = SecurityAlgorithms.RsaSha256,

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             var expectedException = ExpectedException.NotSupportedException();
 #endif
 
-#if NET461 || NET472 || NET_CORE
+#if NET461 || NET462 || NET472 || NET_CORE
             var expectedException = ExpectedException.NoExceptionExpected;
 #endif
             try
@@ -44,7 +44,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             expectedException = ExpectedException.NotSupportedException("IDX10687:");
 #endif
 
-#if NET461 || NET472 || NET_CORE
+#if NET461 || NET462 || NET472 || NET_CORE
             expectedException = ExpectedException.NoExceptionExpected;
 #endif
 
@@ -117,7 +117,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     },
                     theoryData);
 
-#if NET461 || NET472 || NET_CORE
+#if NET461 || NET462 || NET472 || NET_CORE
                 theoryData.Add(new SignatureProviderTheoryData()
                 {
                     SigningAlgorithm = SecurityAlgorithms.RsaSsaPssSha512,
@@ -161,7 +161,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         SigningKey = new RsaSecurityKey(certTuple.Item1.PrivateKey as RSA),
                         TestId = "CapiCapi" + certTuple.Item3,
                         VerifyKey = new RsaSecurityKey(certTuple.Item2.PublicKey.Key as RSA),
-#if NET461 || NET472
+#if NET461 || NET462 || NET472
                         ExpectedException = ExpectedException.NotSupportedException("IDX10634:"),
 #elif NET_CORE
                         ExpectedException = ExpectedException.NoExceptionExpected,
@@ -175,7 +175,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         SigningKey = new RsaSecurityKey(certTuple.Item1.PrivateKey as RSA),
                         TestId = "CapiCng" + certTuple.Item3,
                         VerifyKey = new RsaSecurityKey(certTuple.Item2.GetRSAPublicKey()),
-#if NET461 || NET472
+#if NET461 || NET462 || NET472
                         ExpectedException = ExpectedException.NotSupportedException("IDX10634:"),
 #elif NET_CORE
                         ExpectedException = ExpectedException.NoExceptionExpected,
@@ -189,7 +189,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         SigningKey = new RsaSecurityKey(certTuple.Item1.GetRSAPrivateKey()),
                         TestId = "CngCapi" + certTuple.Item3,
                         VerifyKey = new RsaSecurityKey(certTuple.Item2.PublicKey.Key as RSA),
-#if NET461 || NET472
+#if NET461 || NET462 || NET472
                         ExpectedException = ExpectedException.NotSupportedException("IDX10634:"),
 #elif NET_CORE
                         ExpectedException = ExpectedException.NoExceptionExpected,

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderCacheTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderCacheTests.cs
@@ -602,7 +602,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
 #if NETCOREAPP
         public CryptoProviderCache CryptoProviderCache { get; set; }
-#elif NET452 || NET461 || NET472
+#elif NET452 || NET461 || NET462 || NET472
         public CryptoProviderCache CryptoProviderCache { get; set; }
 #endif
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/MultiThreadingTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/MultiThreadingTests.cs
@@ -152,7 +152,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
                 var jwtEncryptedDir = jwtSecurityTokenHandler.CreateEncodedJwt(securityTokenDescriptorEncryptedDir);
 
-#if NET452 || NET461 || NET472
+#if NET452 || NET461 || NET462 || NET472
                 // RSACng 
                 var securityTokenDescriptorRsaCng = new SecurityTokenDescriptor
                 {
@@ -235,7 +235,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         TokenDescriptor = securityTokenDescriptorEncryptedDir,
                         ValidationParameters = tokenValidationParametersEncryptedDir
                     },
-#if NET452 || NET461 || NET472
+#if NET452 || NET461 || NET462 || NET472
                     new MultiThreadingTheoryData
                     {
                         JwtSecurityTokenHandler = jwtSecurityTokenHandler,

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaCryptoServiceProviderProxyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaCryptoServiceProviderProxyTests.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#if NET461 || NET472
+#if NET461 || NET462 || NET472
 using System.Security.Cryptography.X509Certificates;
 #endif
 
-#if NET452 || NET461 || NET472
+#if NET452 || NET461 || NET462 || NET472
 
 using System;
 using System.Security.Cryptography;
@@ -59,7 +59,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             get
             {
-#if NET461 || NET472
+#if NET461 || NET462 || NET472
                 var rsaCsp = new RSACryptoServiceProvider();
                 rsaCsp.ImportParameters(KeyingMaterial.RsaParameters_2048);
 #else
@@ -111,7 +111,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             get
             {
-#if NET461 || NET472
+#if NET461 || NET462 || NET472
                 var rsaFromX509Cert = new RSACryptoServiceProvider();
                 var rsaCng = KeyingMaterial.DefaultCert_2048.GetRSAPrivateKey() as RSACng;
                 var parameters = rsaCng.ExportParameters(true);
@@ -185,7 +185,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             get
             {
-#if NET461 || NET472
+#if NET461 || NET462 || NET472
                 var rsaCsp = new RSACryptoServiceProvider();
                 rsaCsp.ImportParameters(KeyingMaterial.RsaParameters_2048);
 #else
@@ -254,7 +254,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             get
             {
-#if NET461 || NET472
+#if NET461 || NET462 || NET472
                 var rsaCsp = new RSACryptoServiceProvider();
                 rsaCsp.ImportParameters(KeyingMaterial.RsaParameters_2048);
 #else
@@ -328,7 +328,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         {
             get
             {
-#if NET461 || NET472
+#if NET461 || NET462 || NET472
                 var rsaCsp = new RSACryptoServiceProvider();
                 rsaCsp.ImportParameters(KeyingMaterial.RsaParameters_2048);
 #else

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaSecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaSecurityKeyTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         public static TheoryData<string, SecurityKey, bool> HasPrivateKeyTheoryData()
         {
             var theoryData = new TheoryData<string, SecurityKey, bool>();
-#if NET452 || NET461
+#if NET452 || NET461 || NET462
             theoryData.Add(
                 "KeyingMaterial.RsaSecurityKeyWithCspProvider_2048",
                 KeyingMaterial.RsaSecurityKeyWithCspProvider_2048,
@@ -88,7 +88,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 false
             );
 #endif
-#if NET461
+
+#if NET461 || NET462
 
             theoryData.Add(
                 "KeyingMaterial.RsaSecurityKeyWithCngProvider_2048",

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             var exception = Assert.Throws<NotSupportedException>(() => new ManagedKeyVaultSecurityKey.ManagedKeyVaultSecurityKey("keyid").ComputeJwkThumbprint());
             Assert.Contains("IDX10710", exception.Message);
 
-#if NET452 || NET461
+#if NET452 || NET461 || NET462
             exception = Assert.Throws<PlatformNotSupportedException>(() => new ECDsaSecurityKey(KeyingMaterial.JsonWebKeyP256, false).ComputeJwkThumbprint());
             Assert.Contains("IDX10695", exception.Message);
 #else

--- a/test/Microsoft.IdentityModel.Validators.Tests/Microsoft.IdentityModel.Validators.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Validators.Tests/Microsoft.IdentityModel.Validators.Tests.csproj
@@ -28,7 +28,7 @@
     <ProjectReference Include="..\Microsoft.IdentityModel.Tokens.Tests\Microsoft.IdentityModel.Tokens.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461'  Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472'">
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
@@ -615,7 +615,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 ValidationParameters = Default.SymmetricEncryptSignTokenValidationParameters
             });
 
-#if NET461 || NET_CORE
+#if NET461 || NET462 || NET_CORE
             // RsaPss is not supported on .NET < 4.6
             var rsaPssSigningCredentials = new SigningCredentials(Default.AsymmetricSigningKey, SecurityAlgorithms.RsaSsaPssSha256);
             theoryData.Add(new JwtTheoryData


### PR DESCRIPTION
Moving to System.Text.Json and removing our dependency on our internal Newtonsoft fork will be coupled with adding support for .net 462 and removing .net 45 and .net 461 targets.

Adding this target will be followed by internal classes that are rewritten to use System.Text.Json.
By adding the classes one by one, the size of the work will be manageable.

When we drop the .net 45 and .461 targets, we will promote the internal classes to public.