### PR TITLE
Avoid draining the ArrayPool with undisposed JsonDocuments

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
@@ -22,17 +22,16 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
         internal JsonClaimSet(JsonDocument jsonDocument)
         {
-            RootElement = jsonDocument.RootElement;
+            RootElement = jsonDocument.RootElement.Clone();
+            jsonDocument.Dispose();
         }
 
-        internal JsonClaimSet(byte[] jsonBytes)
+        internal JsonClaimSet(byte[] jsonBytes) : this(JsonDocument.Parse(jsonBytes))
         {
-            RootElement = JsonDocument.Parse(jsonBytes).RootElement;
         }
 
-        internal JsonClaimSet(string json)
+        internal JsonClaimSet(string json) : this(JsonDocument.Parse(json))
         {
-            RootElement = JsonDocument.Parse(json).RootElement;
         }
 
         internal JsonElement RootElement { get; }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
@@ -22,6 +22,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
         internal JsonClaimSet(JsonDocument jsonDocument)
         {
+            // This method is assuming ownership of the JsonDocument, which is backed by one or more ArrayPool arrays.
+            // We need to dispose of it to avoid leaking arrays from the pool.  To achieve that, we clone the root element,
+            // which will result in a new JsonElement being created that's not tied to the original and that's not backed by
+            // ArrayPool memory, after which point we can dispose of the original to return the array(s) to the pool.
             RootElement = jsonDocument.RootElement.Clone();
             jsonDocument.Dispose();
         }


### PR DESCRIPTION
My understanding is this code is likely going to be overhauled to not use JsonDocument at all, but in the meantime we can make a small tweak to significantly improve throughput. JsonDocument.Parse creates a JsonDocument backed by one or more ArrayPool arrays; those arrays are returned when the instance is disposed.  If it's never disposed, the arrays are never returned to the pool. That means that creating but not disposing lots of JsonDocument instances ends up incurring the cost (and contention) of searching the ArrayPool but ends up falling back to allocating anyway.

The problem is that JsonClaimSet isn't disposable and so the underlying JsonDocument is never disposed. As a patch until the code is overhauled, we can use JsonElement.Clone(), which creates a new JsonDocument not backed by ArrayPool arrays... we can then dispose of the original in order to return the arrays to the pool.

This still isn't ideal, as we're doing more allocating and copying than we'd like, but it ends up being much better than without.