### PR TITLE
Lazily initialize TokenValidationParameters.InstancePropertyBag

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -189,6 +189,7 @@ namespace Microsoft.IdentityModel.Tokens
         private TimeSpan _clockSkew = DefaultClockSkew;
         private string _nameClaimType = ClaimsIdentity.DefaultNameClaimType;
         private string _roleClaimType = ClaimsIdentity.DefaultRoleClaimType;
+        private Dictionary<string, object> _instancePropertyBag;
 
         /// <summary>
         /// This is the default value of <see cref="ClaimsIdentity.AuthenticationType"/> when creating a <see cref="ClaimsIdentity"/>.
@@ -483,7 +484,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets a <see cref="IDictionary{String, Object}"/> that is unique to this instance.
         /// Calling <see cref="Clone"/> will result in a new instance of this IDictionary.
         /// </summary>
-        public IDictionary<string, object> InstancePropertyBag { get; } = new Dictionary<string, object>();
+        public IDictionary<string, object> InstancePropertyBag => _instancePropertyBag ??= new Dictionary<string, object>();
 
         /// <summary>
         /// Gets a value indicating if <see cref="Clone"/> was called to obtain this instance.


### PR DESCRIPTION
Fixes https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2155