### PR TITLE
Fix AotCompatibilityTests

### DIFF
--- a/test/Microsoft.IdentityModel.AotCompatibility.TestApp/Microsoft.IdentityModel.AotCompatibility.TestApp.csproj
+++ b/test/Microsoft.IdentityModel.AotCompatibility.TestApp/Microsoft.IdentityModel.AotCompatibility.TestApp.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>full</TrimMode>
-    <ILLinkTreatWarningsAsErrors>true</ILLinkTreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.IdentityModel.AotCompatibility.Tests/AotCompatibilityTests.cs
+++ b/test/Microsoft.IdentityModel.AotCompatibility.Tests/AotCompatibilityTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.IdentityModel.AotCompatibility.Tests
         [Fact(Skip = "need to adjust timeout")]
         public void EnsureAotCompatibility()
         {
-            string testAppPath = @"..\..\..\..\Microsoft.IdentityModel.AotCompatibility.TestApp";
+            string testAppPath = Path.Combine("..", "..", "..", "..", "Microsoft.IdentityModel.AotCompatibility.TestApp");
             string testAppProject = "Microsoft.IdentityModel.AotCompatibility.TestApp.csproj";
 
             // ensure we run a clean publish every time
@@ -58,7 +58,7 @@ namespace Microsoft.IdentityModel.AotCompatibility.Tests
             process.Start();
             process.BeginOutputReadLine();
 
-            Assert.True(process.WaitForExit(milliseconds: 60_000), "dotnet publish command timed out after 60 seconds.");
+            Assert.True(process.WaitForExit(milliseconds: 180_000), "dotnet publish command timed out after 3 minutes.");
 
             Assert.True(process.ExitCode == 0, "Publishing the AotCompatibility app failed. See test output for more details.");
         }


### PR DESCRIPTION
- Use Path.Combine so it works on non-Windows
- Increase the timeout to 3 minutes, since slower machines are seeing this test take around 1 minute
- Use the plain TreatWarningsAsErrors property