### PR TITLE
JsonWebKey and JsonWebKeySet using System.Text.Json for reading and writing

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfigurationRetriever.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfigurationRetriever.cs
@@ -79,7 +79,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                 if (LogHelper.IsEnabled(EventLogLevel.Verbose))
                     LogHelper.LogVerbose(LogMessages.IDX21813, openIdConnectConfiguration.JwksUri);
 
-                openIdConnectConfiguration.JsonWebKeySet = JsonConvert.DeserializeObject<JsonWebKeySet>(keys);
+                openIdConnectConfiguration.JsonWebKeySet = new JsonWebKeySet(keys);
                 foreach (SecurityKey key in openIdConnectConfiguration.JsonWebKeySet.GetSigningKeys())
                 {
                     openIdConnectConfiguration.SigningKeys.Add(key);

--- a/src/Microsoft.IdentityModel.Tokens/Json/EncodedJsonWebKeyParameterNames.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/EncodedJsonWebKeyParameterNames.cs
@@ -1,0 +1,271 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// JsonEncodedText used with utf8Writer when writing property names for JsonWebKey.
+    /// Common names are initialized on startup, lazy for others.
+    /// </summary>
+    internal static class EncodedJsonWebKeyParameterNames
+    {
+        internal static bool _algSet;
+        internal static JsonEncodedText _alg;
+        internal static bool _crvSet;
+        internal static JsonEncodedText _crv;
+        internal static bool _dSet;
+        internal static JsonEncodedText _d;
+        internal static bool _dpSet;
+        internal static JsonEncodedText _dp;
+        internal static bool _dqSet;
+        internal static JsonEncodedText _dq;
+        internal static bool _kSet;
+        internal static JsonEncodedText _k;
+        internal static bool _keyopsSet;
+        internal static JsonEncodedText _keyOps;
+        internal static bool _othSet;
+        internal static JsonEncodedText _oth;
+        internal static bool _pSet;
+        internal static JsonEncodedText _p;
+        internal static bool _qSet;
+        internal static JsonEncodedText _q;
+        internal static bool _qiSet;
+        internal static JsonEncodedText _qi;
+        internal static bool _x5tS256Set;
+        internal static JsonEncodedText _x5tS256;
+        internal static bool _x5uSet;
+        internal static JsonEncodedText _x5u;
+        internal static bool _xSet;
+        internal static JsonEncodedText _x;
+        internal static bool _ySet;
+        internal static JsonEncodedText _y;
+
+        public static JsonEncodedText Alg
+        {
+            get
+            {
+                if (!_algSet)
+                {
+                    _alg = JsonEncodedText.Encode(JsonWebKeyParameterNames.Alg, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _algSet = true;
+                }
+
+                return _alg;
+            }
+        }
+
+        public static JsonEncodedText Crv
+        {
+            get
+            {
+                if (!_crvSet)
+                {
+                    _crv = JsonEncodedText.Encode(JsonWebKeyParameterNames.Crv, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _crvSet = true;
+                }
+
+                return _crv;
+            }
+        }
+
+        public static JsonEncodedText D
+        {
+            get
+            {
+                if (!_dSet)
+                {
+                    _d = JsonEncodedText.Encode(JsonWebKeyParameterNames.D, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _dSet = true;
+                }
+
+                return _d;
+            }
+        }
+
+        public static JsonEncodedText DP
+        {
+            get
+            {
+                if (!_dpSet)
+                {
+                    _dp = JsonEncodedText.Encode(JsonWebKeyParameterNames.DP, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _dpSet = true;
+                }
+
+                return _dp;
+            }
+        }
+
+        public static JsonEncodedText DQ
+        {
+            get
+            {
+                if (!_dqSet)
+                {
+                    _dq = JsonEncodedText.Encode(JsonWebKeyParameterNames.DQ, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _dqSet = true;
+                }
+
+                return _dq;
+            }
+        }
+
+        public static readonly JsonEncodedText E = JsonEncodedText.Encode(JsonWebKeyParameterNames.E, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+
+        public static JsonEncodedText K
+        {
+            get
+            {
+                if (!_kSet)
+                {
+                    _k = JsonEncodedText.Encode(JsonWebKeyParameterNames.K, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _kSet = true;
+                }
+
+                return _k;
+            }
+        }
+
+        public static JsonEncodedText KeyOps
+        {
+            get
+            {
+                if (!_keyopsSet)
+                {
+                    _keyOps = JsonEncodedText.Encode(JsonWebKeyParameterNames.KeyOps, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _keyopsSet = true;
+                }
+
+                return _keyOps;
+            }
+        }
+
+        public static readonly JsonEncodedText Keys = JsonEncodedText.Encode(JsonWebKeyParameterNames.Keys, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+
+        public static readonly JsonEncodedText Kid = JsonEncodedText.Encode(JsonWebKeyParameterNames.Kid, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+
+        public static readonly JsonEncodedText Kty = JsonEncodedText.Encode(JsonWebKeyParameterNames.Kty, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+
+        public static readonly JsonEncodedText N = JsonEncodedText.Encode(JsonWebKeyParameterNames.N, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+
+        public static JsonEncodedText Oth
+        {
+            get
+            {
+                if (!_othSet)
+                {
+                    _oth = JsonEncodedText.Encode(JsonWebKeyParameterNames.Oth, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _othSet = true;
+                }
+
+                return _oth;
+            }
+        }
+        
+        public static JsonEncodedText P
+        {
+            get
+            {
+                if (!_pSet)
+                {
+                    _p = JsonEncodedText.Encode(JsonWebKeyParameterNames.P, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _pSet = true;
+                }
+
+                return _p;
+            }
+        }
+        public static JsonEncodedText Q
+        {
+            get
+            {
+                if (!_qSet)
+                {
+                    _q = JsonEncodedText.Encode(JsonWebKeyParameterNames.Q, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _qSet = true;
+                }
+
+                return _q;
+            }
+        }
+
+        public static JsonEncodedText QI
+        {
+            get
+            {
+                if (!_qiSet)
+                {
+                    _qi = JsonEncodedText.Encode(JsonWebKeyParameterNames.QI, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _qiSet = true;
+                }
+
+                return _qi;
+            }
+        }
+
+        public static readonly JsonEncodedText Use = JsonEncodedText.Encode(JsonWebKeyParameterNames.Use, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+
+        public static readonly JsonEncodedText X5c = JsonEncodedText.Encode(JsonWebKeyParameterNames.X5c, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+
+        public static readonly JsonEncodedText X5t = JsonEncodedText.Encode(JsonWebKeyParameterNames.X5t, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+
+        public static JsonEncodedText X5tS256
+        {
+            get
+            {
+                if (!_x5tS256Set)
+                {
+                    _x5tS256 = JsonEncodedText.Encode(JsonWebKeyParameterNames.X5tS256, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _x5tS256Set = true;
+                }
+
+                return _x5tS256;
+            }
+        }
+
+        public static JsonEncodedText X5u
+        {
+            get
+            {
+                if (!_x5uSet)
+                {
+                    _x5u = JsonEncodedText.Encode(JsonWebKeyParameterNames.X5u, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _x5uSet = true;
+                }
+
+                return _x5u;
+            }
+        }
+        
+        public static JsonEncodedText X
+        {
+            get
+            {
+                if (!_xSet)
+                {
+                    _x = JsonEncodedText.Encode(JsonWebKeyParameterNames.X, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _xSet = true;
+                }
+
+                return _x;
+            }
+        }
+
+        public static JsonEncodedText Y
+        {
+            get
+            {
+                if (!_ySet)
+                {
+                    _y = JsonEncodedText.Encode(JsonWebKeyParameterNames.Y, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                    _ySet = true;
+                }
+
+                return _y;
+            }
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.IdentityModel.Logging;
 
@@ -60,7 +61,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
         internal static string GetPropertyName(ref Utf8JsonReader reader, string className, bool advanceReader)
         {
             if (reader.TokenType == JsonTokenType.None)
-                reader.Read();
+                ReaderRead(ref reader);
 
             if (reader.TokenType != JsonTokenType.PropertyName)
                 throw LogHelper.LogExceptionMessage(CreateJsonReaderExceptionInvalidType(ref reader, "JsonTokenType.PropertyName", string.Empty, className));
@@ -68,187 +69,270 @@ namespace Microsoft.IdentityModel.Tokens.Json
             if (advanceReader)
             {
                 string propertyName = reader.GetString();
-                reader.Read();
+                ReaderRead(ref reader);
                 return propertyName;
             }
 
             return reader.GetString();
         }
 
+        /// <summary>
+        /// This method is called when deserializing a known type where the JSON property does not map to a type property.
+        /// We put the object into a Dictionary[string, object].
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <returns></returns>
+        internal static object GetUnknownProperty(ref Utf8JsonReader reader)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.False:
+                    return false;
+                case JsonTokenType.Number:
+                    return ReadNumber(ref reader);
+                case JsonTokenType.True:
+                    return true;
+                case JsonTokenType.Null:
+                    return null;
+                case JsonTokenType.String:
+                    return reader.GetString();
+                case JsonTokenType.StartObject:
+                case JsonTokenType.StartArray:
+                    return ReadJsonElement(ref reader);
+                default:
+                    // There is something broken here as this was called when the reader is pointing at a property.
+                    // It must be a known Json type.
+                    Debug.Assert(false, $"Utf8JsonReader.TokenType is not one of the expected types: False, Number, True, Null, String, StartArray, StartObject. Is: '{reader.TokenType}'.");
+                    return null;
+            }
+        }
+
         internal static bool IsReaderAtTokenType(ref Utf8JsonReader reader, JsonTokenType tokenType, bool advanceReader)
         {
             if (reader.TokenType == JsonTokenType.None)
-                reader.Read();
+                ReaderRead(ref reader);
 
             if (reader.TokenType != tokenType)
                 return false;
 
             if (advanceReader)
-                reader.Read();
+                ReaderRead(ref reader);
 
             return true;
         }
 
-        internal static bool ReadBoolean(ref Utf8JsonReader reader, string propertyName, string className, bool advanceReader)
+        internal static bool ReaderRead(ref Utf8JsonReader reader)
+        {
+            try
+            {
+                return reader.Read();
+            }
+            catch (JsonException ex)
+            {
+                throw new JsonException(ex.Message, ex);
+            }
+        }
+
+        internal static bool ReadBoolean(ref Utf8JsonReader reader, string propertyName, string className)
         {
             if (reader.TokenType == JsonTokenType.True || reader.TokenType == JsonTokenType.False)
-            {
-                bool retVal = reader.GetBoolean();
-                if (advanceReader)
-                    reader.Read();
-
-                return retVal;
-            }
+                return reader.GetBoolean();
 
             throw LogHelper.LogExceptionMessage(
                 CreateJsonReaderException(ref reader, "JsonTokenType.False or JsonTokenType.True", className, propertyName));
         }
 
-        internal static double ReadDouble(ref Utf8JsonReader reader, string propertyName, string className, bool advanceReader)
+        internal static double ReadDouble(ref Utf8JsonReader reader, string propertyName, string className)
         {
             if (reader.TokenType == JsonTokenType.Number)
             {
-                double retVal;
                 try
                 {
-                    retVal = reader.GetDouble();
+                    return reader.GetDouble();
                 }
                 catch (Exception ex)
                 {
                     throw LogHelper.LogExceptionMessage(
                         CreateJsonReaderException(ref reader, typeof(double).ToString(), className, propertyName, ex));
                 }
-
-                if (advanceReader)
-                    reader.Read();
-
-                return retVal;
-            }
-
-            throw LogHelper.LogExceptionMessage(
-                CreateJsonReaderException(ref reader, typeof(double).ToString(), className, propertyName));
-        }
-
-        internal static int ReadInt(ref Utf8JsonReader reader, string propertyName, string className, bool advanceReader)
-        {
-            if (reader.TokenType == JsonTokenType.Number)
-            {
-                int retVal;
-                try
-                {
-                    retVal = reader.GetInt32();
-                }
-                catch(Exception ex)
-                {
-                    throw LogHelper.LogExceptionMessage(
-                        CreateJsonReaderException(ref reader, typeof(int).ToString(), className, propertyName, ex));
-                }
-
-                if (advanceReader)
-                    reader.Read();
-
-                return retVal;
             }
 
             throw LogHelper.LogExceptionMessage(
                 CreateJsonReaderException(ref reader, "JsonTokenType.Number", className, propertyName));
         }
 
-        internal static object ReadObject(ref Utf8JsonReader reader, bool advanceReader)
+        internal static int ReadInt(ref Utf8JsonReader reader, string propertyName, string className)
         {
-            object retVal = null;
-            using (JsonDocument jsonDocument = JsonDocument.ParseValue(ref reader))
+            if (reader.TokenType == JsonTokenType.Number)
             {
-                if (jsonDocument.RootElement.ValueKind == JsonValueKind.Null)
-                    return null;
-
-                retVal = jsonDocument.RootElement.Clone();
+                try
+                {
+                    return reader.GetInt32();
+                }
+                catch (Exception ex)
+                {
+                    throw LogHelper.LogExceptionMessage(
+                        CreateJsonReaderException(ref reader, typeof(int).ToString(), className, propertyName, ex));
+                }
             }
 
-            if (advanceReader)
-                reader.Read();
-
-            return retVal;
+            throw LogHelper.LogExceptionMessage(
+                CreateJsonReaderException(ref reader, "JsonTokenType.Number", className, propertyName));
         }
 
-        internal static IList<object> ReadObjects(ref Utf8JsonReader reader, IList<object> objects, string propertyName, string className, bool advanceReader)
+        internal static JsonElement ReadJsonElement(ref Utf8JsonReader reader)
         {
+#if NET6_0_OR_GREATER
+            JsonElement? jsonElement;
+            bool ret = JsonElement.TryParseValue(ref reader, out jsonElement);
+            if (ret)
+                return jsonElement.Value;
+
+            return default;
+#else
+            using (JsonDocument jsonDocument = JsonDocument.ParseValue(ref reader))
+                return jsonDocument.RootElement.Clone();
+#endif
+        }
+
+        /// <summary>
+        /// Currently used by test code only
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="objects"></param>
+        /// <param name="propertyName"></param>
+        /// <param name="className"></param>
+        /// <returns></returns>
+        internal static IList<object> ReadObjects(ref Utf8JsonReader reader, IList<object> objects, string propertyName, string className)
+        {
+            _ = objects ?? throw LogHelper.LogExceptionMessage(new ArgumentNullException(nameof(objects)));
+
             // returning null keeps the same logic as JsonSerialization.ReadObject
             if (reader.TokenType == JsonTokenType.Null)
-            {
-                if (advanceReader)
-                    reader.Read();
-
                 return null;
-            }
 
-            if (!IsReaderAtTokenType(ref reader, JsonTokenType.StartArray, true))
-            {
+            if (!IsReaderAtTokenType(ref reader, JsonTokenType.StartArray, false))
                 throw LogHelper.LogExceptionMessage(
                     CreateJsonReaderExceptionInvalidType(ref reader, "JsonTokenType.StartArray", className, propertyName));
-            }
 
-            do
+            while (ReaderRead(ref reader))
             {
                 if (IsReaderAtTokenType(ref reader, JsonTokenType.EndArray, true))
                     break;
 
-                objects.Add(ReadObject(ref reader, false));
-
-            } while (reader.Read());
+                objects.Add(ReadJsonElement(ref reader));
+            } 
 
             return objects;
         }
 
-        internal static string ReadString(ref Utf8JsonReader reader, string propertyName, string className, bool advanceReader)
+        internal static string ReadString(ref Utf8JsonReader reader, string propertyName, string className)
         {
+            // returning null keeps the same logic as JsonSerialization.ReadObject
             if (reader.TokenType == JsonTokenType.Null)
-            {
-                if (advanceReader)
-                    reader.Read();
-
                 return null;
-            }
 
             if (reader.TokenType != JsonTokenType.String)
                 throw LogHelper.LogExceptionMessage(
                     CreateJsonReaderException(ref reader, "JsonTokenType.String", className, propertyName));
 
-            string retVal = reader.GetString();
-            if (advanceReader)
-                reader.Read();
-
-            return retVal;
+            return reader.GetString();
         }
 
-        internal static IList<string> ReadStrings(ref Utf8JsonReader reader, IList<string> strings, string propertyName, string className, bool advanceReader)
+        internal static IList<string> ReadStrings(ref Utf8JsonReader reader, IList<string> strings, string propertyName, string className)
         {
+            // returning null keeps the same logic as JsonSerialization.ReadObject
             if (reader.TokenType == JsonTokenType.Null)
-            {
-                if (advanceReader)
-                    reader.Read();
-
                 return null;
-            }
 
-            if (!IsReaderAtTokenType(ref reader, JsonTokenType.StartArray, true))
+            if (!IsReaderAtTokenType(ref reader, JsonTokenType.StartArray, false))
                 throw LogHelper.LogExceptionMessage(
                     CreateJsonReaderExceptionInvalidType(ref reader, "JsonTokenType.StartArray", className, propertyName));
 
-            do
+            while (ReaderRead(ref reader))
             {
-                if (IsReaderAtTokenType(ref reader, JsonTokenType.EndArray, true))
+                if (IsReaderAtTokenType(ref reader, JsonTokenType.EndArray, false))
                     break;
 
-                strings.Add(ReadString(ref reader, propertyName, className, false));
-
-            } while (reader.Read());
+                strings.Add(ReadString(ref reader, propertyName, className));
+            }
 
             return strings;
         }
 
-        // used by JsonWebKey which will be in this release
+        /// <summary>
+        /// This method is only called when we are on a JsonTokenType.Number AND reading into AdditionalData which is an IDictionary[string, object].
+        /// We have to make a choice of the type to return.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <returns>If possible a .net numerical type, otherwise a JsonElement.</returns>
+        internal static object ReadNumber(ref Utf8JsonReader reader)
+        {
+            // Assume reader is a Utf8JsonReader positioned at a JsonTokenType.Number
+            if (reader.TryGetInt32(out int i))
+                return i;
+            else if (reader.TryGetInt64(out long l))
+                return l;
+            else if (reader.TryGetUInt32(out uint u))
+                return u;
+            else if (reader.TryGetSingle(out float f))
+                return f;
+            else if (reader.TryGetDouble(out double d))
+                return d;
+            else if (reader.TryGetDecimal(out decimal m))
+                return m;
+
+            Debug.Assert(false, "expected to read a number, but none of the Utf8JsonReader.TryGet... methods returned true.");
+
+            return ReadJsonElement(ref reader);
+        }
+
+        internal static void WriteAdditionalData(ref Utf8JsonWriter writer, IDictionary<string, object> additionalData)
+        {
+            if (additionalData.Count > 0)
+            {
+                foreach (KeyValuePair<string,object> kvp in additionalData)
+                {
+                    if (kvp.Value is string)
+                        writer.WriteString(kvp.Key, kvp.Value as string);
+                    else if (kvp.Value is int)
+                         writer.WriteNumber(kvp.Key, (int)kvp.Value);
+                    else if (kvp.Value is bool)
+                        writer.WriteBoolean(kvp.Key, (bool)kvp.Value);
+                    else if (kvp.Value is decimal)
+                        writer.WriteNumber(kvp.Key, (decimal)kvp.Value);
+                    else if (kvp.Value is double)
+                        writer.WriteNumber(kvp.Key, (double)kvp.Value);
+                    else if (kvp.Value is float)
+                        writer.WriteNumber(kvp.Key, (float)kvp.Value);
+                    else if (kvp.Value is long)
+                        writer.WriteNumber(kvp.Key, (long)kvp.Value);
+                    else if (kvp.Value is null)
+                        writer.WriteNull(kvp.Key);
+                    else if (kvp.Value is JsonElement element)
+                    {
+                        writer.WritePropertyName(kvp.Key);
+                        element.WriteTo(writer);
+                    }
+                    else
+                    {
+                        writer.WriteString(kvp.Key, kvp.Value.ToString());
+                    }
+                }
+            }
+        }
+
         internal static void WriteStrings(ref Utf8JsonWriter writer, string propertyName, IList<string> strings)
+        {
+            writer.WritePropertyName(propertyName);
+            writer.WriteStartArray();
+            foreach (string str in strings)
+                writer.WriteStringValue(str);
+
+            writer.WriteEndArray();
+        }
+
+        internal static void WriteStrings(ref Utf8JsonWriter writer, JsonEncodedText propertyName, IList<string> strings)
         {
             writer.WritePropertyName(propertyName);
             writer.WriteStartArray();
@@ -259,4 +343,3 @@ namespace Microsoft.IdentityModel.Tokens.Json
         }
     }
 }
-

--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonWebKeySerializer.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonWebKeySerializer.cs
@@ -1,0 +1,440 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Microsoft.IdentityModel.Logging;
+
+namespace Microsoft.IdentityModel.Tokens.Json
+{
+    internal static class JsonWebKeySerializer
+    {
+        public static HashSet<string> JsonWebKeyParameterNamesUpperCase = new HashSet<string>
+        {
+            "ALG",
+            "CRV",
+            "D",
+            "DP",
+            "DQ",
+            "E",
+            "K",
+            "KEY_OPS",
+            "KEYS",
+            "KID",
+            "KTY",
+            "N",
+            "OTH",
+            "P",
+            "Q",
+            "QI",
+            "USE",
+            "X",
+            "X5C",
+            "X5T",
+            "X5T#S256",
+            "X5U",
+            "Y"
+        };
+
+        #region Read
+        public static JsonWebKey Read(string json)
+        {
+            return Read(json, new JsonWebKey());
+        }
+
+        public static JsonWebKey Read(string json, JsonWebKey jsonWebKey)
+        {
+            Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(json).AsSpan());
+            return Read(ref reader, jsonWebKey);
+        }
+
+        /// <summary>
+        /// Reads a JsonWebKey. see: https://datatracker.ietf.org/doc/html/rfc7517
+        /// </summary>
+        /// <param name="reader">a <see cref="Utf8JsonReader"/> pointing at a StartObject.</param>
+        /// <param name="jsonWebKey"></param>
+        /// <returns>A <see cref="JsonWebKey"/>.</returns>
+        public static JsonWebKey Read(ref Utf8JsonReader reader, JsonWebKey jsonWebKey)
+        {
+            if (!JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartObject, false))
+                throw LogHelper.LogExceptionMessage(
+                    new JsonException(
+                        LogHelper.FormatInvariant(
+                        LogMessages.IDX11023,
+                        LogHelper.MarkAsNonPII("JsonTokenType.StartObject"),
+                        LogHelper.MarkAsNonPII(reader.TokenType),
+                        LogHelper.MarkAsNonPII(JsonWebKey.ClassName),
+                        LogHelper.MarkAsNonPII(reader.TokenStartIndex),
+                        LogHelper.MarkAsNonPII(reader.CurrentDepth),
+                        LogHelper.MarkAsNonPII(reader.BytesConsumed))));
+
+            while(JsonSerializerPrimitives.ReaderRead(ref reader))
+            {
+                #region Check property name using ValueTextEquals
+                // common names are tried first
+                // the JsonWebKey spec, https://datatracker.ietf.org/doc/html/rfc7517#section-4, does not require that we reject JSON with
+                // duplicate member names, in strict mode, we could add logic to try a property once and throw if a duplicate shows up.
+                // 6x uses the last value.
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.K))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.K = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.K, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.E))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.E = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.E, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.Kid))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.Kid = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Kid, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.Kty))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.Kty = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Kty, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.N))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.N = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.N, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.X5c))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        JsonSerializerPrimitives.ReadStrings(ref reader, jsonWebKey.X5c, JsonWebKeyParameterNames.X5c, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.Alg))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.Alg = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Alg, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.Crv))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.Crv = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Crv, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.D))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.D = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.D, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.DP))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.DP = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.DP, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.DQ))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.DQ = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.DQ, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.KeyOps))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        // the value can be null if the value is 'nill'
+                        if (JsonSerializerPrimitives.ReadStrings(ref reader, jsonWebKey.KeyOps, JsonWebKeyParameterNames.KeyOps, JsonWebKey.ClassName) == null)
+                        {
+                            throw LogHelper.LogExceptionMessage(
+                                new ArgumentNullException(
+                                    JsonWebKeyParameterNames.KeyOps,
+                                    new JsonException(
+                                        LogHelper.FormatInvariant(
+                                        LogMessages.IDX11022,
+                                        LogHelper.MarkAsNonPII("JsonTokenType.StartArray"),
+                                        LogHelper.MarkAsNonPII(reader.TokenType),
+                                        LogHelper.MarkAsNonPII(JsonWebKey.ClassName),
+                                        LogHelper.MarkAsNonPII(JsonWebKeyParameterNames.KeyOps),
+                                        LogHelper.MarkAsNonPII(reader.TokenStartIndex),
+                                        LogHelper.MarkAsNonPII(reader.CurrentDepth),
+                                        LogHelper.MarkAsNonPII(reader.BytesConsumed)))));
+                        }
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.Oth))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        JsonSerializerPrimitives.ReadStrings(ref reader, jsonWebKey.Oth, JsonWebKeyParameterNames.Oth, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.P))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.P = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.P, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.Q))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.Q = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Q, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.QI))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.QI = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.QI, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.Use))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.Use = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Use, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.X))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.X = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.X, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.X5t))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.X5t = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.X5t, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.X5tS256))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.X5tS256 = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.X5tS256, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.X5u))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.X5u = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.X5u, JsonWebKey.ClassName);
+                    }
+                    else if (reader.ValueTextEquals(JsonWebKeyParameterUtf8Bytes.Y))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        jsonWebKey.Y = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Y, JsonWebKey.ClassName);
+                    }
+                    #endregion
+                    else
+                    {
+                        #region case-insensitive
+                        // fallback to checking property names as case insensitive
+                        // first check to see if the upper case property value is a valid property name if not add to AdditionalData, to avoid unnecessary string compares.
+                        string propertyName = JsonSerializerPrimitives.GetPropertyName(ref reader, JsonWebKey.ClassName, true);
+                        if (!JsonWebKeyParameterNamesUpperCase.Contains(propertyName.ToUpperInvariant()))
+                        {
+                            jsonWebKey.AdditionalData[propertyName] = JsonSerializerPrimitives.GetUnknownProperty(ref reader);
+                        }
+                        else
+                        {
+                            if (propertyName.Equals(JsonWebKeyParameterNames.E, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.E = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.E, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.Kid, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.Kid = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Kid, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.Kty, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.Kty = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Kty, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.N, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.N = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.N, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.Use, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.Use = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Use, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.Alg, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.Alg = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Alg, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.Crv, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.Crv = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Crv, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.D, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.D = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.D, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.DP, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.DP = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.DP, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.DQ, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.DQ = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.DQ, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.K, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.K = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.K, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.KeyOps, StringComparison.OrdinalIgnoreCase))
+                            {
+                                // the value can be null if the value is 'nill'
+                                if (JsonSerializerPrimitives.ReadStrings(ref reader, jsonWebKey.KeyOps, JsonWebKeyParameterNames.KeyOps, JsonWebKey.ClassName) == null)
+                                {
+                                    throw LogHelper.LogExceptionMessage(
+                                        new ArgumentNullException(
+                                            JsonWebKeyParameterNames.KeyOps,
+                                            new JsonException(
+                                                LogHelper.FormatInvariant(
+                                                LogMessages.IDX11022,
+                                                LogHelper.MarkAsNonPII("JsonTokenType.StartArray"),
+                                                LogHelper.MarkAsNonPII(reader.TokenType),
+                                                LogHelper.MarkAsNonPII(JsonWebKey.ClassName),
+                                                LogHelper.MarkAsNonPII(JsonWebKeyParameterNames.KeyOps),
+                                                LogHelper.MarkAsNonPII(reader.TokenStartIndex),
+                                                LogHelper.MarkAsNonPII(reader.CurrentDepth),
+                                                LogHelper.MarkAsNonPII(reader.BytesConsumed)))));
+                                }
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.Oth, StringComparison.OrdinalIgnoreCase))
+                            {
+                                JsonSerializerPrimitives.ReadStrings(ref reader, jsonWebKey.Oth, JsonWebKeyParameterNames.Oth, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.P, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.P = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.P, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.Q, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.Q = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Q, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.QI, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.QI = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.QI, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.X, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.X = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.X, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.X5c, StringComparison.OrdinalIgnoreCase))
+                            {
+                                JsonSerializerPrimitives.ReadStrings(ref reader, jsonWebKey.X5c, JsonWebKeyParameterNames.X5c, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.X5t, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.X5t = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.X5t, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.X5tS256, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.X5tS256 = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.X5tS256, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.X5u, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.X5u = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.X5u, JsonWebKey.ClassName);
+                            }
+                            else if (propertyName.Equals(JsonWebKeyParameterNames.Y, StringComparison.OrdinalIgnoreCase))
+                            {
+                                jsonWebKey.Y = JsonSerializerPrimitives.ReadString(ref reader, JsonWebKeyParameterNames.Y, JsonWebKey.ClassName);
+                            }
+                        }
+                        #endregion case-insensitive
+                    }
+                }
+                else if (JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.EndObject, false))
+                    break;
+            }
+
+            return jsonWebKey;
+        }
+        #endregion
+
+        #region Write
+        public static string Write(JsonWebKey jsonWebKey)
+        {
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                Utf8JsonWriter writer = null;
+                try
+                {
+                    writer = new Utf8JsonWriter(memoryStream, new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+                    Write(ref writer, jsonWebKey);
+                    writer.Flush();
+                    return Encoding.UTF8.GetString(memoryStream.ToArray());
+                }
+                finally
+                {
+                    writer?.Dispose();
+                }
+            }
+        }
+
+        public static void Write(ref Utf8JsonWriter writer, JsonWebKey jsonWebKey)
+        {
+            _ = jsonWebKey ?? throw new ArgumentNullException(nameof(jsonWebKey));
+            _ = writer ?? throw new ArgumentNullException(nameof(writer));
+
+            writer.WriteStartObject();
+
+            if (!string.IsNullOrEmpty(jsonWebKey.Alg))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.Alg, jsonWebKey.Alg);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.Crv))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.Crv, jsonWebKey.Crv);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.D))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.D, jsonWebKey.D);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.DP))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.DP, jsonWebKey.DP);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.DQ))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.DQ, jsonWebKey.DQ);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.E))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.E, jsonWebKey.E);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.K))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.K, jsonWebKey.K);
+
+            if (jsonWebKey.KeyOps.Count > 0)
+                JsonSerializerPrimitives.WriteStrings(ref writer, EncodedJsonWebKeyParameterNames.KeyOps, jsonWebKey.KeyOps);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.Kid))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.Kid, jsonWebKey.Kid);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.Kty))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.Kty, jsonWebKey.Kty);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.N))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.N, jsonWebKey.N);
+
+            if (jsonWebKey.Oth.Count > 0)
+                JsonSerializerPrimitives.WriteStrings(ref writer, EncodedJsonWebKeyParameterNames.Oth, jsonWebKey.Oth);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.P))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.P, jsonWebKey.P);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.Q))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.Q, jsonWebKey.Q);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.QI))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.QI, jsonWebKey.QI);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.Use))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.Use, jsonWebKey.Use);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.X))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.X, jsonWebKey.X);
+
+            if (jsonWebKey.X5c.Count > 0)
+                JsonSerializerPrimitives.WriteStrings(ref writer, EncodedJsonWebKeyParameterNames.X5c, jsonWebKey.X5c);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.X5t))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.X5t, jsonWebKey.X5t);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.X5tS256))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.X5tS256, jsonWebKey.X5tS256);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.X5u))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.X5u, jsonWebKey.X5u);
+
+            if (!string.IsNullOrEmpty(jsonWebKey.Y))
+                writer.WriteString(EncodedJsonWebKeyParameterNames.Y, jsonWebKey.Y);
+
+            JsonSerializerPrimitives.WriteAdditionalData(ref writer, jsonWebKey.AdditionalData);
+
+            writer.WriteEndObject();
+        }
+        #endregion
+    }
+}
+

--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonWebKeySetSerializer.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonWebKeySetSerializer.cs
@@ -1,0 +1,140 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Microsoft.IdentityModel.Logging;
+
+namespace Microsoft.IdentityModel.Tokens.Json
+{
+    internal static class JsonWebKeySetSerializer
+    {
+        private static readonly byte[] _keysUtf8 = Encoding.UTF8.GetBytes(JsonWebKeySetParameterNames.Keys);
+
+        #region Read
+        public static JsonWebKeySet Read(string json, JsonWebKeySet jsonWebKeySet)
+        {
+            Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(json).AsSpan());
+            return Read(ref reader, jsonWebKeySet);
+        }
+
+        /// <summary>
+        /// Reads a JsonWebKey. see: https://datatracker.ietf.org/doc/html/rfc7517
+        /// </summary>
+        /// <param name="reader">a <see cref="Utf8JsonReader"/> pointing at a StartObject.</param>
+        /// <param name="jsonWebKeySet"></param>
+        /// <returns>A <see cref="JsonWebKeySet"/>.</returns>
+        public static JsonWebKeySet Read(ref Utf8JsonReader reader, JsonWebKeySet jsonWebKeySet)
+        {
+            if (!JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartObject, false))
+                throw LogHelper.LogExceptionMessage(
+                    new JsonException(
+                        LogHelper.FormatInvariant(
+                        LogMessages.IDX11022,
+                        LogHelper.MarkAsNonPII("JsonTokenType.StartObject"),
+                        LogHelper.MarkAsNonPII(reader.TokenType),
+                        LogHelper.MarkAsNonPII(JsonWebKeySet.ClassName),
+                        LogHelper.MarkAsNonPII(reader.TokenStartIndex),
+                        LogHelper.MarkAsNonPII(reader.CurrentDepth),
+                        LogHelper.MarkAsNonPII(reader.BytesConsumed))));
+
+            while (JsonSerializerPrimitives.ReaderRead(ref reader))
+            {
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (reader.ValueTextEquals(_keysUtf8))
+                    {
+                        JsonSerializerPrimitives.ReaderRead(ref reader);
+                        ReadKeys(ref reader, jsonWebKeySet);
+                    }
+                    else
+                    {
+                        string propertyName = JsonSerializerPrimitives.GetPropertyName(ref reader, JsonWebKey.ClassName, true);
+                        if (propertyName.Equals(JsonWebKeyParameterNames.Keys, StringComparison.OrdinalIgnoreCase))
+                            ReadKeys(ref reader, jsonWebKeySet);
+                        else
+                            jsonWebKeySet.AdditionalData[propertyName] = JsonSerializerPrimitives.GetUnknownProperty(ref reader);
+                    }
+                }
+                else if (JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.EndObject, true))
+                {
+                    break;
+                }
+            }
+
+            return jsonWebKeySet;
+        }
+
+        public static void ReadKeys(ref Utf8JsonReader reader, JsonWebKeySet jsonWebKeySet)
+        {
+            if (!JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartArray, false))
+                throw LogHelper.LogExceptionMessage(
+                    JsonSerializerPrimitives.CreateJsonReaderExceptionInvalidType(
+                        ref reader,
+                        "JsonTokenType.StartArray",
+                        JsonWebKeyParameterNames.KeyOps,
+                        JsonWebKeySet.ClassName));
+
+            while (JsonSerializerPrimitives.ReaderRead(ref reader))
+            {
+                if (reader.TokenType == JsonTokenType.StartObject)
+                    jsonWebKeySet.Keys.Add(JsonWebKeySerializer.Read(ref reader, new JsonWebKey()));
+                else if (JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.EndArray, false))
+                    break;
+            }
+        }
+
+        #endregion
+
+        #region Write
+        public static string Write(JsonWebKeySet jsonWebKeySet)
+        {
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                Utf8JsonWriter writer = null;
+                try
+                {
+                    // writing strings without escaping is as we know this is a utf8 encoding
+                    writer = new Utf8JsonWriter(memoryStream, new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
+                    Write(ref writer, jsonWebKeySet);
+                    writer.Flush();
+                    return Encoding.UTF8.GetString(memoryStream.ToArray());
+                }
+                finally
+                {
+                    writer?.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// This method will be used when reading OIDC metadata
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="jsonWebKeySet"></param>
+        public static void Write(ref Utf8JsonWriter writer, JsonWebKeySet jsonWebKeySet)
+        {
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(EncodedJsonWebKeyParameterNames.Keys);
+            writer.WriteStartArray();
+
+            foreach (JsonWebKey jsonWebKey in jsonWebKeySet.Keys)
+                JsonWebKeySerializer.Write(ref writer, jsonWebKey);
+
+            writer.WriteEndArray();
+
+            if (jsonWebKeySet.AdditionalData.Count > 0)
+                JsonSerializerPrimitives.WriteAdditionalData(ref writer, jsonWebKeySet.AdditionalData);
+
+            writer.WriteEndObject();
+        }
+
+        #endregion
+    }
+}
+

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeyParameterNames.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeyParameterNames.cs
@@ -1,14 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text;
+
 namespace Microsoft.IdentityModel.Tokens
 {
+#pragma warning disable 1591
+
     /// <summary>
-    /// Names for Json Web Key Values
+    /// JsonWebKey parameter names
     /// </summary>
     public static class JsonWebKeyParameterNames
     {
-#pragma warning disable 1591
         public const string Alg = "alg";
         public const string Crv = "crv";
         public const string D = "d";
@@ -24,16 +27,41 @@ namespace Microsoft.IdentityModel.Tokens
         public const string Oth = "oth";
         public const string P = "p";
         public const string Q = "q";
-        public const string R = "r";
-        public const string T = "t";
         public const string QI = "qi";
         public const string Use = "use";
+        public const string X = "x";
         public const string X5c = "x5c";
         public const string X5t = "x5t";
         public const string X5tS256 = "x5t#S256";
         public const string X5u = "x5u";
-        public const string X = "x";
         public const string Y = "y";
-#pragma warning restore 1591
     }
+
+    internal static class JsonWebKeyParameterUtf8Bytes
+    {
+        public static readonly byte[] Alg = Encoding.UTF8.GetBytes("alg");
+        public static readonly byte[] Crv = Encoding.UTF8.GetBytes("crv");
+        public static readonly byte[] D = Encoding.UTF8.GetBytes("d");
+        public static readonly byte[] DP = Encoding.UTF8.GetBytes("dp");
+        public static readonly byte[] DQ = Encoding.UTF8.GetBytes("dq");
+        public static readonly byte[] E = Encoding.UTF8.GetBytes("e");
+        public static readonly byte[] K = Encoding.UTF8.GetBytes("k");
+        public static readonly byte[] KeyOps = Encoding.UTF8.GetBytes("key_ops");
+        public static readonly byte[] Keys = Encoding.UTF8.GetBytes("keys");
+        public static readonly byte[] Kid = Encoding.UTF8.GetBytes("kid");
+        public static readonly byte[] Kty = Encoding.UTF8.GetBytes("kty");
+        public static readonly byte[] N = Encoding.UTF8.GetBytes("n");
+        public static readonly byte[] Oth = Encoding.UTF8.GetBytes("oth");
+        public static readonly byte[] P = Encoding.UTF8.GetBytes("p");
+        public static readonly byte[] Q = Encoding.UTF8.GetBytes("q");
+        public static readonly byte[] QI = Encoding.UTF8.GetBytes("qi");
+        public static readonly byte[] Use = Encoding.UTF8.GetBytes("use");
+        public static readonly byte[] X5c = Encoding.UTF8.GetBytes("x5c");
+        public static readonly byte[] X5t = Encoding.UTF8.GetBytes("x5t");
+        public static readonly byte[] X5tS256 = Encoding.UTF8.GetBytes("x5t#S256");
+        public static readonly byte[] X5u = Encoding.UTF8.GetBytes("x5u");
+        public static readonly byte[] X = Encoding.UTF8.GetBytes("x");
+        public static readonly byte[] Y = Encoding.UTF8.GetBytes("y");
+    }
+#pragma warning restore 1591
 }

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
@@ -4,9 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Text.Json.Serialization;
+using System.Threading;
 using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.Logging;
-using Newtonsoft.Json;
+using Microsoft.IdentityModel.Tokens.Json;
 
 namespace Microsoft.IdentityModel.Tokens
 {
@@ -14,10 +16,10 @@ namespace Microsoft.IdentityModel.Tokens
     /// Contains a collection of <see cref="JsonWebKey"/> that can be populated from a json string.
     /// </summary>
     /// <remarks>provides support for https://datatracker.ietf.org/doc/html/rfc7517.</remarks>
-    [JsonObject]
     public class JsonWebKeySet
     {
-        private const string _className = "Microsoft.IdentityModel.Tokens.JsonWebKeySet";
+        internal const string ClassName = "Microsoft.IdentityModel.Tokens.JsonWebKeySet";
+        private IDictionary<string, object> _additionalData;
 
         /// <summary>
         /// Returns a new instance of <see cref="JsonWebKeySet"/>.
@@ -55,13 +57,13 @@ namespace Microsoft.IdentityModel.Tokens
             try
             {
                 if (LogHelper.IsEnabled(EventLogLevel.Verbose))
-                    LogHelper.LogVerbose(LogMessages.IDX10806, json, LogHelper.MarkAsNonPII(_className));
+                    LogHelper.LogVerbose(LogMessages.IDX10806, json, LogHelper.MarkAsNonPII(ClassName));
 
-                JsonConvert.PopulateObject(json, this);
+                JsonWebKeySetSerializer.Read(json, this);
             }
             catch (Exception ex)
             {
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10805, json, LogHelper.MarkAsNonPII(_className)), ex));
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10805, json, LogHelper.MarkAsNonPII(ClassName)), ex));
             }
         }
 
@@ -69,13 +71,15 @@ namespace Microsoft.IdentityModel.Tokens
         /// When deserializing from JSON any properties that are not defined will be placed here.
         /// </summary>
         [JsonExtensionData]
-        public virtual IDictionary<string, object> AdditionalData { get; } = new Dictionary<string, object>();
+        public IDictionary<string, object> AdditionalData => _additionalData ??
+            Interlocked.CompareExchange(ref _additionalData, new Dictionary<string, object>(StringComparer.Ordinal), null) ??
+            _additionalData;
 
         /// <summary>
         /// Gets the <see cref="IList{JsonWebKey}"/>.
-        /// </summary>       
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore, PropertyName = JsonWebKeySetParameterNames.Keys, Required = Required.Default)]
-        public IList<JsonWebKey> Keys { get; private set; } = new List<JsonWebKey>();
+        /// </summary>
+        [JsonPropertyName(JsonWebKeySetParameterNames.Keys)]
+        public IList<JsonWebKey> Keys { get; } = new List<JsonWebKey>();
 
         /// <summary>
         /// Default value for the flag that controls whether unresolved JsonWebKeys will be included in the resulting collection of <see cref="GetSigningKeys"/> method.
@@ -87,6 +91,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// Flag that controls whether unresolved JsonWebKeys will be included in the resulting collection of <see cref="GetSigningKeys"/> method.
         /// </summary>
         [DefaultValue(true)]
+        [JsonIgnore]
         public bool SkipUnresolvedJsonWebKeys { get; set; } = DefaultSkipUnresolvedJsonWebKeys;
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -256,6 +256,7 @@ namespace Microsoft.IdentityModel.Tokens
         // Json parsing errors
         public const string IDX11020 = "IDX11020: The JSON value of type: '{0}', could not be converted to '{1}'. Reading: '{2}.{3}', Position: '{4}', CurrentDepth: '{5}', BytesConsumed: '{6}'.";
         public const string IDX11022 = "IDX11022: Expecting json reader to be positioned on '{0}', reader was positioned at: '{1}', Reading: '{2}.{3}', Position: '{4}', CurrentDepth: '{5}', BytesConsumed: '{6}'.";
+        public const string IDX11023 = "IDX11023: Expecting json reader to be positioned on '{0}', reader was positioned at: '{1}', Reading: '{2}', Position: '{3}', CurrentDepth: '{4}', BytesConsumed: '{5}'.";
 #pragma warning restore 1591
     }
 }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
@@ -145,10 +145,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         public static string OpenIdConnectMetadataPingLabsJWKSString = @"{""jwks_uri"":""PingLabsJWKS.json""}";
         public static string OpenIdConnectMetatadataBadJson = @"{...";
 
-        // interop
-        public static string GoogleCertsFile = "google-certs.json";
-        public static JsonWebKeySet GoogleCertsExpected;
-
         static OpenIdConfigData()
         {
             PingLabs = new OpenIdConnectConfiguration()

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestUtilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestUtilityTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                 };
 
                 httpRequestData.AppendHeaders(theoryData.HttpHeaders);
-                IdentityComparer.AreStingEnumDictionariesEqual(httpRequestData.Headers, theoryData.ExpectedHttpRequestHeaders, context);
+                IdentityComparer.AreStringEnumDictionariesEqual(httpRequestData.Headers, theoryData.ExpectedHttpRequestHeaders, context);
                 theoryData.ExpectedException.ProcessNoException(context);
             }
             catch (Exception ex)
@@ -259,7 +259,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                 IdentityComparer.AreStringsEqual(httpRequestData.Method, theoryData.ExpectedHttpRequestData.Method, context);
                 IdentityComparer.AreUrisEqual(httpRequestData.Uri, theoryData.ExpectedHttpRequestData.Uri, context);
                 IdentityComparer.AreBytesEqual(httpRequestData.Body, theoryData.ExpectedHttpRequestData.Body, context);
-                IdentityComparer.AreStingEnumDictionariesEqual(httpRequestData.Headers, theoryData.ExpectedHttpRequestData.Headers, context);
+                IdentityComparer.AreStringEnumDictionariesEqual(httpRequestData.Headers, theoryData.ExpectedHttpRequestData.Headers, context);
 
                 theoryData.ExpectedException.ProcessNoException(context);
             }

--- a/test/Microsoft.IdentityModel.TestUtils/CompareContext.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/CompareContext.cs
@@ -21,14 +21,14 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public CompareContext(TheoryDataBase theoryData)
         {
-            PropertiesToIgnoreWhenComparing = theoryData.PropertiesToIgnoreWhenComparing;
+            PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>(theoryData.PropertiesToIgnoreWhenComparing);
             Title = theoryData.TestId;
         }
 
         public CompareContext(string testName, TheoryDataBase theoryData)
         {
             Title = testName;
-            PropertiesToIgnoreWhenComparing = theoryData.PropertiesToIgnoreWhenComparing;
+            PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>(theoryData.PropertiesToIgnoreWhenComparing);
         }
 
         public CompareContext(CompareContext other)

--- a/test/Microsoft.IdentityModel.TestUtils/DataSets.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/DataSets.cs
@@ -10,274 +10,113 @@ namespace Microsoft.IdentityModel.TestUtils
 {
     public class DataSets
     {
-        public static JsonWebKey JsonWebKeyFromPing1;
-        public static JsonWebKey JsonWebKeyFromPing2;
-        public static JsonWebKey JsonWebKeyFromPing3;
-        public static JsonWebKey JsonWebKey1;
-        public static JsonWebKey JsonWebKey2;
-        public static JsonWebKey JsonWebKeyAdditionalData1;
-        public static JsonWebKey JsonWebKeyBadX509Data;
-        public static JsonWebKey JsonWebKeyES256;
-        public static JsonWebKey JsonWebKeyES384;
-        public static JsonWebKey JsonWebKeyES512;
+        public static string X5C_1 = "MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng";
+        public static string X5C_2 = "MIIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ";
 
-        public static JsonWebKeySet JsonWebKeySet1;
-        public static JsonWebKeySet JsonWebKeySet2;
-        public static JsonWebKeySet JsonWebKeySetX509Data;
-        public static JsonWebKeySet JsonWebKeySetAdditionalData1;
-        public static JsonWebKeySet JsonWebKeySetEC;
-        public static JsonWebKeySet JsonWebKeySetOnlyX5t;
-
-        // interop
-        public static string GoogleCertsFile = "google-certs.json";
-        public static JsonWebKeySet GoogleCertsExpected;
-
-        public static string JsonWebKey_X5c_1 = "MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng";
-        public static string JsonWebKey_X5c_2 = "MIIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ";
-
-        public static string JsonWebKeyFromPingString1 =
-                                        @"{ ""e"":""AQAB"",
-                                            ""kid"":""20am7"",
-                                            ""kty"":""RSA"",
-                                            ""n"":""mhupHfUtg_gHIqwu2wm8CprXY-gKqbPMV6tEYVqkyYrHugzQ_YDYAHr7vWo5Pe_3gIujSFwpqIfXaP8-Fl3O5fQhMo1lMv4DdRabyDLEpv7YO9qoVKTmDOZqYZx-AYBr5x1Zh2xWByI6_0dsPtCjD1pFZfg_SxNEcLPyH1aY6dT8CWYu32qG4O0WF4EihZzMkzSn8fyh8RXbMf5U9Wm2kgb0g8jK62S7MoF4IlhFaJreq898wgUohhPwR8P3X-gk0XQJAFcogEf04Fw4UmKo3z1B6mcNbPRfImhWw4wtLkhp_KIqKNOkMsSpYGSLrCvqQpgK56EJZExrmb7WozjwHw"",
-                                            ""use"":""sig""
-                                        }";
-
-        public static string JsonWebKeyString1 =
-                                        @"{ ""alg"":""SHA256"",
-                                            ""e"":""AQAB"",
-                                            ""key_ops"":[""signing""],
-                                            ""kid"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
-                                            ""kty"":""RSA"",                                            
-                                            ""n"":""rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw=="",                                            
-                                            ""x5c"":[""MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng""],
-                                            ""x5t"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
-                                            ""x5u"":""https://jsonkeyurl"",
-                                            ""use"":""sig""
-                                        }";
-
-        public static string JsonWebKeyString2 =
-                                        @"{ ""alg"":""SHA256"",
-                                            ""e"":""AQAB"",
-                                            ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""kty"":""RSA"",
-                                            ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",
-                                            ""x5t"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""x5c"":[""MIIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ""],
-                                            ""use"":""sig""
-                                        }";
-
-        public static string JsonWebKeyAdditionalDataString1 =
-                                        @"{ ""alg"":""SHA256"",
-                                            ""e"":""AQAB"",
-                                            ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""kty"":""RSA"",
-                                            ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",
-                                            ""x5t"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""x5c"":[""MIIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ""],
-                                            ""use"":""sig"",
-                                            ""additionalProperty"":""additionalValue""
-                                        }";
+        #region JsonWebKeys
+        public static string JsonWebKeyWithOneRsaKey =
+                                @"{ ""e"":""AQAB"",
+                                    ""kid"":""20am7"",
+                                    ""kty"":""RSA"",
+                                    ""n"":""mhupHfUtg_gHIqwu2wm8CprXY-gKqbPMV6tEYVqkyYrHugzQ_YDYAHr7vWo5Pe_3gIujSFwpqIfXaP8-Fl3O5fQhMo1lMv4DdRabyDLEpv7YO9qoVKTmDOZqYZx-AYBr5x1Zh2xWByI6_0dsPtCjD1pFZfg_SxNEcLPyH1aY6dT8CWYu32qG4O0WF4EihZzMkzSn8fyh8RXbMf5U9Wm2kgb0g8jK62S7MoF4IlhFaJreq898wgUohhPwR8P3X-gk0XQJAFcogEf04Fw4UmKo3z1B6mcNbPRfImhWw4wtLkhp_KIqKNOkMsSpYGSLrCvqQpgK56EJZExrmb7WozjwHw"",
+                                    ""use"":""sig""
+                                }";
 
         public static string JsonWebKeyBadFormatString1 =
-                                        @"{ ""e"":""AQAB"",
-                                            ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""kty"":""RSA"",
-                                            ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",                                                                                                                                            
-                                            ""x5c"":[""MIIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ""],
-                                            ""x5t"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""use""::""sig""
-                                            }";
+                                @"{ ""e"":""AQAB"",
+                                    ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
+                                    ""kty"":""RSA"",
+                                    ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",                                                                                                                                            
+                                    ""x5c"":[""MIIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ""],
+                                    ""x5t"":""kriMPdmBvx68skT8-mPAB3BseeA"",
+                                    ""use""::""sig""
+                                }";
 
         public static string JsonWebKeyBadFormatString2 =
-                                        @"{ ""e"":""AQAB"",
-                                            ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""kty"":""RSA"",
-                                            ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",
-                                            ""x5c"":""M""IIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ""],
-                                            ""x5t"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""use""::""sig""
-                                            }";
+                                @"{ ""e"":""AQAB"",
+                                    ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
+                                    ""kty"":""RSA"",
+                                    ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",
+                                    ""x5c"":""M""IIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ""],
+                                    ""x5t"":""kriMPdmBvx68skT8-mPAB3BseeA"",
+                                    ""use""::""sig""
+                                    }";
 
         public static string JsonWebKeyBadRsaExponentString =
-                                        @"{ ""e"":""AQABC"",
-                                            ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""kty"":""RSA"",
-                                            ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",                                               
-                                            ""use"":""sig""
-                                        }";
+                                @"{ ""e"":""AQABC"",
+                                    ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
+                                    ""kty"":""RSA"",
+                                    ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",                                               
+                                    ""use"":""sig""
+                                }";
 
         public static string JsonWebKeyBadRsaModulusString =
-                                        @"{ ""e"":""AQAB"",
-                                            ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""kty"":""RSA"",
-                                            ""n"":""kSSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",                                               
-                                            ""use"":""sig""
-                                        }";
+                                @"{ ""e"":""AQAB"",
+                                    ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
+                                    ""kty"":""RSA"",
+                                    ""n"":""kSSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",                                               
+                                    ""use"":""sig""
+                                }";
 
         public static string JsonWebKeyRsaNoKidString =
-                                        @"{ ""e"":""AQAB"",
-                                            ""kty"":""RSA"",
-                                            ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",                                               
-                                            ""use"":""sig""
-                                        }";
+                                @"{ ""e"":""AQAB"",
+                                    ""kty"":""RSA"",
+                                    ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",                                               
+                                    ""use"":""sig""
+                                }";
 
         public static string JsonWebKeyKtyNotRsaString =
-                                        @"{ ""e"":""AQAB"",
-                                            ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""kty"":""RSAA"",
-                                            ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",                                               
-                                            ""use"":""sig""
-                                        }";
+                                @"{ ""e"":""AQAB"",
+                                    ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
+                                    ""kty"":""RSAA"",
+                                    ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",                                               
+                                    ""use"":""sig""
+                                }";
 
         public static string JsonWebKeyUseNotSigString =
-                                        @"{ ""e"":""AQAB"",
-                                            ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""kty"":""RSA"",
-                                            ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",                                               
-                                            ""use"":""sigg""
-                                        }";
+                                @"{ ""e"":""AQAB"",
+                                    ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
+                                    ""kty"":""RSA"",
+                                    ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",                                               
+                                    ""use"":""sigg""
+                                }";
 
         public static string JsonWebKeyX509DataString =
-                                        @"{ ""kid"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
-                                            ""kty"":""RSA"",
-                                            ""use"":""sig"",
-                                            ""x5t"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
-                                            ""x5c"":[""MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng""]
-                                        }";
-
-        public static string JsonWebKeyBadX509String =
-                                        @"{ ""e"":""AQAB"",
-                                            ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""kty"":""RSA"",
-                                            ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",
-                                            ""x5c"":[""==MIIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ""],
-                                            ""x5t"":""kriMPdmBvx68skT8-mPAB3BseeA"",
-                                            ""use"":""sig""
-                                        }";
+                                @"{ ""kid"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
+                                    ""kty"":""RSA"",
+                                    ""use"":""sig"",
+                                    ""x5t"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
+                                    ""x5c"":[""MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng""]
+                                }";
 
         public static string JsonWebKeyBadECCurveString =
-                                       @"{
-                                            ""kty"": ""EC"",
-                                            ""alg"": ""ES521"",
-                                            ""use"": ""sig"",
-                                            ""crv"": ""P-999"",
-                                            ""kid"": ""unknownCrv"",
-                                            ""x"": ""AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr"",
-                                            ""y"": ""AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW""
-                                        }";
-
-        public static string JsonWebKeyES256String =
-                                        @"{
-                                            ""kty"": ""EC"",
-                                            ""alg"": ""ES256"",
-                                            ""use"": ""sig"",
-                                            ""crv"": ""P-256"",
-                                            ""kid"": ""JsonWebKeyEcdsa256"",
-                                            ""x"": ""luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA"",
-                                            ""y"": ""tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ""
-                                        }";
-
-        public static string JsonWebKeyES384String =
-                                        @"{
-                                            ""kty"": ""EC"",
-                                            ""alg"": ""ES384"",
-                                            ""use"": ""sig"",
-                                            ""crv"": ""P-384"",
-                                            ""kid"": ""JsonWebKeyEcdsa384"",
-                                            ""x"": ""5mn3HaDoUgdNTFCACaWIvrpriQTloEbMbx4eUu_XvB4pyExig45VIozMnj7FedJg"",
-                                            ""y"": ""Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l""
-                                        }";
-
-        public static string JsonWebKeyES512String =
-                                        @"{
-                                            ""kty"": ""EC"",
-                                            ""alg"": ""ES512"",
-                                            ""use"": ""sig"",
-                                            ""crv"": ""P-521"",
-                                            ""kid"": ""JsonWebKeyEcdsa521"",
-                                            ""x"": ""AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr"",
-                                            ""y"": ""AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW""
-                                        }";
+                                @"{
+                                    ""kty"": ""EC"",
+                                    ""alg"": ""ES521"",
+                                    ""use"": ""sig"",
+                                    ""crv"": ""P-999"",
+                                    ""kid"": ""unknownCrv"",
+                                    ""x"": ""AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr"",
+                                    ""y"": ""AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW""
+                                }";
 
         public static string JsonWebKeyOnlyX5tString =
-                                        @"{
-                                            ""kty"": ""RSA"",
-                                            ""use"": ""sig"",
-                                            ""kid"":""pqoeamb2e5YVzR6_rqFpiCrFZgw"",
-                                            ""x5t"":""pqoeamb2e5YVzR6_rqFpiCrFZgw""
-                                        }";
+                                @"{
+                                    ""kty"": ""RSA"",
+                                    ""use"": ""sig"",
+                                    ""kid"":""pqoeamb2e5YVzR6_rqFpiCrFZgw"",
+                                    ""x5t"":""pqoeamb2e5YVzR6_rqFpiCrFZgw""
+                                }";
 
         public static string JsonWebKeyNoKtyString =
-                                        @"{ ""e"":""AQAB"",
-                                            ""kid"":""20am7"",
-                                            ""n"":""mhupHfUtg_gHIqwu2wm8CprXY-gKqbPMV6tEYVqkyYrHugzQ_YDYAHr7vWo5Pe_3gIujSFwpqIfXaP8-Fl3O5fQhMo1lMv4DdRabyDLEpv7YO9qoVKTmDOZqYZx-AYBr5x1Zh2xWByI6_0dsPtCjD1pFZfg_SxNEcLPyH1aY6dT8CWYu32qG4O0WF4EihZzMkzSn8fyh8RXbMf5U9Wm2kgb0g8jK62S7MoF4IlhFaJreq898wgUohhPwR8P3X-gk0XQJAFcogEf04Fw4UmKo3z1B6mcNbPRfImhWw4wtLkhp_KIqKNOkMsSpYGSLrCvqQpgK56EJZExrmb7WozjwHw"",
-                                            ""use"":""sig""
-                                        }";
+                                @"{ ""e"":""AQAB"",
+                                    ""kid"":""20am7"",
+                                    ""n"":""mhupHfUtg_gHIqwu2wm8CprXY-gKqbPMV6tEYVqkyYrHugzQ_YDYAHr7vWo5Pe_3gIujSFwpqIfXaP8-Fl3O5fQhMo1lMv4DdRabyDLEpv7YO9qoVKTmDOZqYZx-AYBr5x1Zh2xWByI6_0dsPtCjD1pFZfg_SxNEcLPyH1aY6dT8CWYu32qG4O0WF4EihZzMkzSn8fyh8RXbMf5U9Wm2kgb0g8jK62S7MoF4IlhFaJreq898wgUohhPwR8P3X-gk0XQJAFcogEf04Fw4UmKo3z1B6mcNbPRfImhWw4wtLkhp_KIqKNOkMsSpYGSLrCvqQpgK56EJZExrmb7WozjwHw"",
+                                    ""use"":""sig""
+                                }";
 
-        public static string JsonWebKeySetBadRsaExponentString = @"{ ""keys"":[" + JsonWebKeyBadRsaExponentString + "]}";
-        public static string JsonWebKeySetBadRsaModulusString = @"{ ""keys"":[" + JsonWebKeyBadRsaModulusString + "]}";
-        public static string JsonWebKeySetUseNoKidString = @"{ ""keys"":[" + JsonWebKeyRsaNoKidString + "]}";
-        public static string JsonWebKeySetKtyNotRsaString = @"{ ""keys"":[" + JsonWebKeyKtyNotRsaString + "]}";
-        public static string JsonWebKeySetUseNotSigString = @"{ ""keys"":[" + JsonWebKeyUseNotSigString + "]}";
-        public static string JsonWebKeySetX509DataString = @"{ ""keys"":[" + JsonWebKeyX509DataString + "]}";
-        public static string JsonWebKeySetBadX509String = @"{ ""keys"":[" + JsonWebKeyBadX509String + "]}";
-        public static string JsonWebKeySetBadECCurveString = @"{ ""keys"":[" + JsonWebKeyBadECCurveString + "]}";
-        public static string JsonWebKeySetOnlyX5tString = @"{ ""keys"":[" + JsonWebKeyOnlyX5tString + "]}";
-        public static string JsonWebKeySetUseNoKtyString = @"{ ""keys"":[" + JsonWebKeyNoKtyString + "]}";
-
-        // Key Sets
-        public static string JsonWebKeySet = "JsonWebKeySet.json";
-        public static string JsonWebKeySetString1 = @"{ ""keys"":[" + JsonWebKeyString1 + "," + JsonWebKeyString2 + "]}";
-        public static string JsonWebKeySetString2 = @"{ ""keys"":[" + JsonWebKeyString2 + "]}";
-        public static string JsonWebKeySetECCString = @"{ ""keys"":[" + JsonWebKeyES256String + "," + JsonWebKeyES384String + "," + JsonWebKeyES512String + "]}";
-        public static string JsonWebKeySetAdditionalDataString1 = @"{ ""keys"":[" + JsonWebKeyAdditionalDataString1 + "]" + @", ""additionalProperty"":""additionalValue""}";
-        public static string JsonWebKeySetOneValidRsaOneInvalidRsaString = @"{ ""keys"":[" + JsonWebKeyFromPingString1 + "," + JsonWebKeyBadRsaExponentString + "]}";
-        public static string JsonWebKeySetOneInvalidEcOneValidEcString = @"{ ""keys"":[" + JsonWebKeyBadECCurveString + "," + JsonWebKeyES256String + "]}";
-        public static string JsonWebKeySetOneValidRsaOneInvalidEcString = @"{ ""keys"":[" + JsonWebKeyFromPingString1 + "," + JsonWebKeyBadECCurveString + "]}";
-        public static string JsonWebKeySetBadFormatingString =
-                                            @"{ ""keys"":[
-                                                {   ""e"":""AQAB"",
-                                                    ""kid"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
-                                                    ""kty"":""RSA"",
-                                                    ""n"":""rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw=="",
-                                                    ""x5c"":[""MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng""
-                                                    ""x5t"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
-                                                    ""use"":""sig""
-                                                }
-                                            ]}";
-
-        public static string JsonWebKeySetSingleX509DataString =
-                                            @"{ ""keys"":[
-                                                {   ""e"":""AQAB"",                                                                                                
-                                                    ""kid"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",                                               
-                                                    ""kty"":""RSA"",
-                                                    ""n"":""rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw=="",
-                                                    ""x5c"":""MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng"",
-                                                    ""x5t"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
-                                                    ""use"":""sig""
-                                               }
-                                            ]}";
-
-        public static string JsonWebKeySetEvoString =
-                                           @"{ ""keys"":[
-                                               {
-                                                   ""kty"":""RSA"",
-                                                   ""use"":""sig"",
-                                                   ""kid"":""HBxl9mAe6gxavCkcoOU2THsDNa0"",
-                                                   ""x5t"":""HBxl9mAe6gxavCkcoOU2THsDNa0"",
-                                                   ""n"":""0afCaiPd_xl_ewZGfOkxKwYPfI4Efu0COfzajK_gnviWk7w3R-88Dmb0j24DSn1qVR3ptCnA1-QUfUMyhvl8pT5-t7oRkLNPzp0hVV-dAG3ZoMaSEMW0wapshA6LVGROpBncDmc66hx5-t3eOFA24fiKfQiv2TJth3Y9jhHnLe7GBOoomWYx_pJiEG3mhYFIt7shaEwNcEjo34vr1WWzRm8D8gogjrJWd1moyeGftWLzvfp9e79QwHYJv907vQbFrT7LYuy8g7-Rpxujgumw2mx7CewcCZXwPiZ-raM3Ap1FhINiGpd5mbbYrFDDFIWAjWPUY6KNvXtc24yUfZr4MQ"",
-                                                   ""e"":""AQAB"",
-                                                   ""x5c"":[
-                                                      ""MIIDBTCCAe2gAwIBAgIQWcq84CdVhKVEcKbZdMOMGjANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDMxNDAwMDAwMFoXDTIxMDMxNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANGnwmoj3f8Zf3sGRnzpMSsGD3yOBH7tAjn82oyv4J74lpO8N0fvPA5m9I9uA0p9alUd6bQpwNfkFH1DMob5fKU+fre6EZCzT86dIVVfnQBt2aDGkhDFtMGqbIQOi1RkTqQZ3A5nOuocefrd3jhQNuH4in0Ir9kybYd2PY4R5y3uxgTqKJlmMf6SYhBt5oWBSLe7IWhMDXBI6N+L69Vls0ZvA/IKII6yVndZqMnhn7Vi8736fXu/UMB2Cb/dO70Gxa0+y2LsvIO/kacbo4LpsNpsewnsHAmV8D4mfq2jNwKdRYSDYhqXeZm22KxQwxSFgI1j1GOijb17XNuMlH2a+DECAwEAAaMhMB8wHQYDVR0OBBYEFIkZ5wrSV8lohIsreOmig7h5wQDkMA0GCSqGSIb3DQEBCwUAA4IBAQAd8sKZLwZBocM4pMIRKarK60907jQCOi1m449WyToUcYPXmU7wrjy9fkYwJdC5sniItVBJ3RIQbF/hyjwnRoIaEcWYMAftBnH+c19WIuiWjR3EHnIdxmSopezl/9FaTNghbKjZtrKK+jL/RdkMY9uWxwUFLjTAtMm24QOt2+CGntBA9ohQUgiML/mlUpf4qEqa2/Lh+bjiHl3smg4TwuIl0i/TMN9Rg7UgQ6BnqfgiuMl6BtBiatNollwgGNI2zJEi47MjdeMf8+C3tXs//asqqlqJCyVLwN7AN47ynYmkl89MleOfKIojhrGRxryZG2nRjD9u/kZbPJ8e3JE9px67""
-                                                   ],
-                                                   ""issuer"":""https://login.microsoftonline.com/{tenantid}/v2.0""
-                                               }
-                                           ]}";
-
-        static DataSets()
-        {
-            JsonWebKeyFromPing1 = new JsonWebKey
+        public static JsonWebKey JsonWebKeyFromPing1 =>
+            new JsonWebKey
             {
                 E = "AQAB",
                 Kid = "20am7",
@@ -286,7 +125,8 @@ namespace Microsoft.IdentityModel.TestUtils
                 Use = "sig"
             };
 
-            JsonWebKeyFromPing2 = new JsonWebKey
+        public static JsonWebKey JsonWebKeyFromPing2 =>
+            new JsonWebKey
             {
                 E = "AQAB",
                 Kid = "20am3",
@@ -295,7 +135,8 @@ namespace Microsoft.IdentityModel.TestUtils
                 Use = "sig"
             };
 
-            JsonWebKeyFromPing3 = new JsonWebKey
+        public static JsonWebKey JsonWebKeyFromPing3 =>
+            new JsonWebKey
             {
                 E = "AQAB",
                 Kid = "20alz",
@@ -304,34 +145,90 @@ namespace Microsoft.IdentityModel.TestUtils
                 Use = "sig"
             };
 
-            JsonWebKey1 = new JsonWebKey
+        public static JsonWebKey JsonWebKey1
+        {
+            get
             {
-                Alg = "SHA256",
-                E = "AQAB",
-                Kid = "NGTFvdK-fythEuLwjpwAJOM9n-A",
-                Kty = "RSA",
-                N = "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
-                X5t = "NGTFvdK-fythEuLwjpwAJOM9n-A",
-                X5u = "https://jsonkeyurl",
-                Use = "sig",
-            };
+                JsonWebKey jsonWebKey = new JsonWebKey
+                {
+                    Alg = "SHA256",
+                    E = "AQAB",
+                    Kid = "NGTFvdK-fythEuLwjpwAJOM9n-A",
+                    Kty = "RSA",
+                    N = "rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw==",
+                    Use = "sig",
+                    X5t = "NGTFvdK-fythEuLwjpwAJOM9n-A",
+                    X5u = "https://jsonkeyurl",
+                };
 
-            JsonWebKey1.X5c.Add(JsonWebKey_X5c_1);
-            JsonWebKey1.KeyOps.Add("signing");
-            JsonWebKey2 = new JsonWebKey
+                jsonWebKey.X5c.Add(X5C_1);
+                jsonWebKey.KeyOps.Add("signing");
+
+                return jsonWebKey;
+            }
+        }
+
+        public static JsonWebKey JsonWebKey2
+        {
+            get
             {
-                Alg = "SHA256",
-                E = "AQAB",
-                Kid = "kriMPdmBvx68skT8-mPAB3BseeA",
-                Kty = "RSA",
-                N = "kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw==",
-                X5t = "kriMPdmBvx68skT8-mPAB3BseeA",
-                Use = "sig",
-            };
+                JsonWebKey jsonWebKey = new JsonWebKey
+                {
+                    Alg = "SHA256",
+                    E = "AQAB",
+                    Kid = "kriMPdmBvx68skT8-mPAB3BseeA",
+                    Kty = "RSA",
+                    N = "kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw==",
+                    X5t = "kriMPdmBvx68skT8-mPAB3BseeA",
+                    Use = "sig"
+                };
 
-            JsonWebKey2.X5c.Add(JsonWebKey_X5c_2);
+                jsonWebKey.X5c.Add(X5C_2);
 
-            JsonWebKeyES256 = new JsonWebKey
+                return jsonWebKey;
+            }
+        }
+
+        public static string JsonWebKeyString =>
+            @"{ ""alg"":""SHA256"",
+                ""e"":""AQAB"",
+                ""key_ops"":[""signing""],
+                ""kid"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
+                ""kty"":""RSA"",
+                ""n"":""rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw=="",
+                ""use"":""sig"",
+                ""x5c"":[""MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng""],
+                ""x5t"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
+                ""x5u"":""https://jsonkeyurl""
+            }";
+
+        public static string JsonWebKeyString2 =
+            @"{ ""alg"":""SHA256"",
+                ""e"":""AQAB"",
+                ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
+                ""kty"":""RSA"",
+                ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",
+                ""use"":""sig"",
+                ""x5c"":[""MIIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ""],
+                ""x5t"":""kriMPdmBvx68skT8-mPAB3BseeA""
+            }";
+
+        public static string JsonWebKeyMixedCaseString =>
+            @"{ ""Alg"":""SHA256"",
+                ""E"":""AQAB"",
+                ""key_Ops"":[""signing""],
+                ""kid"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
+                ""kty"":""RSA"",
+                ""n"":""rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw=="",
+                ""use"":""sig"",
+                ""x5C"":[""MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng""],
+                ""x5t"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
+                ""x5T#S256"":""NGTFvdK-fythEuLwjpwAJOM9n-A256"",
+                ""x5u"":""https://jsonkeyurl""
+            }";
+
+        public static JsonWebKey JsonWebKeyES256 =>
+            new JsonWebKey
             {
                 Alg = "ES256",
                 Crv = "P-256",
@@ -342,7 +239,19 @@ namespace Microsoft.IdentityModel.TestUtils
                 Y = "tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ"
             };
 
-            JsonWebKeyES384 = new JsonWebKey
+        public static string JsonWebKeyES256String =>
+            @"{
+                ""kty"": ""EC"",
+                ""alg"": ""ES256"",
+                ""use"": ""sig"",
+                ""crv"": ""P-256"",
+                ""kid"": ""JsonWebKeyEcdsa256"",
+                ""x"": ""luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA"",
+                ""y"": ""tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ""
+            }";
+
+        public static JsonWebKey JsonWebKeyES384 =>
+            new JsonWebKey
             {
                 Alg = "ES384",
                 Crv = "P-384",
@@ -353,7 +262,19 @@ namespace Microsoft.IdentityModel.TestUtils
                 Y = "Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l"
             };
 
-            JsonWebKeyES512 = new JsonWebKey
+        public static string JsonWebKeyES384String =
+            @"{
+                ""kty"": ""EC"",
+                ""alg"": ""ES384"",
+                ""use"": ""sig"",
+                ""crv"": ""P-384"",
+                ""kid"": ""JsonWebKeyEcdsa384"",
+                ""x"": ""5mn3HaDoUgdNTFCACaWIvrpriQTloEbMbx4eUu_XvB4pyExig45VIozMnj7FedJg"",
+                ""y"": ""Vh872HVKNHrzlVu0Ko-3dN-eHoDYBeZgdGLAqenyZ0_X_TctwT6MVLxcAvwbJG5l""
+            }";
+
+        public static JsonWebKey JsonWebKeyES512 =>
+            new JsonWebKey
             {
                 Alg = "ES512",
                 Crv = "P-521",
@@ -364,89 +285,189 @@ namespace Microsoft.IdentityModel.TestUtils
                 Y = "AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW"
             };
 
-            JsonWebKeySet1 = new JsonWebKeySet();
-            JsonWebKeySet1.Keys.Add(JsonWebKey1);
-            JsonWebKeySet1.Keys.Add(JsonWebKey2);
+        public static string JsonWebKeyES512String =>
+            @"{
+                ""kty"": ""EC"",
+                ""alg"": ""ES512"",
+                ""use"": ""sig"",
+                ""crv"": ""P-521"",
+                ""kid"": ""JsonWebKeyEcdsa521"",
+                ""x"": ""AX0BXx6mpDjvGk-NLTwobKNjfAP4QCRjtKi8UQsuPqQ2sRKITAcSti3UMn0COcrG_FVgEDNPyPVlSi5LnUl0dREr"",
+                ""y"": ""AZ8DlNxsA6eCj_JL9Rz8uU4eacd-XX--ek8-VCOgv3YNRPeN_2PJauJL7q9Pg1MSe8zEaLIRhM4SGWJ4SI1rMhlW""
+            }";
 
-            JsonWebKeySetEC = new JsonWebKeySet();
-            JsonWebKeySetEC.Keys.Add(JsonWebKeyES256);
-            JsonWebKeySetEC.Keys.Add(JsonWebKeyES384);
-            JsonWebKeySetEC.Keys.Add(JsonWebKeyES512);
+        public static string JsonWebKeyBadX509DataString =>
+            @"{ ""e"":""AQAB"",
+                ""kid"":""kriMPdmBvx68skT8-mPAB3BseeA"",
+                ""kty"":""RSA"",
+                ""n"":""kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw=="",
+                ""x5c"":[""==MIIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ""],
+                ""x5t"":""kriMPdmBvx68skT8-mPAB3BseeA"",
+                ""use"":""sig""
+            }";
 
-            var jwk = new JsonWebKey
+        public static JsonWebKey JsonWebKeyBadX509Data 
+        {
+            get
             {
-                Kid = "NGTFvdK-fythEuLwjpwAJOM9n-A",
-                Kty = "RSA",
-                Use = "sig",
-                X5t = "NGTFvdK-fythEuLwjpwAJOM9n-A"
-            };
-
-            jwk.X5c.Add("MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng");
-
-            JsonWebKeySetX509Data = new JsonWebKeySet();
-            JsonWebKeySetX509Data.Keys.Add(jwk);
-
-            JsonWebKeyAdditionalData1 = new JsonWebKey
-            {
-                Alg = "SHA256",
-                E = "AQAB",
-                Kid = "kriMPdmBvx68skT8-mPAB3BseeA",
-                Kty = "RSA",
-                N = "kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw==",
-                X5t = "kriMPdmBvx68skT8-mPAB3BseeA",
-                Use = "sig",
-            };
-
-            JsonWebKeyAdditionalData1.AdditionalData["additionalProperty"] = "additionalValue";
-            JsonWebKeyAdditionalData1.X5c.Add(JsonWebKey_X5c_2);
-            JsonWebKeySetAdditionalData1 = new JsonWebKeySet();
-            JsonWebKeySetAdditionalData1.Keys.Add(JsonWebKeyAdditionalData1);
-            JsonWebKeySetAdditionalData1.AdditionalData["additionalProperty"] = "additionalValue";
-
-            JsonWebKeyBadX509Data = new JsonWebKey
-            {
-                E = "AQAB",
-                Kid = "kriMPdmBvx68skT8-mPAB3BseeA",
-                Kty = "RSA",
-                N = "kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw==",
-                X5t = "kriMPdmBvx68skT8-mPAB3BseeA",
-                Use = "sig"
-            };
-
-            JsonWebKeyBadX509Data.X5c.Add("==MIIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ");
-
-            GoogleCertsExpected = new JsonWebKeySet();
-            GoogleCertsExpected.Keys.Add(
-                new JsonWebKey
+                JsonWebKey jsonWebKey = new JsonWebKey
                 {
-                    Alg = "RS256",
                     E = "AQAB",
+                    Kid = "kriMPdmBvx68skT8-mPAB3BseeA",
                     Kty = "RSA",
-                    Kid = "ab844f3d4c69feee0de2501b04e1a4c8d78eead1",
-                    N = "AKrMiv5vhYehVKXnSpZZN6lYymUIi+NS97ceYKYClMlNyj2Ln4ErWiOwjwdivG2kZnN0kKCC/XL9E+uEgsZO3ECvvDtgtFhPOR0MiqL7pp/K7d58dbKUWX/cWy8E4bm/Zmwa/g0HDcW6o19+Q85IPYXbY/6Z2oOgA9qDAoGHkjIv",
-                    Use = "sig",
-                });
+                    N = "kSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuw==",
+                    X5t = "kriMPdmBvx68skT8-mPAB3BseeA",
+                    Use = "sig"
+                };
 
-            GoogleCertsExpected.Keys.Add(
-                 new JsonWebKey
-                 {
-                     Alg = "RS256",
-                     E = "AQAB",
-                     Kty = "RSA",
-                     Kid = "550326e0aacb4674d22905a1a51a808cfa7463b0",
-                     N = "ANLFuJO6EoKczde+YP3b1yuz2b46D7Rd7CjrbvKrzbjkH29iRFLBagT7nojwdMOPrsV+WLp/C8lfkRT7UJ38lnQh3m4oEy98HdRRMZh5Vtpbotgt4S/ugh5ansJdHSXSBTxk+X1ZnTzMOUH7ZROpxw3NcX/IFl0sshFlTbebPrDj",
-                     Use = "sig",
-                 });
+                jsonWebKey.X5c.Add("==MIIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ");
 
-            var JsonWebKeyOnlyX5t = new JsonWebKey
-            {
-                Kid = "pqoeamb2e5YVzR6_rqFpiCrFZgw",
-                Kty = "RSA",
-                Use = "sig",
-                X5t = "pqoeamb2e5YVzR6_rqFpiCrFZgw"
-            };
-            JsonWebKeySetOnlyX5t = new JsonWebKeySet();
-            JsonWebKeySetOnlyX5t.Keys.Add(JsonWebKeyOnlyX5t);
+                return jsonWebKey;
+            }
         }
+        #endregion
+
+        #region JsonWebKeySets
+        public static string GoogleCertsFile = "google-certs.json";
+        public static JsonWebKeySet GoogleCertsExpected
+        {
+            get
+            {
+                JsonWebKeySet jsonWebKeySet = new JsonWebKeySet();
+                jsonWebKeySet.Keys.Add(
+                    new JsonWebKey
+                    {
+                        Alg = "RS256",
+                        E = "AQAB",
+                        Kty = "RSA",
+                        Kid = "ab844f3d4c69feee0de2501b04e1a4c8d78eead1",
+                        N = "AKrMiv5vhYehVKXnSpZZN6lYymUIi+NS97ceYKYClMlNyj2Ln4ErWiOwjwdivG2kZnN0kKCC/XL9E+uEgsZO3ECvvDtgtFhPOR0MiqL7pp/K7d58dbKUWX/cWy8E4bm/Zmwa/g0HDcW6o19+Q85IPYXbY/6Z2oOgA9qDAoGHkjIv",
+                        Use = "sig",
+                    });
+
+                jsonWebKeySet.Keys.Add(
+                     new JsonWebKey
+                     {
+                         Alg = "RS256",
+                         E = "AQAB",
+                         Kty = "RSA",
+                         Kid = "550326e0aacb4674d22905a1a51a808cfa7463b0",
+                         N = "ANLFuJO6EoKczde+YP3b1yuz2b46D7Rd7CjrbvKrzbjkH29iRFLBagT7nojwdMOPrsV+WLp/C8lfkRT7UJ38lnQh3m4oEy98HdRRMZh5Vtpbotgt4S/ugh5ansJdHSXSBTxk+X1ZnTzMOUH7ZROpxw3NcX/IFl0sshFlTbebPrDj",
+                         Use = "sig",
+                     });
+
+                return jsonWebKeySet;
+            }
+        }
+
+        public static string JsonWebKeySetString1 = @"{ ""keys"":[" + JsonWebKeyString + "," + JsonWebKeyString2 + "]}";
+        public static string JsonWebKeySetECCString = @"{ ""keys"":[" + JsonWebKeyES256String + "," + JsonWebKeyES384String + "," + JsonWebKeyES512String + "]}";
+        public static string JsonWebKeySetOneValidRsaOneInvalidRsaString = @"{ ""keys"":[" + JsonWebKeyWithOneRsaKey + "," + JsonWebKeyBadRsaExponentString + "]}";
+        public static string JsonWebKeySetOneInvalidEcOneValidEcString = @"{ ""keys"":[" + JsonWebKeyBadECCurveString + "," + JsonWebKeyES256String + "]}";
+        public static string JsonWebKeySetOneValidRsaOneInvalidEcString = @"{ ""keys"":[" + JsonWebKeyWithOneRsaKey + "," + JsonWebKeyBadECCurveString + "]}";
+        public static string JsonWebKeySetBadFormatingString =
+                                @"{ ""keys"":[
+                                    {   ""e"":""AQAB"",
+                                        ""kid"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
+                                        ""kty"":""RSA"",
+                                        ""n"":""rCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVw=="",
+                                        ""x5c"":[""MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng""
+                                        ""x5t"":""NGTFvdK-fythEuLwjpwAJOM9n-A"",
+                                        ""use"":""sig""
+                                    }
+                                ]}";
+
+        public static string JsonWebKeySetEvoString =
+                                @"{ ""keys"":[
+                                    {
+                                        ""kty"":""RSA"",
+                                        ""use"":""sig"",
+                                        ""kid"":""HBxl9mAe6gxavCkcoOU2THsDNa0"",
+                                        ""x5t"":""HBxl9mAe6gxavCkcoOU2THsDNa0"",
+                                        ""n"":""0afCaiPd_xl_ewZGfOkxKwYPfI4Efu0COfzajK_gnviWk7w3R-88Dmb0j24DSn1qVR3ptCnA1-QUfUMyhvl8pT5-t7oRkLNPzp0hVV-dAG3ZoMaSEMW0wapshA6LVGROpBncDmc66hx5-t3eOFA24fiKfQiv2TJth3Y9jhHnLe7GBOoomWYx_pJiEG3mhYFIt7shaEwNcEjo34vr1WWzRm8D8gogjrJWd1moyeGftWLzvfp9e79QwHYJv907vQbFrT7LYuy8g7-Rpxujgumw2mx7CewcCZXwPiZ-raM3Ap1FhINiGpd5mbbYrFDDFIWAjWPUY6KNvXtc24yUfZr4MQ"",
+                                        ""e"":""AQAB"",
+                                        ""x5c"":[
+                                            ""MIIDBTCCAe2gAwIBAgIQWcq84CdVhKVEcKbZdMOMGjANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE5MDMxNDAwMDAwMFoXDTIxMDMxNDAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANGnwmoj3f8Zf3sGRnzpMSsGD3yOBH7tAjn82oyv4J74lpO8N0fvPA5m9I9uA0p9alUd6bQpwNfkFH1DMob5fKU+fre6EZCzT86dIVVfnQBt2aDGkhDFtMGqbIQOi1RkTqQZ3A5nOuocefrd3jhQNuH4in0Ir9kybYd2PY4R5y3uxgTqKJlmMf6SYhBt5oWBSLe7IWhMDXBI6N+L69Vls0ZvA/IKII6yVndZqMnhn7Vi8736fXu/UMB2Cb/dO70Gxa0+y2LsvIO/kacbo4LpsNpsewnsHAmV8D4mfq2jNwKdRYSDYhqXeZm22KxQwxSFgI1j1GOijb17XNuMlH2a+DECAwEAAaMhMB8wHQYDVR0OBBYEFIkZ5wrSV8lohIsreOmig7h5wQDkMA0GCSqGSIb3DQEBCwUAA4IBAQAd8sKZLwZBocM4pMIRKarK60907jQCOi1m449WyToUcYPXmU7wrjy9fkYwJdC5sniItVBJ3RIQbF/hyjwnRoIaEcWYMAftBnH+c19WIuiWjR3EHnIdxmSopezl/9FaTNghbKjZtrKK+jL/RdkMY9uWxwUFLjTAtMm24QOt2+CGntBA9ohQUgiML/mlUpf4qEqa2/Lh+bjiHl3smg4TwuIl0i/TMN9Rg7UgQ6BnqfgiuMl6BtBiatNollwgGNI2zJEi47MjdeMf8+C3tXs//asqqlqJCyVLwN7AN47ynYmkl89MleOfKIojhrGRxryZG2nRjD9u/kZbPJ8e3JE9px67""
+                                        ],
+                                        ""issuer"":""https://login.microsoftonline.com/{tenantid}/v2.0""
+                                    }
+                                ]}";
+
+        public static string JsonWebKeySetBadRsaExponentString = @"{ ""keys"":[" + JsonWebKeyBadRsaExponentString + "]}";
+        public static string JsonWebKeySetBadRsaModulusString = @"{ ""keys"":[" + JsonWebKeyBadRsaModulusString + "]}";
+        public static string JsonWebKeySetUseNoKidString = @"{ ""keys"":[" + JsonWebKeyRsaNoKidString + "]}";
+        public static string JsonWebKeySetKtyNotRsaString = @"{ ""keys"":[" + JsonWebKeyKtyNotRsaString + "]}";
+        public static string JsonWebKeySetUseNotSigString = @"{ ""keys"":[" + JsonWebKeyUseNotSigString + "]}";
+        public static string JsonWebKeySetX509DataString = @"{ ""keys"":[" + JsonWebKeyX509DataString + "]}";
+        public static string JsonWebKeySetBadX509String = @"{ ""keys"":[" + JsonWebKeyBadX509DataString + "]}";
+        public static string JsonWebKeySetBadECCurveString = @"{ ""keys"":[" + JsonWebKeyBadECCurveString + "]}";
+        public static string JsonWebKeySetOnlyX5tString = @"{ ""keys"":[" + JsonWebKeyOnlyX5tString + "]}";
+        public static string JsonWebKeySetUseNoKtyString = @"{ ""keys"":[" + JsonWebKeyNoKtyString + "]}";
+
+        public static JsonWebKeySet JsonWebKeySet1
+        {
+            get
+            {
+                JsonWebKeySet jsonWebKeySet = new JsonWebKeySet();
+                jsonWebKeySet.Keys.Add(JsonWebKey1);
+                jsonWebKeySet.Keys.Add(JsonWebKey2);
+
+                return jsonWebKeySet;
+            }
+        }
+
+        public static JsonWebKeySet JsonWebKeySetX509Data
+        {
+            get
+            {
+                var jsonWebKey = new JsonWebKey
+                {
+                    Kid = "NGTFvdK-fythEuLwjpwAJOM9n-A",
+                    Kty = "RSA",
+                    Use = "sig",
+                    X5t = "NGTFvdK-fythEuLwjpwAJOM9n-A"
+                };
+
+                jsonWebKey.X5c.Add("MIIDPjCCAiqgAwIBAgIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTIwNjA3MDcwMDAwWhcNMTQwNjA3MDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArCz8Sn3GGXmikH2MdTeGY1D711EORX/lVXpr+ecGgqfUWF8MPB07XkYuJ54DAuYT318+2XrzMjOtqkT94VkXmxv6dFGhG8YZ8vNMPd4tdj9c0lpvWQdqXtL1TlFRpD/P6UMEigfN0c9oWDg9U7Ilymgei0UXtf1gtcQbc5sSQU0S4vr9YJp2gLFIGK11Iqg4XSGdcI0QWLLkkC6cBukhVnd6BCYbLjTYy3fNs4DzNdemJlxGl8sLexFytBF6YApvSdus3nFXaMCtBGx16HzkK9ne3lobAwL2o79bP4imEGqg+ibvyNmbrwFGnQrBc1jTF9LyQX9q+louxVfHs6ZiVwIDAQABo2IwYDBeBgNVHQEEVzBVgBCxDDsLd8xkfOLKm4Q/SzjtoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQVWmXY/+9RqFA/OG9kFulHDAJBgUrDgMCHQUAA4IBAQAkJtxxm/ErgySlNk69+1odTMP8Oy6L0H17z7XGG3w4TqvTUSWaxD4hSFJ0e7mHLQLQD7oV/erACXwSZn2pMoZ89MBDjOMQA+e6QzGB7jmSzPTNmQgMLA8fWCfqPrz6zgH+1F1gNp8hJY57kfeVPBiyjuBmlTEBsBlzolY9dd/55qqfQk6cgSeCbHCy/RU/iep0+UsRMlSgPNNmqhj5gmN2AFVCN96zF694LwuPae5CeR2ZcVknexOWHYjFM0MgUSw0ubnGl0h9AJgGyhvNGcjQqu9vd1xkupFgaN+f7P3p3EVN5csBg5H94jEcQZT7EKeTiZ6bTrpDAnrr8tDCy8ng");
+
+                JsonWebKeySet jsonWebKeySet = new JsonWebKeySet();
+                jsonWebKeySet.Keys.Add(jsonWebKey);
+
+                return jsonWebKeySet;
+            }
+        }
+
+        public static JsonWebKeySet JsonWebKeySetEC
+        {
+            get
+            {
+                JsonWebKeySet jsonWebKeySet = new JsonWebKeySet();
+                jsonWebKeySet.Keys.Add(JsonWebKeyES256);
+                jsonWebKeySet.Keys.Add(JsonWebKeyES384);
+                jsonWebKeySet.Keys.Add(JsonWebKeyES512);
+
+                return jsonWebKeySet;
+            }
+        }
+
+        public static JsonWebKeySet JsonWebKeySetOnlyX5t
+        {
+            get
+            {
+                JsonWebKey jsonWebKey = new JsonWebKey
+                {
+                    Kid = "pqoeamb2e5YVzR6_rqFpiCrFZgw",
+                    Kty = "RSA",
+                    Use = "sig",
+                    X5t = "pqoeamb2e5YVzR6_rqFpiCrFZgw"
+                };
+
+                JsonWebKeySet jsonWebKeySet = new JsonWebKeySet();
+                jsonWebKeySet.Keys.Add(jsonWebKey);
+
+                return jsonWebKeySet;
+            }
+        }
+        #endregion
     }
 }

--- a/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
@@ -33,21 +33,44 @@ namespace Microsoft.IdentityModel.TestUtils
 {
     public class IdentityComparer
     {
+        // Dictionary of types and the validation function.
+        // Keep entries in alphabetical order
         private static readonly Dictionary<string, Func<object, object, CompareContext, bool>> _equalityDict =
             new Dictionary<string, Func<object, object, CompareContext, bool>>
             {
+                { typeof(AuthenticationProtocolMessage).ToString(), CompareAllPublicProperties },
                 { typeof(bool).ToString(), AreBoolsEqual },
+                { typeof(byte[]).ToString(), AreBytesEqual },
+                { typeof(CanonicalizingTransfrom).ToString(), CompareAllPublicProperties },
+                { typeof(Claim).ToString(), CompareAllPublicProperties },
+                { typeof(ClaimsIdentity).ToString(), CompareAllPublicProperties },
+                { typeof(ClaimsPrincipal).ToString(), CompareAllPublicProperties },
                 { typeof(Collection<SecurityKey>).ToString(), ContinueCheckingEquality },
                 { typeof(DateTime).ToString(), AreDateTimesEqual },
                 { typeof(Dictionary<string, object>).ToString(), AreObjectDictionariesEqual },
                 { typeof(Dictionary<string, object>.ValueCollection).ToString(), AreValueCollectionsEqual },
+                { typeof(ExclusiveCanonicalizationTransform).ToString(), CompareAllPublicProperties },
+                { typeof(EnvelopedSignatureTransform).ToString(), CompareAllPublicProperties },
+                { typeof(IDictionary<string, string>).ToString(), AreStringDictionariesEqual},
                 { typeof(IEnumerable<Claim>).ToString(), AreClaimsEnumsEqual },
                 { typeof(IEnumerable<ClaimsIdentity>).ToString(), AreClaimsIdentitiesEnumsEqual },
                 { typeof(IEnumerable<object>).ToString(), AreObjectEnumsEqual },
                 { typeof(IEnumerable<SecurityKey>).ToString(), AreSecurityKeyEnumsEqual },
                 { typeof(IEnumerable<string>).ToString(), AreStringEnumsEqual },
                 { typeof(IEnumerable<X509Data>).ToString(), AreX509DataEnumsEqual },
-                { typeof(IDictionary<string, string>).ToString(), AreStringDictionariesEqual},
+                { typeof(IssuerSerial).ToString(), CompareAllPublicProperties },
+                { typeof(JArray).ToString(), AreJArraysEqual },
+                { typeof(JObject).ToString(), AreJObjectsEqual },
+                { typeof(JsonElement).ToString(), AreJsonElementsEqual },
+                { typeof(JsonWebKey).ToString(), AreJsonWebKeysEqual },
+                { typeof(JsonWebKeySet).ToString(), AreJsonWebKeysEqual },
+                { typeof(JsonWebToken).ToString(), CompareAllPublicProperties },
+                { typeof(JsonWebTokenHandler).ToString(), CompareAllPublicProperties },
+                { typeof(JwtHeader).ToString(), CompareAllPublicProperties },
+                { typeof(JwtPayload).ToString(), CompareAllPublicProperties },
+                { typeof(JwtSecurityToken).ToString(), CompareAllPublicProperties },
+                { typeof(JwtSecurityTokenHandler).ToString(), CompareAllPublicProperties },
+                { typeof(KeyInfo).ToString(), CompareAllPublicProperties },
                 { typeof(List<JsonWebKey>).ToString(), AreJsonWebKeyEnumsEqual },
                 { typeof(List<KeyInfo>).ToString(), AreKeyInfoEnumsEqual },
                 { typeof(List<SamlAssertion>).ToString(), AreSamlAssertionEnumsEqual},
@@ -59,28 +82,6 @@ namespace Microsoft.IdentityModel.TestUtils
                 { typeof(List<SecurityKey>).ToString(), AreSecurityKeyEnumsEqual },
                 { typeof(List<Reference>).ToString(), AreReferenceEnumsEqual },
                 { typeof(List<Uri>).ToString(), AreUriEnumsEqual },
-                { typeof(X509Certificate2).ToString(), AreX509Certificate2Equal },
-                { typeof(AuthenticationProtocolMessage).ToString(), CompareAllPublicProperties },
-                { typeof(byte[]).ToString(), AreBytesEqual },
-                { typeof(Claim).ToString(), CompareAllPublicProperties },
-                { typeof(ClaimsIdentity).ToString(), CompareAllPublicProperties },
-                { typeof(ClaimsPrincipal).ToString(), CompareAllPublicProperties },
-                { typeof(ExclusiveCanonicalizationTransform).ToString(), CompareAllPublicProperties },
-                { typeof(CanonicalizingTransfrom).ToString(), CompareAllPublicProperties },
-                { typeof(EnvelopedSignatureTransform).ToString(), CompareAllPublicProperties },
-                { typeof(IssuerSerial).ToString(), CompareAllPublicProperties },
-                { typeof(JArray).ToString(), AreJArraysEqual },
-                { typeof(JObject).ToString(), AreJObjectsEqual },
-                { typeof(JsonElement).ToString(), AreJsonElementsEqual },
-                { typeof(JsonWebKey).ToString(), CompareAllPublicProperties },
-                { typeof(JsonWebKeySet).ToString(), CompareAllPublicProperties },
-                { typeof(JsonWebToken).ToString(), CompareAllPublicProperties },
-                { typeof(JsonWebTokenHandler).ToString(), CompareAllPublicProperties },
-                { typeof(JwtHeader).ToString(), CompareAllPublicProperties },
-                { typeof(JwtPayload).ToString(), CompareAllPublicProperties },
-                { typeof(JwtSecurityToken).ToString(), CompareAllPublicProperties },
-                { typeof(JwtSecurityTokenHandler).ToString(), CompareAllPublicProperties },
-                { typeof(KeyInfo).ToString(), CompareAllPublicProperties },
                 { typeof(OpenIdConnectConfiguration).ToString(), CompareAllPublicProperties },
                 { typeof(OpenIdConnectMessage).ToString(), CompareAllPublicProperties },
                 { typeof(Reference).ToString(), CompareAllPublicProperties },
@@ -143,11 +144,13 @@ namespace Microsoft.IdentityModel.TestUtils
                 { typeof(WsFederationConfiguration).ToString(), CompareAllPublicProperties },
                 { typeof(WsFederationMessage).ToString(), CompareAllPublicProperties },
                 { typeof(Uri).ToString(), AreUrisEqual },
+                { typeof(X509Certificate2).ToString(), AreX509Certificate2Equal },
                 { typeof(X509Data).ToString(), CompareAllPublicProperties },
                 { typeof(X509SigningCredentials).ToString(), CompareAllPublicProperties },
                 { typeof(TokenValidationResult).ToString(), CompareAllPublicProperties },
             };
 
+        // Keep methods in alphabetical order
         public static bool AreBoolsEqual(object object1, object object2, CompareContext context)
         {
             var localContext = new CompareContext(context);
@@ -170,74 +173,63 @@ namespace Microsoft.IdentityModel.TestUtils
             return context.Merge(localContext);
         }
 
-        public static bool AreJsonWebKeyEnumsEqual(object object1, object object2, CompareContext context)
+        public static bool AreBytesEqual(object object1, object object2, CompareContext context)
         {
-            return AreEnumsEqual<JsonWebKey>(object1 as IEnumerable<JsonWebKey>, object2 as IEnumerable<JsonWebKey>, context, AreEqual);
+            var localContext = new CompareContext(context);
+            if (!ContinueCheckingEquality(object1, object2, localContext))
+                return context.Merge(localContext);
+
+            var bytes1 = (byte[])object1;
+            var bytes2 = (byte[])object2;
+
+            if (bytes1.Length != bytes2.Length)
+            {
+                localContext.Diffs.Add("(bytes1.Length != bytes2.Length)");
+            }
+            else
+            {
+                for (int i = 0; i < bytes1.Length; i++)
+                {
+                    if (bytes1[i] != bytes2[i])
+                    {
+                        localContext.Diffs.Add($"'{bytes1}'");
+                        localContext.Diffs.Add("!=");
+                        localContext.Diffs.Add($"'{bytes2}'");
+                    }
+                }
+            }
+
+            return context.Merge(localContext);
         }
 
-        public static bool AreKeyInfoEnumsEqual(object object1, object object2, CompareContext context)
+        public static bool AreClaimsEqual(Claim claim1, Claim claim2, CompareContext context)
         {
-            return AreEnumsEqual<KeyInfo>(object1 as IEnumerable<KeyInfo>, object2 as IEnumerable<KeyInfo>, context, AreEqual);
+            var localContext = new CompareContext(context);
+            if (!ContinueCheckingEquality(claim1, claim2, localContext))
+                return context.Merge(localContext);
+
+            CompareAllPublicProperties(claim1, claim2, localContext);
+            return context.Merge(localContext);
         }
 
-        public static bool AreObjectEnumsEqual(object object1, object object2, CompareContext context)
+        public static bool AreClaimsIdentitiesEqual(ClaimsIdentity identity1, ClaimsIdentity identity2, CompareContext context)
         {
-            return AreEnumsEqual<object>(object1 as IEnumerable<object>, object2 as IEnumerable<object>, context, AreObjectsEqual);
+            var localContext = new CompareContext(context);
+            if (!ContinueCheckingEquality(identity1, identity2, localContext))
+                return context.Merge(localContext);
+
+            CompareAllPublicProperties(identity1, identity2, localContext);
+            return context.Merge(localContext);
         }
 
-        public static bool AreReferenceEnumsEqual(object object1, object object2, CompareContext context)
+        public static bool AreClaimsPrincipalsEqual(ClaimsPrincipal principal1, ClaimsPrincipal principal2, CompareContext context)
         {
-            return AreEnumsEqual<Reference>(object1 as IEnumerable<Reference>, object2 as IEnumerable<Reference>, context, AreEqual);
-        }
+            var localContext = new CompareContext(context);
+            if (!ContinueCheckingEquality(principal1, principal2, localContext))
+                return context.Merge(localContext);
 
-        public static bool AreUriEnumsEqual(object object1, object object2, CompareContext context)
-        {
-            return AreEnumsEqual<Uri>(object1 as IEnumerable<Uri>, object2 as IEnumerable<Uri>, context, AreEqual);
-        }
-
-        public static bool AreSamlAttributeEnumsEqual(object object1, object object2, CompareContext context)
-        {
-            return AreEnumsEqual<SamlAttribute>(object1 as IEnumerable<SamlAttribute>, object2 as IEnumerable<SamlAttribute>, context, AreEqual);
-        }
-
-        public static bool AreSamlConditionEnumsEqual(object object1, object object2, CompareContext context)
-        {
-            return AreEnumsEqual<SamlCondition>(object1 as IEnumerable<SamlCondition>, object2 as IEnumerable<SamlCondition>, context, AreEqual);
-        }
-
-        public static bool AreSamlStatementEnumsEqual(object object1, object object2, CompareContext context)
-        {
-            return AreEnumsEqual<SamlStatement>(object1 as IEnumerable<SamlStatement>, object2 as IEnumerable<SamlStatement>, context, AreEqual);
-        }
-
-        public static bool AreSamlActionEnumsEqual(object object1, object object2, CompareContext context)
-        {
-            return AreEnumsEqual<SamlAction>(object1 as IEnumerable<SamlAction>, object2 as IEnumerable<SamlAction>, context, AreEqual);
-        }
-
-        public static bool AreSamlAuthorityBindingEnumsEqual(object object1, object object2, CompareContext context)
-        {
-            return AreEnumsEqual<SamlAuthorityBinding>(object1 as IEnumerable<SamlAuthorityBinding>, object2 as IEnumerable<SamlAuthorityBinding>, context, AreEqual);
-        }
-
-        public static bool AreSamlAssertionEnumsEqual(object object1, object object2, CompareContext context)
-        {
-            return AreEnumsEqual<SamlAssertion>(object1 as IEnumerable<SamlAssertion>, object2 as IEnumerable<SamlAssertion>, context, AreEqual);
-        }
-
-        public static bool AreStringEnumsEqual(object object1, object object2, CompareContext context)
-        {
-            return AreEnumsEqual<string>(object1 as IEnumerable<string>, object2 as IEnumerable<string>, context, AreStringsEqual);
-        }
-
-        public static bool AreSecurityKeyEnumsEqual(object object1, object object2, CompareContext context)
-        {
-            return AreEnumsEqual<SecurityKey>(object1 as IEnumerable<SecurityKey>, object2 as IEnumerable<SecurityKey>, context, AreSecurityKeysEqual);
-        }
-
-        public static bool AreX509DataEnumsEqual(object object1, object object2, CompareContext context)
-        {
-            return AreEnumsEqual<X509Data>(object1 as IEnumerable<X509Data>, object2 as IEnumerable<X509Data>, context, AreEqual);
+            CompareAllPublicProperties(principal1, principal2, localContext);
+            return context.Merge(localContext);
         }
 
         public static bool AreEnumsEqual<T>(IEnumerable<T> object1, IEnumerable<T> object2, CompareContext context, Func<T, T, CompareContext, bool> areEqual)
@@ -254,8 +246,8 @@ namespace Microsoft.IdentityModel.TestUtils
             int numMatched = 0;
             int numToMatch = toMatch.Count;
             CompareContext localContext = new CompareContext(context);
-            List<KeyValuePair<T,T>> matchedTs = new List<KeyValuePair<T,T>>();
-            
+            List<KeyValuePair<T, T>> matchedTs = new List<KeyValuePair<T, T>>();
+
             // helps debugging to see what didn't match
             List<T> notMatched = new List<T>();
             foreach (var t in object1)
@@ -465,6 +457,15 @@ namespace Microsoft.IdentityModel.TestUtils
             return context.Merge(localContext);
         }
 
+        public static bool AreConfigurationValidationResultEqual(ConfigurationValidationResult result1, ConfigurationValidationResult result2, CompareContext context)
+        {
+            var localContext = new CompareContext(context);
+            if (ContinueCheckingEquality(result1, result2, localContext))
+                CompareAllPublicProperties(result1, result2, localContext);
+
+            return context.Merge(localContext);
+        }
+
         public static bool AreDateTimesEqual(object object1, object object2, CompareContext context)
         {
             var localContext = new CompareContext(context);
@@ -488,7 +489,7 @@ namespace Microsoft.IdentityModel.TestUtils
         public static bool AreEqual(object object1, object object2, CompareContext context)
         {
             var localContext = new CompareContext(context);
-          
+
             // Check if either t1 or t2 are null or references of each other to see if we can terminate early.
             if (!ContinueCheckingEquality(object1, object2, localContext))
                 return context.Merge(localContext);
@@ -512,14 +513,6 @@ namespace Microsoft.IdentityModel.TestUtils
 #endif
                 _equalityDict[inter](object1, object2, localContext);
             }
-//            else
-//            {
-//                CompareAllPublicProperties(object1, object2, localContext);
-//#if CheckIfCompared
-//                wasCompared = true;
-//#endif
-
-//            }
 
 #if CheckIfCompared
             if (!wasCompared)
@@ -556,7 +549,7 @@ namespace Microsoft.IdentityModel.TestUtils
             var a1 = (JObject)object1;
             var a2 = (JObject)object2;
 
-            if (!JToken.DeepEquals(a1,a2))
+            if (!JToken.DeepEquals(a1, a2))
             {
                 localContext.Diffs.Add($"JObjects are not equal.");
             }
@@ -564,81 +557,157 @@ namespace Microsoft.IdentityModel.TestUtils
             return context.Merge(localContext);
         }
 
-        private static bool AreObjectsEqual(object object1, object object2, CompareContext context)
+        public static bool AreJsonElementsEqual(object obj1, object obj2, CompareContext context)
         {
-            var localContext = new CompareContext(context);
-            if (!ContinueCheckingEquality(object1, object2, localContext))
+            var localContext = new CompareContext(context) { IgnoreType = true };
+            if (!ContinueCheckingEquality(obj1, obj2, localContext))
                 return context.Merge(localContext);
 
-            AreEqual(object1, object2, localContext);
+            JsonElement jsonElement1 = (JsonElement)obj1;
+            JsonElement jsonElement2 = (JsonElement)obj2;
+
+            if (jsonElement1.ValueKind != jsonElement2.ValueKind)
+            {
+                localContext.Diffs.Add($"jsonElement1.ValueKind != jsonElement2.ValueKind. '{jsonElement1.ValueKind}' != '{jsonElement2.ValueKind}'.");
+                return context.Merge(localContext);
+            }
+
+            string str1 = jsonElement1.GetRawText();
+            string str2 = jsonElement2.GetRawText();
+
+            if (str1 != str2)
+            {
+                localContext.Diffs.Add($"jsonElement1.GetRawText() != jsonElement2.GetRawText(). '{jsonElement1.GetRawText()}' != '{jsonElement2.GetRawText()}'.");
+                return context.Merge(localContext);
+            }
 
             return context.Merge(localContext);
         }
 
-        private static bool AreValueCollectionsEqual(Object object1, Object object2, CompareContext context)
+        public static bool AreJsonWebKeysEqual(object object1, object object2, CompareContext context)
         {
-            Dictionary<string, object>.ValueCollection vc1 = (Dictionary<string, object>.ValueCollection)object1;
-            Dictionary<string, object>.ValueCollection vc2 = (Dictionary<string, object>.ValueCollection)object2;
-            return true;
-        }
-
-        public static bool AreBytesEqual(object object1, object object2, CompareContext context)
-        {
-            var localContext = new CompareContext(context);
+            var localContext = new CompareContext(context) { IgnoreType = true };
             if (!ContinueCheckingEquality(object1, object2, localContext))
                 return context.Merge(localContext);
 
-            var bytes1 = (byte[]) object1;
-            var bytes2 = (byte[]) object2;
+            Type jsonWebKeyType1 = object1.GetType();
+            Type jsonWebKeyType2 = object2.GetType();
 
-            if (bytes1.Length != bytes2.Length)
-            {
-                localContext.Diffs.Add("(bytes1.Length != bytes2.Length)");
-            }
+            if (jsonWebKeyType1 == jsonWebKeyType2)
+                CompareAllPublicProperties(object1, object2, localContext);
             else
+                CompareAllPublicPropertiesCrossVersion(object1, object2, localContext);
+
+            return context.Merge(localContext);
+        }
+
+        public static bool CompareAllPublicPropertiesCrossVersion(object object1, object object2, CompareContext context)
+        {
+            var localContext = new CompareContext(context) { IgnoreType = true };
+            if (!ContinueCheckingEquality(object1, object2, localContext))
+                return context.Merge(localContext);
+
+            Type objectType1 = object1.GetType();
+            Type objectType2 = object2.GetType();
+
+            var propertyInfos1 = objectType1.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            var propertyInfos2 = objectType2.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+            foreach (PropertyInfo propertyInfo1 in propertyInfos1)
             {
-                for (int i = 0; i < bytes1.Length; i++)
+                bool skipProperty = false;
+                if (context.PropertiesToIgnoreWhenComparing != null && context.PropertiesToIgnoreWhenComparing.TryGetValue(objectType1, out List<string> propertiesToIgnore))
                 {
-                    if (bytes1[i] != bytes2[i])
+                    foreach (var val in propertiesToIgnore)
+                        if (string.Equals(val, propertyInfo1.Name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            skipProperty = true;
+                            break;
+                        }
+                }
+
+                if (skipProperty)
+                    continue;
+
+                // find a PropertyInfo in the second object that matches the first
+                PropertyInfo propertyInfoFound = null;
+                foreach (PropertyInfo propertyInfo2 in propertyInfos2)
+                {
+                    if (propertyInfo2.Name == propertyInfo1.Name)
                     {
-                        localContext.Diffs.Add($"'{bytes1}'");
-                        localContext.Diffs.Add("!=");
-                        localContext.Diffs.Add($"'{bytes2}'");
+                        propertyInfoFound = propertyInfo2;
+                        break;
+                    }
+                }
+
+                // log an error if the property info cannot be found
+                if (propertyInfoFound == null)
+                {
+                    localContext.AddDiff($"property not found when comparing objects: {propertyInfo1.Name}");
+                    continue;
+                }
+
+                // ensure there is a get method
+                if (propertyInfo1.GetMethod != null)
+                {
+                    var propertyContext = new CompareContext(context);
+
+                    object val1 = propertyInfo1.GetValue(object1, null);
+                    object val2 = propertyInfoFound.GetValue(object2, null);
+                    if ((val1 == null) && (val2 == null))
+                        continue;
+
+                    if ((val1 == null) || (val2 == null))
+                    {
+                        propertyContext.Diffs.Add($"{propertyInfo1.Name}:");
+                        propertyContext.Diffs.Add(BuildStringDiff(propertyInfoFound.Name, val1, val2));
+                    }
+                    else if (val1.GetType().BaseType == typeof(System.ValueType) && !_equalityDict.Keys.Contains(val1.GetType().ToString()))
+                    {
+                        if (!val1.Equals(val2))
+                        {
+                            propertyContext.Diffs.Add($"{propertyInfo1.Name}:");
+                            propertyContext.Diffs.Add(BuildStringDiff(propertyInfoFound.Name, val1, val2));
+                        }
+                    }
+                    else
+                    {
+                        AreEqual(val1, val2, propertyContext);
+                        localContext.Merge($"{propertyInfoFound.Name}:", propertyContext);
                     }
                 }
             }
-           
+
             return context.Merge(localContext);
         }
 
-        public static bool AreClaimsEqual(Claim claim1, Claim claim2, CompareContext context)
+        public static bool AreJsonWebKeyEnumsEqual(object object1, object object2, CompareContext context)
+        {
+            return AreEnumsEqual<JsonWebKey>(object1 as IEnumerable<JsonWebKey>, object2 as IEnumerable<JsonWebKey>, context, AreEqual);
+        }
+
+        public static bool AreJwtSecurityTokensEqual(JwtSecurityToken jwt1, JwtSecurityToken jwt2, CompareContext context)
         {
             var localContext = new CompareContext(context);
-            if (!ContinueCheckingEquality(claim1, claim2, localContext))
+            if (!ContinueCheckingEquality(jwt1, jwt2, localContext))
                 return context.Merge(localContext);
 
-            CompareAllPublicProperties(claim1, claim2, localContext);
+            CompareAllPublicProperties(jwt1, jwt2, localContext);
             return context.Merge(localContext);
         }
 
-        public static bool AreClaimsIdentitiesEqual(ClaimsIdentity identity1, ClaimsIdentity identity2, CompareContext context)
+        public static bool AreKeyInfosEqual(KeyInfo keyInfo1, KeyInfo keyInfo2, CompareContext context)
         {
             var localContext = new CompareContext(context);
-            if (!ContinueCheckingEquality(identity1, identity2, localContext))
-                return context.Merge(localContext);
+            if (ContinueCheckingEquality(keyInfo1, keyInfo2, context))
+                CompareAllPublicProperties(keyInfo1, keyInfo2, localContext);
 
-            CompareAllPublicProperties(identity1, identity2, localContext);
             return context.Merge(localContext);
         }
 
-        public static bool AreClaimsPrincipalsEqual(ClaimsPrincipal principal1, ClaimsPrincipal principal2, CompareContext context)
+        public static bool AreKeyInfoEnumsEqual(object object1, object object2, CompareContext context)
         {
-            var localContext = new CompareContext(context);
-            if (!ContinueCheckingEquality(principal1, principal2, localContext))
-                return context.Merge(localContext);
-
-            CompareAllPublicProperties(principal1, principal2, localContext);
-            return context.Merge(localContext);
+            return AreEnumsEqual<KeyInfo>(object1 as IEnumerable<KeyInfo>, object2 as IEnumerable<KeyInfo>, context, AreEqual);
         }
 
         public static bool AreObjectDictionariesEqual(Object object1, Object object2, CompareContext context)
@@ -647,7 +716,7 @@ namespace Microsoft.IdentityModel.TestUtils
             if (!ContinueCheckingEquality(object1, object2, localContext))
                 return context.Merge(localContext);
 
-            IDictionary<string,object> dictionary1 = new Dictionary<string, object>();
+            IDictionary<string, object> dictionary1 = new Dictionary<string, object>();
             foreach (var kv in (IDictionary<string, object>)object1)
                 if (!context.DictionaryKeysToIgnoreWhenComparing.Contains(kv.Key))
                     dictionary1.Add(kv);
@@ -668,7 +737,7 @@ namespace Microsoft.IdentityModel.TestUtils
 
                 if (dictionary2.ContainsKey(key))
                 {
-                    if (dictionary1[key].GetType() != dictionary2[key].GetType())
+                    if (dictionary1[key].GetType() != dictionary2[key].GetType() && dictionary1[key].GetType() != typeof(JsonWebKey))
                     {
                         localContext.Diffs.Add($"dictionary1[{key}].GetType() != dictionary2[{key}].GetType(). '{dictionary1[key].GetType()}' : '{dictionary2[key].GetType()}'");
                         continue;
@@ -704,113 +773,25 @@ namespace Microsoft.IdentityModel.TestUtils
             return context.Merge(localContext);
         }
 
-        public static bool AreStingEnumDictionariesEqual(IDictionary<string, IEnumerable<string>> dictionary1, IDictionary<string, IEnumerable<string>> dictionary2, CompareContext context)
-        {
-            var localContext = new CompareContext(context);
-            if (!ContinueCheckingEquality(dictionary1, dictionary2, localContext))
-                return context.Merge(localContext);
-
-            if (dictionary1.Count != dictionary2.Count)
-                localContext.Diffs.Add($"(dictionary1.Count != dictionary2.Count: {dictionary1.Count}, {dictionary2.Count})");
-
-            int numMatched = 0;
-            foreach (string key in dictionary1.Keys)
-            {
-                if (dictionary2.ContainsKey(key))
-                {
-                    var obj1 = dictionary1[key];
-                    var obj2 = dictionary2[key];
-                    if (obj1.GetType().BaseType == typeof(System.ValueType))
-                    {
-                        if (!obj1.Equals(obj2))
-                            localContext.Diffs.Add(BuildStringDiff(key, obj1, obj2));
-                    }
-                    else
-                    {
-                        if (AreEqual(obj1, obj2, context))
-                            numMatched++;
-                    }
-                }
-                else
-                {
-                    localContext.Diffs.Add("dictionary1[key] ! found in dictionary2. key: " + key);
-                }
-            }
-
-            return context.Merge(localContext);
-        }
-
-        public static bool AreStringDictionariesEqual(Object object1, Object object2, CompareContext context)
+        private static bool AreObjectsEqual(object object1, object object2, CompareContext context)
         {
             var localContext = new CompareContext(context);
             if (!ContinueCheckingEquality(object1, object2, localContext))
                 return context.Merge(localContext);
 
-            IDictionary<string, string> dictionary1 = (IDictionary<string, string>)object1;
-            IDictionary<string, string> dictionary2 = (IDictionary<string, string>)object2;
+            AreEqual(object1, object2, localContext);
 
-            if (dictionary1.Count != dictionary2.Count)
-                localContext.Diffs.Add($"(dictionary1.Count != dictionary2.Count: {dictionary1.Count}, {dictionary2.Count})");
-
-            int numMatched = 0;
-            foreach (string key in dictionary1.Keys)
-            {
-                if (dictionary2.ContainsKey(key))
-                {
-                    if (!dictionary1[key].Equals(dictionary2[key]))
-                    {
-                        localContext.Diffs.Add($"dictionary1[key] != dictionary2[key], key: '{key}' value1, value2: '{dictionary1[key]}' + '{dictionary2[key]}'");
-                    }
-                    else
-                    {
-                        numMatched++;
-                    }
-                }
-                else
-                {
-                    localContext.Diffs.Add("dictionary1[key] ! found in dictionary2. key: " + key);
-                }
-            }
-
-            context.Diffs.AddRange(localContext.Diffs);
-            return localContext.Diffs.Count == 0;
-        }
-
-        public static bool AreJwtSecurityTokensEqual(JwtSecurityToken jwt1, JwtSecurityToken jwt2, CompareContext context)
-        {
-            var localContext = new CompareContext(context);
-            if (!ContinueCheckingEquality(jwt1, jwt2, localContext))
-                return context.Merge(localContext);
-
-            CompareAllPublicProperties(jwt1, jwt2, localContext);
             return context.Merge(localContext);
         }
 
-        public static bool AreSecurityKeysEqual(SecurityKey securityKey1, SecurityKey securityKey2, CompareContext context)
+        public static bool AreObjectEnumsEqual(object object1, object object2, CompareContext context)
         {
-            var localContext = new CompareContext(context);
-            if (!ContinueCheckingEquality(securityKey1, securityKey2, localContext))
-                return context.Merge(localContext);
+            return AreEnumsEqual<object>(object1 as IEnumerable<object>, object2 as IEnumerable<object>, context, AreObjectsEqual);
+        }
 
-            // X509SecurityKey doesn't have to use reflection to get cert.
-            X509SecurityKey x509Key1 = securityKey1 as X509SecurityKey;
-            X509SecurityKey x509Key2 = securityKey2 as X509SecurityKey;
-            if (x509Key1 != null && x509Key2 != null)
-                CompareAllPublicProperties(x509Key1, x509Key2, localContext);
-
-            SymmetricSecurityKey symKey1 = securityKey1 as SymmetricSecurityKey;
-            SymmetricSecurityKey symKey2 = securityKey2 as SymmetricSecurityKey;
-            if (symKey1 != null && symKey2 != null)
-                CompareAllPublicProperties(symKey1, symKey2, localContext);
-
-            RsaSecurityKey rsaKey1 = securityKey1 as RsaSecurityKey;
-            RsaSecurityKey rsaKey2 = securityKey2 as RsaSecurityKey;
-            if (rsaKey1 != null && rsaKey2 != null)
-            {
-                CompareAllPublicProperties(rsaKey1, rsaKey2, localContext);
-            }
-
-            return context.Merge(localContext);
+        public static bool AreReferenceEnumsEqual(object object1, object object2, CompareContext context)
+        {
+            return AreEnumsEqual<Reference>(object1 as IEnumerable<Reference>, object2 as IEnumerable<Reference>, context, AreEqual);
         }
 
         public static bool AreRsaParametersEqual(object object1, object object2, CompareContext context)
@@ -873,6 +854,113 @@ namespace Microsoft.IdentityModel.TestUtils
             return context.Merge(localContext);
         }
 
+        public static bool AreSamlAttributeEnumsEqual(object object1, object object2, CompareContext context)
+        {
+            return AreEnumsEqual<SamlAttribute>(object1 as IEnumerable<SamlAttribute>, object2 as IEnumerable<SamlAttribute>, context, AreEqual);
+        }
+
+        public static bool AreSamlConditionEnumsEqual(object object1, object object2, CompareContext context)
+        {
+            return AreEnumsEqual<SamlCondition>(object1 as IEnumerable<SamlCondition>, object2 as IEnumerable<SamlCondition>, context, AreEqual);
+        }
+
+        public static bool AreSamlStatementEnumsEqual(object object1, object object2, CompareContext context)
+        {
+            return AreEnumsEqual<SamlStatement>(object1 as IEnumerable<SamlStatement>, object2 as IEnumerable<SamlStatement>, context, AreEqual);
+        }
+
+        public static bool AreSamlActionEnumsEqual(object object1, object object2, CompareContext context)
+        {
+            return AreEnumsEqual<SamlAction>(object1 as IEnumerable<SamlAction>, object2 as IEnumerable<SamlAction>, context, AreEqual);
+        }
+
+        public static bool AreSamlAuthorityBindingEnumsEqual(object object1, object object2, CompareContext context)
+        {
+            return AreEnumsEqual<SamlAuthorityBinding>(object1 as IEnumerable<SamlAuthorityBinding>, object2 as IEnumerable<SamlAuthorityBinding>, context, AreEqual);
+        }
+
+        public static bool AreSamlAssertionEnumsEqual(object object1, object object2, CompareContext context)
+        {
+            return AreEnumsEqual<SamlAssertion>(object1 as IEnumerable<SamlAssertion>, object2 as IEnumerable<SamlAssertion>, context, AreEqual);
+        }
+
+        public static bool AreSecurityKeysEqual(SecurityKey securityKey1, SecurityKey securityKey2, CompareContext context)
+        {
+            var localContext = new CompareContext(context);
+            if (!ContinueCheckingEquality(securityKey1, securityKey2, localContext))
+                return context.Merge(localContext);
+
+            // X509SecurityKey doesn't have to use reflection to get cert.
+            X509SecurityKey x509Key1 = securityKey1 as X509SecurityKey;
+            X509SecurityKey x509Key2 = securityKey2 as X509SecurityKey;
+            if (x509Key1 != null && x509Key2 != null)
+                CompareAllPublicProperties(x509Key1, x509Key2, localContext);
+
+            SymmetricSecurityKey symKey1 = securityKey1 as SymmetricSecurityKey;
+            SymmetricSecurityKey symKey2 = securityKey2 as SymmetricSecurityKey;
+            if (symKey1 != null && symKey2 != null)
+                CompareAllPublicProperties(symKey1, symKey2, localContext);
+
+            RsaSecurityKey rsaKey1 = securityKey1 as RsaSecurityKey;
+            RsaSecurityKey rsaKey2 = securityKey2 as RsaSecurityKey;
+            if (rsaKey1 != null && rsaKey2 != null)
+            {
+                CompareAllPublicProperties(rsaKey1, rsaKey2, localContext);
+            }
+
+            return context.Merge(localContext);
+        }
+
+        public static bool AreSecurityKeyEnumsEqual(object object1, object object2, CompareContext context)
+        {
+            return AreEnumsEqual<SecurityKey>(object1 as IEnumerable<SecurityKey>, object2 as IEnumerable<SecurityKey>, context, AreSecurityKeysEqual);
+        }
+
+        public static bool AreSignedInfosEqual(SignedInfo signedInfo1, SignedInfo signedInfo2, CompareContext context)
+        {
+            var localContext = new CompareContext(context);
+            if (ContinueCheckingEquality(signedInfo1, signedInfo2, localContext))
+                CompareAllPublicProperties(signedInfo1, signedInfo2, localContext);
+
+            return context.Merge(localContext);
+        }
+
+        public static bool AreStringDictionariesEqual(Object object1, Object object2, CompareContext context)
+        {
+            var localContext = new CompareContext(context);
+            if (!ContinueCheckingEquality(object1, object2, localContext))
+                return context.Merge(localContext);
+
+            IDictionary<string, string> dictionary1 = (IDictionary<string, string>)object1;
+            IDictionary<string, string> dictionary2 = (IDictionary<string, string>)object2;
+
+            if (dictionary1.Count != dictionary2.Count)
+                localContext.Diffs.Add($"(dictionary1.Count != dictionary2.Count: {dictionary1.Count}, {dictionary2.Count})");
+
+            int numMatched = 0;
+            foreach (string key in dictionary1.Keys)
+            {
+                if (dictionary2.ContainsKey(key))
+                {
+                    if (!dictionary1[key].Equals(dictionary2[key]))
+                    {
+                        localContext.Diffs.Add($"dictionary1[key] != dictionary2[key], key: '{key}' value1, value2: '{dictionary1[key]}' + '{dictionary2[key]}'");
+                    }
+                    else
+                    {
+                        numMatched++;
+                    }
+                }
+                else
+                {
+                    localContext.Diffs.Add("dictionary1[key] ! found in dictionary2. key: " + key);
+                }
+            }
+
+            context.Diffs.AddRange(localContext.Diffs);
+            return localContext.Diffs.Count == 0;
+        }
+
         public static bool AreStringsEqual(object object1, object object2, CompareContext context)
         {
             var localContext = new CompareContext(context);
@@ -893,51 +981,53 @@ namespace Microsoft.IdentityModel.TestUtils
 
             if (!string.Equals(str1, str2, context.StringComparison))
             {
-                localContext.Diffs.Add($"'{str1}'");
-                localContext.Diffs.Add($"!=");
-                localContext.Diffs.Add($"'{str2}'");
-                localContext.Diffs.Add($"'{context.StringComparison}'");
+                localContext.Diffs.Add($"str1 != str2, StringComparison: '{context.StringComparison}'");
+                localContext.Diffs.Add(str1);
+                localContext.Diffs.Add(str2);
             }
 
             return context.Merge(localContext);
         }
 
-        public static bool AreUrisEqual(object object1, object object2, CompareContext context)
+        public static bool AreStringEnumDictionariesEqual(IDictionary<string, IEnumerable<string>> dictionary1, IDictionary<string, IEnumerable<string>> dictionary2, CompareContext context)
         {
             var localContext = new CompareContext(context);
-            if (!ContinueCheckingEquality(object1, object2, localContext))
+            if (!ContinueCheckingEquality(dictionary1, dictionary2, localContext))
                 return context.Merge(localContext);
 
-            Uri uri1 = (Uri)object1;
-            Uri uri2 = (Uri)object2;
+            if (dictionary1.Count != dictionary2.Count)
+                localContext.Diffs.Add($"(dictionary1.Count != dictionary2.Count: {dictionary1.Count}, {dictionary2.Count})");
 
-            if (!string.Equals(uri1.OriginalString, uri2.OriginalString, context.StringComparison))
+            int numMatched = 0;
+            foreach (string key in dictionary1.Keys)
             {
-                localContext.Diffs.Add($"'{uri1.OriginalString}'");
-                localContext.Diffs.Add($"!=");
-                localContext.Diffs.Add($"'{uri2.OriginalString}'");
-                localContext.Diffs.Add($"'{context.StringComparison}'");
+                if (dictionary2.ContainsKey(key))
+                {
+                    var obj1 = dictionary1[key];
+                    var obj2 = dictionary2[key];
+                    if (obj1.GetType().BaseType == typeof(System.ValueType))
+                    {
+                        if (!obj1.Equals(obj2))
+                            localContext.Diffs.Add(BuildStringDiff(key, obj1, obj2));
+                    }
+                    else
+                    {
+                        if (AreEqual(obj1, obj2, context))
+                            numMatched++;
+                    }
+                }
+                else
+                {
+                    localContext.Diffs.Add("dictionary1[key] ! found in dictionary2. key: " + key);
+                }
             }
 
             return context.Merge(localContext);
         }
 
-        public static bool AreKeyInfosEqual(KeyInfo keyInfo1, KeyInfo keyInfo2, CompareContext context)
+        public static bool AreStringEnumsEqual(object object1, object object2, CompareContext context)
         {
-            var localContext = new CompareContext(context);
-            if (ContinueCheckingEquality(keyInfo1, keyInfo2, context))
-                CompareAllPublicProperties(keyInfo1, keyInfo2, localContext);
-
-            return context.Merge(localContext);
-        }
-
-        public static bool AreSignedInfosEqual(SignedInfo signedInfo1, SignedInfo signedInfo2, CompareContext context)
-        {
-            var localContext = new CompareContext(context);
-            if (ContinueCheckingEquality(signedInfo1, signedInfo2, localContext))
-                CompareAllPublicProperties(signedInfo1, signedInfo2, localContext);
-
-            return context.Merge(localContext);
+            return AreEnumsEqual<string>(object1 as IEnumerable<string>, object2 as IEnumerable<string>, context, AreStringsEqual);
         }
 
         public static bool AreTimeSpansEqual(object object1, object object2, CompareContext context)
@@ -953,6 +1043,13 @@ namespace Microsoft.IdentityModel.TestUtils
                 localContext.Diffs.Add($"timeSpan1 != timeSpan2. '{timeSpan1}' != '{timeSpan2}'.");
 
             return context.Merge(localContext);
+        }
+
+        private static bool AreValueCollectionsEqual(Object object1, Object object2, CompareContext context)
+        {
+            Dictionary<string, object>.ValueCollection vc1 = (Dictionary<string, object>.ValueCollection)object1;
+            Dictionary<string, object>.ValueCollection vc2 = (Dictionary<string, object>.ValueCollection)object2;
+            return true;
         }
 
         public static bool AreWsFederationConfigurationsEqual(WsFederationConfiguration configuration1, WsFederationConfiguration configuration2, CompareContext context)
@@ -1002,119 +1099,39 @@ namespace Microsoft.IdentityModel.TestUtils
             return context.Merge(localContext);
         }
 
-        public static bool AreConfigurationValidationResultEqual(ConfigurationValidationResult result1, ConfigurationValidationResult result2, CompareContext context)
+        public static bool AreX509DataEnumsEqual(object object1, object object2, CompareContext context)
+        {
+            return AreEnumsEqual<X509Data>(object1 as IEnumerable<X509Data>, object2 as IEnumerable<X509Data>, context, AreEqual);
+        }
+
+        public static bool AreUrisEqual(object object1, object object2, CompareContext context)
         {
             var localContext = new CompareContext(context);
-            if (ContinueCheckingEquality(result1, result2, localContext))
-                CompareAllPublicProperties(result1, result2, localContext);
+            if (!ContinueCheckingEquality(object1, object2, localContext))
+                return context.Merge(localContext);
+
+            Uri uri1 = (Uri)object1;
+            Uri uri2 = (Uri)object2;
+
+            if (!string.Equals(uri1.OriginalString, uri2.OriginalString, context.StringComparison))
+            {
+                localContext.Diffs.Add($"'{uri1.OriginalString}'");
+                localContext.Diffs.Add($"!=");
+                localContext.Diffs.Add($"'{uri2.OriginalString}'");
+                localContext.Diffs.Add($"'{context.StringComparison}'");
+            }
 
             return context.Merge(localContext);
+        }
+
+        public static bool AreUriEnumsEqual(object object1, object object2, CompareContext context)
+        {
+            return AreEnumsEqual<Uri>(object1 as IEnumerable<Uri>, object2 as IEnumerable<Uri>, context, AreEqual);
         }
 
         public static string BuildStringDiff(string label, object str1, object str2)
         {
             return (label ?? "label") + ": '" + GetString(str1) + "', '" + GetString(str2) + "'";
-        }
-
-        public static bool AreJsonElementsEqual(object obj1, object obj2, CompareContext context)
-        {
-            var localContext = new CompareContext(context) { IgnoreType = true };
-            if (!ContinueCheckingEquality(obj1, obj2, localContext))
-                return context.Merge(localContext);
-
-            JsonElement jsonElement1 = (JsonElement)obj1;
-            JsonElement jsonElement2 = (JsonElement)obj2;
-
-            if (jsonElement1.ValueKind != jsonElement2.ValueKind)
-            {
-                localContext.Diffs.Add($"jsonElement1.ValueKind != jsonElement2.ValueKind. '{jsonElement1.ValueKind}' != '{jsonElement2.ValueKind}'.");
-                return context.Merge(localContext);
-            }
-
-            string str1 = jsonElement1.GetRawText();
-            string str2 = jsonElement2.GetRawText();
-
-            if (str1 != str2)
-            {
-                localContext.Diffs.Add($"jsonElement1.GetRawText() != jsonElement2.GetRawText(). '{jsonElement1.GetRawText()}' != '{jsonElement2.GetRawText()}'.");
-                return context.Merge(localContext);
-            }
-
-            return context.Merge(localContext);
-        }
-
-        public static bool AreJsonWebKeyNet8Equal(object obj1, object obj2, CompareContext context)
-        {
-            var localContext = new CompareContext(context) { IgnoreType = true };
-            if (!ContinueCheckingEquality(obj1, obj2, localContext))
-                return context.Merge(localContext);
-
-            Type jsonWebKeyType = obj2.GetType();
-            var jsonWebKeyPopertyInfos = jsonWebKeyType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-
-            Type jsonWebKeyNet8Type = obj1.GetType();
-            var jsonWebKeyNet8PropertyInfos = jsonWebKeyNet8Type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-
-            foreach (PropertyInfo jsonWebKeyPropertyInfo in jsonWebKeyPopertyInfos)
-            {
-                bool skipProperty = false;
-                if (context.PropertiesToIgnoreWhenComparing != null && context.PropertiesToIgnoreWhenComparing.TryGetValue(jsonWebKeyNet8Type, out List<string> propertiesToIgnore))
-                {
-                    foreach (var val in propertiesToIgnore)
-                        if (string.Equals(val, jsonWebKeyPropertyInfo.Name, StringComparison.OrdinalIgnoreCase))
-                        {
-                            skipProperty = true;
-                            break;
-                        }
-                }
-
-                if (skipProperty)
-                    continue;
-
-                PropertyInfo propertyInfoFound = null;
-                foreach (PropertyInfo jsonWebKeyNet8PropertyInfo in jsonWebKeyNet8PropertyInfos)
-                {
-                    if (jsonWebKeyNet8PropertyInfo.Name == jsonWebKeyPropertyInfo.Name)
-                        propertyInfoFound = jsonWebKeyNet8PropertyInfo;
-                }
-
-                if (propertyInfoFound == null)
-                {
-                    localContext.AddDiff($"jsonWebKeyNet8 property not found: {jsonWebKeyPropertyInfo.Name}");
-                    continue;
-                }
-
-                if (jsonWebKeyPropertyInfo.GetMethod != null)
-                {
-                    var propertyContext = new CompareContext(context);
-
-                    object val1 = jsonWebKeyPropertyInfo.GetValue(obj2, null);
-                    object val2 = propertyInfoFound.GetValue(obj1, null);
-                    if ((val1 == null) && (val2 == null))
-                        continue;
-
-                    if ((val1 == null) || (val2 == null))
-                    {
-                        propertyContext.Diffs.Add($"{jsonWebKeyPropertyInfo.Name}:");
-                        propertyContext.Diffs.Add(BuildStringDiff(propertyInfoFound.Name, val1, val2));
-                    }
-                    else if (val1.GetType().BaseType == typeof(System.ValueType) && !_equalityDict.Keys.Contains(val1.GetType().ToString()))
-                    {
-                        if (!val1.Equals(val2))
-                        {
-                            propertyContext.Diffs.Add($"{jsonWebKeyPropertyInfo.Name}:");
-                            propertyContext.Diffs.Add(BuildStringDiff(propertyInfoFound.Name, val1, val2));
-                        }
-                    }
-                    else
-                    {
-                        AreEqual(val1, val2, propertyContext);
-                        localContext.Merge($"{propertyInfoFound.Name}:", propertyContext);
-                    }
-                }
-            }
-
-            return context.Merge(localContext);
         }
 
         public static bool CompareAllPublicProperties(object obj1, object obj2, CompareContext context)
@@ -1166,14 +1183,6 @@ namespace Microsoft.IdentityModel.TestUtils
                             localContext.Diffs.Add($"{propertyInfo.Name}:");
                             localContext.Diffs.Add(BuildStringDiff(propertyInfo.Name, val1, val2));
                         }
-                        else if (type == typeof(ClaimsIdentity) && String.Equals(propertyInfo.Name, "AuthenticationType") && String.Equals(Convert.ToString(val1), "AuthenticationTypes.Federation") && String.Equals(Convert.ToString(val2), "AuthenticationTypes.Federation"))
-                            continue;
-                        else if (type == typeof(Claim) && String.Equals(propertyInfo.Name, "Value") && (String.Equals((val1 as string), "urn:oasis:names:tc:SAML:1.0:am:password") || String.Equals((val2 as string), "urn:oasis:names:tc:SAML:1.0:am:password")))
-                            continue;
-                        else if (type == typeof(ClaimsPrincipal) && String.Equals(propertyInfo.Name, "Claims") && (val1 as IEnumerable<Claim>).Count() == 0)
-                            continue;
-                        else if (type == typeof(ClaimsIdentity) && String.Equals(propertyInfo.Name, "Claims") && (val1 as IEnumerable<Claim>).Count() == 0)
-                            continue;
                         else if (val1.GetType().BaseType == typeof(System.ValueType) && !_equalityDict.Keys.Contains(val1.GetType().ToString()))
                         {
                             if (!val1.Equals(val2))

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ECDsaAdapterTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ECDsaAdapterTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens.Json.Tests;
 using Xunit;
 
 using KEY = Microsoft.IdentityModel.TestUtils.KeyingMaterial;
@@ -160,19 +161,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     TestId = "successfulCall",
                 },
             };
-        }
-
-        public class JsonWebKeyTheoryData : TheoryDataBase
-        {
-            public string Crv { get; set; }
-
-            public string D { get; set; }
-
-            public bool UsePrivateKey { get; set; }
-
-            public string X { get; set; }
-
-            public string Y { get; set; }
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/IdentityComparerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/IdentityComparerTests.cs
@@ -575,9 +575,9 @@ namespace Microsoft.IdentityModel.TestUtils
             var string2 = "goodbye";
             IdentityComparer.AreEqual(string1, string2, context);
 
-            Assert.True(context.Diffs.Count(s => s == $"'{string1}'") == 1);
-            Assert.True(context.Diffs.Count(s => s == "!=") == 1);
-            Assert.True(context.Diffs.Count(s => s == $"'{string2}'") == 1);
+            Assert.True(context.Diffs.Count(s => s == "str1 != str2, StringComparison: 'Ordinal'") == 1);
+            Assert.True(context.Diffs[1] == string1);
+            Assert.True(context.Diffs[2] == string2);
         }
 
         [Fact]

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonTestClassSerializer.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonTestClassSerializer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
         {
             JsonTestClass jsonTestClass = new JsonTestClass();
 
-            if (!JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartObject, true))
+            if (!JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartObject, false))
                 throw LogHelper.LogExceptionMessage(
                     new JsonException(
                         LogHelper.FormatInvariant(
@@ -65,9 +65,9 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                         LogHelper.MarkAsNonPII(reader.CurrentDepth),
                         LogHelper.MarkAsNonPII(reader.BytesConsumed))));
 
-            do
+            while (JsonSerializerPrimitives.ReaderRead(ref reader))
             {
-                while (reader.TokenType == JsonTokenType.PropertyName)
+                if (reader.TokenType == JsonTokenType.PropertyName)
                 {
                     string propertyName = JsonSerializerPrimitives.GetPropertyName(ref reader, JsonTestClass.ClassName, true);
                     switch (propertyName)
@@ -75,18 +75,18 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                         // optional
                         // https://datatracker.ietf.org/doc/html/rfc7517#section-4.4
                         case "Boolean":
-                            jsonTestClass.Boolean = JsonSerializerPrimitives.ReadBoolean(ref reader, "Boolean",_className, true);
+                            jsonTestClass.Boolean = JsonSerializerPrimitives.ReadBoolean(ref reader, "Boolean",_className);
                             break;
                         case "Double":
-                            jsonTestClass.Double = JsonSerializerPrimitives.ReadDouble(ref reader, "Double", _className, true);
+                            jsonTestClass.Double = JsonSerializerPrimitives.ReadDouble(ref reader, "Double", _className);
                             break;
                         case "Int":
-                            jsonTestClass.Int = JsonSerializerPrimitives.ReadInt(ref reader, "Int", _className, true);
+                            jsonTestClass.Int = JsonSerializerPrimitives.ReadInt(ref reader, "Int", _className);
                             break;
                         case "ListObject":
                             List<object> objects = new List<object>();
 
-                            if (JsonSerializerPrimitives.ReadObjects(ref reader, objects, "ListObject", _className, true) == null)
+                            if (JsonSerializerPrimitives.ReadObjects(ref reader, objects, "ListObject", _className) == null)
                             {
                                 throw LogHelper.LogExceptionMessage(
                                     new ArgumentNullException(
@@ -107,7 +107,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                         case "ListString":
                              List<string> strings = new List<string>();
 
-                            if (JsonSerializerPrimitives.ReadStrings(ref reader, strings, "ListString", _className, true) == null)
+                            if (JsonSerializerPrimitives.ReadStrings(ref reader, strings, "ListString", _className) == null)
                             {
                                 throw LogHelper.LogExceptionMessage(
                                     new ArgumentNullException(
@@ -126,21 +126,20 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                             jsonTestClass.ListString = strings;
                             break;
                         case "String":
-                            jsonTestClass.String = JsonSerializerPrimitives.ReadString(ref reader, "String", _className, true);
+                            jsonTestClass.String = JsonSerializerPrimitives.ReadString(ref reader, "String", _className);
                             break;
                         default:
                             using (JsonDocument jsonDocument = JsonDocument.ParseValue(ref reader))
                                 jsonTestClass.AdditionalData[propertyName] = jsonDocument.RootElement.Clone();
 
-                            reader.Read();
+                            JsonSerializerPrimitives.ReaderRead(ref reader);
                             break;
                     }
                 }
 
                 if (JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.EndObject, true))
                     break;
-
-            } while (reader.Read());
+            }
 
             return jsonTestClass;
         }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonUtilities.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonUtilities.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.IdentityModel.Tokens.Json.Tests
+{
+    public class JsonUtilities
+    {
+        static string _arrayData = @"[""value1"",""value2""]";
+        static string _objectData = @"{""Object"":""string""}";
+        static string DP = "ErP3OpudePAY3uGFSoF16Sde69PnOra62jDEZGnPx_v3nPNpA5sr-tNc8bQP074yQl5kzSFRjRlstyW0TpBVMP0ocbD8RsN4EKsgJ1jvaSIEoP87OxduGkim49wFA0Qxf_NyrcYUnz6XSidY3lC_pF4JDJXg5bP_x0MUkQCTtQE";
+        static string DQ = "YbBsthPt15Pshb8rN8omyfy9D7-m4AGcKzqPERWuX8bORNyhQ5M8JtdXcu8UmTez0j188cNMJgkiN07nYLIzNT3Wg822nhtJaoKVwZWnS2ipoFlgrBgmQiKcGU43lfB5e3qVVYUebYY0zRGBM1Fzetd6Yertl5Ae2g2CakQAcPs";
+        static string Exponent = "AQAB";
+        static string InverseQ = "lbljWyVY-DD_Zuii2ifAz0jrHTMvN-YS9l_zyYyA_Scnalw23fQf5WIcZibxJJll5H0kNTIk8SCxyPzNShKGKjgpyZHsJBKgL3iAgmnwk6k8zrb_lqa0sd1QWSB-Rqiw7AqVqvNUdnIqhm-v3R8tYrxzAqkUsGcFbQYj4M5_F_4";
+        static string Modulus = "6-FrFkt_TByQ_L5d7or-9PVAowpswxUe3dJeYFTY0Lgq7zKI5OQ5RnSrI0T9yrfnRzE9oOdd4zmVj9txVLI-yySvinAu3yQDQou2Ga42ML_-K4Jrd5clMUPRGMbXdV5Rl9zzB0s2JoZJedua5dwoQw0GkS5Z8YAXBEzULrup06fnB5n6x5r2y1C_8Ebp5cyE4Bjs7W68rUlyIlx1lzYvakxSnhUxSsjx7u_mIdywyGfgiT3tw0FsWvki_KYurAPR1BSMXhCzzZTkMWKE8IaLkhauw5MdxojxyBVuNY-J_elq-HgJ_dZK6g7vMNvXz2_vT-SykIkzwiD9eSI9UWfsjw";
+        static string P = "_avCCyuo7hHlqu9Ec6R47ub_Ul_zNiS-xvkkuYwW-4lNnI66A5zMm_BOQVMnaCkBua1OmOgx7e63-jHFvG5lyrhyYEmkA2CS3kMCrI-dx0fvNMLEXInPxd4np_7GUd1_XzPZEkPxBhqf09kqryHMj_uf7UtPcrJNvFY-GNrzlJk";
+        static string Q = "7gvYRkpqM-SC883KImmy66eLiUrGE6G6_7Y8BS9oD4HhXcZ4rW6JJKuBzm7FlnsVhVGro9M-QQ_GSLaDoxOPQfHQq62ERt-y_lCzSsMeWHbqOMci_pbtvJknpMv4ifsQXKJ4Lnk_AlGr-5r5JR5rUHgPFzCk9dJt69ff3QhzG2c";
+        static string P256_D = "OOX7PnYlSTE41BSclDj5Gi_sx_SPgEqStjY3doku4TQ";
+        static string P256_X = "luR290c8sXxbOGhNquQ3J3rh763Os4D609cHK-L_5fA";
+        static string P256_Y = "tUqUwtaVHwc7_CXnuBrCpMQTF5BJKdFnw9_JkSIXWpQ";
+        static string X5C = "MIIDPjCCAiqgAwIBAgIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMTQwMTAxMDcwMDAwWhcNMTYwMTAxMDcwMDAwWjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkSCWg6q9iYxvJE2NIhSyOiKvqoWCO2GFipgH0sTSAs5FalHQosk9ZNTztX0ywS/AHsBeQPqYygfYVJL6/EgzVuwRk5txr9e3n1uml94fLyq/AXbwo9yAduf4dCHTP8CWR1dnDR+Qnz/4PYlWVEuuHHONOw/blbfdMjhY+C/BYM2E3pRxbohBb3x//CfueV7ddz2LYiH3wjz0QS/7kjPiNCsXcNyKQEOTkbHFi3mu0u13SQwNddhcynd/GTgWN8A+6SN1r4hzpjFKFLbZnBt77ACSiYx+IHK4Mp+NaVEi5wQtSsjQtI++XsokxRDqYLwus1I1SihgbV/STTg5enufuwIDAQABo2IwYDBeBgNVHQEEVzBVgBDLebM6bK3BjWGqIBrBNFeNoS8wLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldIIQsRiM0jheFZhKk49YD0SK1TAJBgUrDgMCHQUAA4IBAQCJ4JApryF77EKC4zF5bUaBLQHQ1PNtA1uMDbdNVGKCmSf8M65b8h0NwlIjGGGy/unK8P6jWFdm5IlZ0YPTOgzcRZguXDPj7ajyvlVEQ2K2ICvTYiRQqrOhEhZMSSZsTKXFVwNfW6ADDkN3bvVOVbtpty+nBY5UqnI7xbcoHLZ4wYD251uj5+lo13YLnsVrmQ16NCBYq2nQFNPuNJw6t3XUbwBHXpF46aLT1/eGf/7Xx6iy8yPJX4DyrpFTutDz882RWofGEO5t4Cw+zZg70dJ/hH/ODYRMorfXEW+8uKmXMKmX2wyxMKvfiPbTy5LmAU8Jvjs2tLg4rOBcXWLAIarZ";
+
+        public static JsonElement? CreateJsonElement(string json)
+        {
+            Utf8JsonReader reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json).AsSpan());
+            JsonElement? jsonElement;
+
+#if NET6_0_OR_GREATER
+            bool ret = JsonElement.TryParseValue(ref reader, out jsonElement);
+#else
+            using (JsonDocument jsonDocument = JsonDocument.ParseValue(ref reader))
+                jsonElement = jsonDocument.RootElement.Clone();
+#endif
+            return jsonElement;
+        }
+
+        public static JsonWebKey FullyPopulatedJsonWebKey()
+        {
+            JsonWebKey jsonWebKey = new JsonWebKey
+            {
+                Alg = SecurityAlgorithms.Sha256,
+                Crv = "CRV",
+                D = P256_D,
+                DP = DP,
+                DQ = DQ,
+                E = Exponent,
+                K = "K",
+                KeyId = "NGTFvdK-fythEuLwjpwAJOM9n-A",
+                Kid = "NGTFvdK-fythEuLwjpwAJOM9n-A",
+                Kty = "RSA",
+                N = Modulus,
+                P = P,
+                Q = Q,
+                QI = InverseQ,
+                Use = "sig",
+                X = P256_X,
+                X5t = "NGTFvdK-fythEuLwjpwAJOM9n-A",
+                X5tS256 = "x5t256",
+                X5u = "https://jsonkeyurl",
+                Y = P256_Y
+            };
+
+            jsonWebKey.X5c.Add(X5C);
+            jsonWebKey.KeyOps.Add("keyOps");
+            jsonWebKey.Oth.Add("oth1");
+            jsonWebKey.Oth.Add("oth2");
+            SetAdditionalData(jsonWebKey.AdditionalData);
+
+            return jsonWebKey;
+        }
+
+        public static JsonWebKey6x FullyPopulatedJsonWebKey6x()
+        {
+            JsonWebKey6x jsonWebKey = new JsonWebKey6x
+            {
+                Alg = SecurityAlgorithms.Sha256,
+                Crv = "CRV",
+                D = P256_D,
+                DP = DP,
+                DQ = DQ,
+                E = Exponent,
+                K = "K",
+                KeyId = "NGTFvdK-fythEuLwjpwAJOM9n-A",
+                Kid = "NGTFvdK-fythEuLwjpwAJOM9n-A",
+                Kty = "RSA",
+                N = Modulus,
+                P = P,
+                Q = Q,
+                QI = InverseQ,
+                Use = "sig",
+                X = P256_X,
+                X5t = "NGTFvdK-fythEuLwjpwAJOM9n-A",
+                X5tS256 = "x5t256",
+                X5u = "https://jsonkeyurl",
+                Y = P256_Y
+            };
+
+            jsonWebKey.X5c.Add(X5C);
+            jsonWebKey.KeyOps.Add("keyOps");
+            jsonWebKey.Oth = new List<string>
+            {
+                "oth1",
+                "oth2"
+            };
+
+            SetAdditionalData6x(jsonWebKey.AdditionalData);
+
+            return jsonWebKey;
+        }
+
+        public static JsonWebKeySet FullyPopulatedJsonWebKeySet()
+        {
+            JsonWebKeySet jsonWebKeySet = new JsonWebKeySet();
+            jsonWebKeySet.Keys.Add(FullyPopulatedJsonWebKey());
+            SetAdditionalData(jsonWebKeySet.AdditionalData);
+
+            return jsonWebKeySet;
+        }
+
+        public static JsonWebKeySet6x FullyPopulatedJsonWebKeySet6x()
+        {
+            JsonWebKeySet6x jsonWebKeySet = new JsonWebKeySet6x();
+            jsonWebKeySet.Keys.Add(FullyPopulatedJsonWebKey6x());
+            SetAdditionalData6x(jsonWebKeySet.AdditionalData);
+
+            return jsonWebKeySet;
+        }
+
+        public static void SetAdditionalData(IDictionary<string, object> dictionary, string key = null, object obj = null)
+        {
+            SetAdditionalDataNumbers(dictionary);
+            SetAdditionalDataValues(dictionary);
+            dictionary["Object"] = CreateJsonElement(_objectData);
+            dictionary["Array"] = CreateJsonElement(_arrayData);
+            if (key != null)
+                dictionary[key] = obj;
+        }
+
+        public static void SetAdditionalData6x(IDictionary<string, object> dictionary, string key = null, object obj = null)
+        {
+            SetAdditionalDataNumbers(dictionary);
+            SetAdditionalDataValues(dictionary);
+            dictionary["Object"] = JObject.Parse(_objectData);
+            dictionary["Array"] = JArray.Parse(_arrayData);
+            if (key != null)
+                dictionary[key] = obj;
+        }
+
+        public static void SetAdditionalDataNumbers(IDictionary<string, object> dictionary)
+        {
+            dictionary["int"] = (int)1;
+            dictionary["long"] = (long)1234567890123456;
+        }
+
+        public static void SetAdditionalDataValues(IDictionary<string, object> dictionary)
+        {
+            dictionary["string"] = "string";
+            dictionary["false"] = false;
+            dictionary["true"] = true;
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySerializationTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySerializationTests.cs
@@ -1,0 +1,442 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens.Tests;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Tokens.Json.Tests
+{
+    /// <summary>
+    /// These set of tests ensure that 7x and 6x serialization of JsonWebKey.
+    /// 6x uses Newtonsoft, 7x uses System.Text.Json utf8Readers and utf8Writers.
+    /// Differences will be discovered here and used for release notes.
+    /// </summary>
+    public class JsonWebKeySerializationTests
+    {
+        /// <summary>
+        /// This test is designed to ensure that JsonDeserialize and Utf8Reader are consistent w.r.t. exceptions.
+        /// </summary>
+        /// <param name="theoryData"></param>
+        [Theory, MemberData(nameof(DeserializeTheoryData))]
+        public void DeserializeExceptions(JsonSerializerTheoryData theoryData)
+        {
+            var context = new CompareContext(theoryData);
+            try
+            {
+                JsonWebKeySerializer.Read(theoryData.Json);
+                theoryData.JsonReaderExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.JsonReaderExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<JsonSerializerTheoryData> DeserializeTheoryData
+        {
+            get
+            {
+                var theoryData = new TheoryData<JsonSerializerTheoryData>();
+                AddSingleStringTestCases(theoryData, "Alg", JsonWebKeyParameterNames.Alg);
+                AddArrayOfStringsTestCases(theoryData, "KeyOps", JsonWebKeyParameterNames.KeyOps);
+                return theoryData;
+            }
+        }
+
+        /// <summary>
+        /// Adds tests cases for a type with the property name of the class and the json property name.
+        /// </summary>
+        /// <param name="theoryData">place to add the test case.</param>
+        /// <param name="instancePropertyName">the property name on the class.</param>
+        /// <param name="jsonPropertyName">the property name in the json mapping to the class</param>
+        private static void AddSingleStringTestCases(TheoryData<JsonSerializerTheoryData> theoryData, string instancePropertyName, string jsonPropertyName)
+        {
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_DuplicateProperties")
+            {
+                Json = $@"{{""{jsonPropertyName}"":""string"", ""{jsonPropertyName}"":""string""}}",
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_SingleString")
+            {
+                Json = $@"{{""{jsonPropertyName}"":""string""}}",
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_ArrayString")
+            {
+                Json = $@"{{""{jsonPropertyName}"":[""string1"", ""string2""]}}",
+                JsonReaderExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "IDX11020: "),
+                JsonSerializerExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "The JSON value could not be converted", typeof(InvalidOperationException))
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_Array")
+            {
+                Json = $@"{{""{jsonPropertyName}"":[""value"", 1]}}",
+                JsonReaderExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "IDX11020: "),
+                JsonSerializerExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "The JSON value could not be converted", typeof(InvalidOperationException))
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_true")
+            {
+                Json = $@"{{""{jsonPropertyName}"": true}}",
+                JsonReaderExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "IDX11020: "),
+                JsonSerializerExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "The JSON value could not be converted", typeof(InvalidOperationException))
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_false")
+            {
+                Json = $@"{{""{jsonPropertyName}"": false}}",
+                JsonReaderExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "IDX11020: "),
+                JsonSerializerExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "The JSON value could not be converted", typeof(InvalidOperationException))
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_Object")
+            {
+                Json = $@"{{""{jsonPropertyName}"":{{""property"": ""false""}}}}",
+                JsonReaderExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "IDX11020: "),
+                JsonSerializerExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "The JSON value could not be converted", typeof(InvalidOperationException))
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_Null")
+            {
+                Json = $@"{{""{jsonPropertyName}"":null}}",
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_Number")
+            {
+                Json = $@"{{""d"":""string"",""d"":""string"",""{jsonPropertyName}"":1}}",
+                JsonReaderExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "IDX11020: "),
+                JsonSerializerExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "The JSON value could not be converted", typeof(InvalidOperationException))
+            });
+        }
+
+        /// <summary>
+        /// Adds tests cases for a type with the property name of the class and the json property name.
+        /// </summary>
+        /// <param name="theoryData">place to add the test case.</param>
+        /// <param name="instancePropertyName">the property name on the class.</param>
+        /// <param name="jsonPropertyName">the property name in the json mapping to the class</param>
+        private static void AddArrayOfStringsTestCases(TheoryData<JsonSerializerTheoryData> theoryData, string instancePropertyName, string jsonPropertyName)
+        {
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_SingleString")
+            {
+                Json = $@"{{""{jsonPropertyName}"":""string""}}",
+                JsonReaderExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "IDX11022:"),
+                JsonSerializerExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "The JSON value could not be converted")
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_ArrayString")
+            {
+                Json = $@"{{""{jsonPropertyName}"":[""string1"", ""string2""]}}",
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_Array")
+            {
+                Json = $@"{{""{jsonPropertyName}"":[""value"", 1]}}",
+                JsonReaderExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "IDX11020: "),
+                JsonSerializerExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "The JSON value could not be converted", typeof(InvalidOperationException))
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_true")
+            {
+                Json = $@"{{""{jsonPropertyName}"": true}}",
+                JsonReaderExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "IDX11022: "),
+                JsonSerializerExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "The JSON value could not be converted")
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_false")
+            {
+                Json = $@"{{""{jsonPropertyName}"": false}}",
+                JsonReaderExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "IDX11022: "),
+                JsonSerializerExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "The JSON value could not be converted")
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_Object")
+            {
+                Json = $@"{{""{jsonPropertyName}"":{{""property"": ""false""}}}}",
+                JsonReaderExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "IDX11022: "),
+                JsonSerializerExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "The JSON value could not be converted")
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_Null")
+            {
+                Json = $@"{{""{jsonPropertyName}"":null}}",
+                JsonReaderExpectedException = new ExpectedException(typeof(ArgumentNullException), JsonWebKeyParameterNames.KeyOps, typeof(System.Text.Json.JsonException)),
+                JsonSerializerExpectedException = new ExpectedException(typeof(ArgumentNullException), "IDX10000: ")
+            });
+
+            theoryData.Add(new JsonSerializerTheoryData($"{instancePropertyName}_Number")
+            {
+                Json = $@"{{""d"":""string"",""d"":""string"",""{jsonPropertyName}"":1}}",
+                JsonReaderExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "IDX11022: "),
+                JsonSerializerExpectedException = new ExpectedException(typeof(System.Text.Json.JsonException), "The JSON value could not be converted")
+            });
+        }
+
+        /// <summary>
+        /// Compares and finds differences between our internal Newtonsoft.Json and System.Text.Json
+        /// comparing the results JsonSerializer.Deserialize and Utf8JsonReader.
+        /// </summary>
+        /// <param name="theoryData"></param>
+        [Theory, MemberData(nameof(DeserializeDataSet))]
+        public void Deserialize(JsonWebKeyTheoryData theoryData)
+        {
+            CompareContext context = new CompareContext(theoryData);
+
+            JsonWebKey6x jsonWebKey6x = null;
+            JsonWebKey jsonWebKeyDeserialize = null;
+            JsonWebKey jsonWebKeyUtf8Reader = null;
+
+            try
+            {
+                jsonWebKey6x = new JsonWebKey6x(theoryData.Json);
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            try
+            {
+                jsonWebKeyDeserialize = System.Text.Json.JsonSerializer.Deserialize<JsonWebKey>(theoryData.Json);
+                theoryData.JsonSerializerExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.JsonSerializerExpectedException.ProcessException(ex, context);
+            }
+
+            try
+            {
+                jsonWebKeyUtf8Reader = new JsonWebKey(theoryData.Json);
+                theoryData.JsonReaderExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.JsonReaderExpectedException.ProcessException(ex, context);
+            }
+
+            // when comparing JsonWebKey (JsonSerializer.Deserialize) and (Newtonsoft.Json) ignore the AdditionalData, Oth, X5c, KeyOps properties are they have no getter.
+            // We will need to adjust for a 8.0
+            CompareContext localContext = new CompareContext(theoryData);
+            localContext.PropertiesToIgnoreWhenComparing.Add(typeof(JsonWebKey), new List<string> { "AdditionalData", "Oth", "X5c", "KeyOps" });
+            if (!IdentityComparer.AreEqual(jsonWebKeyDeserialize, jsonWebKey6x, localContext))
+            {
+                localContext.Diffs.Add("jsonWebKeyDeserialize != jsonWebKey6x");
+                localContext.Diffs.Add("=========================================");
+            }
+
+            context.Merge(localContext);
+
+            // when comparing JsonWebKey (JsonSerializer.Deserialize) and (utf8Reader) ignore the AdditionalData, Oth, X5c, KeyOps properties are they have no getter.
+            // We will need to adjust for a 8.0
+            localContext.Diffs.Clear();
+            localContext.PropertiesToIgnoreWhenComparing.Clear();
+
+            //RELNOTE: JsonSerializer.Deserialize does not handle mixed case
+            // DataSets.JsonWebKeyMixedCaseString
+            if (theoryData.TestId == "JsonWebKeyMixedCase")
+                localContext.PropertiesToIgnoreWhenComparing.Add(typeof(JsonWebKey), new List<string> { "AdditionalData", "Oth", "X5c", "KeyOps", "Alg", "E", "X5tS256" });
+            else
+                localContext.PropertiesToIgnoreWhenComparing.Add(typeof(JsonWebKey), new List<string> { "AdditionalData", "Oth", "X5c", "KeyOps" });
+
+            if (!IdentityComparer.AreEqual(jsonWebKeyDeserialize, jsonWebKeyUtf8Reader, localContext))
+            {
+                localContext.Diffs.Add("jsonWebKeyDeserialize != jsonWebKeyUtf8");
+                localContext.Diffs.Add("=========================================");
+            }
+
+            context.Merge(localContext);
+
+            // when comparing JsonWebKey (NewtonSoft) and (utf8Reader) ignore the AdditionalData
+            // (Newtonsoft.Json) sets an Newtonsoft object, utf8Reader sets JsonElement.
+            localContext.Diffs.Clear();
+            localContext.PropertiesToIgnoreWhenComparing.Clear();
+            localContext.AddDictionaryKeysToIgnoreWhenComparing("Object", "Array", "int");
+            if (!IdentityComparer.AreEqual(jsonWebKeyUtf8Reader, jsonWebKey6x, localContext))
+            {
+                localContext.Diffs.Add("jsonWebKeyUtf8Reader != jsonWebKey6x");
+                localContext.Diffs.Add("=========================================");
+            }
+
+            context.Merge(localContext);
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<JsonWebKeyTheoryData> DeserializeDataSet
+        {
+            get
+            {
+                var theoryData = new TheoryData<JsonWebKeyTheoryData>();
+                theoryData.Add(new JsonWebKeyTheoryData("JsonWebKey")
+                {
+                    JsonWebKey = DataSets.JsonWebKey1,
+                    Json = DataSets.JsonWebKeyString
+                });
+
+                theoryData.Add(new JsonWebKeyTheoryData("JsonWebKeyMixedCase")
+                {
+                    JsonWebKey = DataSets.JsonWebKey1,
+                    Json = DataSets.JsonWebKeyMixedCaseString
+                });
+
+                theoryData.Add(new JsonWebKeyTheoryData("JsonWebKeyES256")
+                {
+                    JsonWebKey = DataSets.JsonWebKeyES256,
+                    Json = DataSets.JsonWebKeyES256String
+                });
+
+                theoryData.Add(new JsonWebKeyTheoryData("JsonWebKeyES384")
+                {
+                    JsonWebKey = DataSets.JsonWebKeyES384,
+                    Json = DataSets.JsonWebKeyES384String
+                });
+
+                JsonWebKey jsonWebKey = JsonUtilities.FullyPopulatedJsonWebKey();
+                string json = System.Text.Json.JsonSerializer.Serialize(jsonWebKey);
+                theoryData.Add(new JsonWebKeyTheoryData("FullyPopulated")
+                {
+                    JsonWebKey = jsonWebKey,
+                    Json = json
+                });
+
+                // System.Text.Json throws a JsonException with an inner of JsonReaderException that is internal.
+                // We would have to use reflection to compare.
+                theoryData.Add(new JsonWebKeyTheoryData("BadJson")
+                {
+                    ExpectedException = new ExpectedException(typeof(ArgumentException), "IDX10805: Error deserializing json: ", typeof(JsonReaderException)),
+                    Json = "{adsd}",
+                    JsonReaderExpectedException = new ExpectedException(typeExpected: typeof(ArgumentException), substringExpected: "IDX10805: Error deserializing json:", ignoreInnerException: true),
+                    JsonSerializerExpectedException = new ExpectedException(typeExpected: typeof(System.Text.Json.JsonException), substringExpected: "'a' is an invalid start of a", ignoreInnerException: true)
+                });
+
+                return theoryData;
+            }
+        }
+
+        /// <summary>
+        /// This test is to ensure that a JsonWebKey from 6x == 7x.
+        /// This is different that Deserialize as we are roundtripping objects in AdditionalData.
+        /// </summary>
+        /// <param name="theoryData"></param>
+        [Theory, MemberData(nameof(RoundTripDataSet))]
+        public void RoundTrip(JsonWebKeyTheoryData theoryData)
+        {
+            var context = new CompareContext(theoryData);
+            try
+            {
+                string json6x = JsonConvert.SerializeObject(theoryData.JsonWebKey6x, Formatting.None);
+                string jsonSerialize = System.Text.Json.JsonSerializer.Serialize<JsonWebKey>(theoryData.JsonWebKey);
+                string jsonUtf8Writer = JsonWebKeySerializer.Write(theoryData.JsonWebKey);
+
+                JsonWebKey6x jsonWebKey6x = JsonConvert.DeserializeObject<JsonWebKey6x>(json6x);
+                JsonWebKey jsonWebKeyDeserialize = System.Text.Json.JsonSerializer.Deserialize<JsonWebKey>(jsonUtf8Writer);
+                JsonWebKey jsonWebKeyUtf8Reader = new JsonWebKey(jsonUtf8Writer);
+
+                // ensure that our utf8writer and newtonsoft are the same
+                if (!IdentityComparer.AreEqual(jsonUtf8Writer, json6x, context))
+                {
+                    context.Diffs.Add("jsonUtf8Writer != json6x");
+                    context.Diffs.Add("=========================================");
+                }
+
+                // RELNOTE: ensure that the output from our utf8writer is consummable by JsonSerializer.Deserialize since our collections are not settable, ignore the AdditionalData, KeyOps, Oth, X5c properties are they have no getter.
+                // We will need to adjust for a 8.0 target
+                // use a new CompareContext so that Properties to ignore are just applied to this compare
+                CompareContext localContext = new CompareContext(theoryData);
+                localContext.PropertiesToIgnoreWhenComparing.Add(typeof(JsonWebKey), new List<string> { "AdditionalData", "KeyOps", "Oth", "X5c" });
+                if (!IdentityComparer.AreEqual(jsonWebKeyDeserialize, theoryData.JsonWebKey, localContext))
+                {
+                    localContext.Diffs.Add("jsonWebKeyDeserialize != theoryData.JsonWebKey");
+                    localContext.Diffs.Add("=========================================");
+                }
+
+                context.Merge(localContext);
+
+                // compare our utf8Reader with expected value
+                if (!IdentityComparer.AreEqual(jsonWebKeyUtf8Reader, theoryData.JsonWebKey, context))
+                {
+                    context.Diffs.Add("jsonWebKeyUtf8Reader != theoryData.JsonWebKey");
+                    context.Diffs.Add("=========================================");
+                }
+
+                // RELNOTE: we can give users a sample showing how to deserialize an object into a known type.
+                if (jsonWebKeyUtf8Reader.AdditionalData.TryGetValue("JsonWebKey", out object jsonWebKey))
+                {
+                    JsonElement? jsonElement = jsonWebKey as JsonElement?;
+                    if (jsonElement.HasValue)
+                        jsonWebKeyUtf8Reader.AdditionalData["JsonWebKey"] = JsonWebKeySerializer.Read(jsonElement.Value.GetRawText());
+
+                    jsonWebKey6x.AdditionalData["JsonWebKey"] = JsonConvert.DeserializeObject<JsonWebKey6x>(jsonWebKey6x.AdditionalData["JsonWebKey"].ToString());
+                }
+
+                // ensure what our utf8reader and newtonsoft are the same
+                // RELNOTE:
+                // Object for Newtonsoft will be 'Newtonsoft.Json.Linq.JObject', System.Text.Json 'System.Text.Json.JsonElement'
+                // Array  for Newtonsoft will be 'Newtonsoft.Json.Linq.JArray', System.Text.Json 'System.Text.Json.JsonElement'
+                // int for Newtonsoft will be 'System.Int64', System.Text.Json 'System.Int32'
+                context.AddDictionaryKeysToIgnoreWhenComparing("Object", "Array", "int");
+                if (!IdentityComparer.AreEqual(jsonWebKeyUtf8Reader, jsonWebKey6x, context))
+                {
+                    context.Diffs.Add("jsonWebKeyUtf8Reader != jsonWebKey6x");
+                    context.Diffs.Add("=========================================");
+                }
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+        public static TheoryData<JsonWebKeyTheoryData> RoundTripDataSet
+        {
+            get
+            {
+                var theoryData = new TheoryData<JsonWebKeyTheoryData>();
+
+                theoryData.Add(new JsonWebKeyTheoryData("AdditionalDataWithJsonWebKey")
+                {
+                    JsonWebKey = AdditionalData("JsonWebKey", JsonUtilities.CreateJsonElement(JsonWebKeySerializer.Write(new JsonWebKey { Alg = "Alg" }))),
+                    JsonWebKey6x = AdditionalData6x("JsonWebKey", new JsonWebKey6x { Alg = "Alg" })
+                });
+
+                theoryData.Add(new JsonWebKeyTheoryData("AdditionalData")
+                {
+                    JsonWebKey = AdditionalData(),
+                    JsonWebKey6x = AdditionalData6x()
+                });
+
+                theoryData.Add(new JsonWebKeyTheoryData("FullyPopulated")
+                {
+                    JsonWebKey = JsonUtilities.FullyPopulatedJsonWebKey(),
+                    JsonWebKey6x = JsonUtilities.FullyPopulatedJsonWebKey6x()
+                });
+
+                return theoryData;
+            }
+        }
+
+        private static JsonWebKey AdditionalData(string key = null, object obj = null)
+        {
+            JsonWebKey jsonWebKey = new JsonWebKey();
+            JsonUtilities.SetAdditionalData(jsonWebKey.AdditionalData, key, obj);
+            return jsonWebKey;
+        }
+
+        private static JsonWebKey6x AdditionalData6x(string key = null, object obj = null)
+        {
+            JsonWebKey6x jsonWebKey = new JsonWebKey6x();
+            JsonUtilities.SetAdditionalData6x(jsonWebKey.AdditionalData, key, obj);
+            return jsonWebKey;
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySet6x.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySet6x.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Microsoft.IdentityModel.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.IdentityModel.Tokens.Json.Tests
+{
+    /// <summary>
+    /// Contains a collection of <see cref="JsonWebKey6x"/> that can be populated from a json string.
+    /// </summary>
+    /// <remarks>provides support for https://datatracker.ietf.org/doc/html/rfc7517.</remarks>
+    /// This is the original JsonWebKeySet in the 6x branch.
+    /// Used for ensuring backcompat.
+    [JsonObject]
+    public class JsonWebKeySet6x
+    {
+        private const string _className = "Microsoft.IdentityModel.Tokens.JsonWebKeySet6x";
+
+        /// <summary>
+        /// Returns a new instance of <see cref="JsonWebKeySet6x"/>.
+        /// </summary>
+        /// <param name="json">a string that contains JSON Web Key parameters in JSON format.</param>
+        /// <returns><see cref="JsonWebKeySet6x"/></returns>
+        /// <exception cref="ArgumentNullException">If 'json' is null or empty.</exception>
+        /// <exception cref="ArgumentException">If 'json' fails to deserialize.</exception>
+        public static JsonWebKeySet6x Create(string json)
+        {
+            if (string.IsNullOrEmpty(json))
+                throw LogHelper.LogArgumentNullException(nameof(json));
+
+            return new JsonWebKeySet6x(json);
+        }
+
+        /// <summary>
+        /// Initializes an new instance of <see cref="JsonWebKeySet6x"/>.
+        /// </summary>
+        public JsonWebKeySet6x()
+        {
+        }
+
+        /// <summary>
+        /// Initializes an new instance of <see cref="JsonWebKeySet6x"/> from a json string.
+        /// </summary>
+        /// <param name="json">a json string containing values.</param>
+        /// <exception cref="ArgumentNullException">If 'json' is null or empty.</exception>
+        /// <exception cref="ArgumentException">If 'json' fails to deserialize.</exception>
+        public JsonWebKeySet6x(string json)
+        {
+            if (string.IsNullOrEmpty(json))
+                throw LogHelper.LogArgumentNullException(nameof(json));
+
+            try
+            {
+                LogHelper.LogVerbose(LogMessages.IDX10806, json, LogHelper.MarkAsNonPII(_className));
+                JsonConvert.PopulateObject(json, this);
+            }
+            catch (Exception ex)
+            {
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10805, json, LogHelper.MarkAsNonPII(_className)), ex));
+            }
+        }
+
+        /// <summary>
+        /// When deserializing from JSON any properties that are not defined will be placed here.
+        /// </summary>
+        [JsonExtensionData]
+        public virtual IDictionary<string, object> AdditionalData { get; } = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Gets the <see cref="IList{JsonWebKey}"/>.
+        /// </summary>       
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore, NullValueHandling = NullValueHandling.Ignore, PropertyName = JsonWebKeySetParameterNames.Keys, Required = Required.Default)]
+        public IList<JsonWebKey6x> Keys { get; private set; } = new List<JsonWebKey6x>();
+
+        /// <summary>
+        /// Default value for the flag that controls whether unresolved JsonWebKeys will be included in the resulting collection of <see cref="GetSigningKeys"/> method.
+        /// </summary>
+        [DefaultValue(true)]
+        public static bool DefaultSkipUnresolvedJsonWebKeys = true;
+
+        /// <summary>
+        /// Flag that controls whether unresolved JsonWebKeys will be included in the resulting collection of <see cref="GetSigningKeys"/> method.
+        /// </summary>
+        [DefaultValue(true)]
+        [JsonIgnore]
+        public bool SkipUnresolvedJsonWebKeys { get; set; } = DefaultSkipUnresolvedJsonWebKeys;
+
+        // removed GetSigningKeys as that would pull in too much of 6x and we are only interested in serialization.
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySetSerializationTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySetSerializationTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.IdentityModel.TestUtils;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Tokens.Json.Tests
+{
+    public class JsonWebKeySetSerializationTests
+    {
+        /// <summary>
+        /// This test is to ensure that a JsonWebKeySet1 from 6x == 7x.
+        /// The keysets are fully populated and each property checked.
+        /// </summary>
+        /// <param name="theoryData"></param>
+        [Theory, MemberData(nameof(SerializeDataSet))]
+        public void Serialize(JsonWebKeySetTheoryData theoryData)
+        {
+            var context = new CompareContext(theoryData);
+            try
+            {
+                string json6x = JsonConvert.SerializeObject(theoryData.JsonWebKeySet6x);
+                string jsonSerialize = System.Text.Json.JsonSerializer.Serialize<JsonWebKeySet>(theoryData.JsonWebKeySet);
+                string jsonUtf8Writer = JsonWebKeySetSerializer.Write(theoryData.JsonWebKeySet);
+
+                JsonWebKeySet6x jsonWebKeySet6x = JsonConvert.DeserializeObject<JsonWebKeySet6x>(json6x);
+                JsonWebKeySet jsonWebKeySetDeserialize = System.Text.Json.JsonSerializer.Deserialize<JsonWebKeySet>(jsonUtf8Writer);
+                JsonWebKeySet jsonWebKeySetUtf8Reader = new JsonWebKeySet(jsonUtf8Writer);
+
+                // ensure that our utf8writer and newtonsoft generate the same json string
+                if (!IdentityComparer.AreEqual(jsonUtf8Writer, json6x, context))
+                {
+                    context.Diffs.Add("jsonUtf8Writer != json6x");
+                    context.Diffs.Add("=========================================");
+                }
+
+                // TODO - when a 8.0 target introduced we will need to adjust as JsonSerializer will be able to set collections without setters
+
+                // compare our utf8Reader with expected value
+                if (!IdentityComparer.AreEqual(jsonWebKeySetUtf8Reader, theoryData.JsonWebKeySet, context))
+                {
+                    context.Diffs.Add("jsonWebKeySetUtf8Reader != theoryData.JsonWebKeySet1");
+                    context.Diffs.Add("=========================================");
+                }
+
+                // ensure what our utf8reader and newtonsoft keys are the same
+                CompareContext localContext = new CompareContext(theoryData);
+                localContext.AddDictionaryKeysToIgnoreWhenComparing("Object", "Array", "int");
+                if (jsonWebKeySetUtf8Reader.Keys.Count == jsonWebKeySet6x.Keys.Count)
+                {
+                    // Now compare Keys assuming same order
+                    for (int i = 0; i < jsonWebKeySetUtf8Reader.Keys.Count; i++)
+                        if (!IdentityComparer.AreEqual(jsonWebKeySetUtf8Reader.Keys[i], jsonWebKeySet6x.Keys[i], localContext))
+                        {
+                            localContext.Diffs.Add($"jsonWebKeySetUtf8Reader.Keys'{i}' != jsonWebKey6x.Keys'{i}'");
+                            localContext.Diffs.Add("=========================================");
+                        }
+                }
+                else
+                {
+                    localContext.Diffs.Add("jsonWebKeySetUtf8Reader.Keys.Count != jsonWebKey6x.Keys.Count");
+                    localContext.Diffs.Add("=========================================");
+                }
+
+                context.Merge(localContext);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<JsonWebKeySetTheoryData> SerializeDataSet
+        {
+            get
+            {
+                var theoryData = new TheoryData<JsonWebKeySetTheoryData>();
+
+                theoryData.Add(new JsonWebKeySetTheoryData("FullyPopulated")
+                {
+                    JsonWebKeySet = JsonUtilities.FullyPopulatedJsonWebKeySet(),
+                    JsonWebKeySet6x = JsonUtilities.FullyPopulatedJsonWebKeySet6x()
+                });
+
+                return theoryData;
+            }
+        }
+
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySetTheoryData.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySetTheoryData.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.IdentityModel.TestUtils;
+
+namespace Microsoft.IdentityModel.Tokens.Json.Tests
+{
+    public class JsonWebKeySetTheoryData : TheoryDataBase
+    {
+        public JsonWebKeySetTheoryData() { }
+
+        public JsonWebKeySetTheoryData(string testId) : base(testId) { }
+
+        public IList<SecurityKey> ExpectedSigningKeys { get; set; }
+
+        public string Json { get; set; }
+
+        public JsonWebKeySet JsonWebKeySet { get; set; }
+
+        public JsonWebKeySet6x JsonWebKeySet6x { get; set; }
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeyTheoryData.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeyTheoryData.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.IdentityModel.TestUtils;
+
+namespace Microsoft.IdentityModel.Tokens.Json.Tests
+{
+    public class JsonWebKeyTheoryData : TheoryDataBase
+    {
+        public JsonWebKeyTheoryData() { }
+
+        public JsonWebKeyTheoryData(string testId) : base(testId) { }
+
+        public string Crv { get; set; }
+
+        public string D { get; set; }
+
+        public string Json { get; set; }
+
+        public JsonWebKey JsonWebKey { get; set; }
+
+        public JsonWebKey6x JsonWebKey6x { get; set; }
+
+        public ExpectedException JsonReaderExpectedException { get; set; } = ExpectedException.NoExceptionExpected;
+
+        public ExpectedException JsonSerializerExpectedException { get; set; } = ExpectedException.NoExceptionExpected;
+
+        public string X { get; set; }
+
+        public string Y { get; set; }
+
+        public bool UsePrivateKey { get; set; }
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/SecurityKey6x.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/SecurityKey6x.cs
@@ -3,20 +3,22 @@
 
 using System;
 using Microsoft.IdentityModel.Logging;
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
     /// Base class for Security Key.
     /// </summary>
-    public abstract class SecurityKey
+    /// This is the original SecurityKey in the 6x branch.
+    /// Used for ensuring backcompat.
+    public abstract class SecurityKey6x
     {
         private CryptoProviderFactory _cryptoProviderFactory;
         private object _internalIdLock = new object();
         private string _internalId;
 
-        internal SecurityKey(SecurityKey key)
+        internal SecurityKey6x(SecurityKey6x key)
         {
             _cryptoProviderFactory = key._cryptoProviderFactory;
             KeyId = key.KeyId;
@@ -25,7 +27,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Default constructor
         /// </summary>
-        public SecurityKey()
+        public SecurityKey6x()
         {
             _cryptoProviderFactory = CryptoProviderFactory.Default;
         }
@@ -39,13 +41,10 @@ namespace Microsoft.IdentityModel.Tokens
                 {
                     lock (_internalIdLock)
                     {
-                        if (_internalId == null)
-                        {
-                            if (CanComputeJwkThumbprint())
-                                _internalId = Base64UrlEncoder.Encode(ComputeJwkThumbprint());
-                            else
-                                _internalId = string.Empty;
-                        }
+                        if (CanComputeJwkThumbprint())
+                            _internalId = Base64UrlEncoder.Encode(ComputeJwkThumbprint());
+                        else
+                            _internalId = string.Empty;
                     }
                 }
 
@@ -117,7 +116,11 @@ namespace Microsoft.IdentityModel.Tokens
         public virtual bool IsSupportedAlgorithm(string algorithm)
         {
             // do not throw if algorithm is null or empty to stay in sync with CryptoProviderFactory.IsSupportedAlgorithm.
-            return CryptoProviderFactory.IsSupportedAlgorithm(algorithm, this);
+
+            // will not compile as SecurityKey is expected
+            // return CryptoProviderFactory.IsSupportedAlgorithm(algorithm, this);
+
+            return true;
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
@@ -7,60 +7,141 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
 using Microsoft.IdentityModel.TestUtils;
 using Newtonsoft.Json;
 using Xunit;
 
-namespace Microsoft.IdentityModel.Tokens.Tests
+namespace Microsoft.IdentityModel.Tokens.Json.Tests
 {
     public class JsonWebKeySetTests
     {
-        [Theory, MemberData(nameof(JsonWebKeySetDataSet))]
-        private void Constructors(
-            string testId,
-            string json,
-            JsonWebKeySet compareTo,
-            ExpectedException ee)
+        [Theory, MemberData(nameof(ConstructorDataSet))]
+        public void Constructors(JsonWebKeySetTheoryData theoryData)
         {
-            var context = new CompareContext($"{this}.{testId}");
+            var context = new CompareContext(theoryData);
             context.PropertiesToIgnoreWhenComparing.Add(typeof(JsonWebKeySet), new List<string>() { "SkipUnresolvedJsonWebKeys" });
+
             try
             {
-                var jsonWebKeys = new JsonWebKeySet(json);
+                var jsonWebKeys = new JsonWebKeySet(theoryData.Json);
                 var keys = jsonWebKeys.GetSigningKeys();
-                ee.ProcessNoException(context);
-                if (compareTo != null)
-                    IdentityComparer.AreEqual(jsonWebKeys, compareTo, context);
+                theoryData.ExpectedException.ProcessNoException(context);
+                if (theoryData.JsonWebKeySet != null)
+                    IdentityComparer.AreEqual(jsonWebKeys, theoryData.JsonWebKeySet, context);
+
+                if (theoryData.ExpectedSigningKeys != null)
+                    IdentityComparer.AreEqual(keys, theoryData.ExpectedSigningKeys, context);
             }
             catch (Exception ex)
             {
-                ee.ProcessException(ex, context.Diffs);
+                theoryData.ExpectedException.ProcessException(ex, context);
             }
 
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        public static TheoryData<string, string, JsonWebKeySet, ExpectedException> JsonWebKeySetDataSet
+        public static TheoryData<JsonWebKeySetTheoryData> ConstructorDataSet
         {
             get
             {
-                var dataset = new TheoryData<string, string, JsonWebKeySet, ExpectedException>();
-                dataset.Add("Test1", DataSets.JsonWebKeySetAdditionalDataString1, DataSets.JsonWebKeySetAdditionalData1, ExpectedException.NoExceptionExpected);
-                dataset.Add("Test2", null, null, ExpectedException.ArgumentNullException());
-                dataset.Add("Test3", DataSets.JsonWebKeySetString1, DataSets.JsonWebKeySet1, ExpectedException.NoExceptionExpected);
-                dataset.Add("Test4", DataSets.JsonWebKeySetBadFormatingString, null, ExpectedException.ArgumentException(substringExpected: "IDX10805:", inner: typeof(JsonReaderException)));
-                dataset.Add("Test5", File.ReadAllText(DataSets.GoogleCertsFile), DataSets.GoogleCertsExpected, ExpectedException.NoExceptionExpected);
-                dataset.Add("Test6", DataSets.JsonWebKeySetBadRsaExponentString, null, ExpectedException.NoExceptionExpected);
-                dataset.Add("Test7", DataSets.JsonWebKeySetBadRsaModulusString, null, ExpectedException.NoExceptionExpected);
-                dataset.Add("Test8", DataSets.JsonWebKeySetKtyNotRsaString, null, ExpectedException.NoExceptionExpected);
-                dataset.Add("Test9", DataSets.JsonWebKeySetUseNotSigString, null, ExpectedException.NoExceptionExpected);
-                dataset.Add("Test10", DataSets.JsonWebKeySetBadX509String, null, ExpectedException.NoExceptionExpected);
-                dataset.Add("Test11", DataSets.JsonWebKeySetECCString, DataSets.JsonWebKeySetEC, ExpectedException.NoExceptionExpected);
-                dataset.Add("Test12", DataSets.JsonWebKeySetBadECCurveString, null, ExpectedException.NoExceptionExpected);
-                dataset.Add("Test13", DataSets.JsonWebKeySetOnlyX5tString, DataSets.JsonWebKeySetOnlyX5t, ExpectedException.NoExceptionExpected);
-                dataset.Add("Test14", DataSets.JsonWebKeySetX509DataString, DataSets.JsonWebKeySetX509Data, ExpectedException.NoExceptionExpected);
+                var theoryData = new TheoryData<JsonWebKeySetTheoryData>();
 
-                return dataset;
+                theoryData.Add(
+                    new JsonWebKeySetTheoryData("JsonWebKeySet1")
+                    {
+                        Json = DataSets.JsonWebKeySetString1,
+                        JsonWebKeySet = DataSets.JsonWebKeySet1
+                    });
+
+                theoryData.Add(
+                    new JsonWebKeySetTheoryData("Null")
+                    {
+                        ExpectedException = ExpectedException.ArgumentNullException()
+                    });
+
+                theoryData.Add(
+                    new JsonWebKeySetTheoryData("JsonWebKeySetBadFormatingString")
+                    {
+                        ExpectedException = ExpectedException.ArgumentException(substringExpected: "IDX10805:", inner: typeof(System.Text.Json.JsonException)),
+                        Json = DataSets.JsonWebKeySetBadFormatingString
+                    });
+
+                theoryData.Add(
+                    new JsonWebKeySetTheoryData("GoogleCertsExpected")
+                    {
+                        Json = File.ReadAllText(DataSets.GoogleCertsFile),
+                        JsonWebKeySet = DataSets.GoogleCertsExpected
+                    });
+
+                theoryData.Add(
+                    new JsonWebKeySetTheoryData("JsonWebKeySetBadRsaExponentString")
+                    {
+                        Json = DataSets.JsonWebKeySetBadRsaExponentString,
+                        ExpectedSigningKeys = new List<SecurityKey>()
+                    });
+
+                theoryData.Add(
+                    new JsonWebKeySetTheoryData("JsonWebKeySetBadRsaModulusString")
+                    {
+                        Json = DataSets.JsonWebKeySetBadRsaModulusString,
+                        ExpectedSigningKeys = new List<SecurityKey>()
+                    });
+
+                theoryData.Add(
+                    new JsonWebKeySetTheoryData("JsonWebKeySetKtyNotRsaString")
+                    {
+                        Json = DataSets.JsonWebKeySetKtyNotRsaString,
+                        ExpectedSigningKeys = new List<SecurityKey>()
+                    });
+
+                theoryData.Add(
+                    new JsonWebKeySetTheoryData("JsonWebKeySetUseNotSigString")
+                    {
+                        Json = DataSets.JsonWebKeySetUseNotSigString,
+                        ExpectedSigningKeys = new List<SecurityKey>()
+                    });
+
+                List<SecurityKey> keys = new List<SecurityKey>();
+                if (JsonWebKeyConverter.TryCreateToRsaSecurityKey(DataSets.JsonWebKeyBadX509Data, out SecurityKey securityKey))
+                    keys.Add(securityKey);
+
+                theoryData.Add(
+                    new JsonWebKeySetTheoryData("JsonWebKeySetBadX509String")
+                    {
+                        Json = DataSets.JsonWebKeySetBadX509String,
+                        ExpectedSigningKeys = keys
+                    });
+
+                theoryData.Add(
+                    new JsonWebKeySetTheoryData("JsonWebKeySetECCString")
+                    {
+                        Json = DataSets.JsonWebKeySetECCString,
+                        JsonWebKeySet = DataSets.JsonWebKeySetEC
+                    });
+
+                theoryData.Add(
+                    new JsonWebKeySetTheoryData("JsonWebKeySetBadECCurveString")
+                    {
+                        Json = DataSets.JsonWebKeySetBadECCurveString,
+                        ExpectedSigningKeys = new List<SecurityKey>()
+                    });
+
+                theoryData.Add(
+                    new JsonWebKeySetTheoryData("JsonWebKeySetOnlyX5tString")
+                    {
+                        Json = DataSets.JsonWebKeySetOnlyX5tString,
+                        JsonWebKeySet = DataSets.JsonWebKeySetOnlyX5t
+                    });
+
+                theoryData.Add(
+                    new JsonWebKeySetTheoryData("JsonWebKeySetX509DataString")
+                    {
+                        Json = DataSets.JsonWebKeySetX509DataString,
+                        JsonWebKeySet = DataSets.JsonWebKeySetX509Data
+                    });
+
+                return theoryData;
             }
         }
 
@@ -81,16 +162,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 context.Diffs.Add("jsonWebKeys.AdditionalData.Count != 0");
 
             TestUtilities.AssertFailIfErrors(context);
-        }
-
-        [Fact]
-        public void GetSets()
-        {
-        }
-
-        [Fact]
-        public void Publics()
-        {
         }
 
         [Fact]
@@ -381,12 +452,5 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 KeyId = webKey.KeyId
             };
         }
-
-        public class JsonWebKeySetTheoryData : TheoryDataBase
-        {
-            public JsonWebKeySet JsonWebKeySet { get; set; }
-
-            public List<SecurityKey> ExpectedSigningKeys { get; set; }
-         }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Microsoft.IdentityModel.Tokens.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Microsoft.IdentityModel.Tokens.Tests.csproj
@@ -13,12 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="google-certs.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.ManagedKeyVaultSecurityKey\Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.Protocols.OpenIdConnect\Microsoft.IdentityModel.Protocols.OpenIdConnect.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.Tokens\Microsoft.IdentityModel.Tokens.csproj" />
@@ -32,6 +26,12 @@
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="google-certs.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtHeaderTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtHeaderTests.cs
@@ -123,7 +123,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         [Fact]
         public void Kid()
         {
-            var jsonWebKey = new JsonWebKey(DataSets.JsonWebKeyString1);
+            var jsonWebKey = new JsonWebKey(DataSets.JsonWebKeyString);
             var credentials = new SigningCredentials(jsonWebKey, SecurityAlgorithms.RsaSha256Signature);
             var token = new JwtSecurityToken(claims: Default.Claims, signingCredentials: credentials);
             Assert.Equal(jsonWebKey.Kid, token.Header.Kid);


### PR DESCRIPTION
Reading and Writing JsonWebKey and JsonWebKeySet types now use System.Text.Json.Utf8JsonReaders/Writers for serialization.
JsonWebKey6x and JsonWebKeySet6x were copied from the 6x branch and Deserialization and Roundtrips were compared against what was generated using Newtonsoft.
Differences were captured and will be used to created release notes.

JsonWebKeySerializer and JsonWebKeySetSerializer use JsonSerializerPrimitives as will other types that need serialization.
JsonSerializationPrimitives will provide a robust error message with the type being serialized, the property in play and the reason for the error.

DataSets.cs was modified a considerable amount to make it easier to navigate.
JsonWebKeyTests were modified to use the ctor that takes a TheoryData object, rather than multiple parameters.
JsonSerializerPrimitivesTests was written to understand how failures would be handled, error messages and the difference between Newtonsoft and System.Text.Json.

Microsoft.IdentityModel.Tokens has two additional references to Newtonsoft, those will be removed with modifications that will update OIDC to use System.Text.Json.