### PR TITLE
Add code coverage settings

### DIFF
--- a/build/CodeCoverage.runsettings
+++ b/build/CodeCoverage.runsettings
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Customised run settings file to exclude test assemblies from coverage.
+    See https://msdn.microsoft.com/en-us/library/jj159530.aspx for more info. -->
+
+<!-- File name extension must be .runsettings -->
+<RunSettings>
+    <DataCollectionRunSettings>
+        <DataCollectors>
+            <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+                <Configuration>
+                    <CodeCoverage>
+
+                        <!--  
+About include/exclude lists:  
+Empty "Include" clauses imply all; empty "Exclude" clauses imply none.  
+Each element in the list is a regular expression (ECMAScript syntax). See http://msdn.microsoft.com/library/2k3te2cs.aspx.  
+An item must first match at least one entry in the include list to be included.  
+Included items must then not match any entries in the exclude list to remain included.  
+-->
+
+                        <!-- Match assembly file paths: -->
+                        <ModulePaths>
+                            <Include>
+                                <ModulePath>.*\microsoft.identitymodel.abstractions.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.jsonwebtokens.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.keyvaultextensions.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.logging.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.loggingextensions.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.managedkeyvaultsecuritykey.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.protocols.openidconnect.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.protocols.signedhttprequest.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.protocols.wsfederation.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.protocols.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.testextensions.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.tokens.saml.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.tokens.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.validators.dll</ModulePath>
+                                <ModulePath>.*\microsoft.identitymodel.xml.dll</ModulePath>
+                                <ModulePath>.*\system.identitymodel.tokens.jwt.dll</ModulePath>
+                            </Include>
+                        </ModulePaths>
+
+                    </CodeCoverage>
+                </Configuration>
+            </DataCollector>
+        </DataCollectors>
+    </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
code coverage will be reported in ADO builds. The change to the build task is already done and will be carried over when wilson's build process is translated into yaml files in a separate PR. [Here is an example of the coverage report](https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1140957&view=codecoverage-tab)