### PR TITLE
Initial addition of Nullable property to Abstractions Project.

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -31,7 +31,7 @@
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(SrcTargets)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">$(SrcStandardTargets)</TargetFrameworks>
     <NetStandardImplicitPackageVersion>$(NetStandardVersion)</NetStandardImplicitPackageVersion>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/build/common.props
+++ b/build/common.props
@@ -31,7 +31,7 @@
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(SrcTargets)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">$(SrcStandardTargets)</TargetFrameworks>
     <NetStandardImplicitPackageVersion>$(NetStandardVersion)</NetStandardImplicitPackageVersion>
-    <LangVersion>10</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/Microsoft.IdentityModel.Abstractions/ITelemetryClient.cs
+++ b/src/Microsoft.IdentityModel.Abstractions/ITelemetryClient.cs
@@ -68,11 +68,11 @@ namespace Microsoft.IdentityModel.Abstractions
         /// <param name="guidProperties">Key value pair of Guids to long with the event.</param>
         void TrackEvent(
             string eventName,
-            IDictionary<string, string> stringProperties = null,
-            IDictionary<string, long> longProperties = null,
-            IDictionary<string, bool> boolProperties = null,
-            IDictionary<string, DateTime> dateTimeProperties = null,
-            IDictionary<string, double> doubleProperties = null,
-            IDictionary<string, Guid> guidProperties = null);
+            IDictionary<string, string>? stringProperties = null,
+            IDictionary<string, long>? longProperties = null,
+            IDictionary<string, bool>? boolProperties = null,
+            IDictionary<string, DateTime>? dateTimeProperties = null,
+            IDictionary<string, double>? doubleProperties = null,
+            IDictionary<string, Guid>? guidProperties = null);
     }
 }

--- a/src/Microsoft.IdentityModel.Abstractions/LogEntry.cs
+++ b/src/Microsoft.IdentityModel.Abstractions/LogEntry.cs
@@ -16,7 +16,7 @@ namespace Microsoft.IdentityModel.Abstractions
         /// <summary>
         /// Message to be logged.
         /// </summary>
-        public string Message { get; set; }
+        public string? Message { get; set; }
 
         /// <summary>
         /// A unique identifier for a request that can help with diagnostics across components.
@@ -24,6 +24,6 @@ namespace Microsoft.IdentityModel.Abstractions
         /// <remarks>
         /// Also referred to as ActivityId in Microsoft.IdentityModel.Tokens.CallContext.
         /// </remarks>
-        public string CorrelationId { get; set; }
+        public string? CorrelationId { get; set; }
     }
 }

--- a/src/Microsoft.IdentityModel.Abstractions/Microsoft.IdentityModel.Abstractions.csproj
+++ b/src/Microsoft.IdentityModel.Abstractions/Microsoft.IdentityModel.Abstractions.csproj
@@ -9,6 +9,7 @@
     <PackageId>Microsoft.IdentityModel.Abstractions</PackageId>
     <PackageTags>.NET;Windows;Authentication;Identity;Abstractions</PackageTags>
     <IsTrimmable>true</IsTrimmable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Microsoft.IdentityModel.Abstractions/NullTelemetryClient.cs
+++ b/src/Microsoft.IdentityModel.Abstractions/NullTelemetryClient.cs
@@ -25,7 +25,9 @@ namespace Microsoft.IdentityModel.Abstractions
         /// <remarks>
         /// Private constructor to prevent the default constructor being exposed.
         /// </remarks>
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         private NullTelemetryClient() { }
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         /// <inheritdoc />
         public bool IsEnabled() => false;
@@ -48,12 +50,12 @@ namespace Microsoft.IdentityModel.Abstractions
         /// <inheritdoc/>
         public void TrackEvent(
             string eventName,
-            IDictionary<string, string> stringProperties = null,
-            IDictionary<string, long> longProperties = null,
-            IDictionary<string, bool> boolProperties = null,
-            IDictionary<string, DateTime> dateTimeProperties = null,
-            IDictionary<string, double> doubleProperties = null,
-            IDictionary<string, Guid> guidProperties = null)
+            IDictionary<string, string>? stringProperties = null,
+            IDictionary<string, long>? longProperties = null,
+            IDictionary<string, bool>? boolProperties = null,
+            IDictionary<string, DateTime>? dateTimeProperties = null,
+            IDictionary<string, double>? doubleProperties = null,
+            IDictionary<string, Guid>? guidProperties = null)
         {
             // no-op
         }

--- a/src/Microsoft.IdentityModel.Abstractions/TelemetryEventDetails.cs
+++ b/src/Microsoft.IdentityModel.Abstractions/TelemetryEventDetails.cs
@@ -23,7 +23,7 @@ namespace Microsoft.IdentityModel.Abstractions
         /// <summary>
         /// Name of the telemetry event, should be unique between events.
         /// </summary>
-        public virtual string Name { get; set; }
+        public virtual string? Name { get; set; }
 
         /// <summary>
         /// Properties which describe the event.

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/GlobalSuppressions.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/GlobalSuppressions.cs
@@ -12,3 +12,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "Vendored component", Scope = "module")]
 [assembly: SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "Breaking change", Scope = "type", Target = "~T:Microsoft.IdentityModel.Protocols.SignedHttpRequest.SignedHttpRequestHandler")]
 [assembly: SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Previously released as read / write", Scope = "member", Target = "~P:Microsoft.IdentityModel.Protocols.SignedHttpRequest.SignedHttpRequestInvalidNonceClaimException.PropertyBag")]
+[assembly: SuppressMessage("Globalization", "CA1305:Specify IFormatProvider", Justification = "Breaking Change", Scope = "member", Target = "~T:Microsoft.IdentityModel.Protocols.SignedHttpRequest.SignedHttpRequestHandler)")]

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/Configuration/WsFederationConfiguration.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/Configuration/WsFederationConfiguration.cs
@@ -22,7 +22,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         /// <summary>
         /// The <see cref="Xml.Signature"/> element that was found when reading metadata.
         /// </summary>
-        public Signature Signature
+        public Signature? Signature
         {
             get;
             set;
@@ -31,7 +31,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         /// <summary>
         /// The <see cref="Tokens.SigningCredentials"/> that was used to sign the metadata.
         /// </summary>
-        public SigningCredentials SigningCredentials
+        public SigningCredentials? SigningCredentials
         {
             get;
             set;

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/Configuration/WsFederationConfigurationValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/Configuration/WsFederationConfigurationValidator.cs
@@ -143,7 +143,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
                 var signatureCertData = signatureX509Data.Current.Certificates.GetEnumerator();
                 if (signatureCertData.MoveNext() && !string.IsNullOrWhiteSpace(signatureCertData.Current))
                 {
-                    X509Certificate2 cert = null;
+                    X509Certificate2? cert = null;
 
                     try
                     {

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/Microsoft.IdentityModel.Protocols.WsFederation.csproj
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/Microsoft.IdentityModel.Protocols.WsFederation.csproj
@@ -8,6 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Microsoft.IdentityModel.Protocols.WsFederation</PackageId>
     <PackageTags>.NET;Windows;Authentication;Identity;WsFederation</PackageTags>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/QueryHelper.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/QueryHelper.cs
@@ -34,7 +34,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         /// </summary>
         /// <param name="queryString">The raw query string value, with or without the leading '?'.</param>
         /// <returns>A collection of parsed keys and values, null if there are no entries.</returns>
-        public static IDictionary<string, IList<string>> ParseNullableQuery(string queryString)
+        public static IDictionary<string, IList<string>>? ParseNullableQuery(string queryString)
         {
             var accumulator = new KeyValueAccumulator();
 

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/SecurityTokenServiceTypeRoleDescriptor.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/SecurityTokenServiceTypeRoleDescriptor.cs
@@ -24,7 +24,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         /// Passive Requestor Token endpoint
         /// fed:PassiveRequestorEndpoint, https://docs.oasis-open.org/wsfed/federation/v1.2/os/ws-federation-1.2-spec-os.html#:~:text=fed%3ASecurityTokenServiceType/fed%3APassiveRequestorEndpoint
         /// </summary>
-        public string TokenEndpoint
+        public string? TokenEndpoint
         {
             get;
             set;
@@ -34,7 +34,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         /// Active Requestor Token Endpoint
         /// fed:SecurityTokenServiceType, http://docs.oasis-open.org/wsfed/federation/v1.2/os/ws-federation-1.2-spec-os.html#:~:text=fed%3ASecurityTokenSerivceEndpoint
         /// </summary>
-        public string ActiveTokenEndpoint
+        public string? ActiveTokenEndpoint
         {
             get;
             set;

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMessage.cs
@@ -137,7 +137,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         /// </summary>
         /// <returns>the 'SecurityToken'.</returns>
         /// <exception cref="WsFederationException">if exception occurs while reading security token.</exception>
-        public virtual string GetToken()
+        public virtual string? GetToken()
         {
             return GetTokenUsingXmlReader();
         }
@@ -149,7 +149,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         /// This is only called after it is determined the Wresult is well formed xml. A successful call the GetTokenUsingXmlReader should be made first.
         /// </summary>
         /// <returns>the string version of the security token.</returns>
-        internal static string GetToken(string wresult)
+        internal static string? GetToken(string wresult)
         {
             if (string.IsNullOrEmpty(wresult))
             {
@@ -217,7 +217,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         /// </summary>
         /// <returns>the 'SecurityToken'.</returns>
         /// <exception cref="WsFederationException">if exception occurs while reading security token.</exception>
-        public virtual string GetTokenUsingXmlReader()
+        public virtual string? GetTokenUsingXmlReader()
         {
             if (Wresult == null)
             {
@@ -225,7 +225,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
                 return null;
             }
 
-            string token = null;
+            string? token = null;
             using (var sr = new StringReader(Wresult))
             using (var xmlReader = new XmlTextReader(sr) { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null })
             {

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMetadataSerializer.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMetadataSerializer.cs
@@ -264,7 +264,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         /// <param name="reader"><see cref="XmlReader"/> used to read SecurityTokenServiceEndpoint.</param>
         /// <returns>Active token endpoint string</returns>
         /// <exception cref="XmlReadException">If an error occurs while reading the SecurityTokenServiceEndpoint</exception>
-        protected virtual string ReadSecurityTokenServiceEndpoint(XmlReader reader)
+        protected virtual string? ReadSecurityTokenServiceEndpoint(XmlReader reader)
         {
             XmlUtil.CheckReaderOnEntry(reader, Elements.SecurityTokenServiceEndpoint, Namespace);
 
@@ -286,7 +286,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
             if (reader.IsEmptyElement)
                 throw XmlUtil.LogReadException(LogMessages.IDX22814);
 
-            string tokenEndpoint = null;
+            string? tokenEndpoint = null;
 
             while (reader.IsStartElement())
             {


### PR DESCRIPTION
Initial PR to Abstractions project to enable nullable across the solution allowing variables to have null as a value, which can be useful in cases where a value may not be present or when a value is optional. It also allows for the use of null-forgiving operator, which suppresses nullable warnings for an expression.