### PR TITLE
Add support for RSA-OAEP 256 (#1293)

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -199,9 +199,14 @@ namespace Microsoft.IdentityModel.Tokens
                 RSASignaturePadding = RSASignaturePadding.Pkcs1;
             }
 
-            RSAEncryptionPadding = (algorithm.Equals(SecurityAlgorithms.RsaOAEP) || algorithm.Equals(SecurityAlgorithms.RsaOaepKeyWrap))
-                        ? RSAEncryptionPadding.OaepSHA1
-                        : RSAEncryptionPadding.Pkcs1;
+            RSAEncryptionPadding = algorithm switch
+            {
+                SecurityAlgorithms.RsaOAEP => RSAEncryptionPadding.OaepSHA1,
+                SecurityAlgorithms.RsaOaepKeyWrap => RSAEncryptionPadding.OaepSHA1,
+                SecurityAlgorithms.RsaOAEP256 => RSAEncryptionPadding.OaepSHA256,
+                _ => RSAEncryptionPadding.Pkcs1
+            };
+
             RSA = rsa;
             _decryptFunction = DecryptWithRsa;
             _encryptFunction = EncryptWithRsa;

--- a/src/Microsoft.IdentityModel.Tokens/SecurityAlgorithms.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityAlgorithms.cs
@@ -31,6 +31,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string Aes256KW = "A256KW";
         public const string RsaPKCS1 = "RSA1_5";
         public const string RsaOAEP = "RSA-OAEP";
+        public const string RsaOAEP256 = "RSA-OAEP-256";
 
         // See: https://www.w3.org/TR/xmlenc-core1/#sec-Exclusive-Canonicalization
         public const string ExclusiveC14n = "http://www.w3.org/2001/10/xml-exc-c14n#";

--- a/src/Microsoft.IdentityModel.Tokens/SupportedAlgorithms.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SupportedAlgorithms.cs
@@ -40,6 +40,7 @@ namespace Microsoft.IdentityModel.Tokens
         internal static readonly ICollection<string> RsaEncryptionAlgorithms = new Collection<string>
         {
             SecurityAlgorithms.RsaOAEP,
+            SecurityAlgorithms.RsaOAEP256,
             SecurityAlgorithms.RsaPKCS1,
             SecurityAlgorithms.RsaOaepKeyWrap
         };

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -2745,6 +2745,30 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     },
                     new CreateTokenTheoryData
                     {
+                        TestId = "RsaOAEP256_Aes128CbcHmacSha256",
+                        ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
+                        Payload = Default.PayloadString,
+                        SigningCredentials = Default.SymmetricSigningCredentials,
+                        EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOAEP256, SecurityAlgorithms.Aes128CbcHmacSha256)
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "RsaOAEP256_Aes192CbcHmacSha384",
+                        ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
+                        Payload = Default.PayloadString,
+                        SigningCredentials = Default.SymmetricSigningCredentials,
+                        EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOAEP256, SecurityAlgorithms.Aes192CbcHmacSha384)
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "RsaOAEP256_Aes256CbcHmacSha512",
+                        ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
+                        Payload = Default.PayloadString,
+                        SigningCredentials = Default.SymmetricSigningCredentials,
+                        EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOAEP256, SecurityAlgorithms.Aes256CbcHmacSha512)
+                    },
+                    new CreateTokenTheoryData
+                    {
                         TestId = "RsaOAEP_Aes192CbcHmacSha384",
                         ValidationParameters = Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
                         Payload = Default.PayloadString,

--- a/test/Microsoft.IdentityModel.KeyVaultExtensions.Tests/KeyVaultKeyWrapProviderTests.cs
+++ b/test/Microsoft.IdentityModel.KeyVaultExtensions.Tests/KeyVaultKeyWrapProviderTests.cs
@@ -59,6 +59,12 @@ namespace Microsoft.IdentityModel.KeyVaultExtensions.Tests
                     ExpectedException = ExpectedException.NoExceptionExpected,
                     TestId = nameof(SecurityAlgorithms.RsaOAEP),
                 },
+                new KeyWrapProviderTheoryData
+                {
+                    Algorithm = SecurityAlgorithms.RsaOAEP256,
+                    ExpectedException = ExpectedException.NoExceptionExpected,
+                    TestId = nameof(SecurityAlgorithms.RsaOAEP256),
+                },
             };
         }
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/KeyVaultVerify.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/KeyVaultVerify.cs
@@ -28,6 +28,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 CryptoProviderFactory.Default.ReleaseKeyWrapProvider(keyWrapProvider);
             }
             else if (testParams.Algorithm.Equals(SecurityAlgorithms.RsaOAEP, StringComparison.OrdinalIgnoreCase)
+                    || testParams.Algorithm.Equals(SecurityAlgorithms.RsaOAEP256, StringComparison.OrdinalIgnoreCase)
                     || testParams.Algorithm.Equals(SecurityAlgorithms.RsaPKCS1, StringComparison.OrdinalIgnoreCase))
             {
                 var keyWrapProvider = CryptoProviderFactory.Default.CreateKeyWrapProvider(testParams.Key, testParams.Algorithm);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ReferenceTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ReferenceTests.cs
@@ -182,7 +182,9 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 Assert.True(Utility.AreEqual(unwrappedKey, testParams.KeyToWrap), "Utility.AreEqual(unwrappedKey, testParams.KeyToWrap)");
             }
             else if (testParams.Algorithm.Equals(SecurityAlgorithms.RsaOAEP, StringComparison.OrdinalIgnoreCase)
-                    || testParams.Algorithm.Equals(SecurityAlgorithms.RsaPKCS1, StringComparison.OrdinalIgnoreCase))
+                    || testParams.Algorithm.Equals(SecurityAlgorithms.RsaPKCS1, StringComparison.OrdinalIgnoreCase)
+                    || testParams.Algorithm.Equals(SecurityAlgorithms.RsaOAEP256, StringComparison.OrdinalIgnoreCase)
+                    )
             {
                 var rsaKeyWrapProvider = CryptoProviderFactory.Default.CreateKeyWrapProvider(testParams.Key, testParams.Algorithm);
                 byte[] unwrappedKey = rsaKeyWrapProvider.UnwrapKey(testParams.EncryptedKey);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaKeyWrapProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaKeyWrapProviderTests.cs
@@ -104,6 +104,14 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 },
                 new KeyWrapTheoryData
                 {
+                    ExpectedException =  ExpectedException.SecurityTokenKeyWrapException("IDX10661:"),
+                    TestId = "KeyTooSmall1024",
+                    WillUnwrap = false,
+                    WrapAlgorithm = SecurityAlgorithms.RsaOAEP256,
+                    WrapKey = KeyingMaterial.RsaSecurityKey_1024
+                },
+                new KeyWrapTheoryData
+                {
                     ExpectedException = ExpectedException.SecurityTokenKeyWrapException("IDX10661:"),
                     TestId = "KeyDoesNotMatchAlgorithm",
                     WillUnwrap = false,
@@ -205,8 +213,35 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 new KeyWrapTheoryData
                 {
                     ExpectedException = ExpectedException.KeyWrapException("IDX10659:"),
-                    TestId = "AlgorithmAndKeyMismatchRsaPKCS1Bits4096RsaOAEKey2048",
+                    TestId = "AlgorithmAndKeyMismatchRsaPKCS1Bits4096RsaOAEPKey2048",
                     UnwrapAlgorithm = SecurityAlgorithms.RsaOAEP,
+                    UnwrapKey = KeyingMaterial.RsaSecurityKey_2048,
+                    WrapAlgorithm = SecurityAlgorithms.RsaPKCS1,
+                    WrapKey = KeyingMaterial.RsaSecurityKey_4096_Public,
+                },
+                new KeyWrapTheoryData
+                {
+                    ExpectedException = ExpectedException.KeyWrapException("IDX10659:"),
+                    TestId = "AlgorithmMismatchRsaPKCS1RsaOAEP256",
+                    UnwrapAlgorithm = SecurityAlgorithms.RsaOAEP256,
+                    UnwrapKey = KeyingMaterial.RsaSecurityKey_2048,
+                    WrapAlgorithm = SecurityAlgorithms.RsaPKCS1,
+                    WrapKey = KeyingMaterial.RsaSecurityKey_2048_Public
+                },
+                new KeyWrapTheoryData
+                {
+                    ExpectedException = ExpectedException.KeyWrapException("IDX10659:"),
+                    TestId = "KeyMismatchRsa4096Rsa2048",
+                    UnwrapAlgorithm = SecurityAlgorithms.RsaOAEP256,
+                    UnwrapKey = KeyingMaterial.RsaSecurityKey_2048,
+                    WrapAlgorithm = SecurityAlgorithms.RsaOAEP,
+                    WrapKey = KeyingMaterial.RsaSecurityKey_4096_Public,
+                },
+                new KeyWrapTheoryData
+                {
+                    ExpectedException = ExpectedException.KeyWrapException("IDX10659:"),
+                    TestId = "AlgorithmAndKeyMismatchRsaPKCS1Bits4096RsaOAEP256Key2048",
+                    UnwrapAlgorithm = SecurityAlgorithms.RsaOAEP256,
                     UnwrapKey = KeyingMaterial.RsaSecurityKey_2048,
                     WrapAlgorithm = SecurityAlgorithms.RsaPKCS1,
                     WrapKey = KeyingMaterial.RsaSecurityKey_4096_Public,
@@ -366,6 +401,13 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 KeyingMaterial.RsaSecurityKey_2048,
                 null,
                 ExpectedException.ArgumentNullException(),
+                theoryData);
+
+            AddWrapUnwrapTheoryData(
+                "Test4",
+                SecurityAlgorithms.RsaOAEP256,
+                KeyingMaterial.RsaSecurityKey_2048_Public,
+                KeyingMaterial.RsaSecurityKey_2048,
                 theoryData);
 
             return theoryData;

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
@@ -799,6 +799,30 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 ExpectedException.NoExceptionExpected
             );
 
+            encryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOAEP256, SecurityAlgorithms.Aes128CbcHmacSha256);
+            theoryData.Add(
+                "RsaOAEP256-Aes128CbcHmacSha256",
+                Default.SecurityTokenDescriptor(encryptingCredentials, Default.SymmetricSigningCredentials, ClaimSets.DefaultClaims),
+                Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
+                ExpectedException.NoExceptionExpected
+            );
+
+            encryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOAEP256, SecurityAlgorithms.Aes192CbcHmacSha384);
+            theoryData.Add(
+                "RsaOAEP256-Aes192CbcHmacSha384",
+                Default.SecurityTokenDescriptor(encryptingCredentials, Default.SymmetricSigningCredentials, ClaimSets.DefaultClaims),
+                Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
+                ExpectedException.NoExceptionExpected
+            );
+
+            encryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOAEP256, SecurityAlgorithms.Aes256CbcHmacSha512);
+            theoryData.Add(
+                "RsaOAEP256-Aes256CbcHmacSha512",
+                Default.SecurityTokenDescriptor(encryptingCredentials, Default.SymmetricSigningCredentials, ClaimSets.DefaultClaims),
+                Default.TokenValidationParameters(KeyingMaterial.RsaSecurityKey_2048, Default.SymmetricSigningKey256),
+                ExpectedException.NoExceptionExpected
+            );
+
             encryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaOaepKeyWrap, SecurityAlgorithms.Aes128CbcHmacSha256);
             theoryData.Add(
                 "RsaOaepKeyWrap-Aes128CbcHmacSha256",

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -2767,6 +2767,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             var theoryData = new TheoryData<KeyWrapTokenTheoryData>();
             var handler = new JwtSecurityTokenHandler();
             var rsaOAEPEncryptingCredential = new EncryptingCredentials(KeyingMaterial.DefaultX509Key_2048, SecurityAlgorithms.RsaOAEP, SecurityAlgorithms.Aes256CbcHmacSha512);
+            var rsaOAEP256EncryptingCredential = new EncryptingCredentials(KeyingMaterial.DefaultX509Key_2048, SecurityAlgorithms.RsaOAEP256, SecurityAlgorithms.Aes256CbcHmacSha512);
             var rsaPKCS1EncryptingCredential = new EncryptingCredentials(KeyingMaterial.DefaultX509Key_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes256CbcHmacSha512);
 
             theoryData.Add(new KeyWrapTokenTheoryData
@@ -2774,6 +2775,13 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 EncryptingCredentials = rsaOAEPEncryptingCredential,
                 DecryptingCredentials = rsaOAEPEncryptingCredential,
                 TestId = "Key wrap token test using OAEP padding"
+            });
+
+            theoryData.Add(new KeyWrapTokenTheoryData
+            {
+                EncryptingCredentials = rsaOAEP256EncryptingCredential,
+                DecryptingCredentials = rsaOAEP256EncryptingCredential,
+                TestId = "Key wrap token test using OAEP-256 padding"
             });
 
             theoryData.Add(new KeyWrapTokenTheoryData


### PR DESCRIPTION
This PR adds support for RSA-OAEP-256, as mentioned in RFC 7518 (https://datatracker.ietf.org/doc/html/rfc7518#section-4.1) and fixes Issue 1293