### PR TITLE
(feature): Add ActiveTokenEndpoint to WsFederationConfiguration

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfiguration.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfiguration.cs
@@ -318,6 +318,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
         public override string TokenEndpoint { get; set; }
 
         /// <summary>
+        /// This base class property is not used in OpenIdConnect. 
+        /// </summary>
+        [JsonIgnore]
+        public override string ActiveTokenEndpoint { get; set; }
+
+        /// <summary>
         /// Gets the collection of 'token_endpoint_auth_methods_supported'.
         /// </summary>
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore, PropertyName = OpenIdProviderMetadataNames.TokenEndpointAuthMethodsSupported, Required = Required.Default)]

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/LogMessages.cs
@@ -23,10 +23,10 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         internal const string IDX22904 = "IDX22904: Wresult does not contain a 'RequestedSecurityToken' element.";
 
         // xml metadata messages
-        internal const string IDX22800 = "IDX22800: Exception thrown while reading WsFedereationMetadata. Element '{0}'. Caught exception: '{1}'.";
+        internal const string IDX22800 = "IDX22800: Exception thrown while reading WsFederationMetadata. Element '{0}'. Caught exception: '{1}'.";
         internal const string IDX22801 = "IDX22801: entityID attribute is not found in EntityDescriptor element in metadata file.";
         internal const string IDX22802 = "IDX22802: Current name '{0} and namespace '{1}' do not match the expected name '{2}' and namespace '{3}'.";
-        internal const string IDX22803 = "IDX22803: Token reference address is missing in SecurityTokenServiceEndpoint in metadata file.";
+        internal const string IDX22803 = "IDX22803: Token reference address is missing in PassiveRequestorEndpoint in metadata file.";
         internal const string IDX22804 = "IDX22804: Security token type role descriptor is expected.";
         internal const string IDX22806 = "IDX22806: Key descriptor for signing is missing in security token service type RoleDescriptor.";
         internal const string IDX22807 = "IDX22807: Token endpoint is missing in security token service type RoleDescriptor.";
@@ -34,6 +34,8 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         internal const string IDX22810 = "IDX22810: 'Issuer' value is missing in wsfederationconfiguration.";
         internal const string IDX22811 = "IDX22811: 'TokenEndpoint' value is missing in wsfederationconfiguration.";
         internal const string IDX22812 = "IDX22812: Element: '{0}' was an empty element. 'TokenEndpoint' value is missing in wsfederationconfiguration.";
+        internal const string IDX22813 = "IDX22813: 'ActiveTokenEndpoint' is missing in 'SecurityTokenServiceTypeRoleDescriptor'.";
+        internal const string IDX22814 = "IDX22814: Token reference address is missing in SecurityTokenServiceEndpoint in metadata.";
 
 #pragma warning restore 1591
     }

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/SecurityTokenServiceTypeRoleDescriptor.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/SecurityTokenServiceTypeRoleDescriptor.cs
@@ -21,13 +21,23 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         } = new List<KeyInfo>();
 
         /// <summary>
-        /// Token endpoint
+        /// Passive Requestor Token endpoint
+        /// fed:PassiveRequestorEndpoint, https://docs.oasis-open.org/wsfed/federation/v1.2/os/ws-federation-1.2-spec-os.html#:~:text=fed%3ASecurityTokenServiceType/fed%3APassiveRequestorEndpoint
         /// </summary>
         public string TokenEndpoint
         {
             get;
             set;
         }
+
+        /// <summary>
+        /// Active Requestor Token Endpoint
+        /// fed:SecurityTokenServiceType, http://docs.oasis-open.org/wsfed/federation/v1.2/os/ws-federation-1.2-spec-os.html#:~:text=fed%3ASecurityTokenSerivceEndpoint
+        /// </summary>
+        public string ActiveTokenEndpoint
+        {
+            get;
+            set;
+        }
     }
 }
-

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationConstants.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationConstants.cs
@@ -5,6 +5,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
 {
     /// <summary>
     /// Constants for WsFederation.
+    /// As defined on the http://docs.oasis-open.org/wsfed/federation/v1.2/os/ws-federation-1.2-spec-os.html
     /// </summary>
     public static class WsFederationConstants
     {
@@ -93,6 +94,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
             public const string KeyDescriptor = "KeyDescriptor";
             public const string RoleDescriptor = "RoleDescriptor";
             public const string PassiveRequestorEndpoint = "PassiveRequestorEndpoint";
+            public const string SecurityTokenServiceEndpoint = "SecurityTokenServiceEndpoint";
             public const string SpssoDescriptor = "SPSSODescriptor";
         }
 

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMetadataSerializer.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMetadataSerializer.cs
@@ -106,7 +106,9 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
                             }
                         }
                     }
+
                     configuration.TokenEndpoint = roleDescriptor.TokenEndpoint;
+                    configuration.ActiveTokenEndpoint = roleDescriptor.ActiveTokenEndpoint;
                 }
                 else
                 {
@@ -177,6 +179,8 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
                     roleDescriptor.KeyInfos.Add(ReadKeyDescriptorForSigning(reader));
                 else if (reader.IsStartElement(Elements.PassiveRequestorEndpoint, Namespace))
                     roleDescriptor.TokenEndpoint = ReadPassiveRequestorEndpoint(reader);
+                else if (reader.IsStartElement(Elements.SecurityTokenServiceEndpoint, Namespace))
+                    roleDescriptor.ActiveTokenEndpoint = ReadSecurityTokenServiceEndpoint(reader);
                 else
                     reader.ReadOuterXml();
             }
@@ -190,6 +194,9 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
 
             if (string.IsNullOrEmpty(roleDescriptor.TokenEndpoint))
                 LogHelper.LogWarning(LogMessages.IDX22807);
+
+            if (string.IsNullOrEmpty(roleDescriptor.ActiveTokenEndpoint))
+                LogHelper.LogWarning(LogMessages.IDX22813);
 
             return roleDescriptor;
         }
@@ -211,6 +218,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
             reader.ReadStartElement();
             reader.MoveToContent();
 
+            // <EndpointReference>
             XmlUtil.CheckReaderOnEntry(reader, WsAddressing.Elements.EndpointReference, WsAddressing.Namespace);
             if (reader.IsEmptyElement)
                 throw XmlUtil.LogReadException(LogMessages.IDX22812, WsAddressing.Elements.EndpointReference);
@@ -221,7 +229,9 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
             if (reader.IsEmptyElement)
                 throw XmlUtil.LogReadException(LogMessages.IDX22803);
 
+            // <Address>
             XmlUtil.CheckReaderOnEntry(reader, WsAddressing.Elements.Address, WsAddressing.Namespace);
+
             if (reader.IsEmptyElement)
                 throw XmlUtil.LogReadException(LogMessages.IDX22812, WsAddressing.Elements.Address);
 
@@ -236,6 +246,75 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
             // </Address>
             reader.MoveToContent();
             reader.ReadEndElement();
+
+            // </EndpointReference>
+            reader.MoveToContent();
+            reader.ReadEndElement();
+
+            // </PassiveRequestorEndpoint>
+            reader.MoveToContent();
+            reader.ReadEndElement();
+
+            return tokenEndpoint;
+        }
+
+        /// <summary>
+        /// Read fed:SecurityTokenServiceEndpoint element from metadata XML.
+        /// </summary>
+        /// <param name="reader"><see cref="XmlReader"/> used to read SecurityTokenServiceEndpoint.</param>
+        /// <returns>Active token endpoint string</returns>
+        /// <exception cref="XmlReadException">If an error occurs while reading the SecurityTokenServiceEndpoint</exception>
+        protected virtual string ReadSecurityTokenServiceEndpoint(XmlReader reader)
+        {
+            XmlUtil.CheckReaderOnEntry(reader, Elements.SecurityTokenServiceEndpoint, Namespace);
+
+            // <SecurityTokenServiceEndpoint>
+            if (reader.IsEmptyElement)
+                throw XmlUtil.LogReadException(LogMessages.IDX22812, Elements.SecurityTokenServiceEndpoint);
+
+            reader.ReadStartElement();
+            reader.MoveToContent();
+
+            // <EndpointReference>
+            XmlUtil.CheckReaderOnEntry(reader, WsAddressing.Elements.EndpointReference, WsAddressing.Namespace);
+            if (reader.IsEmptyElement)
+                throw XmlUtil.LogReadException(LogMessages.IDX22812, WsAddressing.Elements.EndpointReference);
+
+            reader.ReadStartElement(WsAddressing.Elements.EndpointReference, WsAddressing.Namespace);
+            reader.MoveToContent();
+
+            if (reader.IsEmptyElement)
+                throw XmlUtil.LogReadException(LogMessages.IDX22814);
+
+            string tokenEndpoint = null;
+
+            while (reader.IsStartElement())
+            {
+                if (reader.IsStartElement(WsAddressing.Elements.Address, WsAddressing.Namespace))
+                {
+                    // <Address>
+                    XmlUtil.CheckReaderOnEntry(reader, WsAddressing.Elements.Address, WsAddressing.Namespace);
+
+                    if (reader.IsEmptyElement)
+                        throw XmlUtil.LogReadException(LogMessages.IDX22812, WsAddressing.Elements.Address);
+
+                    reader.ReadStartElement(WsAddressing.Elements.Address, WsAddressing.Namespace);
+                    reader.MoveToContent();
+
+                    tokenEndpoint = Trim(reader.ReadContentAsString());
+
+                    if (string.IsNullOrEmpty(tokenEndpoint))
+                        throw XmlUtil.LogReadException(LogMessages.IDX22814);
+
+                    // </Address>
+                    reader.MoveToContent();
+                    reader.ReadEndElement();
+                }
+                else
+                {
+                    reader.ReadOuterXml();
+                }
+            }
 
             // </EndpointReference>
             reader.MoveToContent();
@@ -301,7 +380,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
 
             if (string.IsNullOrEmpty(configuration.TokenEndpoint))
                 throw XmlUtil.LogWriteException(LogMessages.IDX22811);
-
+            
             if (configuration.SigningCredentials != null)
                 writer = new EnvelopedSignatureWriter(writer, configuration.SigningCredentials, "id");
 
@@ -332,6 +411,30 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
                     // </KeyDescriptor>
                     writer.WriteEndElement();
                 }
+            }
+
+            if (!string.IsNullOrEmpty(configuration.ActiveTokenEndpoint))
+            {
+                // <fed:SecurityTokenServiceEndpoint>
+                writer.WriteStartElement(PreferredPrefix, Elements.SecurityTokenServiceEndpoint, Namespace);
+
+                // <wsa:EndpointReference xmlns:wsa=""http://www.w3.org/2005/08/addressing"">
+                writer.WriteStartElement(WsAddressing.PreferredPrefix, WsAddressing.Elements.EndpointReference, WsAddressing.Namespace);
+
+                // <wsa:Address>
+                writer.WriteStartElement(WsAddressing.PreferredPrefix, WsAddressing.Elements.Address, WsAddressing.Namespace);
+
+                // write TokenEndpoint
+                writer.WriteString(configuration.ActiveTokenEndpoint);
+
+                // </wsa:Address>
+                writer.WriteEndElement();
+
+                // </wsa:EndpointReference>
+                writer.WriteEndElement();
+
+                // </fed:SecurityTokenServiceEndpoint>
+                writer.WriteEndElement();
             }
 
             // <fed:PassiveRequestorEndpoint>

--- a/src/Microsoft.IdentityModel.Tokens/BaseConfiguration.cs
+++ b/src/Microsoft.IdentityModel.Tokens/BaseConfiguration.cs
@@ -27,10 +27,16 @@ namespace Microsoft.IdentityModel.Tokens
 
         /// <summary>
         /// Gets or sets the token endpoint specified via the metadata endpoint.
-        /// This can be the fed:SecurityTokenServiceType in WS-Federation, http://docs.oasis-open.org/wsfed/federation/v1.2/os/ws-federation-1.2-spec-os.html#:~:text=fed%3ASecurityTokenSerivceEndpoint
+        /// This can be the fed:PassiveRequestorEndpoint in WS-Federation, https://docs.oasis-open.org/wsfed/federation/v1.2/os/ws-federation-1.2-spec-os.html#:~:text=fed%3ASecurityTokenServiceType/fed%3APassiveRequestorEndpoint
         /// Or the token_endpoint in the OIDC metadata.
         /// </summary>
         public virtual string TokenEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the token endpoint specified via the metadata endpoint.
+        /// This can is the fed:SecurityTokenServiceType in WS-Federation, http://docs.oasis-open.org/wsfed/federation/v1.2/os/ws-federation-1.2-spec-os.html#:~:text=fed%3ASecurityTokenSerivceEndpoint
+        /// </summary>
+        public virtual string ActiveTokenEndpoint { get; set; }
 
         /// <summary>
         /// Gets the <see cref="ICollection{SecurityKey}"/> that the IdentityProvider indicates are to be used in order to decrypt tokens.

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationTests.cs
@@ -108,8 +108,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             OpenIdConnectConfiguration configuration = new OpenIdConnectConfiguration();
             Type type = typeof(OpenIdConnectConfiguration);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 48)
-                Assert.True(false, "Number of properties has changed from 47 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 49)
+                Assert.True(false, "Number of properties has changed from 49 to: " + properties.Length + ", adjust tests");
 
             TestUtilities.CallAllPublicInstanceAndStaticPropertyGets(configuration, "OpenIdConnectConfiguration_GetSets");
 

--- a/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/WsFederationConfigurationRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/WsFederationConfigurationRetrieverTests.cs
@@ -23,11 +23,10 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
         public void ReadMetadata(WsFederationMetadataTheoryData theoryData)
         {
             var context  = TestUtilities.WriteHeader($"{this}.ReadMetadata", theoryData);
+            var configuration = new WsFederationConfiguration();
+
             try
             {
-                var config = ReferenceMetadata.AADCommonEndpoint;
-                var configuration = new WsFederationConfiguration();
-
                 if (!string.IsNullOrEmpty(theoryData.Metadata))
                 {
                     var reader = XmlReader.Create(new StringReader(theoryData.Metadata));
@@ -39,8 +38,8 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
                     configuration = theoryData.Serializer.ReadMetadata(reader);
                 }
 
-                if (theoryData.SigingKey != null)
-                    configuration.Signature.Verify(theoryData.SigingKey, theoryData.SigingKey.CryptoProviderFactory);
+                if (theoryData.SigningKey != null)
+                    configuration.Signature.Verify(theoryData.SigningKey, theoryData.SigningKey.CryptoProviderFactory);
 
                 theoryData.ExpectedException.ProcessNoException(context);
                 IdentityComparer.AreWsFederationConfigurationsEqual(configuration, theoryData.Configuration, context);
@@ -64,38 +63,79 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
                 {
                     new WsFederationMetadataTheoryData
                     {
+                        // Base case for common scenario (not tenant specific).
+                        // All data is present as expected.
                         Configuration = ReferenceMetadata.AADCommonEndpoint,
                         First = true,
                         Metadata = ReferenceMetadata.AADCommonMetadata,
-                        SigingKey = ReferenceMetadata.MetadataSigningKey,
+                        SigningKey = ReferenceMetadata.MetadataSigningKey,
                         TestId = nameof(ReferenceMetadata.AADCommonMetadata)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // Only EntityDescriptor tag, empty XML. 
                         Configuration = ReferenceMetadata.EmptyEntityDescriptor,
                         Metadata = ReferenceMetadata.MetadataEmptyEntityDescriptor,
                         TestId = nameof(ReferenceMetadata.MetadataEmptyEntityDescriptor)
                     },
+                    // ---------------------------------------------------------------------------------------------------------------------
+                    // Passive Requestor variations (EntityDescriptor\RoleDescriptor\PassiveRequestorEndpoint)
+                    // ---------------------------------------------------------------------------------------------------------------------
                     new WsFederationMetadataTheoryData
                     {
+                        // Empty EntityDescriptor\RoleDescriptor\PassiveRequestorEndpoint tag <fed:PassiveRequestorEndpoint /> 
+                        // Error Message: "IDX22812: Element: '{0}' was an empty element. 'TokenEndpoint' value is missing in wsfederationconfiguration.";
                         ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX22812:"),
                         Metadata = ReferenceMetadata.MetadataEmptyPassiveRequestorEndpoint,
                         TestId = nameof(ReferenceMetadata.MetadataEmptyPassiveRequestorEndpoint)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // Empty EntityDescriptor\RoleDescriptor\PassiveRequestorEndpoint\EndpointReference\Address tag  <wsa:Address/>
+                        // Error Message:  "IDX22803: Token reference address is missing in PassiveRequestorEndpoint in metadata file."
                         ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX22803:"),
-                        Metadata = ReferenceMetadata.MetadataEmptyEndpointAddress,
-                        TestId = nameof(ReferenceMetadata.MetadataEmptyEndpointAddress)
+                        Metadata = ReferenceMetadata.MetadataEmptyPassiveRequestorEndpointAddress,
+                        TestId = nameof(ReferenceMetadata.MetadataEmptyPassiveRequestorEndpointAddress)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // Empty EntityDescriptor\RoleDescriptor\PassiveRequestorEndpoint\EndpointReference <wsa:EndpointReference xmlns:wsa=""http://www.w3.org/2005/08/addressing"" />
+                        // Error Message: Element: '{0}' was an empty element. 'TokenEndpoint' value is missing in wsfederationconfiguration.";
                         ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX22812:"),
-                        Metadata = ReferenceMetadata.MetadataEmptyEndpointReference,
-                        TestId = nameof(ReferenceMetadata.MetadataEmptyEndpointReference)
+                        Metadata = ReferenceMetadata.MetadataEmptyPassiveRequestorEndpointReference,
+                        TestId = nameof(ReferenceMetadata.MetadataEmptyPassiveRequestorEndpointReference)
+                    },
+                    // ---------------------------------------------------------------------------------------------------------------------
+                    // SecurityTokenServiceEndpoint variations (EntityDescriptor\RoleDescriptor\SecurityTokenServiceEndpoint)
+                    // ---------------------------------------------------------------------------------------------------------------------
+                    new WsFederationMetadataTheoryData
+                    {
+                        // Empty EntityDescriptor\RoleDescriptor\SecurityTokenServiceEndpoint tag <fed:SecurityTokenServiceEndpoint /> 
+                        // Error Message: "IDX22812: Element: '{0}' was an empty element. 'TokenEndpoint' value is missing in wsfederationconfiguration.";
+                        ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX22812:"),
+                        Metadata = ReferenceMetadata.MetadataEmptySecurityTokenServiceEndpoint,
+                        TestId = nameof(ReferenceMetadata.MetadataEmptySecurityTokenServiceEndpoint)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // Empty EntityDescriptor\RoleDescriptor\SecurityTokenServiceEndpoint\EndpointReference\Address tag  <wsa:Address/>
+                        // Error Message: "IDX22814: Token reference address is missing in SecurityTokenServiceEndpoint in metadata file."
+                        ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX22814:"),
+                        Metadata = ReferenceMetadata.MetadataEmptySecurityTokenServiceEndpointAddress,
+                        TestId = nameof(ReferenceMetadata.MetadataEmptySecurityTokenServiceEndpointAddress)
+                    },
+                    new WsFederationMetadataTheoryData
+                    {
+                        // Empty EntityDescriptor\RoleDescriptor\SecurityTokenServiceEndpoint\EndpointReference <wsa:EndpointReference xmlns:wsa=""http://www.w3.org/2005/08/addressing"" />
+                        // Error Message: "IDX22812: Element: '{0}' was an empty element. 'TokenEndpoint' value is missing in wsfederationconfiguration.";
+                        ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX22812:"),
+                        Metadata = ReferenceMetadata.MetadataEmptySecurityTokenServiceEndpointReference,
+                        TestId = nameof(ReferenceMetadata.MetadataEmptySecurityTokenServiceEndpointReference)
+                    },
+                    new WsFederationMetadataTheoryData
+                    {
+                        // Base case for tenant specific scenario (tenant 268da1a1-9db4-48b9-b1fe-683250ba90cc).
+                        // All data is present as expected.
                         Configuration = ReferenceMetadata.AADCommonFormated,
                         Metadata = ReferenceMetadata.AADCommonMetadataFormated,
                         TestId = nameof(ReferenceMetadata.AADCommonMetadataFormated)
@@ -105,17 +145,19 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
                         ExpectedException = new ExpectedException(typeof(XmlValidationException), "IDX30200:"),
                         Configuration = ReferenceMetadata.AADCommonFormated,
                         Metadata = ReferenceMetadata.AADCommonMetadataFormated,
-                        SigingKey = ReferenceMetadata.MetadataSigningKey,
+                        SigningKey = ReferenceMetadata.MetadataSigningKey,
                         TestId = nameof(ReferenceMetadata.AADCommonMetadataFormated) + " Signature Failure"
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // Validate that the presence of spaces or new lines does not affect the parsing of the XML content.
                         Configuration = ReferenceMetadata.AADCommonFormated,
                         Metadata = ReferenceMetadata.MetadataWithBlanks,
                         TestId = nameof(ReferenceMetadata.MetadataWithBlanks)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // EntityDescriptor\RoleDescriptor\KeyDescriptor is missing. Validate the resulting Configuration object only includes the data present.
                         Configuration = new WsFederationConfiguration
                         {
                             Issuer = ReferenceMetadata.Issuer,
@@ -126,54 +168,80 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // EntityDescriptor\@entityID attribute (issuer) is missing from EntityDescriptor tag.
+                        // Error Message: IDX22801: entityID attribute is not found in EntityDescriptor element in metadata file.
                         ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX22801:"),
                         Metadata = ReferenceMetadata.MetadataNoIssuer,
                         TestId = nameof(ReferenceMetadata.MetadataNoIssuer)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // EntityDescriptor\RoleDescriptor\PassiveRequestorEndpoint\EndpointReference\Address Empty Address value (white space and new line only)
+                        // Error Message: "IDX22803: Token reference address is missing in PassiveRequestorEndpoint in metadata file.";
                         ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX22803:"),
-                        Metadata = ReferenceMetadata.MetadataNoTokenUri,
-                        TestId = nameof(ReferenceMetadata.MetadataNoTokenUri)
+                        Metadata = ReferenceMetadata.MetadataNoPassiveRequestorEndpointUri,
+                        TestId = nameof(ReferenceMetadata.MetadataNoPassiveRequestorEndpointUri)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // EntityDescriptor\RoleDescriptor\SecurityTokenServiceEndpoint\EndpointReference\Address Empty Address value (white space and new line only)
+                        // Error Message: "IDX22814: Token reference address is missing in SecurityTokenServiceEndpoint in metadata.";
+                        ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX22814:"),
+                        Metadata = ReferenceMetadata.MetadataNoSecurityTokenServiceEndpointUri,
+                        TestId = nameof(ReferenceMetadata.MetadataNoSecurityTokenServiceEndpointUri)
+                    },
+                    new WsFederationMetadataTheoryData
+                    {
+                        // KeyDescriptor\KeyInfo\X509Data tag holds invalid certificate data.
+                        // Error Message: "IDX22800: Exception thrown while reading WsFedereationMetadata. Element '{0}'. Caught exception: '{1}'.";
                         ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX22800:", typeof(FormatException)),
                         Metadata = ReferenceMetadata.MetadataMalformedCertificate,
                         TestId = nameof(ReferenceMetadata.MetadataMalformedCertificate)
                     },
+                    // ---------------------------------------------------------------------------------------------------------------------
+                    // XML Signature validation (EntityDescriptor\Signature)
+                    // ---------------------------------------------------------------------------------------------------------------------
                     new WsFederationMetadataTheoryData
                     {
+                        // Invalid XML signature. Unknown element before </Signature>
+                        // Error Message: "IDX30025: Unable to read XML. Expecting XmlReader to be at EndElement: '{0}'. Found XmlNode 'type.name': '{1}.{2}'.";
                         ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX30025:"),
                         Metadata = ReferenceMetadata.MetadataUnknownElementBeforeSignatureEndElement,
                         TestId = nameof(ReferenceMetadata.MetadataUnknownElementBeforeSignatureEndElement)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // Invalid XML signature. SignedInfo tag is missing.
+                        // Error Message: "IDX30011: Unable to read XML. Expecting XmlReader to be at ns.element: '{0}.{1}', found: '{2}.{3}'."
                         ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX30011:"),
                         Metadata = ReferenceMetadata.MetadataNoSignedInfoInSignature,
                         TestId = nameof(ReferenceMetadata.MetadataNoSignedInfoInSignature)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // EntityDescriptor tag missing.
+                        // Error Message: "IDX30011: Unable to read XML. Expecting XmlReader to be at ns.element: '{0}.{1}', found: '{2}.{3}'."
                         ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX30011:"),
                         Metadata = ReferenceMetadata.MetadataNoEntityDescriptor,
                         TestId = nameof(ReferenceMetadata.MetadataNoEntityDescriptor)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // EntityDescriptor\RoleDescriptor tag missing.
                         Configuration = ReferenceMetadata.NoRoleDescriptor,
                         Metadata = ReferenceMetadata.MetadataNoRoleDescriptor,
                         TestId = nameof(ReferenceMetadata.MetadataNoRoleDescriptor)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // EntityDescriptor\RoleDescriptor\KeyDescriptor\KeyInfo tag missing.
                         ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX22802:"),
                         Metadata = ReferenceMetadata.MetadataNoKeyInfoInKeyDescriptor,
                         TestId = nameof(ReferenceMetadata.MetadataNoKeyInfoInKeyDescriptor)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // EntityDescriptor\RoleDescriptor\PassiveRequestorEndpoint tag is missing.
                         Configuration = new WsFederationConfiguration
                         {
                             Issuer = ReferenceMetadata.Issuer
@@ -183,55 +251,74 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // EntityDescriptor\RoleDescriptor\PassiveRequestorEndpoint\EndpointReference tag is missing.
+                        // Error Message: "IDX30011: Unable to read XML. Expecting XmlReader to be at ns.element: '{0}.{1}', found: '{2}.{3}'."
                         ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX30011:"),
                         Metadata = ReferenceMetadata.MetadataNoEndpointReference,
                         TestId = nameof(ReferenceMetadata.MetadataNoEndpointReference)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // EntityDescriptor\RoleDescriptor\PassiveRequestorEndpoint\EndpointReference\Address tag is missing.
+                        // Error Message: "IDX30011: Unable to read XML. Expecting XmlReader to be at ns.element: '{0}.{1}', found: '{2}.{3}'."
                         ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX30011:"),
                         Metadata = ReferenceMetadata.MetadataNoAddressInEndpointReference,
                         TestId = nameof(ReferenceMetadata.MetadataNoAddressInEndpointReference)
                     },
+                    // ---------------------------------------------------------------------------------------------------------------------
+                    // Active Directory Federation Services
+                    // ---------------------------------------------------------------------------------------------------------------------
                     new WsFederationMetadataTheoryData
                     {
+                        // Base case for Active Directory Federation Services V2.
+                        // All data present and valid.
                         Metadata = ReferenceMetadata.AdfsV2Metadata,
-                        SigingKey = ReferenceMetadata.AdfsV2MetadataSigningKey,
+                        SigningKey = ReferenceMetadata.AdfsV2MetadataSigningKey,
                         Configuration = ReferenceMetadata.AdfsV2Endpoint,
                         TestId = nameof(ReferenceMetadata.AdfsV2Metadata)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // Base case for Active Directory Federation Services V3.
+                        // All data present and valid.
                         Metadata = ReferenceMetadata.AdfsV3Metadata,
-                        SigingKey = ReferenceMetadata.AdfsV3MetadataSigningKey,
+                        SigningKey = ReferenceMetadata.AdfsV3MetadataSigningKey,
                         Configuration = ReferenceMetadata.AdfsV3Endpoint,
                         TestId = nameof(ReferenceMetadata.AdfsV3Metadata)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // Base case for Active Directory Federation Services V4.
+                        // All data present and valid.
                         Metadata = ReferenceMetadata.AdfsV4Metadata,
-                        SigingKey = ReferenceMetadata.AdfsV4MetadataSigningKey,
+                        SigningKey = ReferenceMetadata.AdfsV4MetadataSigningKey,
                         Configuration = ReferenceMetadata.AdfsV4Endpoint,
                         TestId = nameof(ReferenceMetadata.AdfsV4Metadata)
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // Base case for Active Directory Federation Services V2.
+                        // All data present and valid.
                         MetadataPath = Path.Combine(Directory.GetCurrentDirectory(), "../../../adfs-v2-metadata.xml"),
-                        SigingKey = ReferenceMetadata.AdfsV2MetadataSigningKey,
+                        SigningKey = ReferenceMetadata.AdfsV2MetadataSigningKey,
                         Configuration = ReferenceMetadata.AdfsV2Endpoint,
                         TestId = "AdfsV2Metadata from xml file"
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // Base case for Active Directory Federation Services V3.
+                        // All data present and valid.
                         MetadataPath = Path.Combine(Directory.GetCurrentDirectory(), "../../../adfs-v3-metadata.xml"),
-                        SigingKey = ReferenceMetadata.AdfsV3MetadataSigningKey,
+                        SigningKey = ReferenceMetadata.AdfsV3MetadataSigningKey,
                         Configuration = ReferenceMetadata.AdfsV3Endpoint,
                         TestId = "AdfsV3Metadata from xml file"
                     },
                     new WsFederationMetadataTheoryData
                     {
+                        // Base case for Active Directory Federation Services V4.
+                        // All data present and valid.
                         MetadataPath = Path.Combine(Directory.GetCurrentDirectory(), "../../../adfs-v4-metadata.xml"),
-                        SigingKey = ReferenceMetadata.AdfsV4MetadataSigningKey,
+                        SigningKey = ReferenceMetadata.AdfsV4MetadataSigningKey,
                         Configuration = ReferenceMetadata.AdfsV4Endpoint,
                         TestId = "AdfsV4Metadata from xml file"
                     }
@@ -492,6 +579,8 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
 
                         // remove the signature and do the comparison
                         configuration.Signature = null;
+                        theoryData.Configuration.Signature = null;
+
                         theoryData.ExpectedException.ProcessNoException(context);
                         IdentityComparer.AreWsFederationConfigurationsEqual(configuration, theoryData.Configuration, context);
                     }
@@ -540,6 +629,12 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
                         ExpectedException = new ExpectedException(typeof(XmlWriteException), "IDX22811:"),
                         Configuration = ReferenceMetadata.AADCommonFormatedNoTokenEndpoint,
                         TestId = nameof(ReferenceMetadata.AADCommonFormatedNoTokenEndpoint)
+                    },
+                    new WsFederationMetadataTheoryData
+                    {
+                        // The active token endpoint is optional at this point and should not throw an exception if missing.
+                        Configuration = ReferenceMetadata.AADCommonFormatedNoActiveTokenEndpoint,
+                        TestId = nameof(ReferenceMetadata.AADCommonFormatedNoActiveTokenEndpoint)
                     }
                 };
             }
@@ -555,7 +650,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
 
             public WsFederationMetadataSerializer Serializer { get; set; } = new WsFederationMetadataSerializer();
 
-            public SecurityKey SigingKey { get; set; }
+            public SecurityKey SigningKey { get; set; }
 
             public override string ToString()
             {

--- a/test/Microsoft.IdentityModel.TestUtils/ReferenceMetadata.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ReferenceMetadata.cs
@@ -56,6 +56,10 @@ namespace Microsoft.IdentityModel.TestUtils
         {
             get => new X509Certificate2(Convert.FromBase64String(X509CertificateData3));
         }
+        public static X509Certificate2 X509Certificate4
+        {
+            get => new X509Certificate2(Convert.FromBase64String(X509CertificateData4));
+        }
 
         public static X509Certificate2 X509CertificateAdfsV2
         {
@@ -141,7 +145,8 @@ namespace Microsoft.IdentityModel.TestUtils
                         SignatureValue = AADCommonMetadataSignatureValue,
                         SignedInfo = AADCommonSignedInfo
                     },
-                    TokenEndpoint = TokenEndpointForCommon
+                    TokenEndpoint = TokenEndpointForCommon,
+                    ActiveTokenEndpoint = ActiveTokenEndpointForCommon
                 };
 
                 configuration.KeyInfos.Add(keyInfo1);
@@ -181,7 +186,8 @@ namespace Microsoft.IdentityModel.TestUtils
                         KeyInfo = keyInfo1,
                         SignatureValue = AADCommonMetadataSignatureValue,
                     },
-                    TokenEndpoint = "https://login.microsoftonline.com/268da1a1-9db4-48b9-b1fe-683250ba90cc/wsfed"
+                    TokenEndpoint = "https://login.microsoftonline.com/268da1a1-9db4-48b9-b1fe-683250ba90cc/wsfed",
+                    ActiveTokenEndpoint = "https://login.microsoftonline.com/268da1a1-9db4-48b9-b1fe-683250ba90cc/wsfed"
                 };
 
                 configuration.KeyInfos.Add(keyInfo1);
@@ -227,6 +233,16 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
+        public static WsFederationConfiguration AADCommonFormatedNoActiveTokenEndpoint
+        {
+            get
+            {
+                var configuration = AADCommonFormated;
+                configuration.ActiveTokenEndpoint = null;
+                return configuration;
+            }
+        }
+
         public static WsFederationConfiguration AdfsV2Endpoint
         {
             get
@@ -243,7 +259,8 @@ namespace Microsoft.IdentityModel.TestUtils
                         KeyInfo = keyInfo,
                         SignatureValue = AdfsV2SignatureValue,
                     },
-                    TokenEndpoint = "https://fs.msidlab7.com/adfs/ls/"
+                    TokenEndpoint = "https://fs.msidlab7.com/adfs/ls/",
+                    ActiveTokenEndpoint = "https://fs.msidlab7.com/adfs/services/trust/2005/certificatemixed"
                 };
 
                 configuration.KeyInfos.Add(keyInfo);
@@ -271,7 +288,8 @@ namespace Microsoft.IdentityModel.TestUtils
                         Prefix = "ds",
                         SignatureValue = AdfsV3SignatureValue,
                     },
-                    TokenEndpoint = "https://fs.msidlab2.com/adfs/ls/"
+                    TokenEndpoint = "https://fs.msidlab2.com/adfs/ls/",
+                    ActiveTokenEndpoint = "https://fs.msidlab2.com/adfs/services/trust/2005/certificatemixed"
                 };
 
                 configuration.KeyInfos.Add(keyInfo);
@@ -299,7 +317,8 @@ namespace Microsoft.IdentityModel.TestUtils
                         Prefix = "ds",
                         SignatureValue = AdfsV4SignatureValue,
                     },
-                    TokenEndpoint = "https://fs.msidlab11.com/adfs/ls/"
+                    TokenEndpoint = "https://fs.msidlab11.com/adfs/ls/",
+                    ActiveTokenEndpoint = "https://fs.msidlab11.com/adfs/services/trust/2005/certificatemixed"
                 };
 
                 configuration.KeyInfos.Add(keyInfo);
@@ -424,6 +443,8 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static string X509CertificateData3 { get => "MIIDKDCCAhCgAwIBAgIQBHJvVNxP1oZO4HYKh+rypDANBgkqhkiG9w0BAQsFADAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwHhcNMTYxMTE2MDgwMDAwWhcNMTgxMTE2MDgwMDAwWjAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQChn5BCs24Hh6L0BNitPrV5s+2/DBhaeytOmnghJKnqeJlhv3ZczShRM2Cp38LW8Y3wn7L3AJtolaSkF/joKN1l6GupzM+HOEdq7xZxFehxIHW7+25mG/WigBnhsBzLv1SR4uIbrQeS5M0kkLwJ9pOnVH3uzMGG6TRXPnK3ivlKl97AiUEKdlRjCQNLXvYf1ZqlC77c/ZCOHSX4kvIKR2uG+LNlSTRq2rn8AgMpFT4DSlEZz4RmFQvQupQzPpzozaz/gadBpJy/jgDmJlQMPXkHp7wClvbIBGiGRaY6eZFxNV96zwSR/GPNkTObdw2S8/SiAgvIhIcqWTPLY6aVTqJfAgMBAAGjWDBWMFQGA1UdAQRNMEuAEDUj0BrjP0RTbmoRPTRMY3WhJTAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXOCEARyb1TcT9aGTuB2Cofq8qQwDQYJKoZIhvcNAQELBQADggEBAGnLhDHVz2gLDiu9L34V3ro/6xZDiSWhGyHcGqky7UlzQH3pT5so8iF5P0WzYqVtogPsyC2LPJYSTt2vmQugD4xlu/wbvMFLcV0hmNoTKCF1QTVtEQiAiy0Aq+eoF7Al5fV1S3Sune0uQHimuUFHCmUuF190MLcHcdWnPAmzIc8fv7quRUUsExXmxSX2ktUYQXzqFyIOSnDCuWFm6tpfK5JXS8fW5bpqTlrysXXz/OW/8NFGq/alfjrya4ojrOYLpunGriEtNPwK7hxj1AlCYEWaRHRXaUIW1ByoSff/6Y6+ZhXPUe0cDlNRt/qIz5aflwO7+W8baTS4O8m/icu7ItE="; }
 
+        public static string X509CertificateData4 { get => "MIIHXTCCBUWgAwIBAgITMwBfyXeHIx8iTPP04wAAAF/JdzANBgkqhkiG9w0BAQwFADBZMQswCQYDVQQGEwJVUzEeMBwGA1UEChMVTWljcm9zb2Z0IENvcnBvcmF0aW9uMSowKAYDVQQDEyFNaWNyb3NvZnQgQXp1cmUgVExTIElzc3VpbmcgQ0EgMDEwHhcNMjIwOTE0MjM1NjAzWhcNMjMwOTA5MjM1NjAzWjBxMQswCQYDVQQGEwJVUzELMAkGA1UECBMCV0ExEDAOBgNVBAcTB1JlZG1vbmQxHjAcBgNVBAoTFU1pY3Jvc29mdCBDb3Jwb3JhdGlvbjEjMCEGA1UEAwwaKi5kc3RzLmNvcmUuYXp1cmUtdGVzdC5uZXQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDiwD1xUOpyC71qUdtvVktWMtaaZi6rz88sMdR1+P6d0Jxaze+9IOVHLz5/I9Ge6oxBzndpz9VaM1P/M75B9Wp4v1KMnr+EmCVnkZOQseC50ZUvcYATAATnZ01AIdc3mQ0j9nL1WKl+mMFhmjsCjh2RhzJHvS3cMjl5lwrIyNwjIutLtEFYxbxVhcgjc++QmsZvMwE9qDInzD6Yl5cVHCl0Xm9/vkbjoSbjMXcp6OaWdRZfjqtC9oHF82ZqbQkVH7Hw+EER4rP+aEUam3OhtDGZ5Fs/UymnvoE9i+5wxTKjuKHJJKiggOl+ai8bQ7FkNO+LJgXO4V293SPCx8wv+/4JAgMBAAGjggMEMIIDADAOBgNVHQ8BAf8EBAMCBLAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMB0GA1UdDgQWBBR/FXyrNwBgMGDo3Pu93V9VyjmqdzCBmgYDVR0RBIGSMIGPghoqLmRzdHMuY29yZS5henVyZS10ZXN0Lm5ldIIbKi5kc3RzLmNvcmUud2luZG93cy1pbnQubmV0ghsqLmRzdHMuY29yZS53aW5kb3dzLXRzdC5uZXSCHSouZHN0cy5lMmV0ZXN0Mi5henVyZS1pbnQubmV0ghgqLmRzdHMuaW50LmF6dXJlLWludC5uZXQwHwYDVR0jBBgwFoAUDyBd16FXlduSzyvQx8J3BM5ygHYwZAYDVR0fBF0wWzBZoFegVYZTaHR0cDovL3d3dy5taWNyb3NvZnQuY29tL3BraW9wcy9jcmwvTWljcm9zb2Z0JTIwQXp1cmUlMjBUTFMlMjBJc3N1aW5nJTIwQ0ElMjAwMS5jcmwwga4GCCsGAQUFBwEBBIGhMIGeMG0GCCsGAQUFBzAChmFodHRwOi8vd3d3Lm1pY3Jvc29mdC5jb20vcGtpb3BzL2NlcnRzL01pY3Jvc29mdCUyMEF6dXJlJTIwVExTJTIwSXNzdWluZyUyMENBJTIwMDElMjAtJTIweHNpZ24uY3J0MC0GCCsGAQUFBzABhiFodHRwOi8vb25lb2NzcC5taWNyb3NvZnQuY29tL29jc3AwDAYDVR0TAQH/BAIwADA8BgkrBgEEAYI3FQcELzAtBiUrBgEEAYI3FQiHvdcbgefrRoKBnS6O0AyH8NodXYKE5WmC86c+AgFkAgElMCcGCSsGAQQBgjcVCgQaMBgwCgYIKwYBBQUHAwIwCgYIKwYBBQUHAwEwZgYDVR0gBF8wXTBRBgwrBgEEAYI3TIN9AQEwQTA/BggrBgEFBQcCARYzaHR0cDovL3d3dy5taWNyb3NvZnQuY29tL3BraW9wcy9Eb2NzL1JlcG9zaXRvcnkuaHRtMAgGBmeBDAECAjANBgkqhkiG9w0BAQwFAAOCAgEADdXQBQATdRGyTPLNbslNAWHETaCZhmXkEwHEtG/Srt4TXqP92wojLaPwPlKuyqHtibKqGOE22Hww2JBfwIe+aJtplT5QLH/r05yDYXj6kioZ1BUgXmhZWSTzyaqT1u8nUcZkAGDii8HeSSlvKVUIqbQpUT+mUg6ijmdsp07ZsEDiH7tAc0U+M1oIydjIIwIiTOSuVsoM4Fi+yQ6E7xPSMXdtFlUwUINgnrcFGgQ6L7uY2DsgVCKgw3pzTWa3ulg4sypCelJ1i9ngxn0aIDPBkxWXcauIV/QYHeIp65Zv8JqN1mNACZj2/2a5JkK6AO6zD8fPvTwN+pMUEw3/ha+pQzLWFsx00Y+hC5wMWKpU4AjYVmmTJ6zyovb1eaZG30KdQP3ucdVIJQnzJZ1E8opYgIkvvndb7VbRFDyonsNcOZ9s4VYK/HZvDM4BtULoU1q5/BVPXodJ9dn/A8GHBXS2S6uolxolFtrQz0WTtADWWGr28wlNj5vWBhoNYvWVXc8SWcB2W4caFRSavoZ+2fHwySGRJGJrLhXb3kyMhdS/VVrIsOnuUXUhQA6q6Q/laie6kmMEKDfW8S9XcgUDWe0ay79qww12VZzBZmGoFPGOwpXkeov2NL5FZ48daoK9j826iJn/9kFfvgDBSGBrS8GWof6f90n9Ngt327l1M+RbLOc="; }
+
         public static string X509CertificateDataAdfsV2 { get => @"MIIC2jCCAcKgAwIBAgIQFuP8MbE4ipBGdYQ2Wmg6FDANBgkqhkiG9w0BAQsFADApMScwJQYDVQQDEx5BREZTIFNpZ25pbmcgLSBmcy5tc2lkbGFiNy5jb20wHhcNMTYxMjAzMDIzNjEwWhcNMTcxMjAzMDIzNjEwWjApMScwJQYDVQQDEx5BREZTIFNpZ25pbmcgLSBmcy5tc2lkbGFiNy5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCQXc06bWagsWphlP+yFdK/6YPZNvYC5BSzV2bmbYp76YCzpDAaYTBL6toAgjMBoTWHeeO/K8GpKxjK5RzBCWJL0j6Ao+GLGiX430VEvWCxCVbi4H3GY7T2MUangLIBEbutFbgcKxSdLIG9KEUKZXZSnKxx4W6b/m56dswPwpPJ536KWgjovNKy+/XfAONFkg4Rj6HvFN7ylNSBwWfcFdw+C8aZn4swW8msLMm4ridHxR0jnHgqrJ8RQjBQfcWaCuS18EaJxVrCN13OnDNa1SnQqKdePcczeeL6NRK4luxCTNJ6pJ8GLSxNA5rxbv3uMZ0VcaANLFp0KZDJ7xr3oTEdAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAE3plOFUXZ/O/9pEF4ZiBvjttxXz/ntaKlC9WDZQaysjwAvwwQf6lCWBYrOn9muQrDeAriYOZHxRXxzwdqUgHRUQ6NZxNQUgc+ElH1v+E25ns8vP8yS8U9FhQUU8IfkLYcOt3bY0PcGCJhKsHSJoHrsKqQqWWQN4f48ocrLOdAhS0VLTxpa84i8mGNO9Iaavdd6g0vfC0dgBaBRyWDO0MAywiqx1LsxOXBidxn/Z4bm/2+lcAnRXALowifDPkDvIkx+zjU2YvcYWDiNl3sei3NfS68sYycGMaCmwXUyjQy13FMrOuEo2KqMmWHPMyZbbEyVBsytq5+W1Rx+2ElWAzJg="; }
 
         public static string X509CertificateDataAdfsV3 { get => @"MIIC2jCCAcKgAwIBAgIQE4Ec5zS+mZ1CjdwUbnFNejANBgkqhkiG9w0BAQsFADApMScwJQYDVQQDEx5BREZTIFNpZ25pbmcgLSBmcy5tc2lkbGFiMi5jb20wHhcNMTcwMzEzMTgxMTM0WhcNMTgwMzEzMTgxMTM0WjApMScwJQYDVQQDEx5BREZTIFNpZ25pbmcgLSBmcy5tc2lkbGFiMi5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCYh9E/B76B0jUBedTJCBXYkXd3NVav5GFOI43Cu3mcnQvT82112PY7TSW/GTOJL1oVhAyLR6nNjPKD0f7J+3gkrXYpvDK8g69GWI5Gy3ObA95VhzpWKwqnRJrblJfYvQtiA+dQTGH+x5tSbHieGni71lqanCwGMP4PnLKTAGtRXEm1Yz/l0k57PTiKBybIlhW5YUm/Nl8d1qlp+eQdM/bhkj9imnANghSAcXU//6zeioG63ad0COltc5Eh4bMUNBGdx15gMyu40T2TDojeYIS+3rkYoRmQHJ9LoHt43DgqPBp8K+bdT/5gVUnRcRv0hpTi5JhPyqWm3h4CAJb2NNr7AgMBAAEwDQYJKoZIhvcNAQELBQADggEBAAcvWybsF8Tt/FRahhgWlONayLorboAD3qxUOfzaBQS32Q6AUPWatQCJX6pRC9tLtQr2PdJ4hDWfcGmMuFUzArFqBfAFFvb5CTlplNKQw53iZhEdvKEhY77d+j4BPpHmIvHDq9dshl0oPWV5ywiWJfBmf/6I7DRffXtBkj3IpuVQWrtOycZHsW1ymsURCQEr/YlqPlOCtoMCfl6wvOR/zLF2/sheVBgrwJTVCljBP4DENwK6he3dioyNM9k9ITa0Z2SpXu2+pHJopRc94H+KJG/LTX0y+Fq6bh54/U5ULE/OzDzKRLqJETqOvWNWaMw/tGUTo6gGr4KAbhel/PTIztQ="; }
@@ -437,6 +458,8 @@ namespace Microsoft.IdentityModel.TestUtils
         public static string TokenEndpoint { get => @"https://login.microsoftonline.com/268da1a1-9db4-48b9-b1fe-683250ba90cc/wsfed"; }
 
         public static string TokenEndpointForCommon { get => @"https://login.microsoftonline.com/common/wsfed"; }
+
+        public static string ActiveTokenEndpointForCommon { get => @"https://login.microsoftonline.com/common/wsfed"; }
 
         public static string KeyDescriptorNoKeyUse
         {
@@ -731,7 +754,20 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
-        public static string MetadataEmptyEndpointReference
+        public static string MetadataEmptySecurityTokenServiceEndpoint
+        {
+            get
+            {
+                return
+                @"<EntityDescriptor xmlns=""urn:oasis:names:tc:SAML:2.0:metadata"" ID=""_6c4f3672-45c2-47a6-9515-afda95224009"" entityID=""https://sts.windows.net/268da1a1-9db4-48b9-b1fe-683250ba90cc/"">
+                  <RoleDescriptor xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:fed=""http://docs.oasis-open.org/wsfed/federation/200706"" xsi:type=""fed:SecurityTokenServiceType"" protocolSupportEnumeration=""http://docs.oasis-open.org/wsfed/federation/200706"">
+                    <fed:SecurityTokenServiceEndpoint />
+                  </RoleDescriptor>
+                </EntityDescriptor>";
+            }
+        }
+
+        public static string MetadataEmptyPassiveRequestorEndpointReference
         {
             get
             {
@@ -746,7 +782,22 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
-        public static string MetadataEmptyEndpointAddress
+        public static string MetadataEmptySecurityTokenServiceEndpointReference
+        {
+            get
+            {
+                return
+                @"<EntityDescriptor xmlns=""urn:oasis:names:tc:SAML:2.0:metadata"" ID=""_6c4f3672-45c2-47a6-9515-afda95224009"" entityID=""https://sts.windows.net/268da1a1-9db4-48b9-b1fe-683250ba90cc/"">
+                  <RoleDescriptor xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:fed=""http://docs.oasis-open.org/wsfed/federation/200706"" xsi:type=""fed:SecurityTokenServiceType"" protocolSupportEnumeration=""http://docs.oasis-open.org/wsfed/federation/200706"">
+                    <fed:PassiveRequestorEndpoint>
+                      <wsa:EndpointReference xmlns:wsa=""http://www.w3.org/2005/08/addressing"" />
+                    </fed:PassiveRequestorEndpoint>
+                  </_RoleDescriptor>
+                </EntityDescriptor>";
+            }
+        }
+
+        public static string MetadataEmptyPassiveRequestorEndpointAddress
         {
             get
             {
@@ -758,6 +809,23 @@ namespace Microsoft.IdentityModel.TestUtils
                         <wsa:Address />
                       </wsa:EndpointReference>
                     </fed:PassiveRequestorEndpoint>
+                  </RoleDescriptor>
+                </EntityDescriptor>";
+            }
+        }
+
+        public static string MetadataEmptySecurityTokenServiceEndpointAddress
+        {
+            get
+            {
+                return
+                @"<EntityDescriptor xmlns=""urn:oasis:names:tc:SAML:2.0:metadata"" ID=""_6c4f3672-45c2-47a6-9515-afda95224009"" entityID=""https://sts.windows.net/268da1a1-9db4-48b9-b1fe-683250ba90cc/"">
+                  <RoleDescriptor xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:fed=""http://docs.oasis-open.org/wsfed/federation/200706"" xsi:type=""fed:SecurityTokenServiceType"" protocolSupportEnumeration=""http://docs.oasis-open.org/wsfed/federation/200706"">
+                    <fed:SecurityTokenServiceEndpoint>
+                      <wsa:EndpointReference xmlns:wsa=""http://www.w3.org/2005/08/addressing"">
+                        <wsa:Address />
+                      </wsa:EndpointReference>
+                    </fed:SecurityTokenServiceEndpoint>
                   </RoleDescriptor>
                 </EntityDescriptor>";
             }
@@ -1043,7 +1111,7 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
-        public static string MetadataNoTokenUri
+        public static string MetadataNoPassiveRequestorEndpointUri
         {
             get
             {
@@ -1086,6 +1154,49 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
+        public static string MetadataNoSecurityTokenServiceEndpointUri
+        {
+            get
+            {
+                return
+                @"<EntityDescriptor xmlns=""urn:oasis:names:tc:SAML:2.0:metadata"" ID=""_6c4f3672-45c2-47a6-9515-afda95224009"" entityID=""https://sts.windows.net/268da1a1-9db4-48b9-b1fe-683250ba90cc/"">
+                  <Signature xmlns=""http://www.w3.org/2000/09/xmldsig#"">
+                    <SignedInfo>
+                      <CanonicalizationMethod Algorithm=""http://www.w3.org/2001/10/xml-exc-c14n#""/>
+                      <SignatureMethod Algorithm=""http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"" />
+                      <Reference URI=""#_6c4f3672-45c2-47a6-9515-afda95224009"">
+                        <Transforms>
+                          <Transform Algorithm=""http://www.w3.org/2000/09/xmldsig#enveloped-signature"" />
+                          <Transform Algorithm=""http://www.w3.org/2001/10/xml-exc-c14n#""/>
+                        </Transforms>
+                        <DigestMethod Algorithm=""http://www.w3.org/2001/04/xmlenc#sha256"" />
+                        <DigestValue> i6nrvd1p0+HbCCrFBN5z3jrCe/56R3DlWYQanX6cygM=</DigestValue>
+                      </Reference>
+                    </SignedInfo>
+                    <SignatureValue>
+                      gdmviHtNhy8FQ6gSbyovhzMBxioMs6hoHYYzoyjS4DxHqhLgaPrRe948NKfXRYe4o1syVp+cZaGTcRzlPmCFOxH1zjY9qPUT2tCsJ1aCUCoiepu0uYGkWKV9CifHt7+aixQEufxM06iwZcMdfXPF3lqqdOoC7pRTcPlBJo6m6odXmjIcHPpsBGtkJuS7W6JULFhzBC9ytS0asrVaEZhVijP95QM0SZRL/pnJp1gOtKYKsQV246lV8tHFfFIddtklVYTvhlagjVUHsUtUhfwrt/5i/Rnr40qMNx/H10ZClTAQXthQH3GnzObAmhfoMNS1hAMpnX4BEhBOAqHHv2jyPA==
+                    </SignatureValue>
+                    <KeyInfo>
+                      <X509Data>
+                        <X509Certificate>
+                          MIIDBTCCAe2gAwIBAgIQY4RNIR0dX6dBZggnkhCRoDANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE3MDIxMzAwMDAwMFoXDTE5MDIxNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMBEizU1OJms31S/ry7iav/IICYVtQ2MRPhHhYknHImtU03sgVk1Xxub4GD7R15i9UWIGbzYSGKaUtGU9lP55wrfLpDjQjEgaXi4fE6mcZBwa9qc22is23B6R67KMcVyxyDWei+IP3sKmCcMX7Ibsg+ubZUpvKGxXZ27YgqFTPqCT2znD7K81YKfy+SVg3uW6epW114yZzClTQlarptYuE2mujxjZtx7ZUlwc9AhVi8CeiLwGO1wzTmpd/uctpner6oc335rvdJikNmc1cFKCK+2irew1bgUJHuN+LJA0y5iVXKvojiKZ2Ii7QKXn19Ssg1FoJ3x2NWA06wc0CnruLsCAwEAAaMhMB8wHQYDVR0OBBYEFDAr/HCMaGqmcDJa5oualVdWAEBEMA0GCSqGSIb3DQEBCwUAA4IBAQAiUke5mA86R/X4visjceUlv5jVzCn/SIq6Gm9/wCqtSxYvifRXxwNpQTOyvHhrY/IJLRUp2g9/fDELYd65t9Dp+N8SznhfB6/Cl7P7FRo99rIlj/q7JXa8UB/vLJPDlr+NREvAkMwUs1sDhL3kSuNBoxrbLC5Jo4es+juQLXd9HcRraE4U3UZVhUS2xqjFOfaGsCbJEqqkjihssruofaxdKT1CPzPMANfREFJznNzkpJt4H0aMDgVzq69NxZ7t1JiIuc43xRjeiixQMRGMi1mAB75fTyfFJ/rWQ5J/9kh0HMZVtHsqICBF1tHMTMIK5rwoweY0cuCIpN7A/zMOQtoD
+                        </X509Certificate>
+                      </X509Data>
+                    </KeyInfo>
+                  </Signature>
+                  <RoleDescriptor xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:fed=""http://docs.oasis-open.org/wsfed/federation/200706"" xsi:type=""fed:SecurityTokenServiceType"" protocolSupportEnumeration=""http://docs.oasis-open.org/wsfed/federation/200706"">
+                    <fed:SecurityTokenServiceEndpoint>
+                      <wsa:EndpointReference xmlns:wsa=""http://www.w3.org/2005/08/addressing"">
+                        <wsa:Address>
+                          
+                        </wsa:Address>
+                      </wsa:EndpointReference>
+                    </fed:SecurityTokenServiceEndpoint>
+                  </RoleDescriptor>
+                </EntityDescriptor>";
+            }
+        }
+
         public static string MetadataWithBlanks
         {
             get
@@ -1093,8 +1204,8 @@ namespace Microsoft.IdentityModel.TestUtils
                 return
                 @"<EntityDescriptor xmlns=""urn:oasis:names:tc:SAML:2.0:metadata"" ID=""_6c4f3672-45c2-47a6-9515-afda95224009"" entityID=""https://sts.windows.net/268da1a1-9db4-48b9-b1fe-683250ba90cc/"">
 
-                  <Signature xmlns=""http://www.w3.org/2000/09/xmldsig#"">
-                    <SignedInfo>
+                  <Signature                             xmlns=""http://www.w3.org/2000/09/xmldsig#"">
+                    <SignedInfo>                            
                       <CanonicalizationMethod Algorithm=""http://www.w3.org/2001/10/xml-exc-c14n#""/>
                       <SignatureMethod Algorithm=""http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"" />
                       <Reference URI=""#_0ded55d8-a72f-4e13-ab9e-f40be80b1476"">
@@ -1108,17 +1219,17 @@ namespace Microsoft.IdentityModel.TestUtils
                     </SignedInfo>
                     <SignatureValue>
                       KD9uWOD/9pvF1NlNCpYoXymUPS1l9uIBgBDe0uOQgQv+tUI/1jJX4UpjADDHCOx6HCl5ZgZSXNmOC2lLSJEwmv21BZzI+PAOxF5hdH99cS/lMC/hxgyWdLVeGnr1I4WbPxGqVmjFNuBdBMaourO4z/5f3D2JZQmgnlu8H+4gv2SpjeZz/YhIN6ZrNfmHwsKZashMGtSmE5uHro+uO5yO17Gr9YfUbtokLRIq5Dk9kqnxG8YZF1C1nC9O0PMdlHb4ubwgO20Cvz5sU2iswn9m68btS5TLF5OVhETzyKir1QA+H1tCgGRqIWd4Geyoucdct1r4zAJGCNIekdKnY3NXwg==
-                    </SignatureValue>
+                    </SignatureValue>                            
                     <KeyInfo>
                       <X509Data>
-                        <X509Certificate>MIIDBTCCAe2gAwIBAgIQY4RNIR0dX6dBZggnkhCRoDANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE3MDIxMzAwMDAwMFoXDTE5MDIxNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMBEizU1OJms31S/ry7iav/IICYVtQ2MRPhHhYknHImtU03sgVk1Xxub4GD7R15i9UWIGbzYSGKaUtGU9lP55wrfLpDjQjEgaXi4fE6mcZBwa9qc22is23B6R67KMcVyxyDWei+IP3sKmCcMX7Ibsg+ubZUpvKGxXZ27YgqFTPqCT2znD7K81YKfy+SVg3uW6epW114yZzClTQlarptYuE2mujxjZtx7ZUlwc9AhVi8CeiLwGO1wzTmpd/uctpner6oc335rvdJikNmc1cFKCK+2irew1bgUJHuN+LJA0y5iVXKvojiKZ2Ii7QKXn19Ssg1FoJ3x2NWA06wc0CnruLsCAwEAAaMhMB8wHQYDVR0OBBYEFDAr/HCMaGqmcDJa5oualVdWAEBEMA0GCSqGSIb3DQEBCwUAA4IBAQAiUke5mA86R/X4visjceUlv5jVzCn/SIq6Gm9/wCqtSxYvifRXxwNpQTOyvHhrY/IJLRUp2g9/fDELYd65t9Dp+N8SznhfB6/Cl7P7FRo99rIlj/q7JXa8UB/vLJPDlr+NREvAkMwUs1sDhL3kSuNBoxrbLC5Jo4es+juQLXd9HcRraE4U3UZVhUS2xqjFOfaGsCbJEqqkjihssruofaxdKT1CPzPMANfREFJznNzkpJt4H0aMDgVzq69NxZ7t1JiIuc43xRjeiixQMRGMi1mAB75fTyfFJ/rWQ5J/9kh0HMZVtHsqICBF1tHMTMIK5rwoweY0cuCIpN7A/zMOQtoD</X509Certificate>
+                        <X509Certificate                            >MIIDBTCCAe2gAwIBAgIQY4RNIR0dX6dBZggnkhCRoDANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE3MDIxMzAwMDAwMFoXDTE5MDIxNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMBEizU1OJms31S/ry7iav/IICYVtQ2MRPhHhYknHImtU03sgVk1Xxub4GD7R15i9UWIGbzYSGKaUtGU9lP55wrfLpDjQjEgaXi4fE6mcZBwa9qc22is23B6R67KMcVyxyDWei+IP3sKmCcMX7Ibsg+ubZUpvKGxXZ27YgqFTPqCT2znD7K81YKfy+SVg3uW6epW114yZzClTQlarptYuE2mujxjZtx7ZUlwc9AhVi8CeiLwGO1wzTmpd/uctpner6oc335rvdJikNmc1cFKCK+2irew1bgUJHuN+LJA0y5iVXKvojiKZ2Ii7QKXn19Ssg1FoJ3x2NWA06wc0CnruLsCAwEAAaMhMB8wHQYDVR0OBBYEFDAr/HCMaGqmcDJa5oualVdWAEBEMA0GCSqGSIb3DQEBCwUAA4IBAQAiUke5mA86R/X4visjceUlv5jVzCn/SIq6Gm9/wCqtSxYvifRXxwNpQTOyvHhrY/IJLRUp2g9/fDELYd65t9Dp+N8SznhfB6/Cl7P7FRo99rIlj/q7JXa8UB/vLJPDlr+NREvAkMwUs1sDhL3kSuNBoxrbLC5Jo4es+juQLXd9HcRraE4U3UZVhUS2xqjFOfaGsCbJEqqkjihssruofaxdKT1CPzPMANfREFJznNzkpJt4H0aMDgVzq69NxZ7t1JiIuc43xRjeiixQMRGMi1mAB75fTyfFJ/rWQ5J/9kh0HMZVtHsqICBF1tHMTMIK5rwoweY0cuCIpN7A/zMOQtoD</X509Certificate>
                       </X509Data>
                     </KeyInfo>
                   </Signature>
 
                   <RoleDescriptor xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:fed=""http://docs.oasis-open.org/wsfed/federation/200706"" xsi:type=""fed:SecurityTokenServiceType"" protocolSupportEnumeration=""http://docs.oasis-open.org/wsfed/federation/200706"">
                     
-                    <KeyDescriptor use=""signing"">
+                    <KeyDescriptor                             use=""signing"">
 
                       <KeyInfo xmlns=""http://www.w3.org/2000/09/xmldsig#"">
                         <X509Data>
@@ -1128,34 +1239,39 @@ namespace Microsoft.IdentityModel.TestUtils
 
                     </KeyDescriptor>
 
-                    <KeyDescriptor use=""signing"">
+                    <KeyDescriptor use=""signing""                            >
 
                       <KeyInfo xmlns=""http://www.w3.org/2000/09/xmldsig#"">
                         <X509Data>
                           <X509Certificate>MIIDBTCCAe2gAwIBAgIQXxLnqm1cOoVGe62j7W7wZzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE3MDMyNjAwMDAwMFoXDTE5MDMyNzAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKJGarCm4IF0/Gz5Xx/zyZwD2rdJJZtO2Ukk1Oz+Br1sLVY8I5vj5esB+lotmLEblA9N/w188vmTvykaEzUl49NA4s86x44SW6WtdQbGJ0IjpQJUalUMyy91vIBkK/7K3nBXeVBsRk7tm528leoQ05/aZ+1ycJBIU+1oGYThv8MOjyHAlXJmCaGXwXTisZ+hHjcwlMk/+ZEutHflKLIpPUNEi7j4Xw+zp9UKo5pzWIr/iJ4HjvCkFofW90AMF2xp8dMhpbVcfJGS/Ii3J66LuNLCH/HtSZ42FO+tnRL/nNzzFWUhGT92Q5VFVngfWJ3PAg1zz8I1wowLD2fiB2udGXcCAwEAAaMhMB8wHQYDVR0OBBYEFFXPbFXjmMR3BluF+2MeSXd1NQ3rMA0GCSqGSIb3DQEBCwUAA4IBAQAsd3wGVilJxDtbY1K2oAsWLdNJgmCaYdrtdlAsjGlarSQSzBH0Ybf78fcPX//DYaLXlvaEGKVKp0jPq+RnJ17oP/RJpJTwVXPGRIlZopLIgnKpWlS/PS0uKAdNvLmz1zbGSILdcF+Qf41OozD4QNsS1c9YbDO4vpC9v8x3PVjfJvJwPonzNoOsLXA+8IONSXwCApsnmrwepKu8sifsFYSwgrwxRPGTEAjkdzRJ0yMqiY/VoJ7lqJ/FBJqqAjGPGq/yI9rVoG+mbO1amrIDWHHTKgfbKk0bXGtVUbsayyHR5jSgadmkLBh5AaN/HcgDK/jINrnpiQ+/2ewH/8qLaQ3B</X509Certificate>
-                        </X509Data>
-                      </KeyInfo>
+                        </X509Data>                            
+                      </KeyInfo>     
 
-                    </KeyDescriptor>
+                    </KeyDescriptor>                            
 
-                    <KeyDescriptor use=""signing"">
+                    <KeyDescriptor use=""signing""                            >
 
                       <KeyInfo xmlns=""http://www.w3.org/2000/09/xmldsig#"">
-                        <X509Data>
-                          <X509Certificate>MIIDKDCCAhCgAwIBAgIQBHJvVNxP1oZO4HYKh+rypDANBgkqhkiG9w0BAQsFADAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwHhcNMTYxMTE2MDgwMDAwWhcNMTgxMTE2MDgwMDAwWjAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQChn5BCs24Hh6L0BNitPrV5s+2/DBhaeytOmnghJKnqeJlhv3ZczShRM2Cp38LW8Y3wn7L3AJtolaSkF/joKN1l6GupzM+HOEdq7xZxFehxIHW7+25mG/WigBnhsBzLv1SR4uIbrQeS5M0kkLwJ9pOnVH3uzMGG6TRXPnK3ivlKl97AiUEKdlRjCQNLXvYf1ZqlC77c/ZCOHSX4kvIKR2uG+LNlSTRq2rn8AgMpFT4DSlEZz4RmFQvQupQzPpzozaz/gadBpJy/jgDmJlQMPXkHp7wClvbIBGiGRaY6eZFxNV96zwSR/GPNkTObdw2S8/SiAgvIhIcqWTPLY6aVTqJfAgMBAAGjWDBWMFQGA1UdAQRNMEuAEDUj0BrjP0RTbmoRPTRMY3WhJTAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXOCEARyb1TcT9aGTuB2Cofq8qQwDQYJKoZIhvcNAQELBQADggEBAGnLhDHVz2gLDiu9L34V3ro/6xZDiSWhGyHcGqky7UlzQH3pT5so8iF5P0WzYqVtogPsyC2LPJYSTt2vmQugD4xlu/wbvMFLcV0hmNoTKCF1QTVtEQiAiy0Aq+eoF7Al5fV1S3Sune0uQHimuUFHCmUuF190MLcHcdWnPAmzIc8fv7quRUUsExXmxSX2ktUYQXzqFyIOSnDCuWFm6tpfK5JXS8fW5bpqTlrysXXz/OW/8NFGq/alfjrya4ojrOYLpunGriEtNPwK7hxj1AlCYEWaRHRXaUIW1ByoSff/6Y6+ZhXPUe0cDlNRt/qIz5aflwO7+W8baTS4O8m/icu7ItE=</X509Certificate>
-                        </X509Data>
-                      </KeyInfo>
+                        <X509Data>       
+                          <X509Certificate                            >MIIDKDCCAhCgAwIBAgIQBHJvVNxP1oZO4HYKh+rypDANBgkqhkiG9w0BAQsFADAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwHhcNMTYxMTE2MDgwMDAwWhcNMTgxMTE2MDgwMDAwWjAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQChn5BCs24Hh6L0BNitPrV5s+2/DBhaeytOmnghJKnqeJlhv3ZczShRM2Cp38LW8Y3wn7L3AJtolaSkF/joKN1l6GupzM+HOEdq7xZxFehxIHW7+25mG/WigBnhsBzLv1SR4uIbrQeS5M0kkLwJ9pOnVH3uzMGG6TRXPnK3ivlKl97AiUEKdlRjCQNLXvYf1ZqlC77c/ZCOHSX4kvIKR2uG+LNlSTRq2rn8AgMpFT4DSlEZz4RmFQvQupQzPpzozaz/gadBpJy/jgDmJlQMPXkHp7wClvbIBGiGRaY6eZFxNV96zwSR/GPNkTObdw2S8/SiAgvIhIcqWTPLY6aVTqJfAgMBAAGjWDBWMFQGA1UdAQRNMEuAEDUj0BrjP0RTbmoRPTRMY3WhJTAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXOCEARyb1TcT9aGTuB2Cofq8qQwDQYJKoZIhvcNAQELBQADggEBAGnLhDHVz2gLDiu9L34V3ro/6xZDiSWhGyHcGqky7UlzQH3pT5so8iF5P0WzYqVtogPsyC2LPJYSTt2vmQugD4xlu/wbvMFLcV0hmNoTKCF1QTVtEQiAiy0Aq+eoF7Al5fV1S3Sune0uQHimuUFHCmUuF190MLcHcdWnPAmzIc8fv7quRUUsExXmxSX2ktUYQXzqFyIOSnDCuWFm6tpfK5JXS8fW5bpqTlrysXXz/OW/8NFGq/alfjrya4ojrOYLpunGriEtNPwK7hxj1AlCYEWaRHRXaUIW1ByoSff/6Y6+ZhXPUe0cDlNRt/qIz5aflwO7+W8baTS4O8m/icu7ItE=</X509Certificate>
+                        </X509Data>                            
+                      </KeyInfo>     
 
                     </KeyDescriptor>
+                     <fed:SecurityTokenServiceEndpoint>         
+                                <wsa:EndpointReference xmlns:wsa=""http://www.w3.org/2005/08/addressing"">                                        <wsa:Address>https://login.microsoftonline.com/268da1a1-9db4-48b9-b1fe-683250ba90cc/wsfed
+</wsa:Address>
+    </wsa:EndpointReference>
+                            </fed:SecurityTokenServiceEndpoint>
 
                     <fed:PassiveRequestorEndpoint>
 
                       <wsa:EndpointReference xmlns:wsa=""http://www.w3.org/2005/08/addressing"">
 
                         <wsa:Address>https://login.microsoftonline.com/268da1a1-9db4-48b9-b1fe-683250ba90cc/wsfed</wsa:Address>
-
-                      </wsa:EndpointReference>
-
+                            
+                      </wsa:EndpointReference                            >
+     
                     </fed:PassiveRequestorEndpoint>
 
                   </RoleDescriptor>


### PR DESCRIPTION
Added support to the WsFederationMetadataSerializer to read the SecurityTokenSerivceEndpoint element from WS-Federation metadata and exposed it via the WsFederationConfiguration object as ActiveTokenEndpoint.