### PR TITLE
Mark SecurityTokenUnableToValidateException as obsolete with guidance

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenUnableToValidateException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenUnableToValidateException.cs
@@ -11,7 +11,15 @@ namespace Microsoft.IdentityModel.Tokens
     /// and when validation errors exist over the security token. This exception is not intended to be used as a signal
     /// to refresh keys.
     /// </summary>
+    /// <remarks>
+    /// This exception type is now considered obsolete and will be removed in the next major version (7.0.0).
+    /// </remarks>
     [Serializable]
+    [Obsolete(
+        "This expception is no longer being thrown by Microsoft.IdentityModel and will be removed in the next major " +
+        "version see: https://aka.ms/SecurityTokenUnableToValidateException",
+        false)]
+    [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public class SecurityTokenUnableToValidateException : SecurityTokenInvalidSignatureException
     {
         [NonSerialized]


### PR DESCRIPTION
Marking the exception as obsolete, adding a link with guidance and marking it as not visible from Intellisense in efforts to reduce any adoption which may happen between now and when we remove it in the next major release.

**Release Notes To Append**
Beginning in release [6.28.0](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases/tag/6.28.0) the library stopped throwing `SecurityTokenUnableToValidateException`. This version marks the exception type as obsolete to make this change more discoverable. Not including it in the release notes explicitly for 6.28.0 was a mistake. This exception type will be removed completely in the next few months as the team moves towards a major version bump. More information on how to replace the usage going forward can be found here: [https://aka.ms/SecurityTokenUnableToValidateException](https://aka.ms/SecurityTokenUnableToValidateException)