### PR TITLE
More strongly-type multiple fields and return types

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
@@ -22,10 +22,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
         internal static JsonClaimSet Empty { get; } = new JsonClaimSet("{}"u8.ToArray());
         internal object _claimsLock = new();
-        internal IDictionary<string, object> _jsonClaims;
-        private IList<Claim> _claims;
+        internal readonly Dictionary<string, object> _jsonClaims;
+        private List<Claim> _claims;
 
-        internal JsonClaimSet(IDictionary<string, object> jsonClaims)
+        internal JsonClaimSet(Dictionary<string, object> jsonClaims)
         {
             _jsonClaims = jsonClaims;
         }
@@ -34,7 +34,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             _jsonClaims = JwtTokenUtilities.CreateClaimsDictionary(jsonUtf8Bytes, jsonUtf8Bytes.Length);
         }
 
-        internal IList<Claim> Claims(string issuer)
+        internal List<Claim> Claims(string issuer)
         {
             if (_claims == null)
                 lock (_claimsLock)
@@ -43,16 +43,16 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             return _claims;
         }
 
-        internal IList<Claim> CreateClaims(string issuer)
+        internal List<Claim> CreateClaims(string issuer)
         {
-            IList<Claim> claims = new List<Claim>();
+            var claims = new List<Claim>();
             foreach (KeyValuePair<string, object> kvp in _jsonClaims)
                 CreateClaimFromObject(claims, kvp.Key, kvp.Value, issuer);
 
             return claims;
         }
 
-        internal static void CreateClaimFromObject(IList<Claim> claims, string claimType, object value, string issuer)
+        internal static void CreateClaimFromObject(List<Claim> claims, string claimType, object value, string issuer)
         {
             // Json.net recognized DateTime by default.
             if (value is string str)

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -533,7 +533,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         // We need a shared model for adding claims from object for JsonWebToken and JwtSecurityToken
         // From getting ClaimValueTypes to setting object types
 
-        internal static IDictionary<string, object> CreateClaimsDictionary(byte[] bytes, int length)
+        internal static Dictionary<string, object> CreateClaimsDictionary(byte[] bytes, int length)
         {
             Dictionary<string, object> claims = new();
             Span<byte> utf8Span = bytes;
@@ -575,9 +575,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <param name="startIndex"></param>
         /// <param name="length"></param>
         /// <returns></returns>
-        internal static IDictionary<string,object> ParseJsonBytes(string rawString, int startIndex, int length)
+        internal static Dictionary<string,object> ParseJsonBytes(string rawString, int startIndex, int length)
         {
-            return Base64UrlEncoding.Decode<IDictionary<string,object>>(rawString, startIndex, length, CreateClaimsDictionary);
+            return Base64UrlEncoding.Decode(rawString, startIndex, length, CreateClaimsDictionary);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectProtocolValidator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
     /// </summary>
     public class OpenIdConnectProtocolValidator
     {
-        private IDictionary<string, string> _hashAlgorithmMap =
+        private readonly Dictionary<string, string> _hashAlgorithmMap =
             new Dictionary<string, string>
             {
                 { SecurityAlgorithms.EcdsaSha256, "SHA256" },

--- a/src/Microsoft.IdentityModel.Protocols/AuthenticationProtocolMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols/AuthenticationProtocolMessage.cs
@@ -20,7 +20,7 @@ namespace Microsoft.IdentityModel.Protocols
         private string _scriptButtonText = "Submit";
         private string _scriptDisabledText = "Script is disabled. Click Submit to continue.";
 
-        private IDictionary<string, string> _parameters = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> _parameters = new Dictionary<string, string>();
         private string _issuerAddress = string.Empty;
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Evidence.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2Evidence.cs
@@ -18,9 +18,9 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
     /// </remarks>
     public class Saml2Evidence
     {
-        private ICollection<Saml2Id> _assertionIdReferences = new List<Saml2Id>();
-        private ICollection<Saml2Assertion> _assertions = new List<Saml2Assertion>();
-        private AbsoluteUriCollection _assertionUriReferences = new AbsoluteUriCollection();
+        private readonly List<Saml2Id> _assertionIdReferences = new List<Saml2Id>();
+        private readonly List<Saml2Assertion> _assertions = new List<Saml2Assertion>();
+        private readonly AbsoluteUriCollection _assertionUriReferences = new AbsoluteUriCollection();
 
         /// <summary>
         /// Initializes a new instance of <see cref="Saml2Evidence"/> class.

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -16,9 +16,8 @@ namespace Microsoft.IdentityModel.Tokens
         private DisposableObjectPool<AsymmetricAdapter> _asymmetricAdapterObjectPool;
         private CryptoProviderFactory _cryptoProviderFactory;
         private bool _disposed;
-        private Lazy<bool> _keySizeIsValid;
-        private IReadOnlyDictionary<string, int> _minimumAsymmetricKeySizeInBitsForSigningMap;
-        private IReadOnlyDictionary<string, int> _minimumAsymmetricKeySizeInBitsForVerifyingMap;
+        private Dictionary<string, int> _minimumAsymmetricKeySizeInBitsForSigningMap;
+        private Dictionary<string, int> _minimumAsymmetricKeySizeInBitsForVerifyingMap;
 
         /// <summary>
         /// Mapping from algorithm to minimum <see cref="AsymmetricSecurityKey"/>.KeySize when creating signatures.
@@ -131,7 +130,6 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10634, LogHelper.MarkAsNonPII((algorithm)), key)));
 
             WillCreateSignatures = willCreateSignatures;
-            _keySizeIsValid = new Lazy<bool>(ValidKeySize);
             _asymmetricAdapterObjectPool = new DisposableObjectPool<AsymmetricAdapter>(CreateAsymmetricAdapter, _cryptoProviderFactory.SignatureProviderObjectPoolCacheSize);
         }
 

--- a/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
@@ -94,7 +94,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets all valid last known good configurations.
         /// </summary>
         /// <returns>A collection of all valid last known good configurations.</returns>
-        internal ICollection<BaseConfiguration> GetValidLkgConfigurations()
+        internal BaseConfiguration[] GetValidLkgConfigurations()
         {
             return _lastKnownGoodConfigurationCache.ToArray().Where(x => x.Value.Value > DateTime.UtcNow).Select(x => x.Key).ToArray();
         }

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKey.cs
@@ -19,9 +19,9 @@ namespace Microsoft.IdentityModel.Tokens
     {
         internal const string ClassName = "Microsoft.IdentityModel.Tokens.JsonWebKey";
         private Dictionary<string, object> _additionalData;
-        private IList<string> _keyOps;
-        private IList<string> _oth;
-        private IList<string> _x5c;
+        private List<string> _keyOps;
+        private List<string> _oth;
+        private List<string> _x5c;
         private string _kid;
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
@@ -19,7 +19,7 @@ namespace Microsoft.IdentityModel.Tokens
     public class JsonWebKeySet
     {
         internal const string ClassName = "Microsoft.IdentityModel.Tokens.JsonWebKeySet";
-        private IDictionary<string, object> _additionalData;
+        private Dictionary<string, object> _additionalData;
 
         /// <summary>
         /// Returns a new instance of <see cref="JsonWebKeySet"/>.

--- a/src/Microsoft.IdentityModel.Tokens/TokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenUtilities.cs
@@ -41,7 +41,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         /// <param name="claims"> A list of claims.</param>
         /// <returns> A Dictionary representing claims.</returns>
-        internal static IDictionary<string, object> CreateDictionaryFromClaims(IEnumerable<Claim> claims)
+        internal static Dictionary<string, object> CreateDictionaryFromClaims(IEnumerable<Claim> claims)
         {
             var payload = new Dictionary<string, object>();
 

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationResult.cs
@@ -35,8 +35,8 @@ namespace Microsoft.IdentityModel.Tokens
         private volatile bool _claimsIdentityInitialized;
         private object _claimsIdentitySyncObj;
         private ClaimsIdentity _claimsIdentity;
-        private IDictionary<string, object> _claims;
-        private IDictionary<string, object> _propertyBag;
+        private Dictionary<string, object> _claims;
+        private Dictionary<string, object> _propertyBag;
 
         /// <summary>
         /// Creates an instance of <see cref="TokenValidationResult"/>

--- a/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
@@ -663,7 +663,7 @@ namespace System.IdentityModel.Tokens.Jwt
 #pragma warning restore CS0162 // Unreachable code detected
         }
 
-        internal IList<string> GetIListClaims(string claimType)
+        internal List<string> GetIListClaims(string claimType)
         {
             List<string> claimValues = new List<string>();
 

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -32,7 +32,7 @@ namespace System.IdentityModel.Tokens.Jwt
         private const string _namespace = "http://schemas.xmlsoap.org/ws/2005/05/identity/claimproperties";
         private const string _className = "System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler";
         private IDictionary<string, string> _outboundClaimTypeMap;
-        private IDictionary<string, string> _outboundAlgorithmMap = null;
+        private Dictionary<string, string> _outboundAlgorithmMap = null;
         private static string _shortClaimType = _namespace + "/ShortTypeName";
         private bool _mapInboundClaims = DefaultMapInboundClaims;
 
@@ -741,7 +741,7 @@ namespace System.IdentityModel.Tokens.Jwt
             }
         }
 
-        private IDictionary<string, object> OutboundClaimTypeTransform(IDictionary<string, object> claimCollection)
+        private Dictionary<string, object> OutboundClaimTypeTransform(IDictionary<string, object> claimCollection)
         {
             var claims = new Dictionary<string, object>();
 

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -443,19 +443,19 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             configWithSameKidDiffKeyMaterial.SigningKeys.Add(new SymmetricSecurityKey(KeyingMaterial.DefaultSymmetricSecurityKey_128.Key) { KeyId = KeyingMaterial.DefaultSymmetricSecurityKey_256.KeyId });
 
             var configurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(config, config);
-            IdentityComparer.AreEqual(configurationManager.GetValidLkgConfigurations().Count, 1, context);
+            IdentityComparer.AreEqual(configurationManager.GetValidLkgConfigurations().Length, 1, context);
 
             configurationManager.LastKnownGoodConfiguration = configWithSameKeysDiffOrder;
-            IdentityComparer.AreEqual(configurationManager.GetValidLkgConfigurations().Count, 1, context);
+            IdentityComparer.AreEqual(configurationManager.GetValidLkgConfigurations().Length, 1, context);
 
             configurationManager.LastKnownGoodConfiguration = configWithOverlappingKey;
-            IdentityComparer.AreEqual(configurationManager.GetValidLkgConfigurations().Count, 2, context);
+            IdentityComparer.AreEqual(configurationManager.GetValidLkgConfigurations().Length, 2, context);
 
             configurationManager.LastKnownGoodConfiguration = configWithOverlappingKeyDiffissuer;
-            IdentityComparer.AreEqual(configurationManager.GetValidLkgConfigurations().Count, 3, context);
+            IdentityComparer.AreEqual(configurationManager.GetValidLkgConfigurations().Length, 3, context);
 
             configurationManager.LastKnownGoodConfiguration = configWithSameKidDiffKeyMaterial;
-            IdentityComparer.AreEqual(configurationManager.GetValidLkgConfigurations().Count, 4, context);
+            IdentityComparer.AreEqual(configurationManager.GetValidLkgConfigurations().Length, 4, context);
 
             TestUtilities.AssertFailIfErrors(context);
         }


### PR DESCRIPTION
Some of these, like JsonClaimSet._jsonClaims, help to avoid allocation by ensuring that when the collection is enumerated, we're using its struct enumerator. In other cases, like with CreateClaimFromObject, we reduce the overhead of calls to the object.  And other cases are just good hygiene.