### PR TITLE
Need to check for 'null-or-empty' issuer signing keys

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -1547,7 +1547,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 }
             }
 
-            if (keys == null && validationParameters.TryAllIssuerSigningKeys)
+            if (validationParameters.TryAllIssuerSigningKeys && keys.IsNullOrEmpty())
             {
                 // control gets here if:
                 // 1. User specified delegate: IssuerSigningKeyResolver returned null


### PR DESCRIPTION
In JsonWebTokenHandler.ValidateSignature() method, the issuer signing keys are resolved based on the configuration or the issuer signing keys resolver delegate, and an IEnumerable<SecurityKey> **keys** is returned.

If no matching keys are found and the TokenValidationParameters.TryAllIssuerSigningKeys option is enabled, all signing keys from the configuration and TVP.IssuerSigningKeys will be tried.

However, we should check if the **keys** collection is null or empty (not just null) since a TVP.IssuerSigningKeyResolver can return an empty collection instead of null.

(Release notes)
In previous Wilson versions, when validating a JsonWebToken, all signing keys will be tried when TokenValidationParameters.TryAllIssuerSigningKeys is set to true and the TVP.IssuerSigningKeyResolver delegate (if present) returns null. This behavior could cause keys to not be found if this delegate is present but returns an empty collection instead of null. All signing keys will now be tried when TVP.IssuerSigningKeyResolver returns either null or an empty collection (assuming TokenValidationParameters.TryAllIssuerSigningKeys is set to true).