### PR TITLE
Fix casing of Properties directory in updateAssemblyInfo.ps1 script

### DIFF
--- a/updateAssemblyInfo.ps1
+++ b/updateAssemblyInfo.ps1
@@ -62,7 +62,7 @@ Set-Content $versionPath $version
 foreach($project in $buildConfiguration.SelectNodes("root/projects/src/project"))
 {
     $name = $project.name
-    $assemblyInfoPath = "$root\src\$name\properties\AssemblyInfo.cs"
+    $assemblyInfoPath = "$root\src\$name\Properties\AssemblyInfo.cs"
     Write-Host "assemblyInfoPath: " $assemblyInfoPath
 
     $assemblyInfo = Get-Content $assemblyInfoPath


### PR DESCRIPTION
When attempting to invoke the updateAssemblyInfo.ps1 script from a Linux environment using PowerShell Core, it gets errors because the assembly info paths that are generated do not exist. This is because the generated path uses lowercase `properties` instead of the actual name that exists on disk: `Properties`. Unlike Windows, Linux file system is case-sensitive. This is fixed by using the correct casing.

This change is necessary to support .NET's source-build which builds this repo (see https://github.com/dotnet/source-build/issues/3565).