### PR TITLE
Throws SecurityTokenMalformedTokenException on malformed tokens

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -423,6 +423,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
         internal int NumberOfDots { get; set; }
 
+        /// <summary>
+        /// Converts a string into an instance of <see cref="JsonWebToken"/>.
+        /// </summary>
+        /// <param name="encodedJson">A 'JSON Web Token' (JWT) in JWS or JWE Compact Serialization Format.</param>
+        /// <exception cref="SecurityTokenMalformedException">if <paramref name="encodedJson"/> is malformed, a valid JWT should have either 2 dots (JWS) or 4 dots (JWE).</exception>
+        /// <exception cref="SecurityTokenMalformedException">if <paramref name="encodedJson"/> does not have an non-empty authentication tag after the 4th dot for a JWE.</exception>
+        /// <exception cref="SecurityTokenMalformedException">if <paramref name="encodedJson"/> has more than 4 dots.</exception>
         private void ReadToken(string encodedJson)
         {
             // JWT must have 2 dots

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -428,11 +428,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             // JWT must have 2 dots
             Dot1 = encodedJson.IndexOf('.');
             if (Dot1 == -1 || Dot1 == encodedJson.Length - 1)
-                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX14100, encodedJson)));
+                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedException(LogHelper.FormatInvariant(LogMessages.IDX14100, encodedJson)));
 
             Dot2 = encodedJson.IndexOf('.', Dot1 + 1);
             if (Dot2 == -1)
-                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX14120, encodedJson)));
+                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedException(LogHelper.FormatInvariant(LogMessages.IDX14120, encodedJson)));
 
             if (Dot2 == encodedJson.Length - 1)
                 Dot3 = -1;
@@ -494,15 +494,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
                 // JWE needs to have 4 dots
                 if (Dot4 == -1)
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX14121, encodedJson)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedException(LogHelper.FormatInvariant(LogMessages.IDX14121, encodedJson)));
 
                 // too many dots...
                 if (encodedJson.IndexOf('.', Dot4 + 1) != -1)
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX14122, encodedJson)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedException(LogHelper.FormatInvariant(LogMessages.IDX14122, encodedJson)));
 
                 // must have something after 4th dot
                 if (Dot4 == encodedJson.Length - 1)
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX14310, encodedJson)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedException(LogHelper.FormatInvariant(LogMessages.IDX14310, encodedJson)));
 
                 // right number of dots for JWE
                 _hChars = encodedJson.ToCharArray(0, Dot1);

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -427,17 +427,14 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             // JWT must have 2 dots
             Dot1 = encodedJson.IndexOf('.');
-            if (Dot1 == -1)
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14100, encodedJson)));
-
-            if (Dot1 == encodedJson.Length)
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14100, encodedJson)));
+            if (Dot1 == -1 || Dot1 == encodedJson.Length - 1)
+                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX14100, encodedJson)));
 
             Dot2 = encodedJson.IndexOf('.', Dot1 + 1);
             if (Dot2 == -1)
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14120, encodedJson)));
+                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX14120, encodedJson)));
 
-            if (Dot2 == encodedJson.Length)
+            if (Dot2 == encodedJson.Length - 1)
                 Dot3 = -1;
             else
                 Dot3 = encodedJson.IndexOf('.', Dot2 + 1);
@@ -497,15 +494,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
                 // JWE needs to have 4 dots
                 if (Dot4 == -1)
-                    throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14121, encodedJson)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX14121, encodedJson)));
 
                 // too many dots...
                 if (encodedJson.IndexOf('.', Dot4 + 1) != -1)
-                    throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14122, encodedJson)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX14122, encodedJson)));
 
                 // must have something after 4th dot
                 if (Dot4 == encodedJson.Length - 1)
-                    throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14310, encodedJson)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX14310, encodedJson)));
 
                 // right number of dots for JWE
                 _hChars = encodedJson.ToCharArray(0, Dot1);

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenArgumentException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenArgumentException.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Throw this exception when a received <see cref="SecurityToken"/> has invalid arguments.
+    /// </summary>
+    [Serializable]
+    public class SecurityTokenArgumentException : ArgumentException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenException"/> class.
+        /// </summary>
+        public SecurityTokenArgumentException() : base() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        public SecurityTokenArgumentException(string message) : base(message) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenException"/> class with a specified error message
+        /// and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The <see cref="Exception"/> that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        public SecurityTokenArgumentException(string message, Exception innerException) : base(message, innerException) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenArgumentException"/> class.
+        /// </summary>
+        /// <param name="info">the <see cref="SerializationInfo"/> that holds the serialized object data.</param>
+        /// <param name="context">The contextual information about the source or destination.</param>
+        protected SecurityTokenArgumentException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenMalformedException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenMalformedException.cs
@@ -10,32 +10,32 @@ namespace Microsoft.IdentityModel.Tokens
     /// Represents a <see cref="SecurityToken"/> exception when the token is malformed.
     /// </summary>
     [Serializable]
-    public class SecurityTokenMalformedTokenException : SecurityTokenArgumentException
+    public class SecurityTokenMalformedException : SecurityTokenArgumentException
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SecurityTokenMalformedTokenException"/> class.
+        /// Initializes a new instance of the <see cref="SecurityTokenMalformedException"/> class.
         /// </summary>
-        public SecurityTokenMalformedTokenException() : base() { }
+        public SecurityTokenMalformedException() : base() { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SecurityTokenMalformedTokenException"/> class with a specified error message.
+        /// Initializes a new instance of the <see cref="SecurityTokenMalformedException"/> class with a specified error message.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
-        public SecurityTokenMalformedTokenException(string message) : base(message) { }
+        public SecurityTokenMalformedException(string message) : base(message) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SecurityTokenMalformedTokenException"/> class with a specified error message
+        /// Initializes a new instance of the <see cref="SecurityTokenMalformedException"/> class with a specified error message
         /// and a reference to the inner exception that is the cause of this exception.
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The <see cref="Exception"/> that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
-        public SecurityTokenMalformedTokenException(string message, Exception innerException) : base(message, innerException) { }
+        public SecurityTokenMalformedException(string message, Exception innerException) : base(message, innerException) { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SecurityTokenMalformedTokenException"/> class.
+        /// Initializes a new instance of the <see cref="SecurityTokenMalformedException"/> class.
         /// </summary>
         /// <param name="info">the <see cref="SerializationInfo"/> that holds the serialized object data.</param>
         /// <param name="context">The contextual information about the source or destination.</param>
-        protected SecurityTokenMalformedTokenException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        protected SecurityTokenMalformedException(SerializationInfo info, StreamingContext context) : base(info, context) { }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenMalformedTokenException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenMalformedTokenException.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Represents a <see cref="SecurityToken"/> exception when the token is malformed.
+    /// </summary>
+    [Serializable]
+    public class SecurityTokenMalformedTokenException : SecurityTokenArgumentException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenMalformedTokenException"/> class.
+        /// </summary>
+        public SecurityTokenMalformedTokenException() : base() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenMalformedTokenException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        public SecurityTokenMalformedTokenException(string message) : base(message) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenMalformedTokenException"/> class with a specified error message
+        /// and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The <see cref="Exception"/> that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        public SecurityTokenMalformedTokenException(string message, Exception innerException) : base(message, innerException) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenMalformedTokenException"/> class.
+        /// </summary>
+        /// <param name="info">the <see cref="SerializationInfo"/> that holds the serialized object data.</param>
+        /// <param name="context">The contextual information about the source or destination.</param>
+        protected SecurityTokenMalformedTokenException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
@@ -43,10 +43,10 @@ namespace System.IdentityModel.Tokens.Jwt
             else if (tokenParts.Length == JwtConstants.JweSegmentCount)
             {
                 if (!JwtTokenUtilities.RegexJwe.IsMatch(jwtEncodedString))
-                    throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX12740, jwtEncodedString)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX12740, jwtEncodedString)));
             }
             else
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX12741, jwtEncodedString)));
+                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX12741, jwtEncodedString)));
 
             Decode(tokenParts, jwtEncodedString);
         }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
@@ -20,9 +20,10 @@ namespace System.IdentityModel.Tokens.Jwt
         /// Initializes a new instance of <see cref="JwtSecurityToken"/> from a string in JWS Compact serialized format.
         /// </summary>
         /// <param name="jwtEncodedString">A JSON Web Token that has been serialized in JWS Compact serialized format.</param>
-        /// <exception cref="ArgumentNullException">'jwtEncodedString' is null.</exception>
-        /// <exception cref="ArgumentException">'jwtEncodedString' contains only whitespace.</exception>
-        /// <exception cref="ArgumentException">'jwtEncodedString' is not in JWS Compact serialized format.</exception>
+        /// <exception cref="ArgumentNullException">'jwtEncodedString' is null or contains only whitespace.</exception>
+        /// <exception cref="SecurityTokenMalformedException">'jwtEncodedString' contains only whitespace.</exception>
+        /// <exception cref="SecurityTokenMalformedException">'jwtEncodedString' is not in JWE format.</exception>
+        /// <exception cref="SecurityTokenMalformedException">'jwtEncodedString' is not in JWS or JWE format.</exception>
         /// <remarks>
         /// The contents of this <see cref="JwtSecurityToken"/> have not been validated, the JSON Web Token is simply decoded. Validation can be accomplished using <see cref="JwtSecurityTokenHandler.ValidateToken(String, TokenValidationParameters, out SecurityToken)"/>
         /// </remarks>
@@ -38,15 +39,15 @@ namespace System.IdentityModel.Tokens.Jwt
             if (tokenParts.Length == JwtConstants.JwsSegmentCount)
             {
                 if (!JwtTokenUtilities.RegexJws.IsMatch(jwtEncodedString))
-                    throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX12739, jwtEncodedString)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedException(LogHelper.FormatInvariant(LogMessages.IDX12739, jwtEncodedString)));
             }
             else if (tokenParts.Length == JwtConstants.JweSegmentCount)
             {
                 if (!JwtTokenUtilities.RegexJwe.IsMatch(jwtEncodedString))
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX12740, jwtEncodedString)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedException(LogHelper.FormatInvariant(LogMessages.IDX12740, jwtEncodedString)));
             }
             else
-                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX12741, jwtEncodedString)));
+                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedException(LogHelper.FormatInvariant(LogMessages.IDX12741, jwtEncodedString)));
 
             Decode(tokenParts, jwtEncodedString);
         }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -768,7 +768,7 @@ namespace System.IdentityModel.Tokens.Jwt
                 throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(TokenLogMessages.IDX10209, LogHelper.MarkAsNonPII(token.Length), LogHelper.MarkAsNonPII(MaximumTokenSizeInBytes))));
 
             if (!CanReadToken(token))
-                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX12709, token)));
+                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedException(LogHelper.FormatInvariant(LogMessages.IDX12709, token)));
 
             var jwtToken = new JwtSecurityToken();
             jwtToken.Decode(token.Split('.'), token);
@@ -813,8 +813,8 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <exception cref="ArgumentNullException"><paramref name="token"/> is null or whitespace.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="validationParameters"/> is null.</exception>
         /// <exception cref="ArgumentException"><paramref name="token"/>.Length is greater than <see cref="TokenHandler.MaximumTokenSizeInBytes"/>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="token"/> does not have 3 or 5 parts.</exception>
-        /// <exception cref="ArgumentException"><see cref="CanReadToken(string)"/> returns false.</exception>
+        /// <exception cref="SecurityTokenMalformedException"><paramref name="token"/> does not have 3 or 5 parts.</exception>
+        /// <exception cref="SecurityTokenMalformedException"><see cref="CanReadToken(string)"/> returns false.</exception>
         /// <exception cref="SecurityTokenDecryptionFailedException"><paramref name="token"/> was a JWE was not able to be decrypted.</exception>
         /// <exception cref="SecurityTokenEncryptionKeyNotFoundException"><paramref name="token"/> 'kid' header claim is not null AND decryption fails.</exception>
         /// <exception cref="SecurityTokenException"><paramref name="token"/> 'enc' header claim is null or empty.</exception>
@@ -846,7 +846,7 @@ namespace System.IdentityModel.Tokens.Jwt
             var tokenParts = token.Split(new char[] { '.' }, JwtConstants.MaxJwtSegmentCount + 1);
 
             if (tokenParts.Length != JwtConstants.JwsSegmentCount && tokenParts.Length != JwtConstants.JweSegmentCount)
-                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX12741, token)));
+                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedException(LogHelper.FormatInvariant(LogMessages.IDX12741, token)));
 
             if (tokenParts.Length == JwtConstants.JweSegmentCount)
             {

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -768,7 +768,7 @@ namespace System.IdentityModel.Tokens.Jwt
                 throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(TokenLogMessages.IDX10209, LogHelper.MarkAsNonPII(token.Length), LogHelper.MarkAsNonPII(MaximumTokenSizeInBytes))));
 
             if (!CanReadToken(token))
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX12709, token)));
+                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX12709, token)));
 
             var jwtToken = new JwtSecurityToken();
             jwtToken.Decode(token.Split('.'), token);
@@ -846,7 +846,7 @@ namespace System.IdentityModel.Tokens.Jwt
             var tokenParts = token.Split(new char[] { '.' }, JwtConstants.MaxJwtSegmentCount + 1);
 
             if (tokenParts.Length != JwtConstants.JwsSegmentCount && tokenParts.Length != JwtConstants.JweSegmentCount)
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX12741, token)));
+                throw LogHelper.LogExceptionMessage(new SecurityTokenMalformedTokenException(LogHelper.FormatInvariant(LogMessages.IDX12741, token)));
 
             if (tokenParts.Length == JwtConstants.JweSegmentCount)
             {

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -754,7 +754,7 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <returns>A <see cref="JwtSecurityToken"/></returns>
         /// <exception cref="ArgumentNullException"><paramref name="token"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">'token.Length' is greater than <see cref="TokenHandler.MaximumTokenSizeInBytes"/>.</exception>
-        /// <exception cref="ArgumentException"><see cref="CanReadToken(string)"/></exception>
+        /// <exception cref="SecurityTokenMalformedException"><see cref="CanReadToken(string)"/></exception>
         /// <remarks><para>If the <paramref name="token"/> is in JWE Compact Serialization format, only the protected header will be deserialized.
         /// This method is unable to decrypt the payload. Use <see cref="ValidateToken(string, TokenValidationParameters, out SecurityToken)"/>to obtain the payload.</para>
         /// <para>The token is NOT validated and no security decisions should be made about the contents.

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
@@ -546,7 +546,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
                 theoryData.Add(new JwtTheoryData(nameof(EncodedJwts.JWEEmptyAuthenticationTag))
                 {
-                    ExpectedException = ExpectedException.ArgumentException(substringExpected: "IDX14310:"),
+                    ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(substringExpected: "IDX14310:"),
                     Token = EncodedJwts.JWEEmptyAuthenticationTag,
                 });
 

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
@@ -308,7 +308,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                     new ResolvePopKeyTheoryData
                     {
                         PopKeyString = "dummy",
-                        ExpectedException = new ExpectedException(typeof(ArgumentException), "IDX14100", null, true),
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenMalformedTokenException), "IDX14100", null, true),
                         TestId = "InvalidPopKeyNotAJWK",
                     },
                     new ResolvePopKeyTheoryData

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
@@ -308,7 +308,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                     new ResolvePopKeyTheoryData
                     {
                         PopKeyString = "dummy",
-                        ExpectedException = new ExpectedException(typeof(SecurityTokenMalformedTokenException), "IDX14100", null, true),
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenMalformedException), "IDX14100", null, true),
                         TestId = "InvalidPopKeyNotAJWK",
                     },
                     new ResolvePopKeyTheoryData

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -1429,7 +1429,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                     new ValidateSignedHttpRequestTheoryData
                     {
                         SignedHttpRequestToken = null,
-                        ExpectedException = new ExpectedException(typeof(ArgumentException), "IDX14100"),
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenMalformedTokenException), "IDX14100"),
                         TestId = "InvalidToken",
                     },
                     new ValidateSignedHttpRequestTheoryData

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -1429,7 +1429,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                     new ValidateSignedHttpRequestTheoryData
                     {
                         SignedHttpRequestToken = null,
-                        ExpectedException = new ExpectedException(typeof(SecurityTokenMalformedTokenException), "IDX14100"),
+                        ExpectedException = new ExpectedException(typeof(SecurityTokenMalformedException), "IDX14100"),
                         TestId = "InvalidToken",
                     },
                     new ValidateSignedHttpRequestTheoryData

--- a/test/Microsoft.IdentityModel.SampleTests/SampleTokenValidationClassTests.cs
+++ b/test/Microsoft.IdentityModel.SampleTests/SampleTokenValidationClassTests.cs
@@ -241,7 +241,7 @@ namespace Microsoft.IdentityModel.SampleTests
         {
             TestWithGeneratedToken_Deprecated(
                 () => "InvalidToken",
-                typeof(SecurityTokenMalformedTokenException),
+                typeof(SecurityTokenMalformedException),
                 "IDX12741");
         }
 

--- a/test/Microsoft.IdentityModel.SampleTests/SampleTokenValidationClassTests.cs
+++ b/test/Microsoft.IdentityModel.SampleTests/SampleTokenValidationClassTests.cs
@@ -241,7 +241,7 @@ namespace Microsoft.IdentityModel.SampleTests
         {
             TestWithGeneratedToken_Deprecated(
                 () => "InvalidToken",
-                typeof(ArgumentException),
+                typeof(SecurityTokenMalformedTokenException),
                 "IDX12741");
         }
 

--- a/test/Microsoft.IdentityModel.TestUtils/ExpectedException.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ExpectedException.cs
@@ -52,6 +52,11 @@ namespace Microsoft.IdentityModel.TestUtils
             return new ExpectedException(typeof(SecurityTokenDecryptionFailedException), substringExpected, innerTypeExpected);
         }
 
+        public static ExpectedException SecurityTokenMalformedTokenException(string substringExpected = null, Type innerTypeExpected = null)
+        {
+            return new ExpectedException(typeof(SecurityTokenMalformedTokenException), substringExpected, innerTypeExpected);
+        }
+
         public static ExpectedException InvalidOperationException(string substringExpected = null, Type inner = null, string contains = null)
         {
             return new ExpectedException(typeof(InvalidOperationException), substringExpected, inner);

--- a/test/Microsoft.IdentityModel.TestUtils/ExpectedException.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ExpectedException.cs
@@ -54,7 +54,7 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static ExpectedException SecurityTokenMalformedTokenException(string substringExpected = null, Type innerTypeExpected = null)
         {
-            return new ExpectedException(typeof(SecurityTokenMalformedTokenException), substringExpected, innerTypeExpected);
+            return new ExpectedException(typeof(SecurityTokenMalformedException), substringExpected, innerTypeExpected);
         }
 
         public static ExpectedException InvalidOperationException(string substringExpected = null, Type inner = null, string contains = null)

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -2181,7 +2181,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     },
                     new JwtTheoryData
                     {
-                        ExpectedException = ExpectedException.ArgumentException(substringExpected: "IDX12741:"),
+                        ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(substringExpected: "IDX12741:"),
                         TestId = "Token = Guid().NewGuid().ToString()",
                         Token = Guid.NewGuid().ToString(),
                         ValidationParameters = new TokenValidationParameters()

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
@@ -256,12 +256,12 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             dataSet.Add("ValidJwe2- Construct by string", outerValidJwe2, null, EncodedJwts.ValidJwe2, ExpectedException.NoExceptionExpected);
 
             // Hand in a valid variation. We should fail before the variation is used.
-            dataSet.Add("Invalid outer token 1- Construct by string", outerValidJweDirect, null, EncodedJwts.InvalidJwe, ExpectedException.ArgumentException(substringExpected: "IDX12741"));
-            dataSet.Add("Invalid outer token 2- Construct by string", outerValidJweDirect, null, EncodedJwts.InvalidJwe2, ExpectedException.ArgumentException(substringExpected: "IDX12741"));
-            dataSet.Add("Invalid outer token 3- Construct by string", outerValidJweDirect, null, EncodedJwts.InvalidJwe3, ExpectedException.ArgumentException(substringExpected: "IDX12740"));
-            dataSet.Add("Invalid outer token 4- Construct by string", outerValidJweDirect, null, EncodedJwts.InvalidJwe4, ExpectedException.ArgumentException(substringExpected: "IDX12741"));
-            dataSet.Add("Invalid outer token 5- Construct by string", outerValidJweDirect, null, EncodedJwts.InvalidJwe5, ExpectedException.ArgumentException(substringExpected: "IDX12740"));
-            dataSet.Add("Invalid outer token 6- Construct by string", outerValidJweDirect, null, EncodedJwts.InvalidJwe6, ExpectedException.ArgumentException(substringExpected: "IDX12740"));
+            dataSet.Add("Invalid outer token 1- Construct by string", outerValidJweDirect, null, EncodedJwts.InvalidJwe, ExpectedException.SecurityTokenMalformedTokenException(substringExpected: "IDX12741"));
+            dataSet.Add("Invalid outer token 2- Construct by string", outerValidJweDirect, null, EncodedJwts.InvalidJwe2, ExpectedException.SecurityTokenMalformedTokenException(substringExpected: "IDX12741"));
+            dataSet.Add("Invalid outer token 3- Construct by string", outerValidJweDirect, null, EncodedJwts.InvalidJwe3, ExpectedException.SecurityTokenMalformedTokenException(substringExpected: "IDX12740"));
+            dataSet.Add("Invalid outer token 4- Construct by string", outerValidJweDirect, null, EncodedJwts.InvalidJwe4, ExpectedException.SecurityTokenMalformedTokenException(substringExpected: "IDX12741"));
+            dataSet.Add("Invalid outer token 5- Construct by string", outerValidJweDirect, null, EncodedJwts.InvalidJwe5, ExpectedException.SecurityTokenMalformedTokenException(substringExpected: "IDX12740"));
+            dataSet.Add("Invalid outer token 6- Construct by string", outerValidJweDirect, null, EncodedJwts.InvalidJwe6, ExpectedException.SecurityTokenMalformedTokenException(substringExpected: "IDX12740"));
 
             return dataSet;
         }

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtTestData.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtTestData.cs
@@ -54,42 +54,42 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
-                ExpectedException = ExpectedException.ArgumentException(errorStrings[0]),
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorStrings[0]),
                 TestId = "a",
                 Token = "a"
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
-                ExpectedException = ExpectedException.ArgumentException(errorStrings[1]),
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorStrings[1]),
                 TestId = "a.b",
                 Token = "a.b"
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
-                ExpectedException = ExpectedException.ArgumentException(errorStrings[2]),
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorStrings[2]),
                 TestId = "a.b.c.",
                 Token = "a.b.c."
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
-                ExpectedException = ExpectedException.ArgumentException(errorStrings[3]),
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorStrings[3]),
                 TestId = "a.b.c.d",
                 Token = "a.b.c.d"
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
-                ExpectedException = ExpectedException.ArgumentException(errorStrings[4]),
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorStrings[4]),
                 TestId = "a.b.c.d.",
                 Token = "a.b.c.d."
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
-                ExpectedException = ExpectedException.ArgumentException(errorStrings[5]),
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorStrings[5]),
                 TestId = "a.b.c.d.e.f",
                 Token = "a.b.c.d.e.f"
             });
@@ -106,63 +106,63 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 CanRead = false,
                 TestId = "'invalidRegEx: first position'",
                 Token = invalidRegEx + "." + validRegEx + "." + validRegEx + "." + validRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException("IDX12740:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12740:")
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: second position'",
                 Token = validRegEx + "." + invalidRegEx + "." + validRegEx + "." + validRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException("IDX12740:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12740:")
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: third position'",
                 Token = validRegEx + "." + validRegEx + "." + invalidRegEx + "." + validRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException("IDX12740:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12740:")
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: fourth position'",
                 Token = validRegEx + "." + validRegEx + "." + validRegEx + "." + invalidRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException("IDX12740:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12740:")
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: fifth position'",
                 Token = validRegEx + "." + validRegEx + "." + validRegEx + "." + validRegEx + "." + invalidRegEx,
-                ExpectedException = ExpectedException.ArgumentException("IDX12740:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12740:")
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: first position (dir)'",
                 Token = invalidRegEx + ".." + validRegEx + "." + validRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException("IDX12740:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12740:")
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: third position (dir)'",
                 Token = validRegEx + ".." + invalidRegEx + "." + validRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException("IDX12740:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12740:")
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: fourth position (dir)'",
                 Token = invalidRegEx + ".." + validRegEx + "." + invalidRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException("IDX12740:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12740:")
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: fifth position (dir)'",
                 Token = invalidRegEx + ".." + validRegEx + "." + validRegEx + "." + invalidRegEx,
-                ExpectedException = ExpectedException.ArgumentException("IDX12740:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12740:")
             });
             theoryData.Add(new JwtTheoryData
             {
@@ -197,7 +197,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 CanRead = false,
                 TestId = "'Encoding == SignedEncodedJwts.Asymmetric_LocalSts'",
                 Token = "SignedEncodedJwts.Asymmetric_LocalSts",
-                ExpectedException = ExpectedException.ArgumentException("IDX12741:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12741:")
             });
 
             return theoryData;
@@ -212,98 +212,98 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 CanRead = false,
                 TestId =  "'invalidRegEx: first position'",
                 Token = invalidRegEx + "." + validRegEx + "." + validRegEx + "." + validRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: second position'",
                 Token = validRegEx + "." + invalidRegEx + "." + validRegEx + "." + validRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: third position'",
                 Token = validRegEx + "." + validRegEx + "." + invalidRegEx + "." + validRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: fourth position'",
                 Token = validRegEx + "." + validRegEx + "." + validRegEx + "." + invalidRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: fifth position'",
                 Token = validRegEx + "." + validRegEx + "." + validRegEx + "." + validRegEx + "." + invalidRegEx,
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: first position (dir)'",
                 Token = invalidRegEx + ".." + validRegEx + "." + validRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: third position (dir)'",
                 Token = validRegEx + ".." + invalidRegEx + "." + validRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: fourth position (dir)'",
                 Token = invalidRegEx + ".." + validRegEx + "." + invalidRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: fifth position (dir)'",
                 Token = invalidRegEx + ".." + validRegEx + "." + validRegEx + "." + invalidRegEx,
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: first position (dir, Cipher text missing)'",
                 Token = invalidRegEx + "." + validRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: third position (dir, Cipher text missing)'",
                 Token = validRegEx + "." + invalidRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: third position (four parts)'",
                 Token = validRegEx + "." + invalidRegEx + ".",
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: fifth position (dir, Cipher text missing)'",
                 Token = validRegEx + "." + validRegEx + "." + invalidRegEx,
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'Encoding == SignedEncodedJwts.Asymmetric_LocalSts'",
                 Token = "SignedEncodedJwts.Asymmetric_LocalSts",
-                ExpectedException = ExpectedException.ArgumentException(errorString)
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(errorString)
             });
 
             return theoryData;

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtTestData.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtTestData.cs
@@ -169,28 +169,28 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 CanRead = false,
                 TestId = "'invalidRegEx: first position (dir, Cipher text missing)'",
                 Token = invalidRegEx + "." + validRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException("IDX12739:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12739:")
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: third position (dir, Cipher text missing)'",
                 Token = validRegEx + "." + invalidRegEx + "." + validRegEx,
-                ExpectedException = ExpectedException.ArgumentException("IDX12739:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12739:")
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: third position (four parts)'",
                 Token = validRegEx + "." + invalidRegEx + ".",
-                ExpectedException = ExpectedException.ArgumentException("IDX12739:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12739:")
             });
             theoryData.Add(new JwtTheoryData
             {
                 CanRead = false,
                 TestId = "'invalidRegEx: fifth position (dir, Cipher text missing)'",
                 Token = validRegEx + "." + validRegEx + "." + invalidRegEx,
-                ExpectedException = ExpectedException.ArgumentException("IDX12739:")
+                ExpectedException = ExpectedException.SecurityTokenMalformedTokenException("IDX12739:")
             });
             theoryData.Add(new JwtTheoryData
             {


### PR DESCRIPTION
Currently an ArgumentException is thrown when a token handler fails to parse/read a raw token. Since the ArgumentException is a general exception for any invalid arguments, sometimes it does not provide specific types of errors, ex, invalid header or payload. This PR adds a new exception, SecurityTokenMalformedTokenException, that can be thrown when a malformed token is detected. For example, the exception will be thrown if a SAML token is handled by JsonWebTokenHandler.

This should provide a clearer exception so users to handle it differently.