### PR TITLE
Updated Xml.DelegatingXmlReader to support close and ReadContentAsUniqueId

### DIFF
--- a/src/Microsoft.IdentityModel.Xml/DelegatingXmlDictionaryReader.cs
+++ b/src/Microsoft.IdentityModel.Xml/DelegatingXmlDictionaryReader.cs
@@ -257,6 +257,15 @@ namespace Microsoft.IdentityModel.Xml
         }
 
         /// <summary>
+        /// Closes the reader and changes the System.Xml.XmlReader.ReadState
+        /// to Closed.
+        /// </summary>
+        public override void Close()
+        {
+            UseInnerReader.Close();
+        }
+
+        /// <summary>
         /// Gets the value of the InnerReader's attribute at the given index.
         /// </summary>
         /// <param name="i">The index of the attribute. The index is 0 based index.</param>
@@ -417,6 +426,14 @@ namespace Microsoft.IdentityModel.Xml
         public override int ReadContentAsBinHex(byte[] buffer, int index, int count)
         {
             return UseInnerReader.ReadContentAsBinHex(buffer, index, count);
+        }
+
+        /// <summary>
+        /// Reads the content and returns the contained string.
+        /// </summary>
+        public override UniqueId ReadContentAsUniqueId()
+        {
+            return UseInnerReader.ReadContentAsUniqueId();
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.TestUtils/ExpectedException.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ExpectedException.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Security.Cryptography;
+using System.Xml;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.TestUtils
@@ -65,6 +66,11 @@ namespace Microsoft.IdentityModel.TestUtils
         public static ExpectedException IOException(string substringExpected = null, Type inner = null, string contains = null)
         {
             return new ExpectedException(typeof(IOException), substringExpected, inner);
+        }
+
+        public static ExpectedException XmlException(string substringExpected = null, Type inner = null, string contains = null)
+        {
+            return new ExpectedException(typeof(XmlException), substringExpected, inner);
         }
 
         public static ExpectedException NoExceptionExpected 

--- a/test/Microsoft.IdentityModel.Xml.Tests/DelegatingXmlDictionaryReaderTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/DelegatingXmlDictionaryReaderTests.cs
@@ -20,6 +20,47 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
             try
             {
                 var depth = theoryData.DelegatingReader.Depth;
+
+                if (!theoryData.First)
+                {
+                    Assert.Equal(theoryData.DelegatingReader.InnerReaderPublic.Depth, theoryData.DelegatingReader.Depth);
+                    Assert.Equal(theoryData.DelegatingReader.InnerReaderPublic.Value, theoryData.DelegatingReader.Value);
+                    Assert.Equal(theoryData.DelegatingReader.InnerReaderPublic.Name, theoryData.DelegatingReader.Name);
+                    Assert.Equal(theoryData.DelegatingReader.InnerReaderPublic.NamespaceURI, theoryData.DelegatingReader.NamespaceURI);
+                    Assert.Equal(theoryData.DelegatingReader.InnerReaderPublic.AttributeCount, theoryData.DelegatingReader.AttributeCount);
+                }
+
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Theory, MemberData(nameof(ReadPartialXmlWithUniqueIdTheoryData))]
+        public void ReadPartialXml(DelegatingXmlDictionaryReaderTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.ReadXml", theoryData);
+            try
+            {
+                Assert.Equal(theoryData.DelegatingReader.InnerReaderPublic.Depth, theoryData.DelegatingReader.Depth);
+                Assert.Equal(theoryData.DelegatingReader.InnerReaderPublic.Value, theoryData.DelegatingReader.Value);
+                Assert.Equal(theoryData.DelegatingReader.InnerReaderPublic.Name, theoryData.DelegatingReader.Name);
+                Assert.Equal(theoryData.DelegatingReader.InnerReaderPublic.NamespaceURI, theoryData.DelegatingReader.NamespaceURI);
+                Assert.Equal(theoryData.DelegatingReader.InnerReaderPublic.AttributeCount, theoryData.DelegatingReader.AttributeCount);
+
+                theoryData.DelegatingReader.InnerReaderPublic.MoveToContent();
+                theoryData.DelegatingReader.MoveToContent();
+
+                theoryData.DelegatingReader.InnerReaderPublic.MoveToAttribute("URI");
+                theoryData.DelegatingReader.MoveToAttribute("URI");
+
+                Assert.Equal(theoryData.DelegatingReader.InnerReaderPublic.ReadContentAsUniqueId(),
+                    theoryData.DelegatingReader.ReadContentAsUniqueId());
+
                 theoryData.ExpectedException.ProcessNoException(context);
             }
             catch (Exception ex)
@@ -50,6 +91,34 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
                             InnerReaderPublic = XmlUtilities.CreateDictionaryReader(Default.OuterXml)
                         },
                         TestId = "InnerReader-Set"
+                    }
+                };
+            }
+        }
+
+        public static TheoryData<DelegatingXmlDictionaryReaderTheoryData> ReadPartialXmlWithUniqueIdTheoryData
+        {
+            get
+            {
+                return new TheoryData<DelegatingXmlDictionaryReaderTheoryData>
+                {
+                    new DelegatingXmlDictionaryReaderTheoryData
+                    {
+                        DelegatingReader = new DelegatingXmlDictionaryReaderPublic
+                        {
+                            InnerReaderPublic = XmlUtilities.CreateDictionaryReader(Default.OuterXml)
+                        },
+                        First = true,
+                        ExpectedException = ExpectedException.XmlException(inner: typeof(FormatException)),
+                        TestId = "InnerReader-FullXml"
+                    },
+                    new DelegatingXmlDictionaryReaderTheoryData
+                    {
+                        DelegatingReader = new DelegatingXmlDictionaryReaderPublic
+                        {
+                            InnerReaderPublic = XmlUtilities.CreateDictionaryReader("<Elemnt URI=\"uuid-88d1a312-e27e-4bb8-a69f-e4fd295daf04\" />")
+                        },
+                        TestId = "InnerReader-PartialXmlWithUri"
                     }
                 };
             }


### PR DESCRIPTION
Updated Xml.DelegatingXmlReader to delegate to the inner reader: close() and ReadContentAsUniqueId()