### PR TITLE
Adding support for some standard types when calling JsonWebToken.TryGetPayloadValue<T>

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -614,10 +614,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             {
                 if (_audiences == null)
                 {
-                    var tmp = Payload.TryGetValue(JwtRegisteredClaimNames.Aud, out IList<string> audiences) ?
-                        (audiences is string[] audiencesArray ? audiencesArray : audiences.ToArray()) :
-                        Array.Empty<string>();
-
+                    string[] tmp = Payload.TryGetValue(JwtRegisteredClaimNames.Aud, out string[] audiences) ? audiences : Array.Empty<string>();
                     Interlocked.CompareExchange(ref _audiences, tmp, null);
                 }
 

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -830,21 +830,21 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             if (httpRequestUri == null)
                 throw LogHelper.LogArgumentNullException(nameof(httpRequestUri));
 
-            if (!signedHttpRequest.TryGetPayloadValue(SignedHttpRequestClaimTypes.Q, out IList<object> qClaim) || qClaim == null)
+            if (!signedHttpRequest.TryGetPayloadValue(SignedHttpRequestClaimTypes.Q, out List<object> qClaim) || qClaim == null)
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidQClaimException(LogHelper.FormatInvariant(LogMessages.IDX23003, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.Q))));
 
             httpRequestUri = EnsureAbsoluteUri(httpRequestUri);
             var sanitizedQueryParams = SanitizeQueryParams(httpRequestUri);
             string qClaimBase64UrlEncodedHash = string.Empty;
             string calculatedBase64UrlEncodedHash = string.Empty;
-            IList<object> qClaimQueryParamNames;
+            object[] qClaimQueryParamNames;
 
             try
             {
                 // "q": [["queryParamName1", "queryParamName2",... "queryParamNameN"], "base64UrlEncodedHashValue"]]
-                // deserialzed as IList<object> with q[0] is an IList<obj>, q[1] an object
+                // deserialzed as List<object> with q[0] is an List<obj>, q[1] an object
                 qClaimBase64UrlEncodedHash = (string)qClaim[1];
-                qClaimQueryParamNames = qClaim[0] as IList<object>;
+                qClaimQueryParamNames = qClaim[0] as object[];
             }
             catch (Exception e)
             {
@@ -900,20 +900,20 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// </remarks>
         internal virtual void ValidateHClaim(JsonWebToken signedHttpRequest, SignedHttpRequestValidationContext signedHttpRequestValidationContext)
         {
-            if (!signedHttpRequest.TryGetPayloadValue(SignedHttpRequestClaimTypes.H, out IList<object> hClaim) || hClaim == null)
+            if (!signedHttpRequest.TryGetPayloadValue(SignedHttpRequestClaimTypes.H, out List<object> hClaim) || hClaim == null)
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidHClaimException(LogHelper.FormatInvariant(LogMessages.IDX23003, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.H))));
 
             var sanitizedHeaders = SanitizeHeaders(signedHttpRequestValidationContext.HttpRequestData.Headers);
 
             string hClaimBase64UrlEncodedHash = string.Empty;
             string calculatedBase64UrlEncodedHash = string.Empty;
-            IList<object> hClaimHeaderNames;
+            object[] hClaimHeaderNames;
             try
             {
                 // "h": [["headerName1", "headerName2",... "headerNameN"], "base64UrlEncodedHashValue"]]
-                // deserialzed as IList<object> with h[0] is an IList<obj>, h[1] an object
+                // deserialzed as List<object> with h[0] is an List<obj>, h[1] an object
                 hClaimBase64UrlEncodedHash = (string)hClaim[1];
-                hClaimHeaderNames = hClaim[0] as IList<object>;
+                hClaimHeaderNames = hClaim[0] as object[];
             }
             catch (Exception e)
             {

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -257,6 +257,8 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX11020 = "IDX11020: The JSON value of type: '{0}', could not be converted to '{1}'. Reading: '{2}.{3}', Position: '{4}', CurrentDepth: '{5}', BytesConsumed: '{6}'.";
         public const string IDX11022 = "IDX11022: Expecting json reader to be positioned on '{0}', reader was positioned at: '{1}', Reading: '{2}.{3}', Position: '{4}', CurrentDepth: '{5}', BytesConsumed: '{6}'.";
         public const string IDX11023 = "IDX11023: Expecting json reader to be positioned on '{0}', reader was positioned at: '{1}', Reading: '{2}', Position: '{3}', CurrentDepth: '{4}', BytesConsumed: '{5}'.";
+        public const string IDX11024 = "IDX11024: Cannot create object of type: '{0}' from Json: '{1}'.";
+
 #pragma warning restore 1591
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -257,7 +257,9 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX11020 = "IDX11020: The JSON value of type: '{0}', could not be converted to '{1}'. Reading: '{2}.{3}', Position: '{4}', CurrentDepth: '{5}', BytesConsumed: '{6}'.";
         public const string IDX11022 = "IDX11022: Expecting json reader to be positioned on '{0}', reader was positioned at: '{1}', Reading: '{2}.{3}', Position: '{4}', CurrentDepth: '{5}', BytesConsumed: '{6}'.";
         public const string IDX11023 = "IDX11023: Expecting json reader to be positioned on '{0}', reader was positioned at: '{1}', Reading: '{2}', Position: '{3}', CurrentDepth: '{4}', BytesConsumed: '{5}'.";
-        public const string IDX11024 = "IDX11024: Cannot create object of type: '{0}' from Json: '{1}'.";
+        public const string IDX11025 = "IDX11025: Cannot serialize object of type: '{0}' into property: '{1}'.";
+        public const string IDX11027 = "IDX11027: Cannot create return type: '{0}' from JsonElement.ValueType: '{1}'.";
+        public const string IDX11028 = "IDX11028: '{0}', could not be converted to '{1}'.";
 
 #pragma warning restore 1591
     }

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/GetPayloadValueTheoryData.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/GetPayloadValueTheoryData.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.IdentityModel.JsonWebTokens.Tests
+{
+    public class GetPayloadValueTheoryData : TheoryDataBase
+    {
+        public GetPayloadValueTheoryData(string testId) : base(testId)
+        { }
+
+        public SecurityTokenDescriptor SecurityTokenDescriptor { get; set; }
+
+        public string PropertyName { get; set; }
+
+        public Type PropertyOut { get; set; }
+
+        public Type PropertyType { get; set; }
+
+        public object PropertyValue { get; set; }
+    }
+}

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
@@ -240,7 +240,25 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             var theoryData = new TheoryData<JsonClaimSetTheoryData>();
 
             string header = Base64UrlEncoder.Encode("{}");
-            string payload = Base64UrlEncoder.Encode(@"{""a"":{""prop1"":""value1""},""exp"": 1692706803,""iat"": 1692703203,""nbf"": 1692703203}");
+            string payload = Base64UrlEncoder.Encode(@"{""a"":{""prop1"":""value1""},""b"":{""prop1"":[""value1"",""value2""]}, ""exp"": 1692706803,""iat"": 1692703203,""nbf"": 1692703203}");
+
+            theoryData.Add(
+                new JsonClaimSetTheoryData("DictionaryWithListOfStrings")
+                {
+                    Json = header + "." + payload + ".",
+                    PropertyName = "b",
+                    PropertyType = typeof(Dictionary<string, List<string>>),
+                    PropertyValue = new Dictionary<string, List<string>> { { "prop1", new List<string> { "value1", "value2" } } }
+                });
+
+            theoryData.Add(
+                new JsonClaimSetTheoryData("DictionaryWithArrayOfStrings")
+                {
+                    Json = header + "." + payload + ".",
+                    PropertyName = "b",
+                    PropertyType = typeof(Dictionary<string, string[]>),
+                    PropertyValue = new Dictionary<string, string[]> {{"prop1", new string[]{"value1","value2"}}}
+                });
 
             theoryData.Add(
                 new JsonClaimSetTheoryData("DictionaryOfStrings")
@@ -250,6 +268,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     PropertyType = typeof(Dictionary<string, string>),
                     PropertyValue = new Dictionary<string, string> {{"prop1","value1"}}
                 });
+
 
             return theoryData;
         }
@@ -268,7 +287,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             IdentityComparer.AreEqual(true, success, context);
 
             success = token.TryGetPayloadValue("array", out object[] array);
-            IdentityComparer.AreEqual(new object[] { 1L, "2", 3L }, array, context);
+            IdentityComparer.AreEqual(new object[] { 1, "2", 3 }, array, context);
             IdentityComparer.AreEqual(true, success, context);
 
             success = token.TryGetPayloadValue("string", out string name);
@@ -276,15 +295,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             IdentityComparer.AreEqual(true, success, context);
 
             success = token.TryGetPayloadValue("float", out float floatingPoint);
-            IdentityComparer.AreEqual(42.0, floatingPoint, context);
+            IdentityComparer.AreEqual((float)42.0, floatingPoint, context);
             IdentityComparer.AreEqual(true, success, context);
 
             success = token.TryGetPayloadValue("integer", out int integer);
             IdentityComparer.AreEqual(42, integer, context);
             IdentityComparer.AreEqual(true, success, context);
-
-            success = token.TryGetPayloadValue("nill", out bool b);
-            IdentityComparer.AreEqual(false, success, context);
 
             success = token.TryGetPayloadValue("nill", out bool? bb);
             if (bb != null)

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestTestUtils.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestTestUtils.cs
@@ -205,7 +205,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             if (token.ContainsKey(newProperty.Name))
                 token.Property(newProperty.Name).Remove();
 
-            if (newProperty.Value != null)
+            if (newProperty.Value.Type != JTokenType.Null)
                 token.Add(newProperty);
 
             return CreateDefaultSignedHttpRequestToken(token.ToString(Formatting.None));

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonSerializerPrimitivesTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonSerializerPrimitivesTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                 theoryData.Add(
                     new JsonSerializerTheoryData("Dictionary<string,object>Level3")
                     {
-                        Json = $@"{{""key"":{{""l1_1"":1,""l1_2"":""level1"",""l2_dict"":{{""l2_1"":1,""l2_2"":""level2"",""l3_dict"":""System.Collections.Generic.Dictionary`2[System.String,System.Object]""}}}}}}",
+                        Json = $@"{{""key"":{{""l1_1"":1,""l1_2"":""level1"",""l2_dict"":{{""l2_1"":1,""l2_2"":""level2"",""l3_dict"":{{""l3_1"":1,""l3_2"":""level3""}}}}}}}}",
                         PropertyName = "key",
                         Object = new Dictionary<string, object> { { "l1_1", 1 }, { "l1_2", "level1" },
                                         { "l2_dict", new Dictionary<string, object> { { "l2_1", 1 }, { "l2_2", "level2" },
@@ -108,29 +108,29 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                     });
 
                 theoryData.Add(
-                    new JsonSerializerTheoryData("List<object>Level3")
+                    new JsonSerializerTheoryData("List<object>Level1")
                     {
-                        Json = $@"{{""key"":[1,""string"",1.23,[3,""stringLevel2"",6.52,""System.Collections.Generic.List`1[System.Object]""]]}}",
+                        Json = @$"{{""key"":[1,""stringLevel1"",1.11]}}",
                         PropertyName = "key",
-                        Object = new List<object> { 1, "string", 1.23,
-                                    new List<object> { 3, "stringLevel2", 6.52,
-                                        new List<object> { 3, "stringLevel2", 6.52 } } }
+                        Object = new List<object> { 1, "stringLevel1", 1.11 },
                     });
 
                 theoryData.Add(
                     new JsonSerializerTheoryData("List<object>Level2")
                     {
-                        Json = @$"{{""key"":[1,""string"",1.23,[3,""stringLevel2"",6.52]]}}",
+                        Json = @$"{{""key"":[1,""string"",1.11,[2,""stringLevel2"",2.22]]}}",
                         PropertyName = "key",
-                        Object = new List<object> { 1, "string", 1.23, new List<object> { 3, "stringLevel2", 6.52 } },
+                        Object = new List<object> { 1, "string", 1.11, new List<object> { 2, "stringLevel2", 2.22 } },
                     });
 
                 theoryData.Add(
-                    new JsonSerializerTheoryData("List<object>Level1")
+                    new JsonSerializerTheoryData("List<object>Level3")
                     {
-                        Json = @$"{{""key"":[1,""string"",1.23]}}",
+                        Json = $@"{{""key"":[1,""string"",1.11,[2,""stringLevel2"",2.22,[3,""stringLevel3"",3.33]]]}}",
                         PropertyName = "key",
-                        Object = new List<object> { 1, "string", 1.23 },
+                        Object = new List<object> { 1, "string", 1.11,
+                                                    new List<object> { 2, "stringLevel2", 2.22,
+                                                        new List<object> { 3, "stringLevel3", 3.33 } } }
                     });
 
                 return theoryData;

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonUtilities.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonUtilities.cs
@@ -137,7 +137,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
             SetAdditionalDataNumbers(dictionary);
             SetAdditionalDataValues(dictionary);
             dictionary["Object"] = CreateJsonElement(_objectData);
-            dictionary["Array"] = _arrayDataAsObjectList;
+            dictionary["Array"] = CreateJsonElement(_arrayData);
             if (key != null)
                 dictionary[key] = obj;
         }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JweUsingEchdTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JweUsingEchdTests.cs
@@ -274,7 +274,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             testData.AdditionalHeaderParams = new Dictionary<string, object>();
             testData.AdditionalHeaderParams.Add(JsonWebTokens.JwtHeaderParameterNames.Apu, testData.ApuSender);
             testData.AdditionalHeaderParams.Add(JsonWebTokens.JwtHeaderParameterNames.Apv, testData.ApvSender);
-            testData.AdditionalHeaderParams.Add(JsonWebTokens.JwtHeaderParameterNames.Epk, epkJObject);
+            testData.AdditionalHeaderParams.Add(JsonWebTokens.JwtHeaderParameterNames.Epk, epkJObject.ToString(Newtonsoft.Json.Formatting.None));
 
             return testData;
         }


### PR DESCRIPTION
Added to the support 'T' that were available in 6x.
If possible, Json will be mapped to one of the following types:
string[], List<string>,,Collection<string>, object[], List<object>, Collection<object>, int[], long[]
Dictionary<string, string>>, Dictionary<string, string[]>, Dictionary<string, List<string>>, Dictionary<string, Collection<string>>
Dictionary<string, object>, Dictionary<string, object[]>

With this change 7 will not be as general as 6x but will help with common scenarios.
A general solution will require a new api.

When calling TryGetPayloadValue<T> the priority is generally:
sting, string[], List<string>, Collection<string>, ...

Type.IsAssignable is used in a couple of places which helps in writing as this improves the types that can be written.
If this violates AOT, then we will have to reduce the scope of what can be written.

=================================
Pattern matching is applied when possible.
Json = {“p”:[1,2,3]}
TryGetPayLoadValue<string[]>(“p”) => string[]{“1”,”2”,”3”}

Json = {“p”:”value”}
TryGetPayLoadValue<string[]>(“p”) => string[]{“value”}

Json = {“p”:{”object”:”value”}}
TryGetPayLoadValue<string>(“p”) => “{“object”:”value”}”
This will always return a value if it was the property exists.

=====================================
We still write obj.ToString() when serializing, even if we don't understand the type, as users that are working with Newtosoft.JObject will benefit. We are open to changing this depending on feedback.

