### PR TITLE
Change LangVersion to be 11

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -32,7 +32,7 @@
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(SrcTargets)</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">$(SrcStandardTargets)</TargetFrameworks>
     <NetStandardImplicitPackageVersion>$(NetStandardVersion)</NetStandardImplicitPackageVersion>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">

--- a/src/Microsoft.IdentityModel.KeyVaultExtensions/Microsoft.IdentityModel.KeyVaultExtensions.csproj
+++ b/src/Microsoft.IdentityModel.KeyVaultExtensions/Microsoft.IdentityModel.KeyVaultExtensions.csproj
@@ -6,7 +6,6 @@
     <AssemblyName>Microsoft.IdentityModel.KeyVaultExtensions</AssemblyName>
     <Description>Includes types that provide support for signing and encrypting tokens with Azure Key Vault.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.IdentityModel.KeyVaultExtensions</PackageId>
     <TargetFrameworks Condition="'$(TargetNet8)' == 'True'">netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetNet8)' != 'True'">netstandard2.0;net6.0</TargetFrameworks>

--- a/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.csproj
+++ b/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.csproj
@@ -7,7 +7,6 @@
     <Description>Includes types that provide support for signing and encrypting tokens with Azure Key Vault for 
     Applications that are using Managed identities for Azure resources.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.IdentityModel.ManagedKeyVaultSecurityKey</PackageId>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageTags>.NET;Windows;Authentication;Identity;Azure;Key;Vault;Extensions</PackageTags>

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -300,7 +300,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                     if (!firstQueryParam)
                         stringBuffer.Append("&");
 
-                    stringBuffer.Append($"{queryParam.Key}={queryParam.Value}");
+                    stringBuffer.Append(queryParam.Key).Append('=').Append(queryParam.Value);
 
                     queryParamNameList.Add(queryParam.Key);
                     firstQueryParam = false;
@@ -342,7 +342,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                     if (!firstHeader)
                         stringBuffer.Append(_newlineSeparator);
 
-                    stringBuffer.Append($"{headerName}: {header.Value}");
+                    stringBuffer.Append(headerName).Append(": ").Append(header.Value);
                     firstHeader = false;
                 }
 
@@ -847,7 +847,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                         if (!firstQueryParam)
                             stringBuffer.Append("&");
 
-                        stringBuffer.Append($"{queryParamName}={queryParamsValue}");
+                        stringBuffer.Append(queryParamName).Append('=').Append(queryParamsValue);
                         firstQueryParam = false;
 
                         // remove the query param from the dictionary to mark it as covered.
@@ -915,7 +915,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                         if (!firstHeader)
                             stringBuffer.Append(_newlineSeparator);
 
-                        stringBuffer.Append($"{headerName}: {headerValue}");
+                        stringBuffer.Append(headerName).Append(": ").Append(headerValue);
                         firstHeader = false;
 
                         // remove the header from the dictionary to mark it as covered.

--- a/src/Microsoft.IdentityModel.Tokens/Microsoft.IdentityModel.Tokens.csproj
+++ b/src/Microsoft.IdentityModel.Tokens/Microsoft.IdentityModel.Tokens.csproj
@@ -8,7 +8,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Microsoft.IdentityModel.Tokens</PackageId>
     <PackageTags>.NET;Windows;Authentication;Identity;SecurityTokens;Cryptographic operations;Signing;Verifying Signatures;Encryption</PackageTags>
-    <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   

--- a/test/Microsoft.IdentityModel.KeyVaultExtensions.Tests/Microsoft.IdentityModel.KeyVaultExtensions.Tests.csproj
+++ b/test/Microsoft.IdentityModel.KeyVaultExtensions.Tests/Microsoft.IdentityModel.KeyVaultExtensions.Tests.csproj
@@ -8,7 +8,6 @@
     <DelaySign>true</DelaySign>
     <Description>Tests for Microsoft.IdentityModel.KeyVaultExtensions</Description>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.IdentityModel.KeyVaultExtensions.Tests</PackageId>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>

--- a/test/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.Tests/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.Tests.csproj
+++ b/test/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.Tests/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\build\commonTest.props" />
 
@@ -8,7 +8,6 @@
     <DelaySign>true</DelaySign>
     <Description>Tests for Microsoft.IdentityModel.ManagedKeyVaultSecurityKey</Description>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <LangVersion>latest</LangVersion>
     <PackageId>Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.Tests</PackageId>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>


### PR DESCRIPTION
Downlevel "latest" maps to pre-11. In the future, we'll want to either keep this up-to-date (e.g. update it to 12 when .NET 8 ships) or change it to preview, which will always be up-to-date.