### PR TITLE
Remove object[] allocation from InMemoryCryptoProviderCache.GetCacheKeyPrivate

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
+++ b/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
@@ -102,12 +102,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         private static string GetCacheKeyPrivate(SecurityKey securityKey, string algorithm, string typeofProvider)
         {
-            return string.Format(CultureInfo.InvariantCulture,
-                                 "{0}-{1}-{2}-{3}",
-                                 securityKey.GetType(),
-                                 securityKey.InternalId,
-                                 algorithm,
-                                 typeofProvider);
+            return $"{securityKey.GetType()}-{securityKey.InternalId}-{algorithm}-{typeofProvider}";
         }
 
         /// <summary>


### PR DESCRIPTION
There's a params object[] being allocated. On .NET 6+, using an interpolated string will avoid that. On < .NET 6, it'll be exactly what it was before (InvariantCulture isn't needed as nothing here is affected by culture).