### PR TITLE
Enforce key sizes when creating HMAC

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -445,88 +445,58 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 case SecurityAlgorithms.Aes128CbcHmacSha256:
                 {
-                        if (keyBytes.Length < 16)
-                            throw LogHelper.LogExceptionMessage(
-                                new InvalidOperationException(
-                                    LogHelper.FormatInvariant(LogMessages.IDX10720,
-                                    LogHelper.MarkAsNonPII(algorithm),
-                                    LogHelper.MarkAsNonPII("128"),
-                                    LogHelper.MarkAsNonPII(keyBytes.Length * 8))));
-
-                        return new HMACSHA256(keyBytes);
+                    ValidateKeySize(keyBytes, algorithm, 16);
+                    return new HMACSHA256(keyBytes);
                 }
 
                 case SecurityAlgorithms.Aes192CbcHmacSha384:
                 {
-                    if (keyBytes.Length < 24)
-                        throw LogHelper.LogExceptionMessage(
-                            new InvalidOperationException(
-                                LogHelper.FormatInvariant(LogMessages.IDX10720,
-                                LogHelper.MarkAsNonPII(algorithm),
-                                LogHelper.MarkAsNonPII("192"),
-                                LogHelper.MarkAsNonPII(keyBytes.Length * 8))));
-
+                    ValidateKeySize(keyBytes, algorithm, 24);
                     return new HMACSHA384(keyBytes);
                 }
 
                 case SecurityAlgorithms.Aes256CbcHmacSha512:
                 {
-                    if (keyBytes.Length < 32)
-                        throw LogHelper.LogExceptionMessage(
-                            new InvalidOperationException(
-                                LogHelper.FormatInvariant(LogMessages.IDX10720,
-                                LogHelper.MarkAsNonPII(algorithm),
-                                LogHelper.MarkAsNonPII("256"),
-                                LogHelper.MarkAsNonPII(keyBytes.Length * 8))));
-
+                    ValidateKeySize(keyBytes, algorithm, 32);
                     return new HMACSHA512(keyBytes);
                 }
 
                 case SecurityAlgorithms.HmacSha256Signature:
                 case SecurityAlgorithms.HmacSha256:
                 {
-                        if (keyBytes.Length < 32)
-                        throw LogHelper.LogExceptionMessage(
-                            new InvalidOperationException(
-                                LogHelper.FormatInvariant(LogMessages.IDX10720,
-                                LogHelper.MarkAsNonPII(algorithm),
-                                LogHelper.MarkAsNonPII("256"),
-                                LogHelper.MarkAsNonPII(keyBytes.Length * 8))));
-
+                    ValidateKeySize(keyBytes, algorithm, 32);
                     return new HMACSHA256(keyBytes);
                 }
 
                 case SecurityAlgorithms.HmacSha384Signature:
                 case SecurityAlgorithms.HmacSha384:
                 {
-                    if (keyBytes.Length < 48)
-                        throw LogHelper.LogExceptionMessage(
-                            new InvalidOperationException(
-                                LogHelper.FormatInvariant(LogMessages.IDX10720,
-                                LogHelper.MarkAsNonPII(algorithm),
-                                LogHelper.MarkAsNonPII("384"),
-                                LogHelper.MarkAsNonPII(keyBytes.Length * 8))));
-
+                    ValidateKeySize(keyBytes, algorithm, 48);
                     return new HMACSHA384(keyBytes);
                 }
 
                 case SecurityAlgorithms.HmacSha512Signature:
                 case SecurityAlgorithms.HmacSha512:
                 {
-                    if (keyBytes.Length < 64)
-                        throw LogHelper.LogExceptionMessage(
-                            new InvalidOperationException(
-                                LogHelper.FormatInvariant(LogMessages.IDX10720,
-                                LogHelper.MarkAsNonPII(algorithm),
-                                LogHelper.MarkAsNonPII("512"),
-                                LogHelper.MarkAsNonPII(keyBytes.Length * 8))));
-
+                    ValidateKeySize(keyBytes, algorithm, 64);
                     return new HMACSHA512(keyBytes);
                 }
 
                 default:
                     throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10666, LogHelper.MarkAsNonPII(algorithm))));
             }
+        }
+
+        private static void ValidateKeySize(byte[] keyBytes, string algorithm, int expectedNumberOfBytes)
+        {
+            if (keyBytes.Length < expectedNumberOfBytes)
+                throw LogHelper.LogExceptionMessage(
+                    new ArgumentOutOfRangeException(
+                        nameof(keyBytes),
+                        LogHelper.FormatInvariant(LogMessages.IDX10720,
+                            LogHelper.MarkAsNonPII(algorithm),
+                            LogHelper.MarkAsNonPII(expectedNumberOfBytes * 8),
+                            LogHelper.MarkAsNonPII(keyBytes.Length * 8))));
         }
 
         private SignatureProvider CreateSignatureProvider(SecurityKey key, string algorithm, bool willCreateSignatures, bool cacheProvider)

--- a/src/Microsoft.IdentityModel.Tokens/Encryption/AuthenticatedEncryptionProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/AuthenticatedEncryptionProvider.cs
@@ -28,7 +28,6 @@ namespace Microsoft.IdentityModel.Tokens
         private CryptoProviderFactory _cryptoProviderFactory;
         private bool _disposed;
         private Lazy<bool> _keySizeIsValid;
-        private string _hmacAlgorithm;
         private Lazy<SymmetricSignatureProvider> _symmetricSignatureProvider;
         private DecryptionDelegate DecryptFunction;
         private EncryptionDelegate EncryptFunction;
@@ -86,7 +85,6 @@ namespace Microsoft.IdentityModel.Tokens
         private void InitializeUsingAesCbc()
         {
             _authenticatedkeys = new Lazy<AuthenticatedKeys>(CreateAuthenticatedKeys);
-            _hmacAlgorithm = GetHmacAlgorithm(Algorithm);
             _symmetricSignatureProvider = new Lazy<SymmetricSignatureProvider>(CreateSymmetricSignatureProvider);
             EncryptFunction = EncryptWithAesCbc;
             DecryptFunction = DecryptWithAesCbc;
@@ -208,9 +206,9 @@ namespace Microsoft.IdentityModel.Tokens
             SymmetricSignatureProvider symmetricSignatureProvider;
 
             if (Key.CryptoProviderFactory.GetType() == typeof(CryptoProviderFactory))
-                symmetricSignatureProvider = Key.CryptoProviderFactory.CreateForSigning(_authenticatedkeys.Value.HmacKey, _hmacAlgorithm, false) as SymmetricSignatureProvider;
+                symmetricSignatureProvider = Key.CryptoProviderFactory.CreateForSigning(_authenticatedkeys.Value.HmacKey, Algorithm, false) as SymmetricSignatureProvider;
             else
-                symmetricSignatureProvider = Key.CryptoProviderFactory.CreateForSigning(_authenticatedkeys.Value.HmacKey, _hmacAlgorithm) as SymmetricSignatureProvider;
+                symmetricSignatureProvider = Key.CryptoProviderFactory.CreateForSigning(_authenticatedkeys.Value.HmacKey, Algorithm) as SymmetricSignatureProvider;
 
             if (symmetricSignatureProvider == null)
                 throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10649, LogHelper.MarkAsNonPII(Algorithm))));

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -223,6 +223,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10717 = "IDX10717: '{0} + {1}' must not be greater than {2}, '{3} + {4} > {5}'.";
         public const string IDX10718 = "IDX10718: AlgorithmToValidate is not supported: '{0}'. Algorithm '{1}'.";
         public const string IDX10719 = "IDX10719: SignatureSize (in bytes) was expected to be '{0}', was '{1}'.";
+        public const string IDX10720 = "IDX10720: Unable to create KeyedHashAlgorithm for algorithm '{0}', the key size must be greater than: '{1}' bits, key has '{2}' bits.";
 
         // Json specific errors
         //public const string IDX10801 = "IDX10801:"

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ReferenceTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ReferenceTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
 using Xunit;
@@ -72,7 +73,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         [Theory, MemberData(nameof(AuthenticatedEncryptionTheoryData))]
         public void AuthenticatedEncryptionReferenceTest(AuthenticationEncryptionTestParams testParams)
         {
-            var context = new CompareContext();
+            var context = TestUtilities.WriteHeader("AuthenticatedEncryptionReferenceTest", testParams);
+
             var providerForEncryption = CryptoProviderFactory.Default.CreateAuthenticatedEncryptionProvider(testParams.EncryptionKey, testParams.Algorithm);
             var providerForDecryption = CryptoProviderFactory.Default.CreateAuthenticatedEncryptionProvider(testParams.DecryptionKey, testParams.Algorithm);
             var plaintext = providerForDecryption.Decrypt(testParams.Ciphertext, testParams.AuthenticationData, testParams.IV, testParams.AuthenticationTag);
@@ -99,7 +101,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             {
                 var theoryData = new TheoryData<AuthenticationEncryptionTestParams>();
 
-                theoryData.Add(new AuthenticationEncryptionTestParams
+                theoryData.Add(new AuthenticationEncryptionTestParams("AES_128_CBC_HMAC_SHA_256")
                 {
                     Algorithm = AES_128_CBC_HMAC_SHA_256.Algorithm,
                     AuthenticationData = AES_128_CBC_HMAC_SHA_256.A,
@@ -108,11 +110,10 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     DecryptionKey = new SymmetricSecurityKey(AES_128_CBC_HMAC_SHA_256.K) { KeyId = "DecryptionKey.AES_128_CBC_HMAC_SHA_256.K" },
                     EncryptionKey = new SymmetricSecurityKey(AES_128_CBC_HMAC_SHA_256.K) { KeyId = "EncryptionKey.AES_128_CBC_HMAC_SHA_256.K" },
                     IV = AES_128_CBC_HMAC_SHA_256.IV,
-                    Plaintext = AES_128_CBC_HMAC_SHA_256.P,
-                    TestId = "AES_128_CBC_HMAC_SHA_256"
+                    Plaintext = AES_128_CBC_HMAC_SHA_256.P
                 });
 
-                theoryData.Add(new AuthenticationEncryptionTestParams
+                theoryData.Add(new AuthenticationEncryptionTestParams("AES_192_CBC_HMAC_SHA_384")
                 {
                     Algorithm = AES_192_CBC_HMAC_SHA_384.Algorithm,
                     AuthenticationData = AES_192_CBC_HMAC_SHA_384.A,
@@ -121,11 +122,10 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     DecryptionKey = new SymmetricSecurityKey(AES_192_CBC_HMAC_SHA_384.K) { KeyId = "DecryptionKey.AES_192_CBC_HMAC_SHA_384.K" },
                     EncryptionKey = new SymmetricSecurityKey(AES_192_CBC_HMAC_SHA_384.K) { KeyId = "EncryptionKey.AES_192_CBC_HMAC_SHA_384.K" },
                     IV = AES_192_CBC_HMAC_SHA_384.IV,
-                    Plaintext = AES_192_CBC_HMAC_SHA_384.P,
-                    TestId = "AES_192_CBC_HMAC_SHA_384"
+                    Plaintext = AES_192_CBC_HMAC_SHA_384.P
                 });
 
-                theoryData.Add(new AuthenticationEncryptionTestParams
+                theoryData.Add(new AuthenticationEncryptionTestParams("AES_256_CBC_HMAC_SHA_512")
                 {
                     Algorithm = AES_256_CBC_HMAC_SHA_512.Algorithm,
                     AuthenticationData = AES_256_CBC_HMAC_SHA_512.A,
@@ -134,16 +134,19 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     DecryptionKey = new SymmetricSecurityKey(AES_256_CBC_HMAC_SHA_512.K) { KeyId = "DecryptionKey.AES_256_CBC_HMAC_SHA_512.K" },
                     EncryptionKey = new SymmetricSecurityKey(AES_256_CBC_HMAC_SHA_512.K) { KeyId = "EncryptionKey.AES_256_CBC_HMAC_SHA_512.K" },
                     IV = AES_256_CBC_HMAC_SHA_512.IV,
-                    Plaintext = AES_256_CBC_HMAC_SHA_512.P,
-                    TestId = "AES_256_CBC_HMAC_SHA_512"
+                    Plaintext = AES_256_CBC_HMAC_SHA_512.P
                 });
 
                 return theoryData;
             }
         }
 
-        public class AuthenticationEncryptionTestParams
+        public class AuthenticationEncryptionTestParams : TheoryDataBase
         {
+            public AuthenticationEncryptionTestParams() { }
+
+            public AuthenticationEncryptionTestParams(string testId) : base(testId) { }
+
             public string Algorithm { get; set; }
             public byte[] AuthenticationData { get; set; }
             public byte[] AuthenticationTag { get; set; }
@@ -152,7 +155,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             public SecurityKey EncryptionKey { get; set; }
             public byte[] IV { get; set; }
             public byte[] Plaintext { get; set; }
-            public string TestId { get; set; }
 
             public override string ToString()
             {

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -549,7 +549,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(SymmetricVerifySingatureSizeTheoryData))]
+        [Theory, MemberData(nameof(SymmetricVerifySignatureSizeTheoryData))]
         public void SymmetricVerify1Tests(SignatureProviderTheoryData theoryData)
         {
             // verifies: public bool Verify(byte[] input, byte[] signature)
@@ -567,7 +567,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(SymmetricVerifySingatureSizeTheoryData))]
+        [Theory, MemberData(nameof(SymmetricVerifySignatureSizeTheoryData))]
         public void SymmetricVerify2Tests(SignatureProviderTheoryData theoryData)
         {
             // verifies: public bool Verify(byte[] input, byte[] signature, int length)
@@ -585,7 +585,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(SymmetricVerifySingatureSizeTheoryData))]
+        [Theory, MemberData(nameof(SymmetricVerifySignatureSizeTheoryData))]
         public void SymmetricVerify3Tests(SignatureProviderTheoryData theoryData)
         {
             // verifies: public override bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength)
@@ -603,7 +603,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        public static TheoryData<SignatureProviderTheoryData> SymmetricVerifySingatureSizeTheoryData
+        public static TheoryData<SignatureProviderTheoryData> SymmetricVerifySignatureSizeTheoryData
         {
             get
             {
@@ -634,7 +634,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(SymmetricVerifySingatureSizeInternalTheoryData))]
+        [Theory, MemberData(nameof(SymmetricVerifySignatureSizeInternalTheoryData))]
         public void SymmetricVerify4Tests(SignatureProviderTheoryData theoryData)
         {
             // verifies: internal bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength, string algorithm)
@@ -652,7 +652,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
         
-        public static TheoryData<SignatureProviderTheoryData> SymmetricVerifySingatureSizeInternalTheoryData
+        public static TheoryData<SignatureProviderTheoryData> SymmetricVerifySignatureSizeInternalTheoryData
         {
             get
             {
@@ -767,14 +767,14 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             {
                 SecurityKey = new SymmetricSecurityKey(new byte[16]),
                 Algorithm = ALG.HmacSha256Signature,
-                ExpectedException = EE.InvalidOperationException("IDX10720:")
+                ExpectedException = EE.ArgumentOutOfRangeException("IDX10720:")
             });
 
             theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha256")
             {
                 SecurityKey = new SymmetricSecurityKey(new byte[16]),
                 Algorithm = ALG.HmacSha256,
-                ExpectedException = EE.InvalidOperationException("IDX10720:")
+                ExpectedException = EE.ArgumentOutOfRangeException("IDX10720:")
             });
 
             theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha256_32")
@@ -787,14 +787,14 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             {
                 SecurityKey = new SymmetricSecurityKey(new byte[32]),
                 Algorithm = ALG.HmacSha384Signature,
-                ExpectedException = EE.InvalidOperationException("IDX10720:")
+                ExpectedException = EE.ArgumentOutOfRangeException("IDX10720:")
             });
 
             theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha384")
             {
                 SecurityKey = new SymmetricSecurityKey(new byte[32]),
                 Algorithm = ALG.HmacSha384,
-                ExpectedException = EE.InvalidOperationException("IDX10720:")
+                ExpectedException = EE.ArgumentOutOfRangeException("IDX10720:")
             });
 
             theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha384_48")
@@ -807,14 +807,14 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             {
                 SecurityKey = new SymmetricSecurityKey(new byte[48]),
                 Algorithm = ALG.HmacSha512Signature,
-                ExpectedException = EE.InvalidOperationException("IDX10720:")
+                ExpectedException = EE.ArgumentOutOfRangeException("IDX10720:")
             });
 
             theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha512")
             {
                 SecurityKey = new SymmetricSecurityKey(new byte[48]),
                 Algorithm = ALG.HmacSha512,
-                ExpectedException = EE.InvalidOperationException("IDX10720:")
+                ExpectedException = EE.ArgumentOutOfRangeException("IDX10720:")
             });
 
             theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha512_64")

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -262,12 +262,12 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 new SignatureProviderTheoryData("SymmetricSecurityKey4", ALG.HmacSha256, ALG.HmacSha256Signature, Default.SymmetricSigningKey256,  Default.SymmetricSigningKey256),
 
                 // HmacSha384 <-> HmacSha384Signature
-                new SignatureProviderTheoryData("SymmetricSecurityKey5", ALG.HmacSha384, ALG.HmacSha384Signature, Default.SymmetricSigningKey256,  Default.SymmetricSigningKey256),
-                new SignatureProviderTheoryData("SymmetricSecurityKey6", ALG.HmacSha384Signature, ALG.HmacSha384, Default.SymmetricSigningKey256,  Default.SymmetricSigningKey256),
+                new SignatureProviderTheoryData("SymmetricSecurityKey5", ALG.HmacSha384, ALG.HmacSha384Signature, Default.SymmetricSigningKey384,  Default.SymmetricSigningKey384),
+                new SignatureProviderTheoryData("SymmetricSecurityKey6", ALG.HmacSha384Signature, ALG.HmacSha384, Default.SymmetricSigningKey384,  Default.SymmetricSigningKey384),
                 
                 // HmacSha512 <-> HmacSha512Signature
-                new SignatureProviderTheoryData("SymmetricSecurityKey7", ALG.HmacSha512, ALG.HmacSha512Signature, Default.SymmetricSigningKey256,  Default.SymmetricSigningKey256),
-                new SignatureProviderTheoryData("SymmetricSecurityKey8", ALG.HmacSha512Signature, ALG.HmacSha512, Default.SymmetricSigningKey256,  Default.SymmetricSigningKey256),
+                new SignatureProviderTheoryData("SymmetricSecurityKey7", ALG.HmacSha512, ALG.HmacSha512Signature, Default.SymmetricSigningKey512,  Default.SymmetricSigningKey512),
+                new SignatureProviderTheoryData("SymmetricSecurityKey8", ALG.HmacSha512Signature, ALG.HmacSha512, Default.SymmetricSigningKey512,  Default.SymmetricSigningKey512),
 
                 new SignatureProviderTheoryData("SymmetricSecurityKey9", ALG.HmacSha256Signature, ALG.HmacSha256Signature, KEY.SymmetricSecurityKey2_256, KEY.SymmetricSecurityKey2_256),
                 new SignatureProviderTheoryData("SymmetricSecurityKey10", ALG.RsaSha256Signature, ALG.RsaSha512Signature, KEY.SymmetricSecurityKey2_256, KEY.SymmetricSecurityKey2_256, EE.NotSupportedException("IDX10634:")),
@@ -621,14 +621,14 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         ExpectedException = EE.ArgumentException("IDX10719:"),
                         RawBytes= new byte[32],
                         Signature = new byte[32],
-                        SigningSignatureProvider = new SymmetricSignatureProvider(KEY.SymmetricSecurityKey2_256, ALG.HmacSha384),
+                        SigningSignatureProvider = new SymmetricSignatureProvider(KEY.SymmetricSecurityKey2_384, ALG.HmacSha384),
                     },
                     new SignatureProviderTheoryData("HmacSha512")
                     {
                         ExpectedException = EE.ArgumentException("IDX10719:"),
                         RawBytes= new byte[48],
                         Signature = new byte[48],
-                        SigningSignatureProvider = new SymmetricSignatureProvider(KEY.SymmetricSecurityKey2_256, ALG.HmacSha512),
+                        SigningSignatureProvider = new SymmetricSignatureProvider(KEY.SymmetricSecurityKey2_512, ALG.HmacSha512),
                     }
                 };
             }
@@ -719,6 +719,111 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
                 TestUtilities.AssertFailIfErrors("AsymmetricSignatureProvider_SupportedAlgorithms", errors);
             }
+        }
+
+        [Theory, MemberData(nameof(SymmetricSecurityKeySizesTheoryData))]
+        public void SymmetricSecurityKeySizesSign(SymmetricSignatureProviderTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.SymmetricSecurityKeySizes", theoryData);
+            try
+            {
+                var provider = new SymmetricSignatureProvider(theoryData.SecurityKey, theoryData.Algorithm);
+                provider.Sign(new byte[32]);
+
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Theory, MemberData(nameof(SymmetricSecurityKeySizesTheoryData))]
+        public void SymmetricSecurityKeySizesVerify(SymmetricSignatureProviderTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.SymmetricSecurityKeySizes", theoryData);
+            try
+            {
+                var provider = new SymmetricSignatureProvider(theoryData.SecurityKey, theoryData.Algorithm);
+                provider.Verify(new byte[32], new byte[32]);
+
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<SymmetricSignatureProviderTheoryData> SymmetricSecurityKeySizesTheoryData()
+        {
+            var theoryData = new TheoryData<SymmetricSignatureProviderTheoryData>();
+
+            theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha256Signature")
+            {
+                SecurityKey = new SymmetricSecurityKey(new byte[16]),
+                Algorithm = ALG.HmacSha256Signature,
+                ExpectedException = EE.InvalidOperationException("IDX10720:")
+            });
+
+            theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha256")
+            {
+                SecurityKey = new SymmetricSecurityKey(new byte[16]),
+                Algorithm = ALG.HmacSha256,
+                ExpectedException = EE.InvalidOperationException("IDX10720:")
+            });
+
+            theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha256_32")
+            {
+                SecurityKey = new SymmetricSecurityKey(new byte[32]),
+                Algorithm = ALG.HmacSha256
+            });
+
+            theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha384Signature")
+            {
+                SecurityKey = new SymmetricSecurityKey(new byte[32]),
+                Algorithm = ALG.HmacSha384Signature,
+                ExpectedException = EE.InvalidOperationException("IDX10720:")
+            });
+
+            theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha384")
+            {
+                SecurityKey = new SymmetricSecurityKey(new byte[32]),
+                Algorithm = ALG.HmacSha384,
+                ExpectedException = EE.InvalidOperationException("IDX10720:")
+            });
+
+            theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha384_48")
+            {
+                SecurityKey = new SymmetricSecurityKey(new byte[48]),
+                Algorithm = ALG.HmacSha384
+            });
+
+            theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha512Signature")
+            {
+                SecurityKey = new SymmetricSecurityKey(new byte[48]),
+                Algorithm = ALG.HmacSha512Signature,
+                ExpectedException = EE.InvalidOperationException("IDX10720:")
+            });
+
+            theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha512")
+            {
+                SecurityKey = new SymmetricSecurityKey(new byte[48]),
+                Algorithm = ALG.HmacSha512,
+                ExpectedException = EE.InvalidOperationException("IDX10720:")
+            });
+
+            theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha512_64")
+            {
+                SecurityKey = new SymmetricSecurityKey(new byte[64]),
+                Algorithm = ALG.HmacSha512
+            });
+
+            return theoryData;
         }
 
         [Fact]
@@ -1054,6 +1159,15 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         public string SignatureProviderType { get; set; }
 
         public bool VerifySpecifyingLength { get; set; }
+    }
+
+    public class SymmetricSignatureProviderTheoryData : TheoryDataBase
+    {
+        public SymmetricSignatureProviderTheoryData(string testId) : base(testId) { }
+
+        public string Algorithm { get; set; }
+
+        public SecurityKey SecurityKey { get; set; }
     }
 }
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TamperedTokenTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TamperedTokenTests.cs
@@ -109,17 +109,17 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
             // Symmetric - Key - 256
             theoryData.Add(BuildTestCase("Hmac256_Key256", KeyingMaterial.SymmetricSecurityKey2_256, SecurityAlgorithms.HmacSha256, securityTokenDescriptor, jsonWebTokenHandler));
-            theoryData.Add(BuildTestCase("Hmac384_Key256", KeyingMaterial.SymmetricSecurityKey2_256, SecurityAlgorithms.HmacSha384, securityTokenDescriptor, jsonWebTokenHandler));
-            theoryData.Add(BuildTestCase("Hmac512_Key256", KeyingMaterial.SymmetricSecurityKey2_256, SecurityAlgorithms.HmacSha512, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("Hmac384_Key256", KeyingMaterial.SymmetricSecurityKey2_384, SecurityAlgorithms.HmacSha384, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("Hmac512_Key256", KeyingMaterial.SymmetricSecurityKey2_512, SecurityAlgorithms.HmacSha512, securityTokenDescriptor, jsonWebTokenHandler));
 
             // Symmetric - Key - 384
-            theoryData.Add(BuildTestCase("Hmac256_Key384", KeyingMaterial.SymmetricSecurityKey2_384, SecurityAlgorithms.HmacSha256, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("Hmac256_Key384", KeyingMaterial.SymmetricSecurityKey2_256, SecurityAlgorithms.HmacSha256, securityTokenDescriptor, jsonWebTokenHandler));
             theoryData.Add(BuildTestCase("Hmac384_Key384", KeyingMaterial.SymmetricSecurityKey2_384, SecurityAlgorithms.HmacSha384, securityTokenDescriptor, jsonWebTokenHandler));
-            theoryData.Add(BuildTestCase("Hmac512_Key384", KeyingMaterial.SymmetricSecurityKey2_384, SecurityAlgorithms.HmacSha512, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("Hmac512_Key384", KeyingMaterial.SymmetricSecurityKey2_512, SecurityAlgorithms.HmacSha512, securityTokenDescriptor, jsonWebTokenHandler));
 
             // Symmetric - Key - 512
-            theoryData.Add(BuildTestCase("Hmac256_Key512", KeyingMaterial.SymmetricSecurityKey2_512, SecurityAlgorithms.HmacSha256, securityTokenDescriptor, jsonWebTokenHandler));
-            theoryData.Add(BuildTestCase("Hmac384_Key512", KeyingMaterial.SymmetricSecurityKey2_512, SecurityAlgorithms.HmacSha384, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("Hmac256_Key512", KeyingMaterial.SymmetricSecurityKey2_256, SecurityAlgorithms.HmacSha256, securityTokenDescriptor, jsonWebTokenHandler));
+            theoryData.Add(BuildTestCase("Hmac384_Key512", KeyingMaterial.SymmetricSecurityKey2_384, SecurityAlgorithms.HmacSha384, securityTokenDescriptor, jsonWebTokenHandler));
             theoryData.Add(BuildTestCase("Hmac512_Key512", KeyingMaterial.SymmetricSecurityKey2_512, SecurityAlgorithms.HmacSha512, securityTokenDescriptor, jsonWebTokenHandler));
 
             return theoryData;

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -671,9 +671,15 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     break;
 
                 case SecurityAlgorithms.HmacSha256Signature:
-                case SecurityAlgorithms.HmacSha384Signature:
-                case SecurityAlgorithms.HmacSha512Signature:
                     jwt = handler.CreateJwtSecurityToken(new SecurityTokenDescriptor { SigningCredentials = new SigningCredentials(KeyingMaterial.SymmetricSecurityKey2_256, outboundAlgorithm) });
+                    break;
+
+                case SecurityAlgorithms.HmacSha384Signature:
+                    jwt = handler.CreateJwtSecurityToken(new SecurityTokenDescriptor { SigningCredentials = new SigningCredentials(KeyingMaterial.SymmetricSecurityKey2_384, outboundAlgorithm) });
+                    break;
+
+                case SecurityAlgorithms.HmacSha512Signature:
+                    jwt = handler.CreateJwtSecurityToken(new SecurityTokenDescriptor { SigningCredentials = new SigningCredentials(KeyingMaterial.SymmetricSecurityKey2_512, outboundAlgorithm) });
                     break;
             }
 


### PR DESCRIPTION
This is a fix to ensure when creating a JWS (signed JsonWebToken), the key size is of sufficient size.
The key size must be > the size Hash algorithm returns.
HS256 requires 256 bits, HS384 requires 384 bits, HS512 requires 512 bits.

Allowance is made for authenticated encryption which uses a smaller key for the AuthenticationTag.

If the SymmetricKey is smaller than the required size IdentityModel will throw an ArgumentOutOfRangeException which is the same exception is the SymmetricKey is smaller than the minimum key size.