### PR TITLE
Avoid unnecessary ToArrays in JsonKeyWebSerializer

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonWebKeySerializer.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonWebKeySerializer.cs
@@ -348,7 +348,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     writer = new Utf8JsonWriter(memoryStream, new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
                     Write(ref writer, jsonWebKey);
                     writer.Flush();
-                    return Encoding.UTF8.GetString(memoryStream.ToArray());
+                    return Encoding.UTF8.GetString(memoryStream.GetBuffer(), 0, (int)memoryStream.Length);
                 }
                 finally
                 {

--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonWebKeySetSerializer.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonWebKeySetSerializer.cs
@@ -102,7 +102,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     writer = new Utf8JsonWriter(memoryStream, new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
                     Write(ref writer, jsonWebKeySet);
                     writer.Flush();
-                    return Encoding.UTF8.GetString(memoryStream.ToArray());
+                    return Encoding.UTF8.GetString(memoryStream.GetBuffer(), 0, (int)memoryStream.Length);
                 }
                 finally
                 {


### PR DESCRIPTION
These methods should likely be switched to just use JsonSerializer and let it handle pooling of Utf8JsonWriters and streams and the like. But for now, we can at least avoid an interim byte[] that's not needed.