### PR TITLE
Avoid a few more allocations

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/ClaimTypeMapping.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/ClaimTypeMapping.cs
@@ -11,7 +11,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         // This is the short to long mapping.
         // key is the long claim type
         // value is the short claim type
-        private static Dictionary<string, string> shortToLongClaimTypeMapping = new Dictionary<string, string>
+        private static readonly Dictionary<string, string> shortToLongClaimTypeMapping = new Dictionary<string, string>
         {
             { JwtRegisteredClaimNames.Actort, ClaimTypes.Actor },
             { JwtRegisteredClaimNames.Birthdate, ClaimTypes.DateOfBirth },
@@ -88,8 +88,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             { "winaccountname", ClaimTypes.WindowsAccountName },
         };
 
-        private static IDictionary<string, string> longToShortClaimTypeMapping = new Dictionary<string, string>();
-        private static HashSet<string> inboundClaimFilter = inboundClaimFilter = new HashSet<string>();
+        private static readonly Dictionary<string, string> longToShortClaimTypeMapping = new Dictionary<string, string>();
+        private static readonly HashSet<string> inboundClaimFilter = inboundClaimFilter = new HashSet<string>();
 
         /// <summary>
         /// Initializes static members of the <see cref="ClaimTypeMapping"/> class. 

--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Security.Claims;
-using System.Text;
 using System.Text.Json;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
@@ -271,19 +270,20 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
             if (typeof(T) == typeof(IList<string>))
             {
-                List<string> list = new();
                 if (obj is IList iList)
                 {
-                    foreach (object item in iList)
-                        list.Add(item?.ToString());
+                    string[] arr = new string[iList.Count];
+                    for (int arri = 0; arri < arr.Length; arri++)
+                    {
+                        arr[arri] = iList[arri]?.ToString();
+                    }
 
-                    return (T)((object)list);
+                    return (T)(object)arr;
                 }
                 else
                 {
-                    list.Add(obj.ToString());
+                    return (T)(object)new string[1] { obj.ToString() };
                 }
-                return (T)(object)list;
             }
 
             if (typeof(T) == typeof(int) && int.TryParse(obj.ToString(), out int i))
@@ -309,17 +309,20 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
             if (typeof(T) == typeof(IList<object>))
             {
-                List<object> list = new();
                 if (obj is IList items)
                 {
-                    foreach (object item in items)
-                        list.Add(item);
+                    object[] arr = new object[items.Count];
+                    for (int arri = 0; arri < arr.Length; arri++)
+                    {
+                        arr[arri] = items[arri];
+                    }
+
+                    return (T)(object)arr;
                 }
                 else
                 {
-                    list.Add(obj);
+                    return (T)(object)new object[1] { obj };
                 }
-                return (T)((object)list);
             }
 
             if (typeof(T) == typeof(int[]))

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Security.Claims;
 using System.Text;
 using Microsoft.IdentityModel.Logging;
@@ -23,7 +25,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         // Some of the common values are cached in local variables.
         private string _act;
         private string _alg;
-        private IList<string> _audiences;
+        private string[] _audiences;
         private string _authenticationTag;
         private string _ciphertext;
         private string _cty;
@@ -614,17 +616,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 {
                     lock (_audiencesLock)
                     {
-                        if (_audiences == null)
-                        {
-                            List<string> tmp = new List<string>();
-                            if (Payload.TryGetValue(JwtRegisteredClaimNames.Aud, out IList<string> audiences))
-                            {
-                                foreach (string str in audiences)
-                                    tmp.Add(str);
-                            }
-
-                            _audiences = tmp;
-                        }
+                        _audiences ??= Payload.TryGetValue(JwtRegisteredClaimNames.Aud, out IList<string> audiences) ?
+                            (audiences is string[] audiencesArray ? audiencesArray : audiences.ToArray()) :
+                            Array.Empty<string>();
                     }
                 }
 

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <summary>
         /// Default claim type mapping for inbound claims.
         /// </summary>
-        public static IDictionary<string, string> DefaultInboundClaimTypeMap = new Dictionary<string, string>(ClaimTypeMapping.InboundClaimTypeMap);
+        public static readonly Dictionary<string, string> DefaultInboundClaimTypeMap = new Dictionary<string, string>(ClaimTypeMapping.InboundClaimTypeMap);
 
         /// <summary>
         /// Default value for the flag that determines whether or not the InboundClaimTypeMap is used.

--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -15,8 +15,8 @@ namespace Microsoft.IdentityModel.Tokens
     public class CryptoProviderFactory
     {
         private static CryptoProviderFactory _default;
-        private static ConcurrentDictionary<string, string> _typeToAlgorithmMap = new ConcurrentDictionary<string, string>();
-        private static object _cacheLock = new object();
+        private static readonly ConcurrentDictionary<string, string> _typeToAlgorithmMap = new ConcurrentDictionary<string, string>();
+        private static readonly object _cacheLock = new object();
         private static int _defaultSignatureProviderObjectPoolCacheSize = Environment.ProcessorCount * 4;
         private int _signatureProviderObjectPoolCacheSize = _defaultSignatureProviderObjectPoolCacheSize;
 

--- a/src/Microsoft.IdentityModel.Tokens/Encryption/SymmetricKeyWrapProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/SymmetricKeyWrapProvider.cs
@@ -15,8 +15,8 @@ namespace Microsoft.IdentityModel.Tokens
         private static readonly byte[] _defaultIV = new byte[] { 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6 };
         private const int _blockSizeInBits = 64;
         private const int _blockSizeInBytes = _blockSizeInBits >> 3;
-        private static object _encryptorLock = new object();
-        private static object _decryptorLock = new object();
+        private static readonly object _encryptorLock = new object();
+        private static readonly object _decryptorLock = new object();
 
         private Lazy<SymmetricAlgorithm> _symmetricAlgorithm;
         private ICryptoTransform _symmetricAlgorithmEncryptor;

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -112,7 +112,7 @@ namespace Microsoft.IdentityModel.Tokens
     /// <remarks>The delegate should return a non null string that represents the 'issuer'. If null a default value will be used.
     /// <see cref="IssuerValidatorAsync"/> if set, will be called before <see cref="IssuerSigningKeyValidatorUsingConfiguration"/> or <see cref="IssuerSigningKeyValidator"/>
     /// </remarks>
-    internal delegate Task<string> IssuerValidatorAsync(string issuer, SecurityToken securityToken, TokenValidationParameters validationParameters);
+    internal delegate ValueTask<string> IssuerValidatorAsync(string issuer, SecurityToken securityToken, TokenValidationParameters validationParameters);
 
     /// <summary>
     /// Definition for LifetimeValidator.

--- a/src/Microsoft.IdentityModel.Tokens/Validators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validators.cs
@@ -215,7 +215,10 @@ namespace Microsoft.IdentityModel.Tokens
         /// <remarks>An EXACT match is required.</remarks>
         internal static string ValidateIssuer(string issuer, SecurityToken securityToken, TokenValidationParameters validationParameters, BaseConfiguration configuration)
         {
-            return ValidateIssuerAsync(issuer, securityToken, validationParameters, configuration).GetAwaiter().GetResult();
+            ValueTask<string> vt = ValidateIssuerAsync(issuer, securityToken, validationParameters, configuration);
+            return vt.IsCompletedSuccessfully ?
+                vt.Result :
+                vt.AsTask().GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -232,7 +235,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <exception cref="SecurityTokenInvalidIssuerException">If <see cref="TokenValidationParameters.ValidIssuer"/> is null or whitespace and <see cref="TokenValidationParameters.ValidIssuers"/> is null and <see cref="BaseConfiguration.Issuer"/> is null.</exception>
         /// <exception cref="SecurityTokenInvalidIssuerException">If 'issuer' failed to matched either <see cref="TokenValidationParameters.ValidIssuer"/> or one of <see cref="TokenValidationParameters.ValidIssuers"/> or <see cref="BaseConfiguration.Issuer"/>.</exception>
         /// <remarks>An EXACT match is required.</remarks>
-        internal static async Task<string> ValidateIssuerAsync(
+        internal static async ValueTask<string> ValidateIssuerAsync(
             string issuer,
             SecurityToken securityToken,
             TokenValidationParameters validationParameters,

--- a/src/Microsoft.IdentityModel.Xml/XmlUtil.cs
+++ b/src/Microsoft.IdentityModel.Xml/XmlUtil.cs
@@ -14,7 +14,7 @@ namespace Microsoft.IdentityModel.Xml
     /// </summary>
     public static class XmlUtil
     {
-        private static Dictionary<byte, string> _hexDictionary = new Dictionary<byte, string>
+        private static readonly Dictionary<byte, string> _hexDictionary = new Dictionary<byte, string>
         {
             { 0, "0" },
             { 1, "1" },

--- a/test/Microsoft.IdentityModel.TestUtils/ValidationDelegates.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ValidationDelegates.cs
@@ -87,9 +87,9 @@ namespace Microsoft.IdentityModel.TestUtils
             return issuer;
         }
 
-        public static Task<string> IssuerValidatorAsync(string issuer, SecurityToken token, TokenValidationParameters validationParameters)
+        public static ValueTask<string> IssuerValidatorAsync(string issuer, SecurityToken token, TokenValidationParameters validationParameters)
         {
-            return Task.FromResult(issuer);
+            return new ValueTask<string>(issuer);
         }
 
         public static string IssuerValidatorReturnsDifferentIssuer(string issuer, SecurityToken token, TokenValidationParameters validationParameters)


### PR DESCRIPTION
- JsonWebToken.Audiences can allocate a string[] of exactly the right size, saving on intermediate string[] allocations as well as a List allocation. If empty, it can avoid allocations completely.
- ValidateIssuerAsync can avoid a Task allocation in the common case where it completes synchronously.
- Also make some static fields readonly and change a few types to be concrete classes rather than interfaces; it helps the JIT generate better code.