### PR TITLE
Remove closure from JsonWebTokenHandler.ValidateSignature

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -1760,7 +1760,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             {
                 if (kidMatched)
                 {
-                    var isKidInTVP = keysInTokenValidationParameters.Any(x => x.KeyId.Equals(jwtToken.Kid));
+                    JsonWebToken localJwtToken = jwtToken; // avoid closure on non-exceptional path
+                    var isKidInTVP = keysInTokenValidationParameters.Any(x => x.KeyId.Equals(localJwtToken.Kid));
                     var keyLocation = isKidInTVP ? "TokenValidationParameters" : "Configuration";
                     throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10511,
                         keysAttempted,


### PR DESCRIPTION
The Any call on an exceptional path is closing over the jwtToken parameter, which means a display class gets allocated at the beginning of the method, whether that code path is taken or not.