### PR TITLE
Build NET6.0 TFM on Unix based systems

### DIFF
--- a/build/targets.props
+++ b/build/targets.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
     <SrcTargets>net45;net461;net462;net472;netstandard2.0;net6.0</SrcTargets>
-    <SrcStandardTargets>netstandard2.0</SrcStandardTargets>
+    <SrcStandardTargets>netstandard2.0;net6.0</SrcStandardTargets>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR addresses #2118 

Unix systems such as Linux and macOS are capable of running any Core/5+ version of .NET. There are sections of code (specifically ECDH support) that will only build in recent versions of .NET Framework 4.x and .NET 6.0 and are not present in the `netstandard2.0` TFM.

A straightforward fix would be to add the `net6.0` TFM to the `SrcStandardTargets`.

If `SrcStandardTargets` wants to remain `netstandard` TFMs only, then an alternate solution would be to have `SrcTargets` conditionally include the `net4*` targets when building on a Windows host.

*What about the test targets?* I'm already having issues running the tests on macOS using `netcoreapp`. Targeting .NET6 also introduces some macOS-specific oddities with .NET 6's implementation of X509 certificates. I've encountered these errors on my test projects as well, where well-formed certs and other materials are now throwing 'malformed' exceptions. I honestly don't know how to proceed there without either diagnosing the problem in .NET's crypto implementation, or by regenerating all of the test certificates using OpenSSL instead of the Windows-based APIs. I would honestly be fine developing/building on macOS and then running the tests in a VM.