### PR TITLE
Bash version of updateAssemblyInfo script

### DIFF
--- a/updateAssemblyInfo.sh
+++ b/updateAssemblyInfo.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+scriptroot=$(cd -P "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+packageType=${1:-preview}
+
+date=$(date '+%y%m%d%H%M%S')
+# Formats the date by replacing the 4-digit year with a 2-digit value and then subtract 19
+dateTimeStamp=$(echo $((10#${date:0:2}-19)))${date:2}
+
+buildConfiguration=$(cat $PWD/buildConfiguration.xml)
+commitSha=$(git rev-parse HEAD)
+
+assemblyVersion=$(echo $buildConfiguration | xmllint --xpath 'string(/root/assemblyVersion)' -)
+assemblyFileVersion="$assemblyVersion.${dateTimeStamp::-6}" # Trim minutes/seconds
+assemblyInformationalVersion="$assemblyVersion.$dateTimeStamp.$commitSha"
+
+echo "assemblyVersion: $assemblyVersion"
+echo "assemblyFileVersion: $assemblyFileVersion"
+echo "assemblyInformationalVersion: $assemblyInformationalVersion"
+
+nugetSuffix=$(xmllint --xpath "string(/root/nugetSuffix)" buildConfiguration.xml)
+if [ "$packageType" = "release" ]
+then
+    versionSuffix=""
+else
+    versionSuffix="$nugetSuffix-$dateTimeStamp"
+fi
+
+echo "nugetSuffix: $nugetSuffix"
+
+versionPath="$PWD/build/version.props"
+version=$(cat $versionPath)
+version=$(echo "$version" | sed "s|<VersionPrefix>.*</VersionPrefix>|<VersionPrefix>$assemblyVersion</VersionPrefix>|")
+version=$(echo "$version" | sed "s|<VersionSuffix>.*</VersionSuffix>|<VersionSuffix>$versionSuffix</VersionSuffix>|")
+echo "$version" > $versionPath
+
+projects=$(xmllint --xpath "/root/projects/src/project/@name" buildConfiguration.xml | sed 's/^[^"]*"\([^"]*\)".*/\1/')
+
+for project in $projects; do
+    name="$project"
+    assemblyInfoPath="$PWD/src/$name/Properties/AssemblyInfo.cs"
+    echo "assemblyInfoPath: $assemblyInfoPath"
+
+    assemblyInfo=$(cat $assemblyInfoPath)
+    assemblyInfo=$(echo "$assemblyInfo" | sed "s|AssemblyVersion.*|AssemblyVersion(\"$assemblyVersion\")]|")
+    assemblyInfo=$(echo "$assemblyInfo" | sed "s|AssemblyFileVersion.*|AssemblyFileVersion(\"$assemblyFileVersion\")]|")
+    assemblyInfo=$(echo "$assemblyInfo" | sed "s|AssemblyInformationalVersion.*|AssemblyInformationalVersion(\"$assemblyInformationalVersion\")]|")
+    echo "$assemblyInfo" > $assemblyInfoPath
+done

--- a/updateAssemblyInfo.sh
+++ b/updateAssemblyInfo.sh
@@ -9,10 +9,9 @@ date=$(date '+%y%m%d%H%M%S')
 # Formats the date by replacing the 4-digit year with a 2-digit value and then subtract 19
 dateTimeStamp=$(echo $((10#${date:0:2}-19)))${date:2}
 
-buildConfiguration=$(cat $PWD/buildConfiguration.xml)
 commitSha=$(git rev-parse HEAD)
 
-assemblyVersion=$(echo $buildConfiguration | xmllint --xpath 'string(/root/assemblyVersion)' -)
+assemblyVersion=$(grep -oP '(?<=<assemblyVersion>)[^<]+' $PWD/buildConfiguration.xml)
 assemblyFileVersion="$assemblyVersion.${dateTimeStamp::-6}" # Trim minutes/seconds
 assemblyInformationalVersion="$assemblyVersion.$dateTimeStamp.$commitSha"
 
@@ -20,7 +19,7 @@ echo "assemblyVersion: $assemblyVersion"
 echo "assemblyFileVersion: $assemblyFileVersion"
 echo "assemblyInformationalVersion: $assemblyInformationalVersion"
 
-nugetSuffix=$(xmllint --xpath "string(/root/nugetSuffix)" buildConfiguration.xml)
+nugetSuffix=$(grep -oP '(?<=<nugetSuffix>)[^<]+' $PWD/buildConfiguration.xml)
 if [ "$packageType" = "release" ]
 then
     versionSuffix=""
@@ -36,7 +35,7 @@ version=$(echo "$version" | sed "s|<VersionPrefix>.*</VersionPrefix>|<VersionPre
 version=$(echo "$version" | sed "s|<VersionSuffix>.*</VersionSuffix>|<VersionSuffix>$versionSuffix</VersionSuffix>|")
 echo "$version" > $versionPath
 
-projects=$(xmllint --xpath "/root/projects/src/project/@name" buildConfiguration.xml | sed 's/^[^"]*"\([^"]*\)".*/\1/')
+projects=$(grep -zoP '(?<=<src>)(.|[\s])*?(?=<\/src>)' $PWD/buildConfiguration.xml | grep -aoP 'name="\K[^"]+')
 
 for project in $projects; do
     name="$project"

--- a/updateAssemblyInfo.sh
+++ b/updateAssemblyInfo.sh
@@ -11,7 +11,7 @@ dateTimeStamp=$(echo $((10#${date:0:2}-19)))${date:2}
 
 commitSha=$(git rev-parse HEAD)
 
-assemblyVersion=$(grep -oP '(?<=<assemblyVersion>)[^<]+' $PWD/buildConfiguration.xml)
+assemblyVersion=$(sed -n 's/.*<assemblyVersion>\([^<]*\)<.*/\1/p' $PWD/buildConfiguration.xml)
 assemblyFileVersion="$assemblyVersion.${dateTimeStamp::-6}" # Trim minutes/seconds
 assemblyInformationalVersion="$assemblyVersion.$dateTimeStamp.$commitSha"
 
@@ -19,7 +19,7 @@ echo "assemblyVersion: $assemblyVersion"
 echo "assemblyFileVersion: $assemblyFileVersion"
 echo "assemblyInformationalVersion: $assemblyInformationalVersion"
 
-nugetSuffix=$(grep -oP '(?<=<nugetSuffix>)[^<]+' $PWD/buildConfiguration.xml)
+nugetSuffix=$(sed -n 's/.*<nugetSuffix>\([^<]*\)<.*/\1/p' $PWD/buildConfiguration.xml)
 if [ "$packageType" = "release" ]
 then
     versionSuffix=""
@@ -35,7 +35,7 @@ version=$(echo "$version" | sed "s|<VersionPrefix>.*</VersionPrefix>|<VersionPre
 version=$(echo "$version" | sed "s|<VersionSuffix>.*</VersionSuffix>|<VersionSuffix>$versionSuffix</VersionSuffix>|")
 echo "$version" > $versionPath
 
-projects=$(grep -zoP '(?<=<src>)(.|[\s])*?(?=<\/src>)' $PWD/buildConfiguration.xml | grep -aoP 'name="\K[^"]+')
+projects=$(sed -n '/<src>/,/<\/src>/p' $PWD/buildConfiguration.xml | sed -n 's/.*name="\([^"]*\)".*/\1/p')
 
 for project in $projects; do
     name="$project"


### PR DESCRIPTION
This defines a Bash version of the existing [updateAssemblyInfo.ps1 script](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/updateAssemblyInfo.ps1). Since there are already existing Bash versions of the build and test scripts, it made sense to follow that pattern here as well.

This accommodates .NET's source-build requirements which disallow the dependency on PowerShell because it's not buildable from source by Linux distros. The implementation in this script is necessary for .NET's source-build in order to set the assembly versions correctly (see https://github.com/dotnet/source-build/issues/3565).