### PR TITLE
Francofung/adding nullable post rebase

### DIFF
--- a/src/Common/TrimmingAttributes.cs
+++ b/src/Common/TrimmingAttributes.cs
@@ -39,7 +39,7 @@ namespace System.Diagnostics.CodeAnalysis
         /// Gets or sets an optional URL that contains more information about the method,
         /// why it requires unreferenced code, and what options a consumer has to deal with it.
         /// </summary>
-        public string Url { get; set; }
+        public string? Url { get; set; }
     }
 
     /// <summary>
@@ -91,7 +91,7 @@ namespace System.Diagnostics.CodeAnalysis
         /// The Scope property is an optional argument that specifies the metadata scope for which
         /// the attribute is relevant.
         /// </remarks>
-        public string Scope { get; set; }
+        public string? Scope { get; set; }
 
         /// <summary>
         /// Gets or sets a fully qualified path that represents the target of the attribute.
@@ -102,7 +102,7 @@ namespace System.Diagnostics.CodeAnalysis
         /// Because it is fully qualified, it can be long, particularly for targets such as parameters.
         /// The analysis tool user interface should be capable of automatically formatting the parameter.
         /// </remarks>
-        public string Target { get; set; }
+        public string? Target { get; set; }
 
         /// <summary>
         /// Gets or sets an optional argument expanding on exclusion criteria.
@@ -114,12 +114,12 @@ namespace System.Diagnostics.CodeAnalysis
         /// and it may be desirable to suppress a violation against a statement in the method that will
         /// give a rule violation, but not against all statements in the method.
         /// </remarks>
-        public string MessageId { get; set; }
+        public string? MessageId { get; set; }
 
         /// <summary>
         /// Gets or sets the justification for suppressing the code analysis message.
         /// </summary>
-        public string Justification { get; set; }
+        public string? Justification { get; set; }
     }
 
     [AttributeUsage(

--- a/src/Microsoft.IdentityModel.Abstractions/IIdentityLogger.cs
+++ b/src/Microsoft.IdentityModel.Abstractions/IIdentityLogger.cs
@@ -18,6 +18,6 @@ namespace Microsoft.IdentityModel.Abstractions
         /// Writes a log entry.
         /// </summary>
         /// <param name="entry">Defines a structured message to be logged at the provided <see cref="LogEntry.EventLogLevel"/>.</param>
-        void Log(LogEntry entry);
+        void Log(LogEntry? entry);
     }
 }

--- a/src/Microsoft.IdentityModel.Abstractions/NullIdentityModelLogger.cs
+++ b/src/Microsoft.IdentityModel.Abstractions/NullIdentityModelLogger.cs
@@ -19,7 +19,7 @@ namespace Microsoft.IdentityModel.Abstractions
         public bool IsEnabled(EventLogLevel eventLogLevel) => false;
 
         /// <inheritdoc/>
-        public void Log(LogEntry entry)
+        public void Log(LogEntry? entry)
         {
             // no-op
         }

--- a/src/Microsoft.IdentityModel.KeyVaultExtensions/KeyVaultCryptoProvider.cs
+++ b/src/Microsoft.IdentityModel.KeyVaultExtensions/KeyVaultCryptoProvider.cs
@@ -41,10 +41,10 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
         public object Create(string algorithm, params object[] args)
         {
             if (string.IsNullOrEmpty(algorithm))
-                throw LogHelper.LogArgumentNullException(nameof(algorithm));
+                throw LogHelper.LogArgumentNullException(nameof(algorithm))!;
 
             if (args == null)
-                throw LogHelper.LogArgumentNullException(nameof(args));
+                throw LogHelper.LogArgumentNullException(nameof(args))!;
 
             if (args.FirstOrDefault() is KeyVaultSecurityKey key)
             {
@@ -65,7 +65,7 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
                 }
             }
 
-            throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10652, LogHelper.MarkAsNonPII(algorithm))));
+            throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10652, LogHelper.MarkAsNonPII(algorithm))))!;
         }
 
         /// <summary>
@@ -77,10 +77,10 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
         public bool IsSupportedAlgorithm(string algorithm, params object[] args)
         {
             if (string.IsNullOrEmpty(algorithm))
-                throw LogHelper.LogArgumentNullException(nameof(algorithm));
+                throw LogHelper.LogArgumentNullException(nameof(algorithm))!;
 
             if (args == null)
-                throw LogHelper.LogArgumentNullException(nameof(args));
+                throw LogHelper.LogArgumentNullException(nameof(args))!;
 
             return args.FirstOrDefault() is KeyVaultSecurityKey
                 && (JsonWebKeyEncryptionAlgorithm.AllAlgorithms.Contains(algorithm, StringComparer.Ordinal) || JsonWebKeySignatureAlgorithm.AllAlgorithms.Contains(algorithm, StringComparer.Ordinal));

--- a/src/Microsoft.IdentityModel.KeyVaultExtensions/KeyVaultKeyWrapProvider.cs
+++ b/src/Microsoft.IdentityModel.KeyVaultExtensions/KeyVaultKeyWrapProvider.cs
@@ -39,26 +39,26 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
         /// <param name="key">The <see cref="SecurityKey"/> that will be used for key wrap operations.</param>
         /// <param name="algorithm">The key wrap algorithm to apply.</param>
         /// <param name="client">A mock <see cref="IKeyVaultClient"/> used for testing purposes.</param>
-        internal KeyVaultKeyWrapProvider(SecurityKey key, string algorithm, IKeyVaultClient client)
+        internal KeyVaultKeyWrapProvider(SecurityKey key, string algorithm, IKeyVaultClient? client)
         {
-            _algorithm = string.IsNullOrEmpty(algorithm) ? throw LogHelper.LogArgumentNullException(nameof(algorithm)) : algorithm;
+            _algorithm = string.IsNullOrEmpty(algorithm) ? throw LogHelper.LogArgumentNullException(nameof(algorithm))! : algorithm;
             if (key == null)
-                throw LogHelper.LogArgumentNullException(nameof(key));
+                throw LogHelper.LogArgumentNullException(nameof(key))!;
 
-            _key = key as KeyVaultSecurityKey ?? throw LogHelper.LogExceptionMessage(new NotSupportedException(key.GetType().ToString()));
-            _client = client ?? new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(_key.Callback));
+            _key = key as KeyVaultSecurityKey ?? throw LogHelper.LogExceptionMessage(new NotSupportedException(key.GetType().ToString()))!;
+            _client = client ?? new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(_key.Callback!));
         }
 
         /// <summary>
         /// Gets the KeyWrap algorithm that is being used.
         /// </summary>
-        public override string Algorithm => _algorithm;
+        public override string? Algorithm => _algorithm;
 
         /// <summary>
         /// Gets or sets a user context for a <see cref="KeyWrapProvider"/>.
         /// </summary>
         /// <remarks>This is null by default. This can be used by runtimes or for extensibility scenarios.</remarks>
-        public override string Context { get; set; }
+        public override string? Context { get; set; }
 
         /// <summary>
         /// Gets the <see cref="SecurityKey"/> that is being used.
@@ -116,7 +116,7 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
         private async Task<byte[]> UnwrapKeyAsync(byte[] keyBytes, CancellationToken cancellation)
         {
             if (keyBytes == null || keyBytes.Length == 0)
-                throw LogHelper.LogArgumentNullException(nameof(keyBytes));
+                throw LogHelper.LogArgumentNullException(nameof(keyBytes))!;
 
             return (await _client.UnwrapKeyAsync(_key.KeyId, Algorithm, keyBytes, cancellation).ConfigureAwait(false)).Result;
         }
@@ -132,7 +132,7 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
         private async Task<byte[]> WrapKeyAsync(byte[] keyBytes, CancellationToken cancellation)
         {
             if (keyBytes == null || keyBytes.Length == 0)
-                throw LogHelper.LogArgumentNullException(nameof(keyBytes));
+                throw LogHelper.LogArgumentNullException(nameof(keyBytes))!;
 
             return (await _client.WrapKeyAsync(_key.KeyId, Algorithm, keyBytes, cancellation).ConfigureAwait(false)).Result;
         }

--- a/src/Microsoft.IdentityModel.KeyVaultExtensions/KeyVaultSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.KeyVaultExtensions/KeyVaultSecurityKey.cs
@@ -17,7 +17,7 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
     public class KeyVaultSecurityKey : SecurityKey
     {
         private int? _keySize;
-        private string _keyId;
+        private string? _keyId;
 
         /// <summary>
         /// The authentication callback delegate which is to be implemented by the client code.
@@ -45,7 +45,7 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
         /// <exception cref="ArgumentNullException">if <paramref name="callback"/>is null.</exception>
         public KeyVaultSecurityKey(string keyIdentifier, AuthenticationCallback callback)
         {
-            Callback = callback ?? throw LogHelper.LogArgumentNullException(nameof(callback));
+            Callback = callback ?? throw LogHelper.LogArgumentNullException(nameof(callback))!;
             KeyId = keyIdentifier;
         }
 
@@ -58,18 +58,18 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
         /// <summary>
         /// The authentication callback delegate that retrieves an access token for the KeyVault.
         /// </summary>
-        public AuthenticationCallback Callback { get; protected set; }
+        public AuthenticationCallback? Callback { get; protected set; }
 
         /// <summary>
         /// The uniform resource identifier of the security key.
         /// </summary>
         public override string KeyId
         {
-            get => _keyId;
+            get => _keyId!;
             set
             {
                 if (string.IsNullOrEmpty(value))
-                    throw LogHelper.LogArgumentNullException(nameof(value));
+                    throw LogHelper.LogArgumentNullException(nameof(value))!;
                 else if (StringComparer.Ordinal.Equals(_keyId, value))
                     return;
 
@@ -90,7 +90,7 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
                 if (!_keySize.HasValue)
                     Initialize();
 
-                return _keySize.Value;
+                return _keySize!.Value;
             }
         }
 
@@ -99,7 +99,7 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
         /// </summary>
         private void Initialize()
         {
-            using (var client = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(Callback)))
+            using (var client = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(Callback!)))
             {
                 var bundle = client.GetKeyAsync(_keyId, CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
                 _keySize = new BitArray(bundle.Key.N).Length;

--- a/src/Microsoft.IdentityModel.KeyVaultExtensions/KeyVaultSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.KeyVaultExtensions/KeyVaultSignatureProvider.cs
@@ -41,11 +41,11 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
         /// <param name="algorithm">The signature algorithm to apply.</param>
         /// <param name="willCreateSignatures">Whether this <see cref="KeyVaultSignatureProvider"/> is required to create signatures then set this to true.</param>
         /// <param name="client">A mock <see cref="IKeyVaultClient"/> used for testing purposes.</param>
-        internal KeyVaultSignatureProvider(SecurityKey key, string algorithm, bool willCreateSignatures, IKeyVaultClient client)
+        internal KeyVaultSignatureProvider(SecurityKey key, string algorithm, bool willCreateSignatures, IKeyVaultClient? client)
             : base(key, algorithm)
         {
-            _key = key as KeyVaultSecurityKey ?? throw LogHelper.LogArgumentNullException(nameof(key));
-            _client = client ?? new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(_key.Callback));
+            _key = key as KeyVaultSecurityKey ?? throw LogHelper.LogArgumentNullException(nameof(key))!;
+            _client = client ?? new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(_key.Callback!));
             WillCreateSignatures = willCreateSignatures;
 
             switch (algorithm)
@@ -60,7 +60,7 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
                     _hash = SHA512.Create();
                     break;
                 default:
-                    throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10652, LogHelper.MarkAsNonPII(algorithm)), nameof(algorithm)));
+                    throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10652, LogHelper.MarkAsNonPII(algorithm)), nameof(algorithm)))!;
             }
         }
 
@@ -122,10 +122,10 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
         private async Task<byte[]> SignAsync(byte[] input, CancellationToken cancellation)
         {
             if (input == null || input.Length == 0)
-                throw LogHelper.LogArgumentNullException(nameof(input));
+                throw LogHelper.LogArgumentNullException(nameof(input))!;
 
             if (_disposed)
-                throw LogHelper.LogExceptionMessage(new ObjectDisposedException(GetType().ToString()));
+                throw LogHelper.LogExceptionMessage(new ObjectDisposedException(GetType().ToString()))!;
 
             return (await _client.SignAsync(_key.KeyId, Algorithm, _hash.ComputeHash(input), cancellation).ConfigureAwait(false)).Result;
         }
@@ -143,13 +143,13 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions
         private async Task<bool> VerifyAsync(byte[] input, byte[] signature, CancellationToken cancellation)
         {
             if (input == null || input.Length == 0)
-                throw LogHelper.LogArgumentNullException(nameof(input));
+                throw LogHelper.LogArgumentNullException(nameof(input))!;
 
             if (signature == null || signature.Length == 0)
-                throw LogHelper.LogArgumentNullException(nameof(signature));
+                throw LogHelper.LogArgumentNullException(nameof(signature))!;
 
             if (_disposed)
-                throw LogHelper.LogExceptionMessage(new ObjectDisposedException(GetType().ToString()));
+                throw LogHelper.LogExceptionMessage(new ObjectDisposedException(GetType().ToString()))!;
 
             return await _client.VerifyAsync(_key.KeyId, Algorithm, _hash.ComputeHash(input), signature, cancellation).ConfigureAwait(false);
         }

--- a/src/Microsoft.IdentityModel.KeyVaultExtensions/Microsoft.IdentityModel.KeyVaultExtensions.csproj
+++ b/src/Microsoft.IdentityModel.KeyVaultExtensions/Microsoft.IdentityModel.KeyVaultExtensions.csproj
@@ -11,6 +11,7 @@
     <TargetFrameworks Condition="'$(TargetNet8)' == 'True'">netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetNet8)' != 'True'">netstandard2.0;net6.0</TargetFrameworks>
     <PackageTags>.NET;Windows;Authentication;Identity;Azure;Key;Vault;Extensions</PackageTags>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Microsoft.IdentityModel.Logging/IdentityModelEventSource.cs
+++ b/src/Microsoft.IdentityModel.Logging/IdentityModelEventSource.cs
@@ -93,7 +93,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="message">The log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         [NonEvent]
-        public void WriteAlways(string message, params object[] args)
+        public void WriteAlways(string message, params object[]? args)
         {
             if (IsEnabled())
             {
@@ -124,7 +124,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="message">The log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         [NonEvent]
-        public void WriteVerbose(string message, params object[] args)
+        public void WriteVerbose(string message, params object[]? args)
         {
             if (IsEnabled() && LogLevel >= EventLevel.Verbose)
             {
@@ -155,7 +155,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="message">The log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         [NonEvent]
-        public void WriteInformation(string message, params object[] args)
+        public void WriteInformation(string message, params object[]? args)
         {
             if (IsEnabled() && LogLevel >= EventLevel.Informational)
             {
@@ -186,7 +186,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="message">The log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         [NonEvent]
-        public void WriteWarning(string message, params object[] args)
+        public void WriteWarning(string message, params object[]? args)
         {
             if (args != null)
                 WriteWarning(FormatInvariant(message, args));
@@ -214,7 +214,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="message">The log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         [NonEvent]
-        public void WriteError(string message, params object[] args)
+        public void WriteError(string message, params object[]? args)
         {
             if (IsEnabled() && LogLevel >= EventLevel.Error)
             {
@@ -245,7 +245,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="message">The log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         [NonEvent]
-        public void WriteCritical(string message, params object[] args)
+        public void WriteCritical(string message, params object[]? args)
         {
             if (IsEnabled() && LogLevel >= EventLevel.Critical)
             {
@@ -263,7 +263,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="innerException"><see cref="Exception"/></param>
         /// <param name="message">The log message.</param>
         [NonEvent]
-        public void Write(EventLevel level, Exception innerException, string message)
+        public void Write(EventLevel level, Exception? innerException, string message)
         {
             Write(level, innerException, message, null);
         }
@@ -276,7 +276,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="message">The log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         [NonEvent]
-        public void Write(EventLevel level, Exception innerException, string message, params object[] args)
+        public void Write(EventLevel level, Exception? innerException, string message, params object[]? args)
         {
             if (innerException != null)
             {
@@ -291,7 +291,7 @@ namespace Microsoft.IdentityModel.Logging
             if (!HeaderWritten)
             {
                 // Obtain the current library version dynamically.
-                WriteAlways(string.Format(CultureInfo.InvariantCulture, _versionLogMessage, typeof(IdentityModelEventSource).GetTypeInfo().Assembly.GetName().Version.ToString()));
+                WriteAlways(string.Format(CultureInfo.InvariantCulture, _versionLogMessage, typeof(IdentityModelEventSource).GetTypeInfo().Assembly!.GetName().Version!.ToString()));
                 WriteAlways(string.Format(CultureInfo.InvariantCulture, _dateLogMessage, DateTime.UtcNow));
                 if (ShowPII) 
                     WriteAlways(_piiOnLogMessage);

--- a/src/Microsoft.IdentityModel.Logging/IdentityModelTelemetryUtil.cs
+++ b/src/Microsoft.IdentityModel.Logging/IdentityModelTelemetryUtil.cs
@@ -20,7 +20,7 @@ namespace Microsoft.IdentityModel.Logging
         internal static readonly ConcurrentDictionary<string, string> telemetryData = new ConcurrentDictionary<string, string>()
         {
             [skuTelemetry] = ClientSku,
-            [versionTelemetry] = ClientVer
+            [versionTelemetry] = ClientVer!
         };
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <summary>
         /// Get the string that represents the client version.
         /// </summary>
-        public static string ClientVer => typeof(IdentityModelTelemetryUtil).GetTypeInfo().Assembly.GetName().Version.ToString();
+        public static string? ClientVer => typeof(IdentityModelTelemetryUtil).GetTypeInfo().Assembly!.GetName().Version!.ToString();
 
         /// <summary>
         /// Adds a key and its value to the collection of telemetry data.

--- a/src/Microsoft.IdentityModel.Logging/LogHelper.cs
+++ b/src/Microsoft.IdentityModel.Logging/LogHelper.cs
@@ -319,8 +319,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         private static T? LogExceptionImpl<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string? argumentName, Exception? innerException, string format, params object[]? args) where T : Exception 
         {
-            string? message = null;
-
+            string message;
             if (args != null)
                 message = string.Format(CultureInfo.InvariantCulture, format, args);
             else

--- a/src/Microsoft.IdentityModel.Logging/LogHelper.cs
+++ b/src/Microsoft.IdentityModel.Logging/LogHelper.cs
@@ -49,9 +49,9 @@ namespace Microsoft.IdentityModel.Logging
         /// </summary>
         /// <param name="argument">argument that is null or empty.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static ArgumentNullException LogArgumentNullException(string argument)
+        public static ArgumentNullException? LogArgumentNullException(string? argument)
         {
-            return LogArgumentException<ArgumentNullException>(EventLevel.Error, argument, "IDX10000: The parameter '{0}' cannot be a 'null' or an empty object. ", argument);
+            return LogArgumentException<ArgumentNullException>(EventLevel.Error, argument, "IDX10000: The parameter '{0}' cannot be a 'null' or an empty object. ", argument!);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Microsoft.IdentityModel.Logging
         /// </summary>
         /// <param name="message">message to log.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string message) where T : Exception
+        public static T? LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string message) where T : Exception
         {
             return LogException<T>(EventLevel.Error, null, message, null);
         }
@@ -70,7 +70,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
         /// <param name="message">message to log.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string argumentName, string message) where T : ArgumentException
+        public static T? LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string argumentName, string message) where T : ArgumentException
         {
             return LogArgumentException<T>(EventLevel.Error, argumentName, null, message, null);
         }
@@ -81,7 +81,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string format, params object[] args) where T : Exception
+        public static T? LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string format, params object[] args) where T : Exception
         {
             return LogException<T>(EventLevel.Error, null, format, args);
         }
@@ -93,7 +93,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string argumentName, string format, params object[] args) where T : ArgumentException
+        public static T? LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string argumentName, string format, params object[] args) where T : ArgumentException
         {
             return LogArgumentException<T>(EventLevel.Error, argumentName, null, format, args);
         }
@@ -104,7 +104,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="message">message to log.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Exception innerException, string message) where T : Exception
+        public static T? LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Exception innerException, string message) where T : Exception
         {
             return LogException<T>(EventLevel.Error, innerException, message, null);
         }
@@ -116,7 +116,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="message">message to log.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string argumentName, Exception innerException, string message) where T : ArgumentException
+        public static T? LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string argumentName, Exception innerException, string message) where T : ArgumentException
         {
             return LogArgumentException<T>(EventLevel.Error, argumentName, innerException, message, null);
         }
@@ -128,7 +128,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Exception innerException, string format, params object[] args) where T : Exception
+        public static T? LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Exception innerException, string format, params object[] args) where T : Exception
         {
             return LogException<T>(EventLevel.Error, innerException, format, args);
         }
@@ -141,7 +141,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         /// <remarks>EventLevel is set to Error.</remarks>
-        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string argumentName, Exception innerException, string format, params object[] args) where T : ArgumentException
+        public static T? LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(string argumentName, Exception innerException, string format, params object[] args) where T : ArgumentException
         {
             return LogArgumentException<T>(EventLevel.Error, argumentName, innerException, format, args);
         }
@@ -151,7 +151,7 @@ namespace Microsoft.IdentityModel.Logging
         /// </summary>
         /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
         /// <param name="message">message to log.</param>
-        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string message) where T : Exception
+        public static T? LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string message) where T : Exception
         {
             return LogException<T>(eventLevel, null, message, null);
         }
@@ -162,7 +162,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
         /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
         /// <param name="message">message to log.</param>
-        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string argumentName, string message) where T : ArgumentException
+        public static T? LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string argumentName, string message) where T : ArgumentException
         {
             return LogArgumentException<T>(eventLevel, argumentName, null, message, null);
         }
@@ -173,7 +173,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string format, params object[] args) where T : Exception
+        public static T? LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string format, params object[] args) where T : Exception
         {
             return LogException<T>(eventLevel, null, format, args);
         }
@@ -185,7 +185,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string argumentName, string format, params object[] args) where T : ArgumentException
+        public static T? LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string? argumentName, string format, params object[]? args) where T : ArgumentException
         {
             return LogArgumentException<T>(eventLevel, argumentName, null, format, args);
         }
@@ -196,7 +196,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="message">message to log.</param>
-        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, Exception innerException, string message) where T : Exception
+        public static T? LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, Exception innerException, string message) where T : Exception
         {
             return LogException<T>(eventLevel, innerException, message, null);
         }
@@ -208,7 +208,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="argumentName">Identifies the argument whose value generated the ArgumentException.</param>
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="message">message to log.</param>
-        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string argumentName, Exception innerException, string message) where T : ArgumentException
+        public static T? LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string argumentName, Exception innerException, string message) where T : ArgumentException
         {
             return LogArgumentException<T>(eventLevel, argumentName, innerException, message, null);
         }
@@ -220,7 +220,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public static T LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, Exception innerException, string format, params object[] args) where T : Exception
+        public static T? LogException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, Exception? innerException, string format, params object[]? args) where T : Exception
         {
             return LogExceptionImpl<T>(eventLevel, null, innerException, format, args);
         }
@@ -233,7 +233,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        public static T LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string argumentName, Exception innerException, string format, params object[] args) where T : ArgumentException
+        public static T? LogArgumentException<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string? argumentName, Exception? innerException, string format, params object[]? args) where T : ArgumentException
         {
             return LogExceptionImpl<T>(eventLevel, argumentName, innerException, format, args);
         }
@@ -242,7 +242,7 @@ namespace Microsoft.IdentityModel.Logging
         /// Logs an exception using the event source logger.
         /// </summary>
         /// <param name="exception">The exception to log.</param>
-        public static Exception LogExceptionMessage(Exception exception)
+        public static Exception? LogExceptionMessage(Exception exception)
         {
             return LogExceptionMessage(EventLevel.Error, exception);
         }
@@ -252,7 +252,7 @@ namespace Microsoft.IdentityModel.Logging
         /// </summary>
         /// <param name="eventLevel">Identifies the level of an event to be logged.</param>
         /// <param name="exception">The exception to log.</param>
-        public static Exception LogExceptionMessage(EventLevel eventLevel, Exception exception)
+        public static Exception? LogExceptionMessage(EventLevel eventLevel, Exception exception)
         {
             if (exception == null)
                 return null;
@@ -317,9 +317,9 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="innerException">the inner <see cref="Exception"/> to be added to the outer exception.</param>
         /// <param name="format">Format string of the log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        private static T LogExceptionImpl<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string argumentName, Exception innerException, string format, params object[] args) where T : Exception 
+        private static T? LogExceptionImpl<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(EventLevel eventLevel, string? argumentName, Exception? innerException, string format, params object[]? args) where T : Exception 
         {
-            string message = null;
+            string? message = null;
 
             if (args != null)
                 message = string.Format(CultureInfo.InvariantCulture, format, args);
@@ -335,14 +335,14 @@ namespace Microsoft.IdentityModel.Logging
 
             if (innerException != null) 
                 if (string.IsNullOrEmpty(argumentName))
-                    return (T)Activator.CreateInstance(typeof(T), message, innerException);
+                    return (T)Activator.CreateInstance(typeof(T), message, innerException)!;
                 else
-                    return (T)Activator.CreateInstance(typeof(T), argumentName, message, innerException);
+                    return (T)Activator.CreateInstance(typeof(T), argumentName, message, innerException)!;
             else
                 if (string.IsNullOrEmpty(argumentName))
-                    return (T)Activator.CreateInstance(typeof(T), message);
+                    return (T)Activator.CreateInstance(typeof(T), message)!;
                 else
-                    return (T)Activator.CreateInstance(typeof(T), argumentName, message);
+                    return (T)Activator.CreateInstance(typeof(T), argumentName, message)!;
         }
 
         /// <summary>
@@ -351,7 +351,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="format">Format string.</param>
         /// <param name="args">Format arguments.</param>
         /// <returns>Formatted string.</returns>
-        public static string FormatInvariant(string format, params object[] args)
+        public static string FormatInvariant(string? format, params object[] args)
         {
             if (format == null)
                 return string.Empty;
@@ -371,25 +371,25 @@ namespace Microsoft.IdentityModel.Logging
                 return "null";
 
             if (IdentityModelEventSource.LogCompleteSecurityArtifact && arg is ISafeLogSecurityArtifact)
-                return (arg as ISafeLogSecurityArtifact).UnsafeToString();
+                return ((ISafeLogSecurityArtifact)arg).UnsafeToString();
 
             return arg;
         }
 
-        private static string RemovePII(object arg)
+        private static string? RemovePII(object arg)
         {
             if (arg is Exception ex && IsCustomException(ex))
                 return ex.ToString();
 
             if (arg is NonPII)
-                return arg.ToString();
+                return arg!.ToString();
 
             return string.Format(CultureInfo.InvariantCulture, IdentityModelEventSource.HiddenPIIString, arg?.GetType().ToString() ?? "Null");
         }
 
         internal static bool IsCustomException(Exception ex)
         {
-            return ex.GetType().FullName.StartsWith("Microsoft.IdentityModel.", StringComparison.Ordinal);
+            return ex!.GetType().FullName!.StartsWith("Microsoft.IdentityModel.", StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -424,7 +424,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="innerException"><see cref="Exception"/></param>
         /// <param name="message">The log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        private static LogEntry WriteEntry(EventLogLevel eventLogLevel, Exception innerException, string message, params object[] args)
+        private static LogEntry? WriteEntry(EventLogLevel eventLogLevel, Exception? innerException, string? message, params object[]? args)
         {
             if (string.IsNullOrEmpty(message))
                 return null;
@@ -447,7 +447,7 @@ namespace Microsoft.IdentityModel.Logging
             if (!_isHeaderWritten)
             {
                 string headerMessage = string.Format(CultureInfo.InvariantCulture, "Microsoft.IdentityModel Version: {0}. Date {1}. {2}",
-                    typeof(IdentityModelEventSource).Assembly.GetName().Version.ToString(),
+                    typeof(IdentityModelEventSource).Assembly!.GetName().Version!.ToString(),
                     DateTime.UtcNow,
                     IdentityModelEventSource.ShowPII ? _piiOnLogMessage : _piiOffLogMessage);
 

--- a/src/Microsoft.IdentityModel.Logging/LoggerContext.cs
+++ b/src/Microsoft.IdentityModel.Logging/LoggerContext.cs
@@ -52,6 +52,6 @@ namespace Microsoft.IdentityModel.Logging
         /// <summary>
         /// Gets or sets an <see cref="IDictionary{String, Object}"/> that enables custom extensibility scenarios.
         /// </summary>
-        public IDictionary<string, object> PropertyBag { get; set; }
+        public IDictionary<string, object>? PropertyBag { get; set; }
     }
 }

--- a/src/Microsoft.IdentityModel.Logging/Microsoft.IdentityModel.Logging.csproj
+++ b/src/Microsoft.IdentityModel.Logging/Microsoft.IdentityModel.Logging.csproj
@@ -9,6 +9,7 @@
     <PackageId>Microsoft.IdentityModel.Logging</PackageId>
     <PackageTags>.NET;Windows;Authentication;Identity;Logging</PackageTags>
     <IsTrimmable>true</IsTrimmable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Microsoft.IdentityModel.Logging/TextWriterEventListener.cs
+++ b/src/Microsoft.IdentityModel.Logging/TextWriterEventListener.cs
@@ -45,7 +45,7 @@ namespace Microsoft.IdentityModel.Logging
         public TextWriterEventListener(string filePath)
         {
             if (string.IsNullOrEmpty(filePath))
-                throw LogHelper.LogArgumentNullException(nameof(filePath));
+                throw LogHelper.LogArgumentNullException(nameof(filePath))!;
 
             try
             {
@@ -67,7 +67,7 @@ namespace Microsoft.IdentityModel.Logging
         public TextWriterEventListener(StreamWriter streamWriter)
         {
             if (streamWriter == null)
-                throw LogHelper.LogArgumentNullException("streamWriter");
+                throw LogHelper.LogArgumentNullException("streamWriter")!;
 
             _streamWriter = streamWriter;
             _disposeStreamWriter = false;
@@ -80,7 +80,7 @@ namespace Microsoft.IdentityModel.Logging
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
             if (eventData == null)
-                throw LogHelper.LogArgumentNullException("eventData");
+                throw LogHelper.LogArgumentNullException("eventData")!;
 
             if (eventData.Payload == null || eventData.Payload.Count <= 0)
             {
@@ -90,7 +90,7 @@ namespace Microsoft.IdentityModel.Logging
 
             for (int i = 0; i < eventData.Payload.Count; i++)
             {
-                _streamWriter.WriteLine(eventData.Payload[i].ToString());
+                _streamWriter.WriteLine(eventData!.Payload[i]!.ToString());
             }
         }
 

--- a/src/Microsoft.IdentityModel.LoggingExtensions/IdentityLoggerAdapter.cs
+++ b/src/Microsoft.IdentityModel.LoggingExtensions/IdentityLoggerAdapter.cs
@@ -33,7 +33,7 @@ namespace Microsoft.IdentityModel.LoggingExtensions
         }
 
         /// <inheritdoc/>
-        public void Log(LogEntry entry)
+        public void Log(LogEntry? entry)
         {
             if (entry != null)
             {

--- a/src/Microsoft.IdentityModel.LoggingExtensions/Microsoft.IdentityModel.LoggingExtensions.csproj
+++ b/src/Microsoft.IdentityModel.LoggingExtensions/Microsoft.IdentityModel.LoggingExtensions.csproj
@@ -9,6 +9,7 @@
     <PackageId>Microsoft.IdentityModel.LoggingExtensions</PackageId>
     <PackageTags>.NET;Windows;Authentication;Identity;Extensions;Logging</PackageTags>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/ManagedKeyVaultSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/ManagedKeyVaultSecurityKey.cs
@@ -49,13 +49,13 @@ namespace Microsoft.IdentityModel.ManagedKeyVaultSecurityKey
         public ManagedKeyVaultSecurityKey(string keyIdentifier, string clientId, string clientSecret)
         {
             if (string.IsNullOrEmpty(keyIdentifier))
-                throw LogHelper.LogArgumentNullException(nameof(keyIdentifier));
+                throw LogHelper.LogArgumentNullException(nameof(keyIdentifier))!;
 
             if (string.IsNullOrEmpty(clientId))
-                throw LogHelper.LogArgumentNullException(nameof(clientId));
+                throw LogHelper.LogArgumentNullException(nameof(clientId))!;
 
             if (string.IsNullOrEmpty(clientSecret))
-                throw LogHelper.LogArgumentNullException(nameof(clientSecret));
+                throw LogHelper.LogArgumentNullException(nameof(clientSecret))!;
 
             KeyId = keyIdentifier;
             Callback = new AuthenticationCallback(async (string authority, string resource, string scope) =>

--- a/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.csproj
+++ b/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.csproj
@@ -11,7 +11,6 @@
     <PackageId>Microsoft.IdentityModel.ManagedKeyVaultSecurityKey</PackageId>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageTags>.NET;Windows;Authentication;Identity;Azure;Key;Vault;Extensions</PackageTags>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.csproj
+++ b/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.csproj
@@ -11,6 +11,7 @@
     <PackageId>Microsoft.IdentityModel.ManagedKeyVaultSecurityKey</PackageId>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageTags>.NET;Windows;Authentication;Identity;Azure;Key;Vault;Extensions</PackageTags>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/Configuration/WsFederationConfigurationRetriever.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/Configuration/WsFederationConfigurationRetriever.cs
@@ -28,7 +28,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         public static Task<WsFederationConfiguration> GetAsync(string address, CancellationToken cancel)
         {
             if (string.IsNullOrEmpty(address))
-                throw LogArgumentNullException(nameof(address));
+                throw LogArgumentNullException(nameof(address))!;
 
             return GetAsync(address, new HttpDocumentRetriever(), cancel);
         }
@@ -45,10 +45,10 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         public static Task<WsFederationConfiguration> GetAsync(string address, HttpClient httpClient, CancellationToken cancel)
         {
             if (string.IsNullOrEmpty(address))
-                throw LogArgumentNullException(nameof(address));
+                throw LogArgumentNullException(nameof(address))!;
 
             if (httpClient == null)
-                throw LogArgumentNullException(nameof(httpClient));
+                throw LogArgumentNullException(nameof(httpClient))!;
 
             return GetAsync(address, new HttpDocumentRetriever(httpClient), cancel);
         }
@@ -71,10 +71,10 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         public static async Task<WsFederationConfiguration> GetAsync(string address, IDocumentRetriever retriever, CancellationToken cancel)
         {
             if (string.IsNullOrEmpty(address))
-                throw LogArgumentNullException(nameof(address));
+                throw LogArgumentNullException(nameof(address))!;
 
             if (retriever == null)
-                throw LogArgumentNullException(nameof(retriever));
+                throw LogArgumentNullException(nameof(retriever))!;
 
             string document = await retriever.GetDocumentAsync(address, cancel).ConfigureAwait(false);
 

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/Configuration/WsFederationConfigurationValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/Configuration/WsFederationConfigurationValidator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         public ConfigurationValidationResult Validate(WsFederationConfiguration configuration)
         {
             if (configuration == null)
-                throw LogArgumentNullException(nameof(configuration));
+                throw LogArgumentNullException(nameof(configuration))!;
 
             if (string.IsNullOrWhiteSpace(configuration.Issuer))
             {

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMessage.cs
@@ -287,7 +287,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
                 }
 
                 if (token == null)
-                    throw LogExceptionMessage(new WsFederationException(LogMessages.IDX22902));
+                    throw LogExceptionMessage(new WsFederationException(LogMessages.IDX22902))!;
 
                 return token;
             }

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMetadataSerializer.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/WsFederationMetadataSerializer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         public string PreferredPrefix
         {
             get => _preferredPrefix;
-            set => _preferredPrefix = string.IsNullOrEmpty(value) ? throw LogExceptionMessage(new ArgumentNullException(nameof(value))) : value;
+            set => _preferredPrefix = string.IsNullOrEmpty(value) ? throw LogExceptionMessage(new ArgumentNullException(nameof(value)))! : value;
         }
 
         #region Read Metadata
@@ -370,10 +370,10 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation
         public void WriteMetadata(XmlWriter writer, WsFederationConfiguration configuration)
         {
             if (writer == null)
-                throw LogArgumentNullException(nameof(writer));
+                throw LogArgumentNullException(nameof(writer))!;
 
             if (configuration == null)
-                throw LogArgumentNullException(nameof(configuration));
+                throw LogArgumentNullException(nameof(configuration))!;
 
             if (string.IsNullOrEmpty(configuration.Issuer))
                 throw XmlUtil.LogWriteException(LogMessages.IDX22810);

--- a/src/Microsoft.IdentityModel.TestExtensions/Microsoft.IdentityModel.TestExtensions.csproj
+++ b/src/Microsoft.IdentityModel.TestExtensions/Microsoft.IdentityModel.TestExtensions.csproj
@@ -10,6 +10,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageId>Microsoft.IdentityModel.TestExtensions</PackageId>
     <SignAssembly>true</SignAssembly>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.IdentityModel.TestExtensions/TestTokenCreator.cs
+++ b/src/Microsoft.IdentityModel.TestExtensions/TestTokenCreator.cs
@@ -136,7 +136,7 @@ namespace Microsoft.IdentityModel.TestExtensions
         /// <summary>
         /// Gets or sets the SigningCredentials used to sign the tokens created.
         /// </summary>
-        public SigningCredentials SigningCredentials { get; set; }
+        public SigningCredentials? SigningCredentials { get; set; }
 
         #region Create Test Token Methods
         /// <summary>


### PR DESCRIPTION
Second PR for logging and KeyVaultExtension dll's with the goal to enable nullable across the solution. This allows variables to have null as a value, which can be useful in cases where a value may not be present or when a value is optional. It also allows for the use of null-forgiving operator, which suppresses nullable warnings for an expression that has been checked for nulls.