### PR TITLE
Support serialization for common scenarios

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
@@ -197,23 +197,25 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 else
                     return default;
 
-            // When the JsonClaimSet is created JsonArray and JsonObject are stored as JsonElement's
-            if (obj is JsonElement jsonElement)
-                return (T)JsonSerializerPrimitives.CreateTypeFromJsonElement<T>(jsonElement);
-
-            // the below here should only be simple types, string, int, ...
             Type objType = obj.GetType();
-
             if (typeof(T) == objType)
                 return (T)(obj);
 
             if (typeof(T) == typeof(object))
                 return (T)obj;
 
-            if (typeof(T) == typeof(string))
+            // When the JsonClaimSet is created JsonArray and JsonObject are stored as JsonElement's
+            if (obj is JsonElement jsonElement)
+            {
+                if (JsonSerializerPrimitives.TryCreateTypeFromJsonElement<T>(jsonElement, out T t))
+                    return t;
+            }
+            // the below here should only be simple types, string, int, ...
+            else if (typeof(T) == typeof(string))
+            {
                 return (T)((object)obj.ToString());
-
-            if (typeof(T) == typeof(int))
+            }
+            else if (typeof(T) == typeof(int))
             {
                 if (objType == typeof(int))
                     return (T)obj;
@@ -232,24 +234,21 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 if (long.TryParse(obj.ToString(), out long value))
                     return (T)(object)value;
             }
-
-            if (typeof(T) == typeof(string[]))
+            else if (typeof(T) == typeof(string[]))
             {
                 if (objType == typeof(string))
                     return (T)(object)new string[] { (string)obj };
 
                 return (T)(object)new string[] { obj.ToString() };
             }
-
-            if (typeof(T) == typeof(List<string>))
+            else if (typeof(T) == typeof(List<string>))
             {
                 if (objType == typeof(string))
                     return (T)(object)new List<string> { (string)obj };
 
                 return (T)(object)new List<string> { obj.ToString() };
             }
-
-            if (typeof(T) == typeof(Collection<string>))
+            else if (typeof(T) == typeof(Collection<string>))
             {
                 if (objType == typeof(string))
                     return (T)(object)new Collection<string> { (string)obj };
@@ -257,16 +256,16 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 return (T)(object)new Collection<string> { obj.ToString() };
             }
 
-            if (typeof(T) == typeof(object[]))
+            else if (typeof(T) == typeof(object[]))
                 return (T)(object)new object[] { obj };
 
-            if (typeof(T) == typeof(List<object>))
+            else if (typeof(T) == typeof(List<object>))
                 return (T)(object)new List<object> { obj };
 
-            if (typeof(T) == typeof(Collection<object>))
+            else if (typeof(T) == typeof(Collection<object>))
                 return (T)(object)new Collection<object> { obj };
 
-            if (typeof(T) == typeof(DateTime))
+            else if (typeof(T) == typeof(DateTime))
             {
                 if (objType == typeof(DateTime))
                     return (T)obj;
@@ -328,9 +327,23 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
             found = false;
             if (throwEx)
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14305, key, typeof(T), objType, obj.ToString())));
+                throw LogHelper.LogExceptionMessage(
+                    new ArgumentException(
+                        LogHelper.FormatInvariant(
+                            LogMessages.IDX14305,
+                            LogHelper.MarkAsNonPII(key),
+                            LogHelper.MarkAsNonPII(typeof(T)),
+                            LogHelper.MarkAsNonPII(objType),
+                            obj.ToString())));
             else
-                LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14305, key, typeof(T), objType, obj.ToString())));
+                LogHelper.LogExceptionMessage(
+                    new ArgumentException(
+                        LogHelper.FormatInvariant(
+                            LogMessages.IDX14305,
+                            LogHelper.MarkAsNonPII(key),
+                            LogHelper.MarkAsNonPII(typeof(T)),
+                            LogHelper.MarkAsNonPII(objType),
+                            obj.ToString())));
 
             return default;
         }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Json;
 
 namespace Microsoft.IdentityModel.JsonWebTokens
 {
@@ -20,18 +22,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens
     {
         internal const string ClassName = "Microsoft.IdentityModel.JsonWebTokens.JsonClaimSet";
 
-        internal static JsonClaimSet Empty { get; } = new JsonClaimSet("{}"u8.ToArray());
         internal object _claimsLock = new();
         internal readonly Dictionary<string, object> _jsonClaims;
         private List<Claim> _claims;
 
+        internal JsonClaimSet() { _jsonClaims = new Dictionary<string, object>(); }
+
         internal JsonClaimSet(Dictionary<string, object> jsonClaims)
         {
             _jsonClaims = jsonClaims;
-        }
-        internal JsonClaimSet(byte[] jsonUtf8Bytes)
-        {
-            _jsonClaims = JwtTokenUtilities.CreateClaimsDictionary(jsonUtf8Bytes, jsonUtf8Bytes.Length);
         }
 
         internal List<Claim> Claims(string issuer)
@@ -96,94 +95,45 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 }
         }
 
-        internal static Claim CreateClaimFromJsonElement(string claimType, string issuer, JsonElement value)
+        internal static Claim CreateClaimFromJsonElement(string claimType, string issuer, JsonElement jsonElement)
         {
             // Json.net recognized DateTime by default.
-            if (value.ValueKind == JsonValueKind.String)
+            if (jsonElement.ValueKind == JsonValueKind.String)
             {
-                string claimValue = value.ToString();
+                string claimValue = jsonElement.ToString();
                 return new Claim(claimType, claimValue, JwtTokenUtilities.GetStringClaimValueType(claimValue), issuer, issuer);
             }
-            else if (value.ValueKind == JsonValueKind.Null)
+            else if (jsonElement.ValueKind == JsonValueKind.Null)
                 return new Claim(claimType, string.Empty, JsonClaimValueTypes.JsonNull, issuer, issuer);
-            else if (value.ValueKind == JsonValueKind.Object)
-                return new Claim(claimType, value.ToString(), JsonClaimValueTypes.Json, issuer, issuer);
-            else if (value.ValueKind == JsonValueKind.False)
+            else if (jsonElement.ValueKind == JsonValueKind.Object)
+                return new Claim(claimType, jsonElement.ToString(), JsonClaimValueTypes.Json, issuer, issuer);
+            else if (jsonElement.ValueKind == JsonValueKind.False)
                 return new Claim(claimType, "False", ClaimValueTypes.Boolean, issuer, issuer);
-            else if (value.ValueKind == JsonValueKind.True)
+            else if (jsonElement.ValueKind == JsonValueKind.True)
                 return new Claim(claimType, "True", ClaimValueTypes.Boolean, issuer, issuer);
-            else if (value.ValueKind == JsonValueKind.Number)
+            else if (jsonElement.ValueKind == JsonValueKind.Number)
             {
-                if (value.TryGetInt32(out int i))
-                    return new Claim(claimType, i.ToString(CultureInfo.InvariantCulture), ClaimValueTypes.Integer, issuer, issuer);
-                else if (value.TryGetInt64(out long l))
+                if (jsonElement.TryGetInt32(out int i))
+                    return new Claim(claimType, i.ToString(CultureInfo.InvariantCulture), ClaimValueTypes.Integer32, issuer, issuer);
+                else if (jsonElement.TryGetInt64(out long l))
                     return new Claim(claimType, l.ToString(CultureInfo.InvariantCulture), ClaimValueTypes.Integer64, issuer, issuer);
-                else if (value.TryGetUInt32(out uint u))
-                    return new Claim(claimType, u.ToString(CultureInfo.InvariantCulture), ClaimValueTypes.UInteger32, issuer, issuer);
-                else if (value.TryGetDouble(out double d))
+                else if (jsonElement.TryGetDouble(out double d))
                     return new Claim(claimType, d.ToString(CultureInfo.InvariantCulture), ClaimValueTypes.Double, issuer, issuer);
-                else if (value.TryGetDecimal(out decimal m))
-                    return new Claim(claimType, m.ToString(CultureInfo.InvariantCulture), ClaimValueTypes.Double, issuer, issuer);
-                else if (value.TryGetUInt64(out ulong ul))
+                else if (jsonElement.TryGetUInt32(out uint u))
+                    return new Claim(claimType, u.ToString(CultureInfo.InvariantCulture), ClaimValueTypes.UInteger32, issuer, issuer);
+                else if (jsonElement.TryGetUInt64(out ulong ul))
                     return new Claim(claimType, ul.ToString(CultureInfo.InvariantCulture), ClaimValueTypes.UInteger64, issuer, issuer);
+                else if (jsonElement.TryGetSingle(out float f))
+                    return new Claim(claimType, f.ToString(CultureInfo.InvariantCulture), ClaimValueTypes.Double, issuer, issuer);
+                else if (jsonElement.TryGetDecimal(out decimal m))
+                    return new Claim(claimType, m.ToString(CultureInfo.InvariantCulture), ClaimValueTypes.Double, issuer, issuer);
             }
-            else if (value.ValueKind == JsonValueKind.Array)
+            else if (jsonElement.ValueKind == JsonValueKind.Array)
             {
-                return new Claim(claimType, value.ToString(), JsonClaimValueTypes.JsonArray, issuer, issuer);
+                return new Claim(claimType, jsonElement.ToString(), JsonClaimValueTypes.JsonArray, issuer, issuer);
             }
 
             return null;
-        }
-
-        internal static object CreateObjectFromJsonElement(JsonElement jsonElement)
-        {
-            if (jsonElement.ValueKind == JsonValueKind.Array)
-            {
-                int numberOfElements = 0;
-                // is this an array of properties
-                foreach (JsonElement element in jsonElement.EnumerateArray())
-                    numberOfElements++;
-
-                object[] objects = new object[numberOfElements];
-
-                int index = 0;
-                foreach (JsonElement element in jsonElement.EnumerateArray())
-                    objects[index++] = CreateObjectFromJsonElement(element);
-
-                return (object)objects;
-            }
-            else if (jsonElement.ValueKind == JsonValueKind.String)
-            {
-                if (DateTime.TryParse(jsonElement.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime dateTime))
-                    return (object)dateTime;
-
-                return jsonElement.GetString();
-            }
-            else if (jsonElement.ValueKind == JsonValueKind.Null)
-                return (object)null;
-            else if (jsonElement.ValueKind == JsonValueKind.Object)
-                return jsonElement.ToString();
-            else if (jsonElement.ValueKind == JsonValueKind.False)
-                return (object)false;
-            else if (jsonElement.ValueKind == JsonValueKind.True)
-                return (object)true;
-            else if (jsonElement.ValueKind == JsonValueKind.Number)
-            {
-                if (jsonElement.TryGetInt64(out long longValue))
-                    return longValue;
-                else if (jsonElement.TryGetInt32(out int intValue))
-                    return intValue;
-                else if (jsonElement.TryGetDecimal(out decimal decimalValue))
-                    return decimalValue;
-                else if (jsonElement.TryGetDouble(out double doubleValue))
-                    return doubleValue;
-                else if (jsonElement.TryGetUInt32(out uint uintValue))
-                    return uintValue;
-                else if (jsonElement.TryGetUInt64(out ulong ulongValue))
-                    return ulongValue;
-            }
-
-            return jsonElement.GetString();
         }
 
         internal Claim GetClaim(string key, string issuer)
@@ -211,16 +161,16 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
         internal DateTime GetDateTime(string key)
         {
-            if (!_jsonClaims.TryGetValue(key, out object value))
-                return DateTime.MinValue;
+            long l = GetValue<long>(key, false, out bool found);
+            if (found)
+                return EpochTime.DateTime(l);
 
-            return EpochTime.DateTime(Convert.ToInt64(Math.Truncate((double)GetValueAsLong(key, value))));
+            return DateTime.MinValue;
         }
 
         internal T GetValue<T>(string key)
         {
-            T retval = GetValue<T>(key, true, out bool _);
-            return retval;
+            return GetValue<T>(key, true, out bool _);
         }
 
         /// <summary>
@@ -231,7 +181,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
-        /// <param name="throwEx"></param>
+        /// <param name="throwEx">if this is called from TryGetValue then we don't want to throw.</param>
         /// <param name="found"></param>
         /// <returns></returns>
         internal T GetValue<T>(string key, bool throwEx, out bool found)
@@ -239,24 +189,19 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             found = _jsonClaims.TryGetValue(key, out object obj);
 
             if (!found)
-            {
-                if (throwEx)
-                    throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14304, key)));
-                else
-                    return default;
-            }
+                return throwEx ? throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14304, key))) : default;
 
             if (obj == null)
                 if (typeof(T) == typeof(object) || typeof(T).IsClass || Nullable.GetUnderlyingType(typeof(T)) != null)
-                {
                     return (T)(object)null;
-                }
                 else
-                {
-                    found = false;
                     return default;
-                }
 
+            // When the JsonClaimSet is created JsonArray and JsonObject are stored as JsonElement's
+            if (obj is JsonElement jsonElement)
+                return (T)JsonSerializerPrimitives.CreateTypeFromJsonElement<T>(jsonElement);
+
+            // the below here should only be simple types, string, int, ...
             Type objType = obj.GetType();
 
             if (typeof(T) == objType)
@@ -268,109 +213,124 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (typeof(T) == typeof(string))
                 return (T)((object)obj.ToString());
 
-            if (typeof(T) == typeof(IList<string>))
+            if (typeof(T) == typeof(int))
             {
-                if (obj is IList iList)
-                {
-                    string[] arr = new string[iList.Count];
-                    for (int arri = 0; arri < arr.Length; arri++)
-                    {
-                        arr[arri] = iList[arri]?.ToString();
-                    }
+                if (objType == typeof(int))
+                    return (T)obj;
 
-                    return (T)(object)arr;
-                }
-                else
-                {
-                    return (T)(object)new string[1] { obj.ToString() };
-                }
+                if (int.TryParse(obj.ToString(), out int value))
+                    return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(long))
+            {
+                if (objType == typeof(long))
+                    return (T)obj;
+
+                if (objType == typeof(int))
+                    return (T)(object)(long)(int)obj;
+
+                if (long.TryParse(obj.ToString(), out long value))
+                    return (T)(object)value;
             }
 
-            if (typeof(T) == typeof(int) && int.TryParse(obj.ToString(), out int i))
-                return (T)(object)i;
-
-            if (typeof(T) == typeof(long) && long.TryParse(obj.ToString(), out long l))
-                return (T)(object)l;
-
-            if (typeof(T) == typeof(double) && double.TryParse(obj.ToString(), out double d))
-                return (T)(object)d;
-
-            if (typeof(T) == typeof(DateTime) && DateTime.TryParse(obj.ToString(), out DateTime dt))
-                return (T)(object)dt;
-
-            if (typeof(T) == typeof(uint) && uint.TryParse(obj.ToString(), out uint u))
-                return (T)(object)u;
-
-            if (typeof(T) == typeof(float) && float.TryParse(obj.ToString(), out float f))
-                return (T)(object)f;
-
-            if (typeof(T) == typeof(decimal) && decimal.TryParse(obj.ToString(), out decimal m))
-                return (T)(object)m;
-
-            if (typeof(T) == typeof(IList<object>))
+            if (typeof(T) == typeof(string[]))
             {
-                if (obj is IList items)
-                {
-                    object[] arr = new object[items.Count];
-                    for (int arri = 0; arri < arr.Length; arri++)
-                    {
-                        arr[arri] = items[arri];
-                    }
+                if (objType == typeof(string))
+                    return (T)(object)new string[] { (string)obj };
 
-                    return (T)(object)arr;
-                }
-                else
-                {
-                    return (T)(object)new object[1] { obj };
-                }
+                return (T)(object)new string[] { obj.ToString() };
             }
 
-            if (typeof(T) == typeof(int[]))
+            if (typeof(T) == typeof(List<string>))
             {
-                int[] ints;
-                if (obj is IList ilist)
-                {
-                    ints = new int[ilist.Count];
-                    int index = 0;
-                    foreach (object item in ilist)
-                    {
-                        if (typeof(int) == item.GetType())
-                            ints[index++] = (int)item;
-                    }
+                if (objType == typeof(string))
+                    return (T)(object)new List<string> { (string)obj };
 
-                    // all items must be int
-                    if (index == ilist.Count)
-                        return (T)(object)(int[])ints;
-                }
-                else if (objType == typeof(int))
-                {
-                    ints = new int[]{(int)obj};
-                    return (T)(object)(int[])ints;
-                }
+                return (T)(object)new List<string> { obj.ToString() };
+            }
+
+            if (typeof(T) == typeof(Collection<string>))
+            {
+                if (objType == typeof(string))
+                    return (T)(object)new Collection<string> { (string)obj };
+
+                return (T)(object)new Collection<string> { obj.ToString() };
             }
 
             if (typeof(T) == typeof(object[]))
+                return (T)(object)new object[] { obj };
+
+            if (typeof(T) == typeof(List<object>))
+                return (T)(object)new List<object> { obj };
+
+            if (typeof(T) == typeof(Collection<object>))
+                return (T)(object)new Collection<object> { obj };
+
+            if (typeof(T) == typeof(DateTime))
             {
-                object[] objects;
-                if (obj is IList ilist)
-                {
-                    objects = new object[ilist.Count];
-                    int index = 0;
-                    foreach (object item in ilist)
-                        objects[index++] = item;
-                }
-                else
-                {
-                    objects = new object[] { obj };
-                }
+                if (objType == typeof(DateTime))
+                    return (T)obj;
 
-                return (T)(object)(object[])objects;
+                if (DateTime.TryParse(obj.ToString(), out DateTime value))
+                    return (T)(object)value;
             }
+            else if (typeof(T) == typeof(int[]))
+            {
+                if (objType == typeof(int))
+                    return (T)(object)new int[] { (int)obj };
 
+                if (int.TryParse(obj.ToString(), out int value))
+                    return (T)(object)new int[] { value };
+            }
+            else if (typeof(T) == typeof(long[]))
+            {
+                if (objType == typeof(long))
+                    return (T)(object)new long[] { (long)obj };
+
+                if(objType == typeof(int))
+                    return (T)(object)new long[] { (int)obj };
+
+                if (long.TryParse(obj.ToString(), out long value))
+                    return (T)(object)new long[] { value };
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                if (objType == typeof(double))
+                    return (T)obj;
+
+                if(double.TryParse(obj.ToString(), out double value))
+                    return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(uint))
+            {
+                if (objType == typeof(uint))
+                    return (T)obj;
+
+                if (uint.TryParse(obj.ToString(), out uint value))
+                    return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(float))
+            {
+                if (objType == typeof(float))
+                    return (T)obj;
+
+                if (float.TryParse(obj.ToString(), out float value))
+                    return (T)(object)value;
+            }
+            else if (typeof(T) == typeof(decimal))
+            {
+                if (objType == typeof(decimal))
+                    return (T)obj;
+
+                if (decimal.TryParse(obj.ToString(), out decimal value))
+                    return (T)(object)value;
+            }
 
             found = false;
             if (throwEx)
                 throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14305, key, typeof(T), objType, obj.ToString())));
+            else
+                LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14305, key, typeof(T), objType, obj.ToString())));
 
             return default;
         }
@@ -410,50 +370,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         internal bool HasClaim(string claimName)
         {
             return _jsonClaims.TryGetValue(claimName, out _);
-        }
-
-        private static long GetValueAsLong(string claimName, object obj)
-        {
-            if (obj is int i)
-                return (long)i;
-
-            if (obj is long)
-                return (long)(obj);
-
-            if (obj is double d)
-                return (long)d;
-
-            if (obj is uint u)
-                return (long)u;
-
-            if (obj is float f)
-                return (long)f;
-
-            if (obj is decimal m)
-                return (long) m;
-
-            if (obj is string str)
-            {
-                if (int.TryParse(str, out int ii))
-                    return (long)ii;
-
-                if (long.TryParse(str, out long l))
-                    return l;
-
-                if (double.TryParse(str, out double dd))
-                    return (long)dd;
-
-                if (uint.TryParse(str, out uint uu))
-                    return (long)uu;
-
-                if (float.TryParse(str, out float ff))
-                    return (long)ff;
-
-                if (decimal.TryParse(str, out decimal mm))
-                    return (long)mm;
-            }
-
-            throw LogHelper.LogExceptionMessage(new FormatException(LogHelper.FormatInvariant(LogMessages.IDX14300, claimName, obj?.ToString(), typeof(long))));
         }
     }
 }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonWebToken.HeaderClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonWebToken.HeaderClaimSet.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.Tokens.Json;
+
+namespace Microsoft.IdentityModel.JsonWebTokens
+{
+    public partial class JsonWebToken
+    {
+        internal JsonClaimSet CreateHeaderClaimSet(byte[] bytes)
+        {
+            return CreateHeaderClaimSet(bytes, bytes.Length);
+        }
+
+        internal JsonClaimSet CreateHeaderClaimSet(byte[] bytes, int length)
+        {
+            Utf8JsonReader reader = new(bytes.AsSpan().Slice(0, length));
+            if (!JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartObject, false))
+                throw LogHelper.LogExceptionMessage(
+                    new JsonException(
+                        LogHelper.FormatInvariant(
+                        Tokens.LogMessages.IDX11023,
+                        LogHelper.MarkAsNonPII("JsonTokenType.StartObject"),
+                        LogHelper.MarkAsNonPII(reader.TokenType),
+                        LogHelper.MarkAsNonPII(ClassName),
+                        LogHelper.MarkAsNonPII(reader.TokenStartIndex),
+                        LogHelper.MarkAsNonPII(reader.CurrentDepth),
+                        LogHelper.MarkAsNonPII(reader.BytesConsumed))));
+
+            Dictionary<string, object> claims = new();
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (reader.ValueTextEquals(JwtHeaderUtf8Bytes.Alg))
+                    {
+                        _alg = JsonSerializerPrimitives.ReadString(ref reader, JwtHeaderParameterNames.Alg, ClassName, true);
+                        claims[JwtHeaderParameterNames.Alg] = _alg;
+                    }
+                    else if (reader.ValueTextEquals(JwtHeaderUtf8Bytes.Cty))
+                    {
+                        _cty = JsonSerializerPrimitives.ReadString(ref reader, JwtHeaderParameterNames.Cty, ClassName, true);
+                        claims[JwtHeaderParameterNames.Cty] = _cty;
+                    }
+                    else if (reader.ValueTextEquals(JwtHeaderUtf8Bytes.Kid))
+                    {
+                        _kid = JsonSerializerPrimitives.ReadString(ref reader, JwtHeaderParameterNames.Kid, ClassName, true);
+                        claims[JwtHeaderParameterNames.Kid] = _kid;
+                    }
+                    else if (reader.ValueTextEquals(JwtHeaderUtf8Bytes.Typ))
+                    {
+                        _typ = JsonSerializerPrimitives.ReadString(ref reader, JwtHeaderParameterNames.Typ, ClassName, true);
+                        claims[JwtHeaderParameterNames.Typ] = _typ;
+                    }
+                    else if (reader.ValueTextEquals(JwtHeaderUtf8Bytes.X5t))
+                    {
+                        _x5t = JsonSerializerPrimitives.ReadString(ref reader, JwtHeaderParameterNames.X5t, ClassName, true);
+                        claims[JwtHeaderParameterNames.X5t] = _x5t;
+                    }
+                    else if (reader.ValueTextEquals(JwtHeaderUtf8Bytes.Zip))
+                    {
+                        _zip = JsonSerializerPrimitives.ReadString(ref reader, JwtHeaderParameterNames.Zip, ClassName, true);
+                        claims[JwtHeaderParameterNames.Zip] = _zip;
+                    }
+                    else
+                    {
+                        string propertyName = reader.GetString();
+                        claims[propertyName] = JsonSerializerPrimitives.ReadPropertyValueAsObject(ref reader, propertyName, JsonClaimSet.ClassName, true);
+                    }
+                }
+                else if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    break;
+                }
+            };
+
+            return new JsonClaimSet(claims);
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonWebToken.PayloadClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonWebToken.PayloadClaimSet.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Json;
+
+namespace Microsoft.IdentityModel.JsonWebTokens
+{
+    public partial class JsonWebToken
+    {
+        internal JsonClaimSet CreatePayloadClaimSet(byte[] bytes, int length)
+        {
+            Utf8JsonReader reader = new(bytes.AsSpan().Slice(0, length));
+            if (!JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartObject, false))
+                throw LogHelper.LogExceptionMessage(
+                    new JsonException(
+                        LogHelper.FormatInvariant(
+                        Tokens.LogMessages.IDX11023,
+                        LogHelper.MarkAsNonPII("JsonTokenType.StartObject"),
+                        LogHelper.MarkAsNonPII(reader.TokenType),
+                        LogHelper.MarkAsNonPII(ClassName),
+                        LogHelper.MarkAsNonPII(reader.TokenStartIndex),
+                        LogHelper.MarkAsNonPII(reader.CurrentDepth),
+                        LogHelper.MarkAsNonPII(reader.BytesConsumed))));
+
+            Dictionary<string, object> claims = new();
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Aud))
+                    {
+                        _audiences = new List<string>();
+                        reader.Read();
+                        if (reader.TokenType == JsonTokenType.StartArray)
+                        {
+                            JsonSerializerPrimitives.ReadStrings(ref reader, _audiences, JwtRegisteredClaimNames.Aud, ClassName, false);
+                            claims[JwtRegisteredClaimNames.Aud] = _audiences;
+                        }
+                        else
+                        {
+                            _audiences.Add(JsonSerializerPrimitives.ReadString(ref reader, JwtRegisteredClaimNames.Aud, ClassName, false));
+                            claims[JwtRegisteredClaimNames.Aud] = _audiences;
+                        }
+                    }
+                    else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Azp))
+                    {
+                        _azp = JsonSerializerPrimitives.ReadString(ref reader, JwtRegisteredClaimNames.Azp, ClassName, true);
+                        claims[JwtRegisteredClaimNames.Azp] = _azp;
+                    }
+                    else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Exp))
+                    {
+                        _exp = JsonSerializerPrimitives.ReadLong(ref reader, JwtRegisteredClaimNames.Exp, ClassName, true);
+                        _expDateTime = EpochTime.DateTime(_exp.Value);
+                        claims[JwtRegisteredClaimNames.Exp] = _exp;
+                    }
+                    else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Iat))
+                    {
+                        _iat = JsonSerializerPrimitives.ReadLong(ref reader, JwtRegisteredClaimNames.Iat, ClassName, true);
+                        _iatDateTime = EpochTime.DateTime(_iat.Value);
+                        claims[JwtRegisteredClaimNames.Iat] = _iat;
+                    }
+                    else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Iss))
+                    {
+                        _iss = JsonSerializerPrimitives.ReadString(ref reader, JwtRegisteredClaimNames.Iss, ClassName, true);
+                        claims[JwtRegisteredClaimNames.Iss] = _iss;
+                    }
+                    else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Jti))
+                    {
+                        _jti = JsonSerializerPrimitives.ReadString(ref reader, JwtRegisteredClaimNames.Jti, ClassName, true);
+                        claims[JwtRegisteredClaimNames.Jti] = _jti;
+                    }
+                    else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Nbf))
+                    {
+                        _nbf = JsonSerializerPrimitives.ReadLong(ref reader, JwtRegisteredClaimNames.Nbf, ClassName, true);
+                        _nbfDateTime = EpochTime.DateTime(_nbf.Value);
+                        claims[JwtRegisteredClaimNames.Nbf] = _nbf;
+                    }
+                    else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Sub))
+                    {
+                        _sub = JsonSerializerPrimitives.ReadString(ref reader, JwtRegisteredClaimNames.Sub, ClassName, true);
+                        claims[JwtRegisteredClaimNames.Sub] = _sub;
+                    }
+                    else
+                    {
+                        string propertyName = reader.GetString();
+                        claims[propertyName] = JsonSerializerPrimitives.ReadPropertyValueAsObject(ref reader, propertyName, JsonClaimSet.ClassName, true);
+                    }
+                }
+                else if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    break;
+                }
+            };
+
+            return new JsonClaimSet(claims);
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Security.Claims;
 using System.Text;
 using System.Threading;
@@ -16,35 +14,50 @@ namespace Microsoft.IdentityModel.JsonWebTokens
     /// <summary>
     /// A <see cref="SecurityToken"/> designed for representing a JSON Web Token (JWT). 
     /// </summary>
-    public class JsonWebToken : SecurityToken
+    public partial class JsonWebToken : SecurityToken
     {
+        internal const string ClassName = "Microsoft.IdentityModel.JsonWebTokens.JsonWebToken";
+
         private ClaimsIdentity _claimsIdentity;
         private bool _wasClaimsIdentitySet;
 
-        // When System.Text.Json reads a value from the JsonDocument a new string will be created.
-        // Some of the common values are cached in local variables.
         private string _act;
-        private string _alg;
-        private string[] _audiences;
         private string _authenticationTag;
         private string _ciphertext;
-        private string _cty;
-        private string _enc;
         private string _encodedHeader;
         private string _encodedPayload;
         private string _encodedSignature;
         private string _encryptedKey;
-        private DateTime? _iat;
-        private string _id;
         private string _initializationVector;
-        private string _iss;
-        private string _kid;
-        private string _sub;
-        private string _typ;
-        private DateTime? _validFrom;
-        private DateTime? _validTo;
-        private string _x5t;
-        private string _zip;
+        private List<string> _audiences;
+
+        #region properties relating to the header
+        // when constructing a JWT, these properties, when found, will be set
+        internal string _alg;
+        internal string _cty;
+        internal string _enc;
+        internal string _kid;
+        internal string _typ;
+        internal string _x5t;
+        internal string _zip;
+        #endregion
+
+        #region properties relating to the payload
+        // when constructing a JWT, these properties, when found, will be set
+        internal string _azp;
+        internal long? _exp;
+        internal DateTime? _expDateTime;
+        internal long? _iat;
+        internal DateTime? _iatDateTime;
+        internal string _id;
+        internal string _iss;
+        internal string _jti;
+        internal string _sub;
+        internal long? _nbf;
+        internal DateTime? _nbfDateTime;
+        internal DateTime? _validFrom;
+        internal DateTime? _validTo;
+        #endregion
 
         /// <summary>
         /// Initializes a new instance of <see cref="JsonWebToken"/> from a string in JWS or JWE Compact serialized format.
@@ -116,9 +129,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             get
             {
-                if (_authenticationTag == null)
-                    _authenticationTag = AuthenticationTagBytes == null ? string.Empty : UTF8Encoding.UTF8.GetString(AuthenticationTagBytes);
-
+                _authenticationTag ??= AuthenticationTagBytes == null ? string.Empty : UTF8Encoding.UTF8.GetString(AuthenticationTagBytes);
                 return _authenticationTag;
             }
         }
@@ -146,9 +157,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             get
             {
-                if (_ciphertext == null)
-                    _ciphertext = CipherTextBytes == null ? string.Empty : UTF8Encoding.UTF8.GetString(CipherTextBytes);
-
+                _ciphertext ??= CipherTextBytes == null ? string.Empty : UTF8Encoding.UTF8.GetString(CipherTextBytes);
                 return _ciphertext;
             }
         }
@@ -160,61 +169,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             get;
             set;
-        }
-
-        internal ClaimsIdentity ClaimsIdentity
-        {
-            get
-            {
-                if (!_wasClaimsIdentitySet)
-                {
-                    _wasClaimsIdentitySet = true;
-                    string actualIssuer = ActualIssuer ?? Issuer;
-
-                    foreach (Claim claim in Claims)
-                    {
-                        string claimType = claim.Type;
-                        if (claimType == ClaimTypes.Actor)
-                        {
-                            if (_claimsIdentity.Actor != null)
-                                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX14112, LogHelper.MarkAsNonPII(JwtRegisteredClaimNames.Actort), claim.Value)));
-
-#pragma warning disable CA1031 // Do not catch general exception types
-                            try
-                            {
-                                JsonWebToken actorToken = new JsonWebToken(claim.Value);
-                                _claimsIdentity.Actor = ActorClaimsIdentity;
-                            }
-                            catch
-                            {
-
-                            }
-#pragma warning restore CA1031 // Do not catch general exception types
-                        }
-
-                        if (claim.Properties.Count == 0)
-                        {
-                            _claimsIdentity.AddClaim(new Claim(claimType, claim.Value, claim.ValueType, actualIssuer, actualIssuer, _claimsIdentity));
-                        }
-                        else
-                        {
-                            Claim newClaim = new Claim(claimType, claim.Value, claim.ValueType, actualIssuer, actualIssuer, _claimsIdentity);
-
-                            foreach (var kv in claim.Properties)
-                                newClaim.Properties[kv.Key] = kv.Value;
-
-                            _claimsIdentity.AddClaim(newClaim);
-                        }
-                    }
-                }
-
-                return _claimsIdentity;
-            }
-
-            set
-            {
-                _claimsIdentity = value;
-            }
         }
 
         internal int Dot1 { get; set; }
@@ -324,11 +278,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </remarks>
         public string EncodedToken { get; private set; }
 
-        internal bool HasPayloadClaim(string claimName)
-        {
-            return Payload.HasClaim(claimName);
-        }
-
         internal JsonClaimSet Header { get; set; }
 
         internal byte[] HeaderAsciiBytes { get; set; }
@@ -404,7 +353,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <exception cref="SecurityTokenMalformedException">if <paramref name="encodedJson"/> is malformed, a valid JWT should have either 2 dots (JWS) or 4 dots (JWE).</exception>
         /// <exception cref="SecurityTokenMalformedException">if <paramref name="encodedJson"/> does not have an non-empty authentication tag after the 4th dot for a JWE.</exception>
         /// <exception cref="SecurityTokenMalformedException">if <paramref name="encodedJson"/> has more than 4 dots.</exception>
-        private void ReadToken(string encodedJson)
+        internal void ReadToken(string encodedJson)
         {
             // JWT must have 2 dots
             Dot1 = encodedJson.IndexOf('.');
@@ -429,7 +378,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 IsSigned = !(Dot2 + 1 == encodedJson.Length);
                 try
                 {
-                    Header = new JsonClaimSet(JwtTokenUtilities.ParseJsonBytes(encodedJson, 0, Dot1));
+                    Header = CreateClaimSet(encodedJson, 0, Dot1, CreateHeaderClaimSet);
                 }
                 catch (Exception ex)
                 {
@@ -438,7 +387,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
                 try
                 {
-                    Payload = new JsonClaimSet(JwtTokenUtilities.ParseJsonBytes(encodedJson, Dot1 + 1, Dot2 - Dot1 - 1));
+                    Payload = CreateClaimSet(encodedJson, Dot1 + 1, Dot2 - Dot1 - 1, CreatePayloadClaimSet);
                 }
                 catch (Exception ex)
                 {
@@ -450,7 +399,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 // JWE: https://www.rfc-editor.org/rfc/rfc7516
                 // Format: https://www.rfc-editor.org/rfc/rfc7516#page-8
                 // empty payload for JWE's {encrypted tokens}.
-                Payload = JsonClaimSet.Empty;
+                Payload = new JsonClaimSet();
 
                 if (Dot3 == encodedJson.Length)
                     throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX14121, encodedJson)));
@@ -493,7 +442,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
                 try
                 {
-                    Header = new JsonClaimSet(Base64UrlEncoder.UnsafeDecode(hChars));
+                    Header = CreateHeaderClaimSet(Base64UrlEncoder.UnsafeDecode(hChars));
                 }
                 catch (Exception ex)
                 {
@@ -555,76 +504,24 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             EncodedToken = encodedJson;
         }
 
+        internal static JsonClaimSet CreateClaimSet(string rawString, int startIndex, int length, Func<byte[], int, JsonClaimSet> action)
+        {
+            return Base64UrlEncoding.Decode(rawString, startIndex, length, action);
+        }
+
+        /// <summary>
+        /// Returns the encoded token without signature or authentication tag.
+        /// </summary>
+        /// <returns>Encoded token string without signature or authentication tag.</returns>
+        public override string ToString()
+        {
+            return EncodedToken.Substring(0, EncodedToken.LastIndexOf("."));
+        }
+
         /// <inheritdoc/>
         public override string UnsafeToString() => EncodedToken;
 
-        #region Claims
-        /// <summary>
-        /// Gets the 'value' of the 'actort' claim the payload.
-        /// </summary>
-        /// <remarks>
-        /// If the 'actort' claim is not found, an empty string is returned.
-        /// </remarks>
-        public string Actor
-        {
-            get
-            {
-                if (_act == null)
-                    _act = Payload.GetStringValue(JwtRegisteredClaimNames.Actort);
-
-                return _act;
-            }
-        }
-
-        /// <summary>
-        /// Gets the 'value' of the 'alg' claim from the header.
-        /// </summary>
-        /// <remarks>
-        /// Identifies the cryptographic algorithm used to encrypt or determine the value of the Content Encryption Key.
-        /// Applicable to an encrypted JWT {JWE}.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4-1-1
-        /// <para>
-        /// If the 'alg' claim is not found, an empty string is returned.
-        /// </para>
-        /// </remarks>
-        public string Alg
-        {
-            get
-            {
-                if (_alg == null)
-                    _alg = Header.GetStringValue(JwtHeaderParameterNames.Alg);
-
-                return _alg;
-            }
-        }
-
-        /// <summary>
-        /// Gets the list of 'aud' claims from the payload.
-        /// </summary>
-        /// <remarks>
-        /// Identifies the recipients that the JWT is intended for.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4-1-3
-        /// <para>
-        /// If the 'aud' claim is not found, enumeration will be empty.
-        /// </para>
-        /// </remarks>
-        public IEnumerable<string> Audiences
-        {
-            get
-            {
-                if (_audiences == null)
-                {
-                    var tmp = Payload.TryGetValue(JwtRegisteredClaimNames.Aud, out IList<string> audiences) ?
-                        (audiences is string[] audiencesArray ? audiencesArray : audiences.ToArray()) :
-                        Array.Empty<string>();
-
-                    Interlocked.CompareExchange(ref _audiences, tmp, null);
-                }
-
-                return _audiences;
-            }
-        }
-
+        #region System.Security.Claims.Claim methods
         /// <summary>
         /// Gets a <see cref="IEnumerable{Claim}"/> where each claim in the JWT { name, value } is returned as a <see cref="Claim"/>.
         /// </summary>
@@ -641,47 +538,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         }
 
         /// <summary>
-        /// Gets the 'value' of the 'cty' claim from the header.
-        /// </summary>
-        /// <remarks>
-        /// Used by JWS applications to declare the media type[IANA.MediaTypes] of the secured content (the payload).
-        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.12 (JWE)
-        /// see: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.10 (JWS)
-        /// <para>
-        /// If the 'cty' claim is not found, an empty string is returned.
-        /// </para>
-        /// </remarks>
-        public string Cty
-        {
-            get
-            {
-                if (_cty == null)
-                    _cty = Header.GetStringValue(JwtHeaderParameterNames.Cty);
-
-                return _cty;
-            }
-        }
-
-        /// <summary>
-        /// Gets the 'value' of the 'enc' claim from the header.
-        /// </summary>
-        /// <remarks>
-        /// Identifies the content encryption algorithm used to perform authenticated encryption
-        /// on the plaintext to produce the ciphertext and the Authentication Tag.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.2
-        /// </remarks>
-        public string Enc
-        {
-            get
-            {
-                if (_enc == null)
-                    _enc = Header.GetStringValue(JwtHeaderParameterNames.Enc);
-
-                return _enc;
-            }
-        }
-
-        /// <summary>
         /// Gets a <see cref="Claim"/> representing the { key, 'value' } pair corresponding to the provided <paramref name="key"/>.
         /// </summary>
         /// <remarks>
@@ -694,6 +550,82 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         public Claim GetClaim(string key)
         {
             return Payload.GetClaim(key, Issuer ?? ClaimsIdentity.DefaultIssuer);
+        }
+
+        internal ClaimsIdentity ClaimsIdentity
+        {
+            get
+            {
+                if (!_wasClaimsIdentitySet)
+                {
+                    _wasClaimsIdentitySet = true;
+                    string actualIssuer = ActualIssuer ?? Issuer;
+
+                    foreach (Claim claim in Claims)
+                    {
+                        string claimType = claim.Type;
+                        if (claimType == ClaimTypes.Actor)
+                        {
+                            if (_claimsIdentity.Actor != null)
+                                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX14112, LogHelper.MarkAsNonPII(JwtRegisteredClaimNames.Actort), claim.Value)));
+
+#pragma warning disable CA1031 // Do not catch general exception types
+                            try
+                            {
+                                JsonWebToken actorToken = new JsonWebToken(claim.Value);
+                                _claimsIdentity.Actor = ActorClaimsIdentity;
+                            }
+                            catch
+                            {
+
+                            }
+#pragma warning restore CA1031 // Do not catch general exception types
+                        }
+
+                        if (claim.Properties.Count == 0)
+                        {
+                            _claimsIdentity.AddClaim(new Claim(claimType, claim.Value, claim.ValueType, actualIssuer, actualIssuer, _claimsIdentity));
+                        }
+                        else
+                        {
+                            Claim newClaim = new Claim(claimType, claim.Value, claim.ValueType, actualIssuer, actualIssuer, _claimsIdentity);
+
+                            foreach (var kv in claim.Properties)
+                                newClaim.Properties[kv.Key] = kv.Value;
+
+                            _claimsIdentity.AddClaim(newClaim);
+                        }
+                    }
+                }
+
+                return _claimsIdentity;
+            }
+
+            set
+            {
+                _claimsIdentity = value;
+            }
+        }
+
+        /// <summary>
+        /// Try to get a <see cref="Claim"/> representing the { key, 'value' } pair corresponding to the provided <paramref name="key"/>.
+        /// The value is obtained from the Payload.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="Claim"/> requires each value to be represented as a string. If the value was not a string, then <see cref="Claim.Type"/> contains the json type.
+        /// <see cref="JsonClaimValueTypes"/> and <see cref="ClaimValueTypes"/> to determine the json type.
+        /// </remarks>
+        /// <returns>true if successful, false otherwise.</returns>
+        public bool TryGetClaim(string key, out Claim value)
+        {
+            return Payload.TryGetClaim(key, Issuer ?? ClaimsIdentity.DefaultIssuer, out value);
+        }
+        #endregion
+
+        #region Get Claims from the JWT Header and Payload
+        internal bool HasPayloadClaim(string claimName)
+        {
+            return Payload.HasClaim(claimName);
         }
 
         /// <summary>
@@ -736,139 +668,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         }
 
         /// <summary>
-        /// Gets the 'value' of the 'jti' claim from the payload.
+        /// Tries to get the claim from the JWT payload.
         /// </summary>
         /// <remarks>
-        /// Provides a unique identifier for the JWT.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7
-        /// <para>
-        /// If the 'jti' claim is not found, an empty string is returned.
-        /// </para>
-        /// </remarks>
-        public override string Id
-        {
-            get
-            {
-                if (_id == null)
-                    _id = Payload.GetStringValue(JwtRegisteredClaimNames.Jti);
-
-                return _id;
-            }
-        }
-
-        /// <summary>
-        /// Gets the 'value' of the 'iat' claim converted to a <see cref="DateTime"/> from the payload.
-        /// </summary>
-        /// <remarks>
-        /// Identifies the time at which the JWT was issued.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6
-        /// <para>
-        /// If the 'iat' claim is not found, then <see cref="DateTime.MinValue"/> is returned.
-        /// </para>
-        /// </remarks>
-        public DateTime IssuedAt
-        {
-            get
-            {
-                if (_iat == null)
-                    _iat = Payload.GetDateTime(JwtRegisteredClaimNames.Iat);
-
-                return _iat.Value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the 'value' of the 'iss' claim from the payload.
-        /// </summary>
-        /// <remarks>
-        /// Identifies the principal that issued the JWT.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1
-        /// <para>
-        /// If the 'iss' claim is not found, an empty string is returned.
-        /// </para>
-        /// </remarks>
-        public override string Issuer
-        {
-            get
-            {
-                if (_iss == null)
-                    _iss = Payload.GetStringValue(JwtRegisteredClaimNames.Iss);
-
-                return _iss;
-            }
-        }
-
-        /// <summary>
-        /// Gets the 'value' of the 'kid' claim from the header.
-        /// </summary>
-        /// <remarks>
-        /// 'kid'is a hint indicating which key was used to secure the JWS.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4 (JWS)
-        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.6 (JWE)
-        /// <para>
-        /// If the 'kid' claim is not found, an empty string is returned.
-        /// </para>
-        /// </remarks>
-        public string Kid
-        {
-            get
-            {
-                if (_kid == null)
-                    _kid = Header.GetStringValue(JwtHeaderParameterNames.Kid);
-
-                return _kid;
-            }
-        }
-
-        /// <summary>
-        /// Gets the 'value' of the 'sub' claim from the payload.
-        /// </summary>
-        /// <remarks>
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2
-        /// Identifies the principal that is the subject of the JWT.
-        /// <para>
-        /// If the 'sub' claim is not found, an empty string is returned.
-        /// </para>
-        /// </remarks>
-        public string Subject
-        {
-            get
-            {
-                if (_sub == null)
-                    _sub = Payload.GetStringValue(JwtRegisteredClaimNames.Sub);
-
-                return _sub;
-            }
-        }
-
-        /// <summary>
-        /// Returns the encoded token without signature or authentication tag.
-        /// </summary>
-        /// <returns>Encoded token string without signature or authentication tag.</returns>
-        public override string ToString()
-        {
-            return EncodedToken.Substring(0, EncodedToken.LastIndexOf("."));
-        }
-
-        /// <summary>
-        /// Try to get a <see cref="Claim"/> representing the { key, 'value' } pair corresponding to the provided <paramref name="key"/>.
-        /// The value is obtained from the Payload.
-        /// </summary>
-        /// <remarks>
-        /// A <see cref="Claim"/> requires each value to be represented as a string. If the value was not a string, then <see cref="Claim.Type"/> contains the json type.
-        /// <see cref="JsonClaimValueTypes"/> and <see cref="ClaimValueTypes"/> to determine the json type.
-        /// </remarks>
-        /// <returns>true if successful, false otherwise.</returns>
-        public bool TryGetClaim(string key, out Claim value)
-        {
-            return Payload.TryGetClaim(key, Issuer ?? ClaimsIdentity.DefaultIssuer, out value);
-        }
-
-        /// <summary>
-        /// Tries to get the value
-        /// </summary>
-        /// <remarks>
-        /// The expectation is that the 'value' corresponds to a type expected in a JWT token.
+        /// The 'value' a type T if possible.
         /// </remarks>
         /// <returns>true if successful, false otherwise.</returns>
         public bool TryGetValue<T>(string key, out T value)
@@ -928,6 +731,85 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
             return Payload.TryGetValue(key, out value);
         }
+        #endregion
+
+        #region Header Properties
+        /// <summary>
+        /// Gets the 'value' of the 'alg' claim from the header.
+        /// </summary>
+        /// <remarks>
+        /// Identifies the cryptographic algorithm used to encrypt or determine the value of the Content Encryption Key.
+        /// Applicable to an encrypted JWT {JWE}.
+        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4-1-1
+        /// <para>
+        /// If the 'alg' claim is not found, an empty string is returned.
+        /// </para>
+        /// </remarks>
+        public string Alg
+        {
+            get
+            {
+                _alg ??= Header.GetStringValue(JwtHeaderParameterNames.Alg);
+                return _alg;
+            }
+        }
+
+        /// <summary>
+        /// Gets the 'value' of the 'cty' claim from the header.
+        /// </summary>
+        /// <remarks>
+        /// Used by JWS applications to declare the media type[IANA.MediaTypes] of the secured content (the payload).
+        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.12 (JWE)
+        /// see: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.10 (JWS)
+        /// <para>
+        /// If the 'cty' claim is not found, an empty string is returned.
+        /// </para>
+        /// </remarks>
+        public string Cty
+        {
+            get
+            {
+                _cty ??= Header.GetStringValue(JwtHeaderParameterNames.Cty);
+                return _cty;
+            }
+        }
+
+        /// <summary>
+        /// Gets the 'value' of the 'enc' claim from the header.
+        /// </summary>
+        /// <remarks>
+        /// Identifies the content encryption algorithm used to perform authenticated encryption
+        /// on the plaintext to produce the ciphertext and the Authentication Tag.
+        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.2
+        /// </remarks>
+        public string Enc
+        {
+            get
+            {
+                _enc ??= Header.GetStringValue(JwtHeaderParameterNames.Enc);
+                return _enc;
+            }
+        }
+
+        /// <summary>
+        /// Gets the 'value' of the 'kid' claim from the header.
+        /// </summary>
+        /// <remarks>
+        /// 'kid'is a hint indicating which key was used to secure the JWS.
+        /// see: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4 (JWS)
+        /// see: https://datatracker.ietf.org/doc/html/rfc7516#section-4.1.6 (JWE)
+        /// <para>
+        /// If the 'kid' claim is not found, an empty string is returned.
+        /// </para>
+        /// </remarks>
+        public string Kid
+        {
+            get
+            {
+                _kid ??= Header.GetStringValue(JwtHeaderParameterNames.Kid);
+                return _kid;
+            }
+        }
 
         /// <summary>
         /// Gets the 'value' of the 'typ' claim from the header.
@@ -943,11 +825,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             get
             {
-                if (_typ == null)
-                    _typ = Header.GetStringValue(JwtHeaderParameterNames.Typ);
-
+                _typ ??= Header.GetStringValue(JwtHeaderParameterNames.Typ);
                 return _typ;
             }
+
+            internal set => _typ = value;
         }
 
         /// <summary>
@@ -964,52 +846,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             get
             {
-                if (_x5t == null)
-                    _x5t = Header.GetStringValue(JwtHeaderParameterNames.X5t);
-
+                _x5t ??= Header.GetStringValue(JwtHeaderParameterNames.X5t);
                 return _x5t;
-            }
-        }
-
-        /// <summary>
-        /// Gets the 'value' of the 'nbf' claim converted to a <see cref="DateTime"/> from the payload.
-        /// </summary>
-        /// <remarks>
-        /// Identifies the time before which the JWT MUST NOT be accepted for processing.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5
-        /// <para>
-        /// If the 'nbf' claim is not found, then <see cref="DateTime.MinValue"/> is returned.
-        /// </para>
-        /// </remarks>
-        public override DateTime ValidFrom
-        {
-            get
-            {
-                if (_validFrom == null)
-                    _validFrom = Payload.GetDateTime(JwtRegisteredClaimNames.Nbf);
-
-                return _validFrom.Value;
-            }
-        }
-
-        /// <summary>
-        /// Gets the 'value' of the 'exp' claim converted to a <see cref="DateTime"/> from the payload.
-        /// </summary>
-        /// <remarks>
-        /// Identifies the expiration time on or after which the JWT MUST NOT be accepted for processing.
-        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
-        /// <para>
-        /// If the 'exp' claim is not found, then <see cref="DateTime.MinValue"/> is returned.
-        /// </para>
-        /// </remarks>
-        public override DateTime ValidTo
-        {
-            get
-            {
-                if (_validTo == null)
-                    _validTo = Payload.GetDateTime(JwtRegisteredClaimNames.Exp);
-
-                return _validTo.Value;
             }
         }
 
@@ -1027,13 +865,199 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             get
             {
-                if (_zip == null)
-                    _zip = Header.GetStringValue(JwtHeaderParameterNames.Zip);
-
+                _zip ??= Header.GetStringValue(JwtHeaderParameterNames.Zip);
                 return _zip;
             }
         }
+        #endregion
 
-#endregion
+        #region Payload Properties
+        /// <summary>
+        /// Gets the 'value' of the 'actort' claim the payload.
+        /// </summary>
+        /// <remarks>
+        /// If the 'actort' claim is not found, an empty string is returned.
+        /// </remarks>
+        public string Actor
+            {
+                get
+                {
+                    _act ??= Payload.GetStringValue(JwtRegisteredClaimNames.Actort);
+                    return _act;
+                }
+            }
+
+        /// <summary>
+        /// Gets the list of 'aud' claims from the payload.
+        /// </summary>
+        /// <remarks>
+        /// Identifies the recipients that the JWT is intended for.
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4-1-3
+        /// <para>
+        /// If the 'aud' claim is not found, enumeration will be empty.
+        /// </para>
+        /// </remarks>
+        public IEnumerable<string> Audiences
+        {
+            get
+            {
+                if (_audiences == null)
+                {
+                    List<string> tmp = TryGetValue(JwtRegisteredClaimNames.Aud, out List<string> audiences) ? audiences : new List<string>();
+                    Interlocked.CompareExchange(ref _audiences, tmp, null);
+                }
+
+                return _audiences;
+            }
+        }
+
+        /// <summary>
+        /// Gets the 'azp' claim from the payload.
+        /// </summary>
+        /// <remarks>
+        /// Identifies the authorized party for the id_token.
+        /// see: https://openid.net/specs/openid-connect-core-1_0.html
+        /// </remarks>
+        public string Azp
+        {
+            get
+            {
+                _azp ??= Payload.GetStringValue(JwtRegisteredClaimNames.Azp);
+                return _azp;
+            }
+        }
+
+        /// <summary>
+        /// Gets the 'value' of the 'iat' claim converted to a <see cref="DateTime"/> from the payload.
+        /// </summary>
+        /// <remarks>
+        /// Identifies the time at which the JWT was issued.
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6
+        /// <para>
+        /// If the 'iat' claim is not found, then <see cref="DateTime.MinValue"/> is returned.
+        /// </para>
+        /// </remarks>
+        public DateTime IssuedAt
+        {
+            get
+            {
+                _iatDateTime ??= Payload.GetDateTime(JwtRegisteredClaimNames.Iat);
+                return _iatDateTime.Value;
+            }
+        }
+
+        /// <summary>
+        /// Gets the 'value' of the 'iss' claim from the payload.
+        /// </summary>
+        /// <remarks>
+        /// Identifies the principal that issued the JWT.
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1
+        /// <para>
+        /// If the 'iss' claim is not found, an empty string is returned.
+        /// </para>
+        /// </remarks>
+        public override string Issuer
+        {
+            get
+            {
+                _iss ??= Payload.GetStringValue(JwtRegisteredClaimNames.Iss);
+                return _iss;
+            }
+        }
+
+        /// <summary>
+        /// Gets the 'value' of the 'jti' claim from the payload.
+        /// </summary>
+        /// <remarks>
+        /// Provides a unique identifier for the JWT.
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7
+        /// <para>
+        /// If the 'jti' claim is not found, an empty string is returned.
+        /// </para>
+        /// </remarks>
+        public override string Id
+        {
+            get
+            {
+                _jti ??= Payload.GetStringValue(JwtRegisteredClaimNames.Jti);
+                return _jti;
+            }
+        }
+
+        /// <summary>
+        /// Gets the 'value' of the 'sub' claim from the payload.
+        /// </summary>
+        /// <remarks>
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2
+        /// Identifies the principal that is the subject of the JWT.
+        /// <para>
+        /// If the 'sub' claim is not found, an empty string is returned.
+        /// </para>
+        /// </remarks>
+        public string Subject
+        {
+            get
+            {
+                _sub ??= Payload.GetStringValue(JwtRegisteredClaimNames.Sub);
+                return _sub;
+            }
+        }
+
+        /// <summary>
+        /// Gets the 'value' of the 'nbf' claim converted to a <see cref="DateTime"/> from the payload.
+        /// </summary>
+        /// <remarks>
+        /// Identifies the time before which the JWT MUST NOT be accepted for processing.
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5
+        /// <para>
+        /// If the 'nbf' claim is not found, then <see cref="DateTime.MinValue"/> is returned.
+        /// </para>
+        /// </remarks>
+        public override DateTime ValidFrom
+        {
+            get
+            {
+                _validFrom ??= Payload.GetDateTime(JwtRegisteredClaimNames.Nbf);
+                return _validFrom.Value;
+            }
+        }
+
+        internal DateTime? ValidFromNullable
+        {
+            get
+            {
+                _validFrom ??= Payload.GetDateTime(JwtRegisteredClaimNames.Nbf);
+                return _validFrom;
+            }
+        }
+
+        /// <summary>
+        /// Gets the 'value' of the 'exp' claim converted to a <see cref="DateTime"/> from the payload.
+        /// </summary>
+        /// <remarks>
+        /// Identifies the expiration time on or after which the JWT MUST NOT be accepted for processing.
+        /// see: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
+        /// <para>
+        /// If the 'exp' claim is not found, then <see cref="DateTime.MinValue"/> is returned.
+        /// </para>
+        /// </remarks>
+        public override DateTime ValidTo
+        {
+            get
+            {
+                _validTo ??= Payload.GetDateTime(JwtRegisteredClaimNames.Exp);
+                return _validTo.Value;
+            }
+        }
+
+        internal DateTime? ValidToNullable
+        {
+            get
+            {
+                _validTo ??= Payload.GetDateTime(JwtRegisteredClaimNames.Exp);
+                return _validTo;
+            }
+        }
+        #endregion
     }
 }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -126,19 +126,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             }
         }
 
-        internal static IDictionary<string, object> AddCtyClaimDefaultValue(IDictionary<string, object> additionalClaims, bool setDefaultCtyClaim)
-        {
-            if (!setDefaultCtyClaim)
-                return additionalClaims;
-
-            if (additionalClaims == null)
-                additionalClaims = new Dictionary<string, object> { { JwtHeaderParameterNames.Cty, JwtConstants.HeaderType } };
-            else if (!additionalClaims.TryGetValue(JwtHeaderParameterNames.Cty, out _))
-                additionalClaims.Add(JwtHeaderParameterNames.Cty, JwtConstants.HeaderType);
-
-            return additionalClaims;
-        }
-
         /// <summary>
         /// Determines if the string is a well formed Json Web Token (JWT).
         /// <para>See: https://datatracker.ietf.org/doc/html/rfc7519 </para>
@@ -1936,15 +1923,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                         jwtToken)));
                 }
 
-                var expires = jwtToken.TryGetClaim(JwtRegisteredClaimNames.Exp, out var _) ? (DateTime?)jwtToken.ValidTo : null;
-                var notBefore = jwtToken.TryGetClaim(JwtRegisteredClaimNames.Nbf, out var _) ? (DateTime?)jwtToken.ValidFrom : null;
-
                 if (!validationParameters.ValidateSignatureLast)
                 {
                     InternalValidators.ValidateAfterSignatureFailed(
                         jwtToken,
-                        notBefore,
-                        expires,
+                        jwtToken.ValidFromNullable,
+                        jwtToken.ValidToNullable,
                         jwtToken.Audiences,
                         validationParameters,
                         configuration);
@@ -1960,43 +1944,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     jwtToken)));
 
             throw LogHelper.LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(TokenLogMessages.IDX10500));
-        }
-
-        /// <summary>
-        /// Obtains a <see cref="SignatureProvider "/> and validates the signature.
-        /// </summary>
-        /// <param name="encodedBytes">Bytes to validate.</param>
-        /// <param name="signature">Signature to compare against.</param>
-        /// <param name="key"><See cref="SecurityKey"/> to use.</param>
-        /// <param name="algorithm">Crypto algorithm to use.</param>
-        /// <param name="securityToken">The <see cref="SecurityToken"/> being validated.</param>
-        /// <param name="validationParameters">Priority will be given to <see cref="TokenValidationParameters.CryptoProviderFactory"/> over <see cref="SecurityKey.CryptoProviderFactory"/>.</param>
-        /// <returns>'true' if signature is valid.</returns>
-        internal static bool ValidateSignature(byte[] encodedBytes, byte[] signature, SecurityKey key, string algorithm, SecurityToken securityToken, TokenValidationParameters validationParameters)
-        {
-            var cryptoProviderFactory = validationParameters.CryptoProviderFactory ?? key.CryptoProviderFactory;
-            if (!cryptoProviderFactory.IsSupportedAlgorithm(algorithm, key))
-            {
-                if (LogHelper.IsEnabled(EventLogLevel.Informational))
-                    LogHelper.LogInformation(LogMessages.IDX14000, LogHelper.MarkAsNonPII(algorithm), key);
-
-                return false;
-            }
-
-            Validators.ValidateAlgorithm(algorithm, key, securityToken, validationParameters);
-
-            var signatureProvider = cryptoProviderFactory.CreateForVerifying(key, algorithm);
-            if (signatureProvider == null)
-                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(TokenLogMessages.IDX10636, key == null ? "Null" : key.ToString(), LogHelper.MarkAsNonPII(algorithm))));
-
-            try
-            {
-                return signatureProvider.Verify(encodedBytes, signature);
-            }
-            finally
-            {
-                cryptoProviderFactory.ReleaseSignatureProvider(signatureProvider);
-            }
         }
 
         internal static bool IsSignatureValid(byte[] signatureBytes, int signatureBytesLength, SignatureProvider signatureProvider, byte[] dataToVerify, int dataToVerifyLength)

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtRegisteredClaimNames.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtRegisteredClaimNames.cs
@@ -157,10 +157,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens
     }
 
     /// <summary>
-    /// Parameter names for JsonWebToken  registered claim names in UTF8 bytes.
+    /// Parameter names for JsonWebToken registered claim names in UTF8 bytes.
     /// Used by UTF8JsonReader/Writer for performance gains.
     /// </summary>
-    internal readonly struct JwtRegisteredClaimNamesUtf8Bytes
+    internal readonly struct JwtPayloadUtf8Bytes
     {
         // Please keep in alphabetical order
 

--- a/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
@@ -41,11 +41,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
 
         // parsing
-        internal const string IDX14300 = "IDX14300: Could not parse '{0}' : '{1}' as a '{2}'.";
+        //internal const string IDX14300 = "IDX14300: Could not parse '{0}' : '{1}' as a '{2}'.";
         //internal const string IDX14301 = "IDX14301: Unable to parse the header into a JSON object. \nHeader: '{0}'.";
         //internal const string IDX14302 = "IDX14302: Unable to parse the payload into a JSON object. \nPayload: '{0}'.";
         //internal const string IDX14303 = "IDX14303: Claim with name '{0}' does not exist in the header.";
-        internal const string IDX14304 = "IDX14304: Claim with name '{0}' does not exist in the payload.";
+        internal const string IDX14304 = "IDX14304: Claim with name '{0}' does not exist in the JsonClaimSet.";
         internal const string IDX14305 = "IDX14305: Unable to convert the '{0}' json property to the following type: '{1}'. Property type was: '{2}'. Value: '{3}'.";
         internal const string IDX14306 = "IDX14306: JWE Ciphertext cannot be an empty string. jwtEncodedString: '{0}'.";
         internal const string IDX14307 = "IDX14307: JWE header is missing. jwtEncodedString: '{0}'.";

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -830,21 +830,21 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             if (httpRequestUri == null)
                 throw LogHelper.LogArgumentNullException(nameof(httpRequestUri));
 
-            if (!signedHttpRequest.TryGetPayloadValue(SignedHttpRequestClaimTypes.Q, out IList<object> qClaim) || qClaim == null)
+            if (!signedHttpRequest.TryGetPayloadValue(SignedHttpRequestClaimTypes.Q, out List<object> qClaim) || qClaim == null)
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidQClaimException(LogHelper.FormatInvariant(LogMessages.IDX23003, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.Q))));
 
             httpRequestUri = EnsureAbsoluteUri(httpRequestUri);
             var sanitizedQueryParams = SanitizeQueryParams(httpRequestUri);
             string qClaimBase64UrlEncodedHash = string.Empty;
             string calculatedBase64UrlEncodedHash = string.Empty;
-            IList<object> qClaimQueryParamNames;
+            object[] qClaimQueryParamNames;
 
             try
             {
                 // "q": [["queryParamName1", "queryParamName2",... "queryParamNameN"], "base64UrlEncodedHashValue"]]
-                // deserialzed as IList<object> with q[0] is an IList<obj>, q[1] an object
+                // deserialzed as List<object> with q[0] is an List<obj>, q[1] an object
                 qClaimBase64UrlEncodedHash = (string)qClaim[1];
-                qClaimQueryParamNames = qClaim[0] as IList<object>;
+                qClaimQueryParamNames = qClaim[0] as object[];
             }
             catch (Exception e)
             {
@@ -900,20 +900,20 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// </remarks>
         internal virtual void ValidateHClaim(JsonWebToken signedHttpRequest, SignedHttpRequestValidationContext signedHttpRequestValidationContext)
         {
-            if (!signedHttpRequest.TryGetPayloadValue(SignedHttpRequestClaimTypes.H, out IList<object> hClaim) || hClaim == null)
+            if (!signedHttpRequest.TryGetPayloadValue(SignedHttpRequestClaimTypes.H, out List<object> hClaim) || hClaim == null)
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidHClaimException(LogHelper.FormatInvariant(LogMessages.IDX23003, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.H))));
 
             var sanitizedHeaders = SanitizeHeaders(signedHttpRequestValidationContext.HttpRequestData.Headers);
 
             string hClaimBase64UrlEncodedHash = string.Empty;
             string calculatedBase64UrlEncodedHash = string.Empty;
-            IList<object> hClaimHeaderNames;
+            object[] hClaimHeaderNames;
             try
             {
                 // "h": [["headerName1", "headerName2",... "headerNameN"], "base64UrlEncodedHashValue"]]
-                // deserialzed as IList<object> with h[0] is an IList<obj>, h[1] an object
+                // deserialzed as List<object> with h[0] is an List<obj>, h[1] an object
                 hClaimBase64UrlEncodedHash = (string)hClaim[1];
-                hClaimHeaderNames = hClaim[0] as IList<object>;
+                hClaimHeaderNames = hClaim[0] as object[];
             }
             catch (Exception e)
             {

--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
@@ -179,26 +179,12 @@ namespace Microsoft.IdentityModel.Tokens.Json
             return jsonElement.GetString();
         }
 
-        public static T CreateTypeFromJsonElement<T>(JsonElement jsonElement)
+        public static bool TryCreateTypeFromJsonElement<T>(JsonElement jsonElement, out T t)
         {
             if (typeof(T) == typeof(string))
-                return (T)(object)jsonElement.ToString();
-            else if (jsonElement.ValueKind == JsonValueKind.Number)
             {
-                if(typeof(T) == typeof(string))
-                    return (T)(object)jsonElement.ToString();
-                else if (typeof(T) == typeof(int))
-                    return (T)(object)jsonElement.GetInt32();
-                else if (typeof(T) == typeof(long))
-                    return (T)(object)jsonElement.GetInt64();
-                else if (typeof(T) == typeof(decimal))
-                    return (T)(object)jsonElement.GetDecimal();
-                else if (typeof(T) == typeof(double))
-                    return (T)(object)jsonElement.GetDouble();
-                else if (typeof(T) == typeof(uint))
-                    return (T)(object)jsonElement.GetUInt32();
-                else if (typeof(T) == typeof(ulong))
-                    return (T)(object)jsonElement.GetUInt64();
+                t = (T)(object)jsonElement.ToString();
+                return true;
             }
             else if (jsonElement.ValueKind == JsonValueKind.Object)
             {
@@ -211,7 +197,8 @@ namespace Microsoft.IdentityModel.Tokens.Json
                         else
                             dictionary[property.Name] = property.Value.GetRawText();
 
-                    return (T)(object)dictionary;
+                    t = (T)(object)dictionary;
+                    return true;
                 }
                 else if (typeof(T) == typeof(Dictionary<string, string[]>))
                 {
@@ -236,7 +223,8 @@ namespace Microsoft.IdentityModel.Tokens.Json
                         dictionary[property.Name] = items;
                     }
 
-                    return (T)(object)dictionary;
+                    t = (T)(object)dictionary;
+                    return true;
                 }
                 else if (typeof(T) == typeof(Dictionary<string, List<string>>))
                 {
@@ -256,7 +244,8 @@ namespace Microsoft.IdentityModel.Tokens.Json
                         dictionary[property.Name] = items;
                     }
 
-                    return (T)(object)dictionary;
+                    t = (T)(object)dictionary;
+                    return true;
                 }
                 else if (typeof(T) == typeof(Dictionary<string, Collection<string>>))
                 {
@@ -276,7 +265,8 @@ namespace Microsoft.IdentityModel.Tokens.Json
                         dictionary[property.Name] = items;
                     }
 
-                    return (T)(object)dictionary;
+                    t = (T)(object)dictionary;
+                    return true;
                 }
                 else if (typeof(T) == typeof(Dictionary<string, object>))
                 {
@@ -284,7 +274,8 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     foreach (JsonProperty property in jsonElement.EnumerateObject())
                         dictionary[property.Name] = CreateObjectFromJsonElement(property.Value);
 
-                    return (T)(object)dictionary;
+                    t = (T)(object)dictionary;
+                    return true;
                 }
             }
             else if (jsonElement.ValueKind == JsonValueKind.Array)
@@ -304,7 +295,8 @@ namespace Microsoft.IdentityModel.Tokens.Json
                         else
                             items[numItems++] = j.GetRawText();
 
-                    return (T)(object)items;
+                    t = (T)(object)items;
+                    return true;
                 }
                 else if (typeof(T) == typeof(List<string>))
                 {
@@ -315,7 +307,8 @@ namespace Microsoft.IdentityModel.Tokens.Json
                         else
                             items.Add(j.GetRawText());
 
-                    return (T)(object)items;
+                    t = (T)(object)items;
+                    return true;
                 }
                 else if (typeof(T) == typeof(Collection<string>))
                 {
@@ -326,7 +319,8 @@ namespace Microsoft.IdentityModel.Tokens.Json
                         else
                             items.Add(j.GetRawText());
 
-                    return (T)(object)items;
+                    t = (T)(object)items;
+                    return true;
                 }
                 else if (typeof(T) == typeof(object[]))
                 {
@@ -340,7 +334,8 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     foreach (JsonElement j in jsonElement.EnumerateArray())
                         items[numItems++] = CreateObjectFromJsonElement(j);
 
-                    return (T)(object)items;
+                    t = (T)(object)items;
+                    return true;
                 }
                 else if (typeof(T) == typeof(List<object>))
                 {
@@ -348,7 +343,8 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     foreach (JsonElement j in jsonElement.EnumerateArray())
                         items.Add(CreateObjectFromJsonElement(j));
 
-                    return (T)(object)items;
+                    t = (T)(object)items;
+                    return true;
                 }
                 else if (typeof(T) == typeof(Collection<object>))
                 {
@@ -356,7 +352,8 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     foreach (JsonElement j in jsonElement.EnumerateArray())
                         items.Add(CreateObjectFromJsonElement(j));
 
-                    return (T)(object)items;
+                    t = (T)(object)items;
+                    return true;
                 }
                 else if (typeof(T) == typeof(int[]))
                 {
@@ -374,14 +371,13 @@ namespace Microsoft.IdentityModel.Tokens.Json
                         else if (int.TryParse(j.GetRawText(), out int value))
                             items[numItems++] = value;
                         else
-                            throw LogHelper.LogExceptionMessage(
-                                new JsonException(
-                                    LogHelper.FormatInvariant(
-                                        LogMessages.IDX11028,
-                                        jsonElement.GetRawText(),
-                                        "Integer32")));
+                        {
+                            t = default;
+                            return false;
+                        }
 
-                    return (T)(object)items;
+                    t = (T)(object)items;
+                    return true;
                 }
                 else if (typeof(T) == typeof(long[]))
                 {
@@ -398,31 +394,28 @@ namespace Microsoft.IdentityModel.Tokens.Json
                         else if (long.TryParse(j.GetRawText(), out long value))
                             items[numItems++] = value;
                         else
-                            throw LogHelper.LogExceptionMessage(
-                                new JsonException(
-                                    LogHelper.FormatInvariant(
-                                        LogMessages.IDX11028,
-                                        jsonElement.GetRawText(),
-                                        "Integer64")));
+                        {
+                            t = default;
+                            return false;
+                        }
                     }
 
-                    return (T)(object)items;
+                    t = (T)(object)items;
+                    return true;
                 }
             }
             else if (typeof(T) == typeof(string))
             {
                 if (jsonElement.ValueKind == JsonValueKind.String)
-                    return (T)(object)jsonElement.GetString();
+                    t = (T)(object)jsonElement.GetString();
+                else
+                    t = (T)(object)jsonElement.GetRawText();
 
-                return (T)(object)jsonElement.GetRawText();
+                return true;
             }
 
-            throw LogHelper.LogExceptionMessage(
-                new JsonException(
-                    LogHelper.FormatInvariant(
-                        LogMessages.IDX11027,
-                        typeof(T).ToString(),
-                        jsonElement.ValueKind.ToString())));
+            t = default;
+            return false;
         }
 
         #region Read
@@ -542,47 +535,47 @@ namespace Microsoft.IdentityModel.Tokens.Json
 #endif
         }
 
-        internal static int GetInt(JsonElement jsonElement)
-        {
-            if (jsonElement.ValueKind == JsonValueKind.Number)
-            {
-                if (jsonElement.TryGetInt32(out int i))
-                    return i;
-            }
-            else if (jsonElement.ValueKind == JsonValueKind.String)
-            {
-                if (int.TryParse(jsonElement.GetRawText(), out int value))
-                    return value;
-            }
+        //internal static int GetInt(JsonElement jsonElement)
+        //{
+        //    if (jsonElement.ValueKind == JsonValueKind.Number)
+        //    {
+        //        if (jsonElement.TryGetInt32(out int i))
+        //            return i;
+        //    }
+        //    else if (jsonElement.ValueKind == JsonValueKind.String)
+        //    {
+        //        if (int.TryParse(jsonElement.GetRawText(), out int value))
+        //            return value;
+        //    }
 
-            throw LogHelper.LogExceptionMessage(
-                new JsonException(
-                    LogHelper.FormatInvariant(
-                        LogMessages.IDX11028,
-                        jsonElement.GetRawText(),
-                        "Integer32")));
-        }
+        //    throw LogHelper.LogExceptionMessage(
+        //        new JsonException(
+        //            LogHelper.FormatInvariant(
+        //                LogMessages.IDX11028,
+        //                jsonElement.GetRawText(),
+        //                "Integer32")));
+        //}
 
-        internal static double GetDouble(JsonElement jsonElement)
-        {
-            if (jsonElement.ValueKind == JsonValueKind.Number)
-            {
-                if (jsonElement.TryGetDouble(out double d))
-                    return d;
-            }
-            else if (jsonElement.ValueKind == JsonValueKind.String)
-            {
-                if (double.TryParse(jsonElement.GetRawText(), out double value))
-                    return value;
-            }
+        //internal static double GetDouble(JsonElement jsonElement)
+        //{
+        //    if (jsonElement.ValueKind == JsonValueKind.Number)
+        //    {
+        //        if (jsonElement.TryGetDouble(out double d))
+        //            return d;
+        //    }
+        //    else if (jsonElement.ValueKind == JsonValueKind.String)
+        //    {
+        //        if (double.TryParse(jsonElement.GetRawText(), out double value))
+        //            return value;
+        //    }
 
-            throw LogHelper.LogExceptionMessage(
-                new JsonException(
-                    LogHelper.FormatInvariant(
-                        LogMessages.IDX11028,
-                        jsonElement.GetRawText(),
-                        "Double")));
-        }
+        //    throw LogHelper.LogExceptionMessage(
+        //        new JsonException(
+        //            LogHelper.FormatInvariant(
+        //                LogMessages.IDX11028,
+        //                jsonElement.GetRawText(),
+        //                "Double")));
+        //}
 
         internal static List<object> ReadArrayOfObjects(ref Utf8JsonReader reader, string propertyName, string className)
         {
@@ -738,7 +731,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
         /// Normally we put the object into a Dictionary[string, object].
         /// </summary>
         /// <param name="reader">the <see cref="Utf8JsonReader"/></param>
-        /// <param name="propertyName">the propertyr name that is being read</param>
+        /// <param name="propertyName">the property name that is being read</param>
         /// <param name="className">the type that is being deserialized</param>
         /// <param name="read">if true reader.Read() will be called.</param>
         /// <returns></returns>

--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
@@ -535,48 +535,6 @@ namespace Microsoft.IdentityModel.Tokens.Json
 #endif
         }
 
-        //internal static int GetInt(JsonElement jsonElement)
-        //{
-        //    if (jsonElement.ValueKind == JsonValueKind.Number)
-        //    {
-        //        if (jsonElement.TryGetInt32(out int i))
-        //            return i;
-        //    }
-        //    else if (jsonElement.ValueKind == JsonValueKind.String)
-        //    {
-        //        if (int.TryParse(jsonElement.GetRawText(), out int value))
-        //            return value;
-        //    }
-
-        //    throw LogHelper.LogExceptionMessage(
-        //        new JsonException(
-        //            LogHelper.FormatInvariant(
-        //                LogMessages.IDX11028,
-        //                jsonElement.GetRawText(),
-        //                "Integer32")));
-        //}
-
-        //internal static double GetDouble(JsonElement jsonElement)
-        //{
-        //    if (jsonElement.ValueKind == JsonValueKind.Number)
-        //    {
-        //        if (jsonElement.TryGetDouble(out double d))
-        //            return d;
-        //    }
-        //    else if (jsonElement.ValueKind == JsonValueKind.String)
-        //    {
-        //        if (double.TryParse(jsonElement.GetRawText(), out double value))
-        //            return value;
-        //    }
-
-        //    throw LogHelper.LogExceptionMessage(
-        //        new JsonException(
-        //            LogHelper.FormatInvariant(
-        //                LogMessages.IDX11028,
-        //                jsonElement.GetRawText(),
-        //                "Double")));
-        //}
-
         internal static List<object> ReadArrayOfObjects(ref Utf8JsonReader reader, string propertyName, string className)
         {
             // returning null keeps the same logic as JsonSerialization.ReadObject

--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -16,8 +18,6 @@ namespace Microsoft.IdentityModel.Tokens.Json
 {
     internal static class JsonSerializerPrimitives
     {
-        internal const int MaxDepth = 2;
-
         /// <summary>
         /// Creates a JsonException that provides information on what went wrong
         /// </summary>
@@ -73,7 +73,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     LogHelper.MarkAsNonPII(reader.BytesConsumed)));
         }
 
-        public static JsonElement CreateJsonElement(IList<string> strings)
+        public static JsonElement CreateJsonElement(List<string> strings)
         {
             using (MemoryStream memoryStream = new())
             {
@@ -119,6 +119,312 @@ namespace Microsoft.IdentityModel.Tokens.Json
 #endif
         }
 
+        internal static object CreateObjectFromJsonElement(JsonElement jsonElement)
+        {
+            if (jsonElement.ValueKind == JsonValueKind.String)
+            {
+                if (DateTime.TryParse(jsonElement.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime dateTime))
+                    return dateTime;
+
+                return jsonElement.GetString();
+            }
+            else if (jsonElement.ValueKind == JsonValueKind.False)
+                return false;
+            else if (jsonElement.ValueKind == JsonValueKind.True)
+                return true;
+            else if (jsonElement.ValueKind == JsonValueKind.Number)
+            {
+                if (jsonElement.TryGetInt32(out int intValue))
+                    return intValue;
+                else if (jsonElement.TryGetInt64(out long longValue))
+                    return longValue;
+                else if (jsonElement.TryGetDecimal(out decimal decimalValue))
+                    return decimalValue;
+                else if (jsonElement.TryGetDouble(out double doubleValue))
+                    return doubleValue;
+                else if (jsonElement.TryGetUInt32(out uint uintValue))
+                    return uintValue;
+                else if (jsonElement.TryGetUInt64(out ulong ulongValue))
+                    return ulongValue;
+            }
+            else if (jsonElement.ValueKind == JsonValueKind.Null)
+                return null;
+            else if (jsonElement.ValueKind == JsonValueKind.Array)
+            {
+                int numItems = 0;
+                foreach (JsonElement j in jsonElement.EnumerateArray())
+                    numItems++;
+
+                object[] items = new object[numItems];
+
+                int index = 0;
+                foreach (JsonElement j in jsonElement.EnumerateArray())
+                    items[index++] = CreateObjectFromJsonElement(j);
+
+                return items;
+            }
+            else if (jsonElement.ValueKind == JsonValueKind.Object)
+            {
+                int numItems = 0;
+                foreach (JsonProperty property in jsonElement.EnumerateObject())
+                    numItems++;
+
+                KeyValuePair<string, object>[] kvps = new KeyValuePair<string, object>[numItems];
+                foreach (JsonProperty property in jsonElement.EnumerateObject())
+                    kvps[numItems++] = new KeyValuePair<string, object>(property.Name, CreateObjectFromJsonElement(property.Value));
+
+                return kvps;
+            }
+
+            return jsonElement.GetString();
+        }
+
+        public static T CreateTypeFromJsonElement<T>(JsonElement jsonElement)
+        {
+            if (typeof(T) == typeof(string))
+                return (T)(object)jsonElement.ToString();
+            else if (jsonElement.ValueKind == JsonValueKind.Number)
+            {
+                if(typeof(T) == typeof(string))
+                    return (T)(object)jsonElement.ToString();
+                else if (typeof(T) == typeof(int))
+                    return (T)(object)jsonElement.GetInt32();
+                else if (typeof(T) == typeof(long))
+                    return (T)(object)jsonElement.GetInt64();
+                else if (typeof(T) == typeof(decimal))
+                    return (T)(object)jsonElement.GetDecimal();
+                else if (typeof(T) == typeof(double))
+                    return (T)(object)jsonElement.GetDouble();
+                else if (typeof(T) == typeof(uint))
+                    return (T)(object)jsonElement.GetUInt32();
+                else if (typeof(T) == typeof(ulong))
+                    return (T)(object)jsonElement.GetUInt64();
+            }
+            else if (jsonElement.ValueKind == JsonValueKind.Object)
+            {
+                if (typeof(T) == typeof(Dictionary<string, string>))
+                {
+                    Dictionary<string, string> dictionary = new();
+                    foreach (JsonProperty property in jsonElement.EnumerateObject())
+                        if (property.Value.ValueKind == JsonValueKind.String)
+                            dictionary[property.Name] = property.Value.GetString();
+                        else
+                            dictionary[property.Name] = property.Value.GetRawText();
+
+                    return (T)(object)dictionary;
+                }
+                else if (typeof(T) == typeof(Dictionary<string, string[]>))
+                {
+                    Dictionary<string, string[]> dictionary = new();
+                    foreach (JsonProperty property in jsonElement.EnumerateObject())
+                    {
+                        if (property.Value.ValueKind != JsonValueKind.Array)
+                            dictionary[property.Name] = new string[] { property.Value.GetRawText() };
+
+                        int numItems = 0;
+                        foreach (JsonElement j in property.Value.EnumerateArray())
+                            numItems++;
+
+                        string[] items = new string[numItems];
+                        numItems = 0;
+                        foreach (JsonElement j in property.Value.EnumerateArray())
+                            if (j.ValueKind == JsonValueKind.String)
+                                items[numItems++] = j.GetString();
+                            else
+                                items[numItems++] = j.GetRawText();
+
+                        dictionary[property.Name] = items;
+                    }
+
+                    return (T)(object)dictionary;
+                }
+                else if (typeof(T) == typeof(Dictionary<string, List<string>>))
+                {
+                    Dictionary<string, List<string>> dictionary = new();
+                    foreach (JsonProperty property in jsonElement.EnumerateObject())
+                    {
+                        if (property.Value.ValueKind != JsonValueKind.Array)
+                            dictionary[property.Name] = new List<string> { property.Value.GetRawText() };
+
+                        List<string> items = new();
+                        foreach (JsonElement j in property.Value.EnumerateArray())
+                            if (j.ValueKind == JsonValueKind.String)
+                                items.Add(j.GetString());
+                            else
+                                items.Add(j.GetRawText());
+
+                        dictionary[property.Name] = items;
+                    }
+
+                    return (T)(object)dictionary;
+                }
+                else if (typeof(T) == typeof(Dictionary<string, Collection<string>>))
+                {
+                    Dictionary<string, Collection<string>> dictionary = new();
+                    foreach (JsonProperty property in jsonElement.EnumerateObject())
+                    {
+                        if (property.Value.ValueKind != JsonValueKind.Array)
+                            dictionary[property.Name] = new Collection<string> { property.Value.GetRawText() };
+
+                        Collection<string> items = new();
+                        foreach (JsonElement j in property.Value.EnumerateArray())
+                            if (j.ValueKind == JsonValueKind.String)
+                                items.Add(j.GetString());
+                            else
+                                items.Add(j.GetRawText());
+
+                        dictionary[property.Name] = items;
+                    }
+
+                    return (T)(object)dictionary;
+                }
+                else if (typeof(T) == typeof(Dictionary<string, object>))
+                {
+                    Dictionary<string, object> dictionary = new();
+                    foreach (JsonProperty property in jsonElement.EnumerateObject())
+                        dictionary[property.Name] = CreateObjectFromJsonElement(property.Value);
+
+                    return (T)(object)dictionary;
+                }
+            }
+            else if (jsonElement.ValueKind == JsonValueKind.Array)
+            {
+                if (typeof(T) == typeof(string[]))
+                {
+                    int numItems = 0;
+                    // is this an array of properties
+                    foreach (JsonElement j in jsonElement.EnumerateArray())
+                        numItems++;
+
+                    string[] items = new string[numItems];
+                    numItems = 0;
+                    foreach (JsonElement j in jsonElement.EnumerateArray())
+                        if (j.ValueKind == JsonValueKind.String)
+                            items[numItems++] = j.GetString();
+                        else
+                            items[numItems++] = j.GetRawText();
+
+                    return (T)(object)items;
+                }
+                else if (typeof(T) == typeof(List<string>))
+                {
+                    List<string> items = new();
+                    foreach (JsonElement j in jsonElement.EnumerateArray())
+                        if (j.ValueKind == JsonValueKind.String)
+                            items.Add(j.GetString());
+                        else
+                            items.Add(j.GetRawText());
+
+                    return (T)(object)items;
+                }
+                else if (typeof(T) == typeof(Collection<string>))
+                {
+                    Collection<string> items = new();
+                    foreach (JsonElement j in jsonElement.EnumerateArray())
+                        if (j.ValueKind == JsonValueKind.String)
+                            items.Add(j.GetString());
+                        else
+                            items.Add(j.GetRawText());
+
+                    return (T)(object)items;
+                }
+                else if (typeof(T) == typeof(object[]))
+                {
+                    int numItems = 0;
+                    // is this an array of properties
+                    foreach (JsonElement j in jsonElement.EnumerateArray())
+                        numItems++;
+
+                    object[] items = new object[numItems];
+                    numItems = 0;
+                    foreach (JsonElement j in jsonElement.EnumerateArray())
+                        items[numItems++] = CreateObjectFromJsonElement(j);
+
+                    return (T)(object)items;
+                }
+                else if (typeof(T) == typeof(List<object>))
+                {
+                    List<object> items = new();
+                    foreach (JsonElement j in jsonElement.EnumerateArray())
+                        items.Add(CreateObjectFromJsonElement(j));
+
+                    return (T)(object)items;
+                }
+                else if (typeof(T) == typeof(Collection<object>))
+                {
+                    Collection<object> items = new();
+                    foreach (JsonElement j in jsonElement.EnumerateArray())
+                        items.Add(CreateObjectFromJsonElement(j));
+
+                    return (T)(object)items;
+                }
+                else if (typeof(T) == typeof(int[]))
+                {
+                    int numItems = 0;
+                    // is this an array of properties
+                    foreach (JsonElement j in jsonElement.EnumerateArray())
+                        numItems++;
+
+                    int[] items = new int[numItems];
+                    numItems = 0;
+
+                    foreach (JsonElement j in jsonElement.EnumerateArray())
+                        if (j.TryGetInt32(out int i))
+                            items[numItems++] = i;
+                        else if (int.TryParse(j.GetRawText(), out int value))
+                            items[numItems++] = value;
+                        else
+                            throw LogHelper.LogExceptionMessage(
+                                new JsonException(
+                                    LogHelper.FormatInvariant(
+                                        LogMessages.IDX11028,
+                                        jsonElement.GetRawText(),
+                                        "Integer32")));
+
+                    return (T)(object)items;
+                }
+                else if (typeof(T) == typeof(long[]))
+                {
+                    int numItems = 0;
+                    foreach (JsonElement j in jsonElement.EnumerateArray())
+                        numItems++;
+
+                    long[] items = new long[numItems];
+                    numItems = 0;
+                    foreach (JsonElement j in jsonElement.EnumerateArray())
+                    {
+                        if (j.TryGetInt64(out long l))
+                            items[numItems++] = l;
+                        else if (long.TryParse(j.GetRawText(), out long value))
+                            items[numItems++] = value;
+                        else
+                            throw LogHelper.LogExceptionMessage(
+                                new JsonException(
+                                    LogHelper.FormatInvariant(
+                                        LogMessages.IDX11028,
+                                        jsonElement.GetRawText(),
+                                        "Integer64")));
+                    }
+
+                    return (T)(object)items;
+                }
+            }
+            else if (typeof(T) == typeof(string))
+            {
+                if (jsonElement.ValueKind == JsonValueKind.String)
+                    return (T)(object)jsonElement.GetString();
+
+                return (T)(object)jsonElement.GetRawText();
+            }
+
+            throw LogHelper.LogExceptionMessage(
+                new JsonException(
+                    LogHelper.FormatInvariant(
+                        LogMessages.IDX11027,
+                        typeof(T).ToString(),
+                        jsonElement.ValueKind.ToString())));
+        }
+
         #region Read
         internal static bool IsReaderAtTokenType(ref Utf8JsonReader reader, JsonTokenType tokenType, bool advanceReader)
         {
@@ -146,6 +452,32 @@ namespace Microsoft.IdentityModel.Tokens.Json
                 CreateJsonReaderException(ref reader, "JsonTokenType.False or JsonTokenType.True", className, propertyName));
         }
 
+        internal static long ReadLong(ref Utf8JsonReader reader, string propertyName, string className, bool read = false)
+        {
+            if (read)
+                reader.Read();
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt64(out long l))
+                    return l;
+
+                if (reader.TryGetDouble(out double d))
+                    return Convert.ToInt64(d);
+            }
+            else if (reader.TokenType == JsonTokenType.String)
+            {
+                if (long.TryParse(reader.GetString(), out long value))
+                    return value;
+
+                if (double.TryParse(reader.GetString(), out double d))
+                    return Convert.ToInt64(d);
+            }
+
+            throw LogHelper.LogExceptionMessage(
+                CreateJsonReaderException(ref reader, "JsonTokenType.Number", className, propertyName));
+        }
+
         internal static double ReadDouble(ref Utf8JsonReader reader, string propertyName, string className, bool read = false)
         {
             if (read)
@@ -162,6 +494,11 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     throw LogHelper.LogExceptionMessage(
                         CreateJsonReaderException(ref reader, typeof(double).ToString(), className, propertyName, ex));
                 }
+            }
+            else if (reader.TokenType == JsonTokenType.String)
+            {
+                if (double.TryParse(reader.GetString(), out double value))
+                    return value;
             }
 
             throw LogHelper.LogExceptionMessage(
@@ -205,30 +542,49 @@ namespace Microsoft.IdentityModel.Tokens.Json
 #endif
         }
 
-        internal static object ReadNumber(ref Utf8JsonReader reader)
+        internal static int GetInt(JsonElement jsonElement)
         {
+            if (jsonElement.ValueKind == JsonValueKind.Number)
+            {
+                if (jsonElement.TryGetInt32(out int i))
+                    return i;
+            }
+            else if (jsonElement.ValueKind == JsonValueKind.String)
+            {
+                if (int.TryParse(jsonElement.GetRawText(), out int value))
+                    return value;
+            }
 
-            if (reader.TryGetInt32(out int i))
-                return i;
-            else if (reader.TryGetInt64(out long l))
-                return l;
-            else if (reader.TryGetDouble(out double d))
-                return d;
-            else if (reader.TryGetUInt32(out uint u))
-                return u;
-            else if (reader.TryGetUInt64(out ulong ul))
-                return ul;
-            else if (reader.TryGetSingle(out float f))
-                return f;
-            else if (reader.TryGetDecimal(out decimal m))
-                return m;
-
-            Debug.Assert(false, "expected to read a number, but none of the Utf8JsonReader.TryGet... methods returned true.");
-
-            return ReadJsonElement(ref reader);
+            throw LogHelper.LogExceptionMessage(
+                new JsonException(
+                    LogHelper.FormatInvariant(
+                        LogMessages.IDX11028,
+                        jsonElement.GetRawText(),
+                        "Integer32")));
         }
 
-        internal static IList<object> ReadArrayOfObjects(ref Utf8JsonReader reader, string propertyName, string className)
+        internal static double GetDouble(JsonElement jsonElement)
+        {
+            if (jsonElement.ValueKind == JsonValueKind.Number)
+            {
+                if (jsonElement.TryGetDouble(out double d))
+                    return d;
+            }
+            else if (jsonElement.ValueKind == JsonValueKind.String)
+            {
+                if (double.TryParse(jsonElement.GetRawText(), out double value))
+                    return value;
+            }
+
+            throw LogHelper.LogExceptionMessage(
+                new JsonException(
+                    LogHelper.FormatInvariant(
+                        LogMessages.IDX11028,
+                        jsonElement.GetRawText(),
+                        "Double")));
+        }
+
+        internal static List<object> ReadArrayOfObjects(ref Utf8JsonReader reader, string propertyName, string className)
         {
             // returning null keeps the same logic as JsonSerialization.ReadObject
             if (reader.TokenType == JsonTokenType.Null)
@@ -381,12 +737,16 @@ namespace Microsoft.IdentityModel.Tokens.Json
         /// This method is called when deserializing a property value as an object.
         /// Normally we put the object into a Dictionary[string, object].
         /// </summary>
-        /// <param name="reader"></param>
-        /// <param name="propertyName"></param>
-        /// <param name="className"></param>
+        /// <param name="reader">the <see cref="Utf8JsonReader"/></param>
+        /// <param name="propertyName">the propertyr name that is being read</param>
+        /// <param name="className">the type that is being deserialized</param>
+        /// <param name="read">if true reader.Read() will be called.</param>
         /// <returns></returns>
-        internal static object ReadPropertyValueAsObject(ref Utf8JsonReader reader, string propertyName, string className)
+        internal static object ReadPropertyValueAsObject(ref Utf8JsonReader reader, string propertyName, string className, bool read = false)
         {
+            if (read)
+                reader.Read();
+
             switch (reader.TokenType)
             {
                 case JsonTokenType.False:
@@ -402,7 +762,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                 case JsonTokenType.StartObject:
                     return ReadJsonElement(ref reader);
                 case JsonTokenType.StartArray:
-                    return ReadArrayOfObjects(ref reader, propertyName, className);
+                    return ReadJsonElement(ref reader);
                 default:
                     // There is something broken here as this was called when the reader is pointing at a property.
                     // It must be a known Json type.
@@ -410,8 +770,30 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     return null;
             }
         }
-        #endregion
 
+        internal static object ReadNumber(ref Utf8JsonReader reader)
+        {
+            if (reader.TryGetInt32(out int i))
+                return i;
+            else if (reader.TryGetInt64(out long l))
+                return l;
+            else if (reader.TryGetDouble(out double d))
+                return d;
+            else if (reader.TryGetUInt32(out uint u))
+                return u;
+            else if (reader.TryGetUInt64(out ulong ul))
+                return ul;
+            else if (reader.TryGetSingle(out float f))
+                return f;
+            else if (reader.TryGetDecimal(out decimal m))
+                return m;
+
+            Debug.Assert(false, "expected to read a number, but none of the Utf8JsonReader.TryGet... methods returned true.");
+
+            return ReadJsonElement(ref reader);
+        }
+        #endregion
+    
         #region Write
         public static void WriteAsJsonElement(ref Utf8JsonWriter writer, string json)
         {
@@ -442,80 +824,64 @@ namespace Microsoft.IdentityModel.Tokens.Json
         /// <param name="writer"></param>
         /// <param name="key"></param>
         /// <param name="obj"></param>
-        /// <param name="depth">The current depth of recursive call for objects.
-        /// Maximum is 2.</param>
-        public static void WriteObject(ref Utf8JsonWriter writer, string key, object obj, int depth = 0)
+        public static void WriteObject(ref Utf8JsonWriter writer, string key, object obj)
         {
+            if (obj is null)
+            {
+                writer.WriteNull(key);
+                return;
+            }
+
+            Type objType = obj.GetType();
+
             if (obj is string str)
                 writer.WriteString(key, str);
-            else if (obj is DateTime dt)
-                writer.WriteString(key, dt.ToUniversalTime());
+            else if (obj is long l)
+                writer.WriteNumber(key, l);
             else if (obj is int i)
                 writer.WriteNumber(key, i);
             else if (obj is bool b)
                 writer.WriteBoolean(key, b);
-            else if (obj is decimal d)
-                writer.WriteNumber(key, d);
-            else if (obj is double dub)
-                writer.WriteNumber(key, dub);
-            else if (obj is float f)
-                writer.WriteNumber(key, f);
-            else if (obj is long l)
-                writer.WriteNumber(key, l);
-            else if (obj is null)
-                writer.WriteNull(key);
-            else if (obj is List<string> strs)
+            else if (obj is DateTime dt)
+                writer.WriteString(key, dt.ToUniversalTime());
+            else if (typeof(IDictionary).IsAssignableFrom(objType))
             {
+                IDictionary dictionary = (IDictionary)obj;
+                writer.WritePropertyName(key);
+
+                writer.WriteStartObject();
+                foreach (var k in dictionary.Keys)
+                    WriteObject(ref writer, k.ToString(), dictionary[k]);
+
+                writer.WriteEndObject();
+            }
+            else if (typeof(IList).IsAssignableFrom(objType))
+            {
+                IList list = (IList)obj;
                 writer.WriteStartArray(key);
-                foreach (string item in strs)
-                    writer.WriteStringValue(item);
+                foreach (var k in list)
+                    WriteObjectValue(ref writer, k);
 
                 writer.WriteEndArray();
-            }
-            else if (depth < MaxDepth && obj is List<object> objs)
-            {
-                depth++;
-                writer.WriteStartArray(key);
-                foreach (object item in objs)
-                    WriteObjectValue(ref writer, item, depth);
-
-                writer.WriteEndArray();
-            }
-            else if (obj is IDictionary<string, string> idics)
-            {
-                writer.WriteStartObject(key);
-                foreach (KeyValuePair<string, string> kvp in idics)
-                    writer.WriteString(kvp.Key, kvp.Value);
-
-                writer.WriteEndObject();
-            }
-            else if (depth < MaxDepth && obj is IDictionary<string, object> idic)
-            {
-                depth++;
-                writer.WriteStartObject(key);
-                foreach (KeyValuePair<string, object> kvp in idic)
-                    WriteObject(ref writer, kvp.Key, kvp.Value, depth);
-
-                writer.WriteEndObject();
-            }
-            else if (depth < MaxDepth && obj is Dictionary<string, object> dic)
-            {
-                depth++;
-                writer.WriteStartObject(key);
-                foreach (KeyValuePair<string, object> kvp in dic)
-                    WriteObject(ref writer, kvp.Key, kvp.Value, depth);
-
-                writer.WriteEndObject();
             }
             else if (obj is JsonElement j)
             {
                 writer.WritePropertyName(key);
                 j.WriteTo(writer);
             }
+            else if (obj is double dub)
+                writer.WriteNumber(key, dub);
+            else if (obj is decimal d)
+                writer.WriteNumber(key, d);
+            else if (obj is float f)
+                writer.WriteNumber(key, f);
             else
-            {
-                writer.WriteString(key, obj.ToString());
-            }
+                throw LogHelper.LogExceptionMessage(
+                    new ArgumentException(
+                        LogHelper.FormatInvariant(
+                            LogMessages.IDX11025,
+                            LogHelper.MarkAsNonPII(objType.ToString()),
+                            LogHelper.MarkAsNonPII(key))));
         }
 
         /// <summary>
@@ -524,10 +890,10 @@ namespace Microsoft.IdentityModel.Tokens.Json
         /// </summary>
         /// <param name="writer"></param>
         /// <param name="obj"></param>
-        /// <param name="depth">The current depth of recursive call for objects.
-        /// Maximum is 2.</param>
-        public static void WriteObjectValue(ref Utf8JsonWriter writer, object obj, int depth = 0)
+        public static void WriteObjectValue(ref Utf8JsonWriter writer, object obj)
         {
+            Type objType = obj.GetType();
+
             if (obj is string str)
                 writer.WriteStringValue(str);
             else if (obj is DateTime dt)
@@ -536,35 +902,36 @@ namespace Microsoft.IdentityModel.Tokens.Json
                 writer.WriteNumberValue(i);
             else if (obj is bool b)
                 writer.WriteBooleanValue(b);
-            else if (obj is double d)
-                writer.WriteNumberValue((decimal)d);
-            else if (obj is decimal m)
-                writer.WriteNumberValue(m);
-            else if (obj is float f)
-                writer.WriteNumberValue(f);
             else if (obj is long l)
                 writer.WriteNumberValue(l);
             else if (obj is null)
                 writer.WriteNullValue();
+            else if (obj is double d)
+                writer.WriteNumberValue((decimal)d);
             else if (obj is JsonElement j)
                 j.WriteTo(writer);
-            else if (obj is List<string> strings)
+            else if (typeof(IDictionary).IsAssignableFrom(objType))
             {
+                IDictionary dictionary = (IDictionary)obj;
+                writer.WriteStartObject();
+                foreach (var k in dictionary.Keys)
+                    WriteObject(ref writer, k.ToString(), dictionary[k]);
+
+                writer.WriteEndObject();
+            }
+            else if (typeof(IList).IsAssignableFrom(objType))
+            {
+                IList list = (IList)obj;
                 writer.WriteStartArray();
-                foreach (string strValue in strings)
-                    writer.WriteStringValue(strValue);
+                foreach (var k in list)
+                    WriteObjectValue(ref writer, k);
 
                 writer.WriteEndArray();
             }
-            else if (depth < MaxDepth && obj is List<object> objs)
-            {
-                depth++;
-                writer.WriteStartArray();
-                foreach (object item in objs)
-                    WriteObjectValue(ref writer, item, depth);
-
-                writer.WriteEndArray();
-            }
+            else if (obj is decimal m)
+                writer.WriteNumberValue(m);
+            else if (obj is float f)
+                writer.WriteNumberValue(f);
             else
                 writer.WriteStringValue(obj.ToString());
         }
@@ -586,15 +953,6 @@ namespace Microsoft.IdentityModel.Tokens.Json
 
             writer.WriteEndArray();
         }
-
-        public static void WriteStrings(ref Utf8JsonWriter writer, JsonEncodedText propertyName, IList<string> strings)
-        {
-            writer.WriteStartArray(propertyName);
-            foreach (string str in strings)
-                writer.WriteStringValue(str);
-
-            writer.WriteEndArray();
-        }
-#endregion
+        #endregion
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -257,6 +257,10 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX11020 = "IDX11020: The JSON value of type: '{0}', could not be converted to '{1}'. Reading: '{2}.{3}', Position: '{4}', CurrentDepth: '{5}', BytesConsumed: '{6}'.";
         public const string IDX11022 = "IDX11022: Expecting json reader to be positioned on '{0}', reader was positioned at: '{1}', Reading: '{2}.{3}', Position: '{4}', CurrentDepth: '{5}', BytesConsumed: '{6}'.";
         public const string IDX11023 = "IDX11023: Expecting json reader to be positioned on '{0}', reader was positioned at: '{1}', Reading: '{2}', Position: '{3}', CurrentDepth: '{4}', BytesConsumed: '{5}'.";
+        public const string IDX11025 = "IDX11025: Cannot serialize object of type: '{0}' into property: '{1}'.";
+        public const string IDX11027 = "IDX11027: Cannot create return type: '{0}' from JsonElement.ValueType: '{1}'.";
+        public const string IDX11028 = "IDX11028: '{0}', could not be converted to '{1}'.";
+
 #pragma warning restore 1591
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -258,8 +258,6 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX11022 = "IDX11022: Expecting json reader to be positioned on '{0}', reader was positioned at: '{1}', Reading: '{2}.{3}', Position: '{4}', CurrentDepth: '{5}', BytesConsumed: '{6}'.";
         public const string IDX11023 = "IDX11023: Expecting json reader to be positioned on '{0}', reader was positioned at: '{1}', Reading: '{2}', Position: '{3}', CurrentDepth: '{4}', BytesConsumed: '{5}'.";
         public const string IDX11025 = "IDX11025: Cannot serialize object of type: '{0}' into property: '{1}'.";
-        public const string IDX11027 = "IDX11027: Cannot create return type: '{0}' from JsonElement.ValueType: '{1}'.";
-        public const string IDX11028 = "IDX11028: '{0}', could not be converted to '{1}'.";
 
 #pragma warning restore 1591
     }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtHeader.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtHeader.cs
@@ -64,32 +64,7 @@ namespace System.IdentityModel.Tokens.Jwt
                     else
                         obj = JsonPrimitives.ReadPropertyValueAsObject(ref reader, propertyName, ClassName);
 
-                    if (TryGetValue(propertyName, out object existingValue))
-                    {
-                        if (existingValue is not IList<object> claimValues)
-                        {
-                            claimValues = new List<object>
-                            {
-                                existingValue
-                            };
-
-                            this[propertyName] = claimValues;
-                        }
-
-                        if (obj is IList<object> objectList)
-                        {
-                            foreach (object item in objectList)
-                                claimValues.Add(item);
-                        }
-                        else
-                        {
-                            claimValues.Add(obj);
-                        }
-                    }
-                    else
-                    {
-                        this[propertyName] = obj;
-                    }
+                     this[propertyName] = obj;
                 }
             }
         }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
@@ -9,11 +9,11 @@ using System.Security.Claims;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Threading;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
-
-using JsonPrimitives = Microsoft.IdentityModel.Tokens.Json.JsonSerializerPrimitives;
+using Microsoft.IdentityModel.Tokens.Json;
 
 namespace System.IdentityModel.Tokens.Jwt
 {
@@ -25,6 +25,20 @@ namespace System.IdentityModel.Tokens.Jwt
     {
         internal const string ClassName = "System.IdentityModel.Tokens.Jwt.JwtPayload";
 
+        internal List<string> _audiences;
+        internal string _azp;
+        internal long? _exp;
+        internal DateTime? _expDateTime;
+        internal long? _iat;
+        internal DateTime? _iatDateTime;
+        internal string _id;
+        internal string _iss;
+        internal string _jti;
+        internal long? _nbf;
+        internal DateTime? _nbfDateTime;
+        internal string _sub;
+        internal string _tid;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="JwtPayload"/> class with no claims. Default string comparer <see cref="StringComparer.Ordinal"/>. 
         /// Creates a empty <see cref="JwtPayload"/>
@@ -34,76 +48,107 @@ namespace System.IdentityModel.Tokens.Jwt
         {
         }
 
-        internal JwtPayload (string json)
+        internal static JwtPayload CreatePayload(byte[] bytes, int length)
         {
-            Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(json));
+            JwtPayload payload = new();
+            Utf8JsonReader reader = new(bytes.AsSpan().Slice(0, length));
 
-            try
-            {
-                if (!JsonPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartObject, false))
-                    throw LogHelper.LogExceptionMessage(
-                        new JsonException(
-                            LogHelper.FormatInvariant(
-                            Microsoft.IdentityModel.Tokens.LogMessages.IDX11023,
-                            LogHelper.MarkAsNonPII("JsonTokenType.StartObject"),
-                            LogHelper.MarkAsNonPII(reader.TokenType),
-                            LogHelper.MarkAsNonPII(ClassName),
-                            LogHelper.MarkAsNonPII(reader.TokenStartIndex),
-                            LogHelper.MarkAsNonPII(reader.CurrentDepth),
-                            LogHelper.MarkAsNonPII(reader.BytesConsumed))));
-
-                while (reader.Read())
-                {
-                    if (reader.TokenType == JsonTokenType.PropertyName)
-                    {
-                        string propertyName = JsonPrimitives.ReadPropertyName(ref reader, ClassName, true);
-                        object obj;
-                        if (reader.TokenType == JsonTokenType.StartArray)
-                            obj = JsonPrimitives.ReadArrayOfObjects(ref reader, propertyName, ClassName);
-                        else
-                            obj = JsonPrimitives.ReadPropertyValueAsObject(ref reader, propertyName, ClassName);
-
-                        if (TryGetValue(propertyName, out object existingValue))
-                        {
-                            if (existingValue is not IList<object> claimValues)
-                            {
-                                claimValues = new List<object>
-                            {
-                                existingValue
-                            };
-
-                                this[propertyName] = claimValues;
-                            }
-
-                            if (obj is IList<object> objectList)
-                            {
-                                foreach (object item in objectList)
-                                    claimValues.Add(item);
-                            }
-                            else
-                            {
-                                claimValues.Add(obj);
-                            }
-                        }
-                        else
-                        {
-                            this[propertyName] = obj;
-                        }
-                    }
-                }
-            }
-            catch (JsonException ex)
-            {
-                if (ex.GetType() == typeof(JsonException))
-                    throw;
-
+            if (!JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartObject, false))
                 throw LogHelper.LogExceptionMessage(
                     new JsonException(
                         LogHelper.FormatInvariant(
-                            Microsoft.IdentityModel.Tokens.LogMessages.IDX10805,
-                            LogHelper.MarkAsNonPII(json),
-                            LogHelper.MarkAsNonPII(ClassName))));
+                        Microsoft.IdentityModel.Tokens.LogMessages.IDX11023,
+                        LogHelper.MarkAsNonPII("JsonTokenType.StartObject"),
+                        LogHelper.MarkAsNonPII(reader.TokenType),
+                        LogHelper.MarkAsNonPII(ClassName),
+                        LogHelper.MarkAsNonPII(reader.TokenStartIndex),
+                        LogHelper.MarkAsNonPII(reader.CurrentDepth),
+                        LogHelper.MarkAsNonPII(reader.BytesConsumed))));
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Aud))
+                    {
+                        reader.Read();
+                        payload._audiences = new List<string>();
+                        if (reader.TokenType == JsonTokenType.StartArray)
+                        {
+                            JsonSerializerPrimitives.ReadStrings(ref reader, payload._audiences, JwtRegisteredClaimNames.Aud, ClassName, false);
+                            payload[JwtRegisteredClaimNames.Aud] = payload._audiences;
+                        }
+                        else
+                        {
+                            payload._audiences.Add(JsonSerializerPrimitives.ReadString(ref reader, JwtRegisteredClaimNames.Aud, ClassName, false));
+                            payload[JwtRegisteredClaimNames.Aud] = payload._audiences[0];
+                        }
+                    }
+                    else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Exp))
+                    {
+                        payload._exp = JsonSerializerPrimitives.ReadLong(ref reader, JwtRegisteredClaimNames.Exp, ClassName, true);
+                        payload[JwtRegisteredClaimNames.Exp] = payload._exp;
+                        payload._expDateTime = EpochTime.DateTime(payload._exp.Value);
+                    }
+                    else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Iat))
+                    {
+                        payload._iat = JsonSerializerPrimitives.ReadLong(ref reader, JwtRegisteredClaimNames.Iat, ClassName, true);
+                        payload[JwtRegisteredClaimNames.Iat] = payload._iat;
+                        payload._iatDateTime = EpochTime.DateTime(payload._iat.Value);
+                    }
+                    else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Iss))
+                    {
+                        payload._iss = JsonSerializerPrimitives.ReadString(ref reader, JwtRegisteredClaimNames.Iss, ClassName, true);
+                        payload[JwtRegisteredClaimNames.Iss] = payload._iss;
+                    }
+                    else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Jti))
+                    {
+                        payload._jti = JsonSerializerPrimitives.ReadString(ref reader, JwtRegisteredClaimNames.Jti, ClassName, true);
+                        payload[JwtRegisteredClaimNames.Jti] = payload._jti;
+                    }
+                    else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Nbf))
+                    {
+                        payload._nbf = JsonSerializerPrimitives.ReadLong(ref reader, JwtRegisteredClaimNames.Nbf, ClassName, true);
+                        payload._nbfDateTime = EpochTime.DateTime(payload._nbf.Value);
+                        payload[JwtRegisteredClaimNames.Nbf] = payload._nbf;
+                    }
+                    else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Sub))
+                    {
+                        reader.Read();
+                        if (reader.TokenType == JsonTokenType.String)
+                        {
+                            payload._sub = JsonSerializerPrimitives.ReadString(ref reader, JwtRegisteredClaimNames.Sub, ClassName, false);
+                            payload[JwtRegisteredClaimNames.Sub] = payload._sub;
+                        }
+                        else if (reader.TokenType == JsonTokenType.StartArray)
+                        {
+                            payload._audiences = new List<string>();
+                            JsonSerializerPrimitives.ReadStrings(ref reader, payload._audiences, JwtRegisteredClaimNames.Sub, ClassName, false);
+                            payload[JwtRegisteredClaimNames.Sub] = payload._audiences;
+                        }
+                        else
+                        {
+                            throw LogHelper.LogExceptionMessage(
+                                new JsonException(
+                                    LogHelper.FormatInvariant(
+                                        Microsoft.IdentityModel.Tokens.LogMessages.IDX11023,
+                                        LogHelper.MarkAsNonPII("JsonTokenType.String or JsonTokenType.StartArray"),
+                                        LogHelper.MarkAsNonPII(reader.TokenType),
+                                        LogHelper.MarkAsNonPII(ClassName),
+                                        LogHelper.MarkAsNonPII(reader.TokenStartIndex),
+                                        LogHelper.MarkAsNonPII(reader.CurrentDepth),
+                                        LogHelper.MarkAsNonPII(reader.BytesConsumed))));
+                        }
+                    }
+                    else
+                    {
+                        string propertyName = JsonSerializerPrimitives.ReadPropertyName(ref reader, ClassName, true);
+                        payload[propertyName] = JsonSerializerPrimitives.ReadPropertyValueAsObject(ref reader, propertyName, ClassName);
+                    }
+                }
             }
+
+            return payload;
         }
 
         /// <summary>
@@ -194,14 +239,14 @@ namespace System.IdentityModel.Tokens.Jwt
                         throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX12401, LogHelper.MarkAsNonPII(expires.Value), LogHelper.MarkAsNonPII(notBefore.Value))));
                     }
 
-                    this[JwtRegisteredClaimNames.Nbf] = (int)EpochTime.GetIntDate(notBefore.Value.ToUniversalTime());
+                    this[JwtRegisteredClaimNames.Nbf] = EpochTime.GetIntDate(notBefore.Value.ToUniversalTime());
                 }
 
-                this[JwtRegisteredClaimNames.Exp] = (int)EpochTime.GetIntDate(expires.Value.ToUniversalTime());
+                this[JwtRegisteredClaimNames.Exp] = EpochTime.GetIntDate(expires.Value.ToUniversalTime());
             }
 
             if (issuedAt.HasValue)
-                this[JwtRegisteredClaimNames.Iat] = (int)EpochTime.GetIntDate(issuedAt.Value.ToUniversalTime());
+                this[JwtRegisteredClaimNames.Iat] = EpochTime.GetIntDate(issuedAt.Value.ToUniversalTime());
 
             if (!string.IsNullOrEmpty(issuer))
                 this[JwtRegisteredClaimNames.Iss] = issuer;
@@ -243,7 +288,7 @@ namespace System.IdentityModel.Tokens.Jwt
         {
             get
             {
-                return this.GetIListClaims(JwtRegisteredClaimNames.Amr);
+                return this.GetListOfClaims(JwtRegisteredClaimNames.Amr);
             }
         }
 
@@ -267,7 +312,13 @@ namespace System.IdentityModel.Tokens.Jwt
         {
             get
             {
-                return this.GetIListClaims(JwtRegisteredClaimNames.Aud);
+                if (_audiences == null)
+                {
+                    List<string> tmp = GetListOfClaims(JwtRegisteredClaimNames.Aud);
+                    Interlocked.CompareExchange(ref _audiences, tmp, null);
+                }
+
+                return _audiences;
             }
         }
 
@@ -301,7 +352,7 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <remarks>If the 'expiration' claim is not found OR could not be converted to <see cref="Int32"/>, null is returned.</remarks>
         public int? Exp
         {
-            get { return this.GetIntClaim(JwtRegisteredClaimNames.Exp); }
+            get => GetIntClaim(JwtRegisteredClaimNames.Exp);
         }
 
         /// <summary>
@@ -312,7 +363,8 @@ namespace System.IdentityModel.Tokens.Jwt
         {
             get
             {
-                return this.GetStandardClaim(JwtRegisteredClaimNames.Jti);
+                _jti ??= GetStandardClaim(JwtRegisteredClaimNames.Jti);
+                return _jti;
             }
         }
 
@@ -333,7 +385,8 @@ namespace System.IdentityModel.Tokens.Jwt
         {
             get
             {
-                return this.GetStandardClaim(JwtRegisteredClaimNames.Iss);
+                _iss ??= GetStandardClaim(JwtRegisteredClaimNames.Iss);
+                return _iss;
             }
         }
 
@@ -366,7 +419,8 @@ namespace System.IdentityModel.Tokens.Jwt
         {
             get
             {
-                return this.GetStandardClaim(JwtRegisteredClaimNames.Sub);
+                _sub ??= GetStandardClaim(JwtRegisteredClaimNames.Sub);
+                return _sub;
             }
         }
 
@@ -378,7 +432,16 @@ namespace System.IdentityModel.Tokens.Jwt
         {
             get
             {
-                return this.GetDateTime(JwtRegisteredClaimNames.Nbf);
+                if (_nbfDateTime.HasValue)
+                    return _nbfDateTime.Value;
+
+                long? l = GetLongClaim(JwtRegisteredClaimNames.Nbf);
+                if (l.HasValue)
+                    return EpochTime.DateTime(l.Value);
+
+                _nbfDateTime = DateTime.MinValue;
+
+                return _nbfDateTime.Value;
             }
         }
 
@@ -390,7 +453,16 @@ namespace System.IdentityModel.Tokens.Jwt
         {
             get
             {
-                return this.GetDateTime(JwtRegisteredClaimNames.Exp);
+                if (_expDateTime.HasValue)
+                    return _expDateTime.Value;
+
+                long? l = GetLongClaim(JwtRegisteredClaimNames.Exp);
+                if (l.HasValue)
+                    return EpochTime.DateTime(l.Value);
+
+                _expDateTime = DateTime.MinValue;
+
+                return _expDateTime.Value;
             }
         }
 
@@ -402,7 +474,16 @@ namespace System.IdentityModel.Tokens.Jwt
         {
             get
             {
-                return this.GetDateTime(JwtRegisteredClaimNames.Iat);
+                if (_iatDateTime.HasValue)
+                    return _iatDateTime.Value;
+
+                long? l = GetLongClaim(JwtRegisteredClaimNames.Iat);
+                if (l.HasValue)
+                    return EpochTime.DateTime(l.Value);
+
+                _iatDateTime = DateTime.MinValue;
+
+                return _iatDateTime.Value;
             }
         }
 
@@ -603,21 +684,21 @@ namespace System.IdentityModel.Tokens.Jwt
         {
             if (TryGetValue(claimType, out object claimValue))
             {
-                if (claimValue is IList<object> objects)
-                {
-                    foreach (object obj in objects)
-                    {
-                        int i = default;
-                        if (TryConvertToInt(obj, ref i))
-                            return i;
-                    }
-                }
-                else
-                {
-                    int i = default;
-                    if (TryConvertToInt(claimValue, ref i))
-                        return i;
-                }
+                int i = default;
+                if (TryConvertToInt(claimValue, ref i))
+                    return i;
+            }
+
+            return null;
+        }
+
+        internal long? GetLongClaim(string claimType)
+        {
+            if (TryGetValue(claimType, out object claimValue))
+            {
+                long l = default;
+                if (TryConvertToLong(claimValue, ref l))
+                    return l;
             }
 
             return null;
@@ -641,6 +722,11 @@ namespace System.IdentityModel.Tokens.Jwt
                         return true;
                     }
 
+                if (value is JsonElement jsonElement)
+                {
+                    outVal = JsonSerializerPrimitives.GetInt(jsonElement);
+                    return true;
+                }
 
                 outVal = Convert.ToInt32(Math.Truncate(Convert.ToDouble(value, CultureInfo.InvariantCulture)));
                 return true;
@@ -663,91 +749,75 @@ namespace System.IdentityModel.Tokens.Jwt
 #pragma warning restore CS0162 // Unreachable code detected
         }
 
-        internal List<string> GetIListClaims(string claimType)
+        private static bool TryConvertToLong(object value, ref long outVal)
         {
-            List<string> claimValues = new List<string>();
-
-            object value = null;
-            if (!TryGetValue(claimType, out value))
-            {
-                return claimValues;
-            }
-
-            string str = value as string;
-            if (str != null)
-            {
-                claimValues.Add(str);
-                return claimValues;
-            }
-
-            // values must be an enumeration of strings;
-            IEnumerable<object> values = value as IEnumerable<object>;
-            if (values != null)
-            {
-                foreach (var item in values)
-                {
-                    claimValues.Add(item.ToString());
-                }
-            }
-            else
-            {
-                // TODO - do we need to do anything else
-            }
-
-            return claimValues;
-        }
-
-        /// <summary>
-        /// Gets the DateTime using the number of seconds from 1970-01-01T0:0:0Z (UTC)
-        /// </summary>
-        /// <param name="key">Claim in the payload that should map to an integer.</param>
-        /// <remarks>If the claim is not found, the function returns: DateTime.MinValue
-        /// </remarks>
-        /// <exception cref="SecurityTokenException">If an overflow exception is thrown by the runtime.</exception>
-        /// <returns>The DateTime representation of a claim.</returns>
-        private DateTime GetDateTime(string key)
-        {
-            object dateValue;
-            if (!TryGetValue(key, out dateValue))
-            {
-                return DateTime.MinValue;
-            }
-
-            // if there are multiple dates, take the first one.
+            outVal = default;
             try
             {
-                long secondsAfterBaseTime;
-                IList<object> dateValues = dateValue as IList<object>;
-                if (dateValues != null)
+                if (value is long l)
                 {
-                    if (dateValues.Count == 0)
-                    {
-                        return DateTime.MinValue;
-                    }
-                    else
-                    {
-                        dateValue = dateValues[0];
-                    }
+                    outVal = l;
+                    return true;
                 }
 
-                // null converts to 0.
-                secondsAfterBaseTime = Convert.ToInt64(Math.Truncate(Convert.ToDouble(dateValue, CultureInfo.InvariantCulture)));
-                return EpochTime.DateTime(secondsAfterBaseTime);
+                if (value is string str)
+                    if (long.TryParse(str, out long result))
+                    {
+                        outVal = result;
+                        return true;
+                    }
+
+                if (value is JsonElement jsonElement)
+                {
+                    outVal = Convert.ToInt64(Math.Truncate(JsonSerializerPrimitives.GetDouble(jsonElement)));
+                    return true;
+                }
+
+                outVal = Convert.ToInt64(Math.Truncate(Convert.ToDouble(value, CultureInfo.InvariantCulture)));
+
+                return true;
             }
-            catch (Exception ex)
+            catch (FormatException)
             {
-                if (ex is FormatException || ex is ArgumentException || ex is InvalidCastException)
-                {
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenException(LogHelper.FormatInvariant(LogMessages.IDX12700, key, LogHelper.MarkAsNonPII((dateValue ?? "Null"))), ex));
-                }
-
-                if (ex is OverflowException)
-                {
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenException(LogHelper.FormatInvariant(LogMessages.IDX12701, key, LogHelper.MarkAsNonPII((dateValue ?? "Null"))), ex));
-                }
-
-                throw;
+                return false;
             }
+            catch (OverflowException)
+            {
+                return false;
+            }
+            catch (InvalidCastException)
+            {
+                return false;
+            }
+
+#pragma warning disable CS0162 // Unreachable code detected
+            return false;
+#pragma warning restore CS0162 // Unreachable code detected
+        }
+
+        internal List<string> GetListOfClaims(string claimType)
+        {
+            List<string> claimValues = new();
+            if (!TryGetValue(claimType, out object value))
+                return claimValues;
+
+            // JsonArray and JsonObject are storred in the dictionary as JsonElement
+            if (value is JsonElement jsonElement)
+                return JsonSerializerPrimitives.CreateTypeFromJsonElement<List<string>>(jsonElement);
+
+            if (value is string str)
+                claimValues.Add(str);
+
+            // value may not be a string, use ToString();
+            else if (value is IEnumerable<object> values)
+            {
+                foreach (object item in values)
+                    claimValues.Add(item.ToString());
+            }
+            else
+                claimValues.Add(value.ToString());
+
+            return claimValues;
         }
 
         /// <summary>
@@ -759,13 +829,12 @@ namespace System.IdentityModel.Tokens.Jwt
             using (MemoryStream memoryStream = new MemoryStream())
             {
                 Utf8JsonWriter writer = null;
-
                 try
                 {
                     writer = new Utf8JsonWriter(memoryStream, new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
                     writer.WriteStartObject();
 
-                    JsonPrimitives.WriteObjects(ref writer, this);
+                    JsonSerializerPrimitives.WriteObjects(ref writer, this);
 
                     writer.WriteEndObject();
                     writer.Flush();
@@ -779,16 +848,15 @@ namespace System.IdentityModel.Tokens.Jwt
         }
 
         /// <summary>
-        /// Deserializes Base64UrlEncoded JSON into a <see cref="JwtHeader"/> instance.
+        /// Deserializes Base64UrlEncoded JSON into a <see cref="JwtPayload"/>.
         /// </summary>
         /// <param name="base64UrlEncodedJsonString">Base64url encoded JSON to deserialize.</param>
-        /// <returns>An instance of <see cref="JwtHeader"/>.</returns>
+        /// <returns>An instance of <see cref="JwtPayload"/>.</returns>
         public static JwtPayload Base64UrlDeserialize(string base64UrlEncodedJsonString)
         {
             _ = base64UrlEncodedJsonString ?? throw LogHelper.LogArgumentNullException(nameof(base64UrlEncodedJsonString));
-            return new JwtPayload(Base64UrlEncoder.Decode(base64UrlEncodedJsonString));
+            return Base64UrlEncoding.Decode(base64UrlEncodedJsonString, 0, base64UrlEncodedJsonString.Length, CreatePayload);
         }
-
 
         /// <summary>
         /// Encodes this instance as Base64UrlEncoded JSON.
@@ -806,9 +874,9 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <returns>An instance of <see cref="JwtPayload"/>.</returns>
         public static JwtPayload Deserialize(string jsonString)
         {
-            return new JwtPayload(jsonString);
+            _ = jsonString ?? throw LogHelper.LogArgumentNullException(nameof(jsonString));
+            byte[] bytes = Encoding.UTF8.GetBytes(jsonString);
+            return CreatePayload(bytes, bytes.Length);
         }
-
-        internal JsonClaimSet ClaimSet { get; set; }
     }
 }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
@@ -722,12 +722,6 @@ namespace System.IdentityModel.Tokens.Jwt
                         return true;
                     }
 
-                if (value is JsonElement jsonElement)
-                {
-                    outVal = JsonSerializerPrimitives.GetInt(jsonElement);
-                    return true;
-                }
-
                 outVal = Convert.ToInt32(Math.Truncate(Convert.ToDouble(value, CultureInfo.InvariantCulture)));
                 return true;
             }
@@ -767,12 +761,6 @@ namespace System.IdentityModel.Tokens.Jwt
                         return true;
                     }
 
-                if (value is JsonElement jsonElement)
-                {
-                    outVal = Convert.ToInt64(Math.Truncate(JsonSerializerPrimitives.GetDouble(jsonElement)));
-                    return true;
-                }
-
                 outVal = Convert.ToInt64(Math.Truncate(Convert.ToDouble(value, CultureInfo.InvariantCulture)));
 
                 return true;
@@ -789,10 +777,6 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 return false;
             }
-
-#pragma warning disable CS0162 // Unreachable code detected
-            return false;
-#pragma warning restore CS0162 // Unreachable code detected
         }
 
         internal List<string> GetListOfClaims(string claimType)
@@ -801,11 +785,13 @@ namespace System.IdentityModel.Tokens.Jwt
             if (!TryGetValue(claimType, out object value))
                 return claimValues;
 
-            // JsonArray and JsonObject are storred in the dictionary as JsonElement
+            // JsonArray and JsonObject are stored in the dictionary as JsonElement
             if (value is JsonElement jsonElement)
-                return JsonSerializerPrimitives.CreateTypeFromJsonElement<List<string>>(jsonElement);
-
-            if (value is string str)
+            {
+                if (JsonSerializerPrimitives.TryCreateTypeFromJsonElement(jsonElement, out List<string> list))
+                    return list;
+            }
+            else if (value is string str)
                 claimValues.Add(str);
 
             // value may not be a string, use ToString();

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityToken.cs
@@ -495,17 +495,21 @@ namespace System.IdentityModel.Tokens.Jwt
             if (tokenParts.Length == JwtConstants.JweSegmentCount)
                 DecodeJwe(tokenParts);
             else
-                DecodeJws(tokenParts);
+            {
+                DecodeJws(tokenParts[1]);
+                RawHeader = tokenParts[0];
+                RawPayload = tokenParts[1];
+                RawSignature = tokenParts[2];
+            }
 
             RawData = rawData;
         }
 
         /// <summary>
-        /// Decodes the payload and signature from the JWS parts.
+        /// Decodes the base64url encoded payload.
         /// </summary>
-        /// <param name="tokenParts">Parts of the JWS including the header.</param>
-        /// <remarks>Assumes Header has already been set.</remarks>
-        private void DecodeJws(string[] tokenParts)
+        /// <param name="payload">the encoded payload.</param>
+        private void DecodeJws(string payload)
         {
             // Log if CTY is set, assume compact JWS
             if (Header.Cty != null && LogHelper.IsEnabled(EventLogLevel.Verbose))
@@ -513,16 +517,13 @@ namespace System.IdentityModel.Tokens.Jwt
 
             try
             {
-                Payload = JwtPayload.Base64UrlDeserialize(tokenParts[1]);
+                Payload = Base64UrlEncoding.Decode(payload, 0, payload.Length, JwtPayload.CreatePayload);
             }
             catch (Exception ex)
             {
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX12723, tokenParts[1], RawData), ex));
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX12723, payload, RawData), ex));
             }
 
-            RawHeader = tokenParts[0];
-            RawPayload = tokenParts[1];
-            RawSignature = tokenParts[2];
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/GetPayloadValueTheoryData.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/GetPayloadValueTheoryData.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.IdentityModel.JsonWebTokens.Tests
+{
+    public class GetPayloadValueTheoryData : TheoryDataBase
+    {
+        public GetPayloadValueTheoryData(string testId) : base(testId)
+        { }
+
+        public SecurityTokenDescriptor SecurityTokenDescriptor { get; set; }
+
+        public string PropertyName { get; set; }
+
+        public Type PropertyOut { get; set; }
+
+        public Type PropertyType { get; set; }
+
+        public object PropertyValue { get; set; }
+    }
+}

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Security.Claims;
-using System.Text;
 using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
 using Xunit;
 
 namespace Microsoft.IdentityModel.JsonWebTokens.Tests
@@ -39,7 +39,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             
             try
             {
-                JsonClaimSet jsonClaimSet = new JsonClaimSet(Encoding.UTF8.GetBytes(theoryData.Json));
+                JsonWebToken jwt = new JsonWebToken("{}", theoryData.Json);
+                JsonClaimSet jsonClaimSet = jwt.Payload;
                 var methods = typeof(JsonClaimSet).GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
                 var method = typeof(JsonClaimSet).GetMethod("GetValue", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, null, CallingConventions.Standard, new Type[] { typeof(string) }, null);
                 var retval = method.MakeGenericMethod(theoryData.PropertyType).Invoke(jsonClaimSet, new object[] { theoryData.PropertyName });
@@ -212,6 +213,66 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             return theoryData;
         }
 
+        [Theory, MemberData(nameof(GetClaimAsTypeTheoryData))]
+        public void GetClaimAsType(JsonClaimSetTheoryData theoryData)
+        {
+            CompareContext context = TestUtilities.WriteHeader($"{this}.GetClaimAsType", theoryData);
+            try
+            {
+                JsonWebToken token = new JsonWebToken(theoryData.Json);
+
+                var methods = typeof(JsonWebToken).GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+                var method = typeof(JsonWebToken).GetMethod("GetPayloadValue", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, null, CallingConventions.Standard, new Type[] { typeof(string) }, null);
+                var retval = method.MakeGenericMethod(theoryData.PropertyType).Invoke(token, new object[] { theoryData.PropertyName });
+                theoryData.ExpectedException.ProcessNoException(context);
+                IdentityComparer.AreEqual(retval, theoryData.PropertyValue, context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<JsonClaimSetTheoryData> GetClaimAsTypeTheoryData()
+        {
+            var theoryData = new TheoryData<JsonClaimSetTheoryData>();
+
+            string header = Base64UrlEncoder.Encode("{}");
+            string payload = Base64UrlEncoder.Encode(@"{""a"":{""prop1"":""value1""},""b"":{""prop1"":[""value1"",""value2""]}, ""exp"": 1692706803,""iat"": 1692703203,""nbf"": 1692703203}");
+
+            theoryData.Add(
+                new JsonClaimSetTheoryData("DictionaryWithListOfStrings")
+                {
+                    Json = header + "." + payload + ".",
+                    PropertyName = "b",
+                    PropertyType = typeof(Dictionary<string, List<string>>),
+                    PropertyValue = new Dictionary<string, List<string>> { { "prop1", new List<string> { "value1", "value2" } } }
+                });
+
+            theoryData.Add(
+                new JsonClaimSetTheoryData("DictionaryWithArrayOfStrings")
+                {
+                    Json = header + "." + payload + ".",
+                    PropertyName = "b",
+                    PropertyType = typeof(Dictionary<string, string[]>),
+                    PropertyValue = new Dictionary<string, string[]> {{"prop1", new string[]{"value1","value2"}}}
+                });
+
+            theoryData.Add(
+                new JsonClaimSetTheoryData("DictionaryOfStrings")
+                {
+                    Json = header + "." + payload + ".",
+                    PropertyName = "a",
+                    PropertyType = typeof(Dictionary<string, string>),
+                    PropertyValue = new Dictionary<string, string> {{"prop1","value1"}}
+                });
+
+
+            return theoryData;
+        }
+
         // Test checks to make sure that claim values of various types can be successfully retrieved from the payload.
         [Fact]
         public void TryGetPayloadValues()
@@ -226,7 +287,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             IdentityComparer.AreEqual(true, success, context);
 
             success = token.TryGetPayloadValue("array", out object[] array);
-            IdentityComparer.AreEqual(new object[] { 1L, "2", 3L }, array, context);
+            IdentityComparer.AreEqual(new object[] { 1, "2", 3 }, array, context);
             IdentityComparer.AreEqual(true, success, context);
 
             success = token.TryGetPayloadValue("string", out string name);
@@ -234,15 +295,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             IdentityComparer.AreEqual(true, success, context);
 
             success = token.TryGetPayloadValue("float", out float floatingPoint);
-            IdentityComparer.AreEqual(42.0, floatingPoint, context);
+            IdentityComparer.AreEqual((float)42.0, floatingPoint, context);
             IdentityComparer.AreEqual(true, success, context);
 
             success = token.TryGetPayloadValue("integer", out int integer);
             IdentityComparer.AreEqual(42, integer, context);
             IdentityComparer.AreEqual(true, success, context);
-
-            success = token.TryGetPayloadValue("nill", out bool b);
-            IdentityComparer.AreEqual(false, success, context);
 
             success = token.TryGetPayloadValue("nill", out bool? bb);
             if (bb != null)

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -959,7 +959,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             { JwtRegisteredClaimNames.Aud, Default.Audience },
                             { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Default.Expires) },
                             { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(Default.IssueInstant) },
-                            { JwtRegisteredClaimNames.Jti, Default.Jti },
                             { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(Default.NotBefore) },
                         }.ToString(Formatting.None),
                         TokenDescriptor =  new SecurityTokenDescriptor
@@ -970,7 +969,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             Expires = Default.Expires,
                             SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
                             EncryptingCredentials = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes256_Sha512_512,
-                            Claims = new Dictionary<string, object>{ { JwtRegisteredClaimNames.Jti, Default.Jti } }
+                            Claims = new Dictionary<string, object>()
                         },
                         JsonWebTokenHandler = new JsonWebTokenHandler(),
                         ValidationParameters = new TokenValidationParameters

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -959,6 +959,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             { JwtRegisteredClaimNames.Aud, Default.Audience },
                             { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Default.Expires) },
                             { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(Default.IssueInstant) },
+                            { JwtRegisteredClaimNames.Jti, Default.Jti },
                             { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(Default.NotBefore) },
                         }.ToString(Formatting.None),
                         TokenDescriptor =  new SecurityTokenDescriptor
@@ -969,7 +970,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             Expires = Default.Expires,
                             SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
                             EncryptingCredentials = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes256_Sha512_512,
-                            Claims = new Dictionary<string, object>()
+                            Claims = new Dictionary<string, object>{ { JwtRegisteredClaimNames.Jti, Default.Jti } }
                         },
                         JsonWebTokenHandler = new JsonWebTokenHandler(),
                         ValidationParameters = new TokenValidationParameters
@@ -1026,13 +1027,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         TestId = "UseSecurityTokenDescriptorProperties",
                         Payload = new JObject()
                         {
-                            { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
-                            { JwtRegisteredClaimNames.GivenName, "Bob" },
-                            { JwtRegisteredClaimNames.Iss, "Issuer" },
+                            { JwtRegisteredClaimNames.Azp, Default.Azp },
                             { JwtRegisteredClaimNames.Aud, "Audience" },
-                            { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(DateTime.Parse("2018-03-17T18:33:37.080Z")) },
-                            { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(DateTime.Parse("2018-03-17T18:33:37.080Z")) },
+                            { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
                             { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(DateTime.Parse("2023-03-17T18:33:37.080Z")) },
+                            { JwtRegisteredClaimNames.GivenName, "Bob" },
+                            { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(DateTime.Parse("2038-03-17T18:33:37.080Z")) },
+                            { JwtRegisteredClaimNames.Iss, "Issuer" },
+                            { JwtRegisteredClaimNames.Jti, Default.Jti },
+                            { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(DateTime.Parse("2018-03-17T18:33:37.080Z")) },
                         }.ToString(Formatting.None),
                         TokenDescriptor =  new SecurityTokenDescriptor
                         {
@@ -1041,7 +1044,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             Claims = Default.PayloadDictionary,
                             Issuer = "Issuer",
                             Audience = "Audience",
-                            IssuedAt = DateTime.Parse("2018-03-17T18:33:37.080Z"),
+                            IssuedAt = DateTime.Parse("2038-03-17T18:33:37.080Z"),
                             NotBefore = DateTime.Parse("2018-03-17T18:33:37.080Z"),
                             Expires = DateTime.Parse("2023-03-17T18:33:37.080Z")
                         },
@@ -1310,7 +1313,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                        TokenDescriptor =  new SecurityTokenDescriptor
                        {
                             SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
-                            Claims = Default.PayloadDictionary,
+                            Claims = ReferenceTokens.PayloadDictionary,
                             AdditionalHeaderClaims = new Dictionary<string, object> () { { JwtHeaderParameterNames.Typ, "TEST" } }
                        },
                        JwtToken = ReferenceTokens.JWSWithDifferentTyp
@@ -1321,7 +1324,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         TestId = "MultipleAdditionalHeaderClaims",
                         TokenDescriptor =  new SecurityTokenDescriptor
                         {
-                            Claims = Default.PayloadDictionary,
+                            Claims = ReferenceTokens.PayloadDictionary,
                             SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
                             AdditionalHeaderClaims = new Dictionary<string, object>() { { "int", 123 }, { "string", "string" } }
                         },
@@ -1333,7 +1336,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                        TokenDescriptor =  new SecurityTokenDescriptor
                        {
                             SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
-                            Claims = Default.PayloadDictionary,
+                            Claims = ReferenceTokens.PayloadDictionary,
                             AdditionalHeaderClaims = new Dictionary<string, object> () { { "int", 123 } }
                        },
                        JwtToken = ReferenceTokens.JWSWithSingleAdditionalHeaderClaim
@@ -1344,17 +1347,17 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                        TokenDescriptor =  new SecurityTokenDescriptor
                        {
                             SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
-                            Claims = Default.PayloadDictionary,
+                            Claims = ReferenceTokens.PayloadDictionary,
                             AdditionalHeaderClaims = new Dictionary<string, object>()
                        },
-                       JwtToken = new JsonWebTokenHandler().CreateToken(Default.PayloadString, KeyingMaterial.JsonWebKeyRsa256SigningCredentials)
+                       JwtToken = new JsonWebTokenHandler().CreateToken(ReferenceTokens.PayloadString, KeyingMaterial.JsonWebKeyRsa256SigningCredentials)
                     },
                     new CreateTokenTheoryData
                     {
                        TestId = "UnsignedJWS",
                        TokenDescriptor =  new SecurityTokenDescriptor
                        {
-                            Claims = Default.PayloadDictionary,
+                            Claims = ReferenceTokens.PayloadDictionary,
                             AdditionalHeaderClaims = new Dictionary<string, object> () { { "int", 123 } }
                        },
                        JwtToken = ReferenceTokens.UnsignedJWSWithSingleAdditionalHeaderClaim
@@ -1588,10 +1591,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     {
                         First = true,
                         TestId = "JWEDirectEncryption",
-                        Payload = Default.PayloadString,
+                        Payload = ReferenceTokens.PayloadString,
                         TokenDescriptor =  new SecurityTokenDescriptor
                         {
-                            Claims = Default.PayloadDictionary,
+                            Claims = ReferenceTokens.PayloadDictionary,
                             SigningCredentials = Default.SymmetricSigningCredentials,
                             EncryptingCredentials = Default.SymmetricEncryptingCredentials,
                             AdditionalHeaderClaims = new Dictionary<string, object>() { { "int", 123 }, { "string", "string" } }
@@ -1600,18 +1603,18 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         {
                             IssuerSigningKey = Default.SymmetricSigningCredentials.Key,
                             TokenDecryptionKey = Default.SymmetricEncryptingCredentials.Key,
-                            ValidAudience = Default.Audience,
-                            ValidIssuer = Default.Issuer
+                            ValidAudience = ReferenceTokens.Audience,
+                            ValidIssuer = ReferenceTokens.Issuer
                         },
                         JwtToken = ReferenceTokens.JWEDirectEcryptionWithAdditionalHeaderClaims
                     },
                     new CreateTokenTheoryData
                     {
                         TestId = "JWEDirectEncryptionWithCty",
-                        Payload = Default.PayloadString,
+                        Payload = ReferenceTokens.PayloadString,
                         TokenDescriptor =  new SecurityTokenDescriptor
                         {
-                            Claims = Default.PayloadDictionary,
+                            Claims = ReferenceTokens.PayloadDictionary,
                             SigningCredentials = Default.SymmetricSigningCredentials,
                             EncryptingCredentials = Default.SymmetricEncryptingCredentials,
                             AdditionalHeaderClaims = new Dictionary<string, object>() { { JwtHeaderParameterNames.Cty, JwtConstants.HeaderType} }
@@ -1620,18 +1623,18 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         {
                             IssuerSigningKey = Default.SymmetricSigningCredentials.Key,
                             TokenDecryptionKey = Default.SymmetricEncryptingCredentials.Key,
-                            ValidAudience = Default.Audience,
-                            ValidIssuer = Default.Issuer
+                            ValidAudience = ReferenceTokens.Audience,
+                            ValidIssuer = ReferenceTokens.Issuer
                         },
                         JwtToken = ReferenceTokens.JWEDirectEcryptionWithCtyInAdditionalHeaderClaims
                     },
                     new CreateTokenTheoryData
                     {
                         TestId = "JWEDirectEncryptionWithDifferentTyp",
-                        Payload = Default.PayloadString,
+                        Payload = ReferenceTokens.PayloadString,
                         TokenDescriptor =  new SecurityTokenDescriptor
                         {
-                            Claims = Default.PayloadDictionary,
+                            Claims = ReferenceTokens.PayloadDictionary,
                             SigningCredentials = Default.SymmetricSigningCredentials,
                             EncryptingCredentials = Default.SymmetricEncryptingCredentials,
                             AdditionalHeaderClaims = new Dictionary<string, object>() { { JwtHeaderParameterNames.Typ, "TEST" } }
@@ -1640,66 +1643,66 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         {
                             IssuerSigningKey = Default.SymmetricSigningCredentials.Key,
                             TokenDecryptionKey = Default.SymmetricEncryptingCredentials.Key,
-                            ValidAudience = Default.Audience,
-                            ValidIssuer = Default.Issuer
+                            ValidAudience = ReferenceTokens.Audience,
+                            ValidIssuer = ReferenceTokens.Issuer
                         },
                         JwtToken = ReferenceTokens.JWEDirectEcryptionWithDifferentTyp
                     },
                     new CreateTokenTheoryData
                     {
                        TestId = "JWEKeyWrapping",
-                       Payload = Default.PayloadString,
+                       Payload = ReferenceTokens.PayloadString,
                        TokenDescriptor =  new SecurityTokenDescriptor
                        {
                             SigningCredentials = Default.SymmetricSigningCredentials,
                             EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256),
-                            Claims = Default.PayloadDictionary,
+                            Claims = ReferenceTokens.PayloadDictionary,
                             AdditionalHeaderClaims = new Dictionary<string, object>() { { "int", 123 }, { "string", "string" } }
                        },
                        ValidationParameters = new TokenValidationParameters
                        {
                             IssuerSigningKey = Default.SymmetricSigningCredentials.Key,
                             TokenDecryptionKey = KeyingMaterial.RsaSecurityKey_2048,
-                            ValidAudience = Default.Audience,
-                            ValidIssuer = Default.Issuer
+                            ValidAudience = ReferenceTokens.Audience,
+                            ValidIssuer = ReferenceTokens.Issuer
                        },
                        JwtToken = ReferenceTokens.JWEKeyWrappingWithAdditionalHeaderClaims
                     },
                     new CreateTokenTheoryData
                     {
                        TestId = "JWEKeyWrappingDifferentTyp",
-                       Payload = Default.PayloadString,
+                       Payload = ReferenceTokens.PayloadString,
                        TokenDescriptor =  new SecurityTokenDescriptor
                        {
                             SigningCredentials = Default.SymmetricSigningCredentials,
                             EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256),
-                            Claims = Default.PayloadDictionary,
+                            Claims = ReferenceTokens.PayloadDictionary,
                             AdditionalHeaderClaims = new Dictionary<string, object>() { { JwtHeaderParameterNames.Typ, "TEST" } }
                        },
                        ValidationParameters = new TokenValidationParameters
                        {
                             IssuerSigningKey = Default.SymmetricSigningCredentials.Key,
                             TokenDecryptionKey = KeyingMaterial.RsaSecurityKey_2048,
-                            ValidAudience = Default.Audience,
-                            ValidIssuer = Default.Issuer
+                            ValidAudience = ReferenceTokens.Audience,
+                            ValidIssuer = ReferenceTokens.Issuer
                        },
                        JwtToken = ReferenceTokens.JWEKeyWrappingWithDifferentTyp
                     },
                     new CreateTokenTheoryData
                     {
                        TestId = "JWEKeyWrappingUnsignedInnerJwt",
-                       Payload = Default.PayloadString,
+                       Payload = ReferenceTokens.PayloadString,
                        TokenDescriptor =  new SecurityTokenDescriptor
                        {
                             EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256),
-                            Claims = Default.PayloadDictionary,
+                            Claims = ReferenceTokens.PayloadDictionary,
                             AdditionalHeaderClaims = new Dictionary<string, object>() { { "int", 123 }, { "string", "string" } }
                        },
                        ValidationParameters = new TokenValidationParameters
                        {
                             TokenDecryptionKey = KeyingMaterial.RsaSecurityKey_2048,
-                            ValidAudience = Default.Audience,
-                            ValidIssuer = Default.Issuer,
+                            ValidAudience = ReferenceTokens.Audience,
+                            ValidIssuer = ReferenceTokens.Issuer,
                             RequireSignedTokens = false
                        },
                        JwtToken = ReferenceTokens.JWEKeyWrappingUnsignedInnerJWTWithAdditionalHeaderClaims
@@ -1707,18 +1710,18 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     new CreateTokenTheoryData
                     {
                         TestId = "JWEDirectEncryptionUnsignedInnerJWT",
-                        Payload = Default.PayloadString,
+                        Payload = ReferenceTokens.PayloadString,
                         TokenDescriptor =  new SecurityTokenDescriptor
                         {
-                            Claims = Default.PayloadDictionary,
+                            Claims = ReferenceTokens.PayloadDictionary,
                             EncryptingCredentials = Default.SymmetricEncryptingCredentials,
                             AdditionalHeaderClaims = new Dictionary<string, object>() { { "int", 123 }, { "string", "string" } }
                         },
                         ValidationParameters = new TokenValidationParameters
                         {
                             TokenDecryptionKey = Default.SymmetricEncryptingCredentials.Key,
-                            ValidAudience = Default.Audience,
-                            ValidIssuer = Default.Issuer,
+                            ValidAudience = ReferenceTokens.Audience,
+                            ValidIssuer = ReferenceTokens.Issuer,
                             RequireSignedTokens = false
                         },
                         JwtToken = ReferenceTokens.JWEDirectEncryptionUnsignedInnerJWTWithAdditionalHeaderClaims
@@ -2082,13 +2085,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     {
                         Payload = new JObject()
                         {
+                            { JwtRegisteredClaimNames.Aud, "Audience" },
+                            { JwtRegisteredClaimNames.Azp, Default.Azp },
                             { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
+                            { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(DateTime.Parse("2023-03-17T18:33:37.080Z")) },
                             { JwtRegisteredClaimNames.GivenName, "Bob" },
                             { JwtRegisteredClaimNames.Iss, "Issuer" },
-                            { JwtRegisteredClaimNames.Aud, "Audience" },
                             { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(DateTime.Parse("2018-03-17T18:33:37.080Z")) },
-                            { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(DateTime.Parse("2018-03-17T18:33:37.080Z")) },
-                            { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(DateTime.Parse("2023-03-17T18:33:37.080Z")) },
+                            { JwtRegisteredClaimNames.Jti, Default.Jti },
+                            { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(DateTime.Parse("2038-03-17T18:33:37.080Z")) },
                         }.ToString(Formatting.None),
                         TokenDescriptor =  new SecurityTokenDescriptor
                         {
@@ -2097,7 +2102,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             Issuer = "Issuer",
                             Audience = "Audience",
                             IssuedAt = DateTime.Parse("2018-03-17T18:33:37.080Z"),
-                            NotBefore = DateTime.Parse("2018-03-17T18:33:37.080Z"),
+                            NotBefore = DateTime.Parse("2038-03-17T18:33:37.080Z"),
                             Expires = DateTime.Parse("2023-03-17T18:33:37.080Z")
                         },
                         JsonWebTokenHandler = new JsonWebTokenHandler(),

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -2235,10 +2235,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 new Claim(JwtRegisteredClaimNames.Iss, Default.Issuer, ClaimValueTypes.String, Default.Issuer, Default.Issuer),
                 new Claim(JwtRegisteredClaimNames.Aud, Default.Audience, ClaimValueTypes.String, Default.Issuer, Default.Issuer),
                 new Claim(JwtRegisteredClaimNames.Aud.ToUpper(), "Audience", ClaimValueTypes.String, Default.Issuer, Default.Issuer),
-                new Claim(JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(Default.IssueInstant).ToString(), ClaimValueTypes.String, Default.Issuer, Default.Issuer),
+                new Claim(JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(Default.IssueInstant).ToString(), ClaimValueTypes.Integer64, Default.Issuer, Default.Issuer),
                 new Claim(JwtRegisteredClaimNames.Iat.ToUpper(), EpochTime.GetIntDate(utcNow).ToString(), ClaimValueTypes.String, Default.Issuer, Default.Issuer),
-                new Claim(JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(Default.NotBefore).ToString(), ClaimValueTypes.String, Default.Issuer, Default.Issuer),
-                new Claim(JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Default.Expires).ToString(), ClaimValueTypes.String, Default.Issuer, Default.Issuer),
+                new Claim(JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(Default.NotBefore).ToString(), ClaimValueTypes.Integer64, Default.Issuer, Default.Issuer),
+                new Claim(JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Default.Expires).ToString(), ClaimValueTypes.Integer64, Default.Issuer, Default.Issuer),
             });
 
             var securityTokenDescriptor = new SecurityTokenDescriptor()

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
@@ -423,7 +423,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                     new OidcProtocolValidatorTheoryData
                     {
-                        ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolException), "IDX21343:", typeof(System.Text.Json.JsonException)),
+                        ExpectedException = new ExpectedException(typeof(OpenIdConnectProtocolException), "IDX21343:", typeof(System.Text.Json.JsonException), true),
                         ProtocolValidator = new PublicOpenIdConnectProtocolValidator(),
                         TestId = "UserInfoEndpointResponse is not valid JSON",
                         ValidationContext = new OpenIdConnectProtocolValidationContext

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestTestUtils.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestTestUtils.cs
@@ -205,7 +205,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             if (token.ContainsKey(newProperty.Name))
                 token.Property(newProperty.Name).Remove();
 
-            if (newProperty.Value != null)
+            if (newProperty.Value.Type != JTokenType.Null)
                 token.Add(newProperty);
 
             return CreateDefaultSignedHttpRequestToken(token.ToString(Formatting.None));

--- a/test/Microsoft.IdentityModel.TestUtils/Default.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/Default.cs
@@ -300,6 +300,8 @@ namespace Microsoft.IdentityModel.TestUtils
                 "http://Default.Issuer3.com" };
         }
 
+        public static string Jti => "Jti";
+
         public static string Jwt(SecurityTokenDescriptor tokenDescriptor)
         {
             return (new JwtSecurityTokenHandler()).CreateEncodedJwt(tokenDescriptor);
@@ -390,13 +392,15 @@ namespace Microsoft.IdentityModel.TestUtils
         {
             get => new JObject()
             {
+                { JwtRegisteredClaimNames.Aud, Audience },
+                { JwtRegisteredClaimNames.Azp, Azp },
                 { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
+                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString() },
                 { JwtRegisteredClaimNames.GivenName, "Bob" },
                 { JwtRegisteredClaimNames.Iss, Issuer },
-                { JwtRegisteredClaimNames.Aud, Audience },
                 { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(IssueInstant).ToString() },
+                { JwtRegisteredClaimNames.Jti, Jti },
                 { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(NotBefore).ToString()},
-                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString() },
             }.ToString(Formatting.None);
         }
 
@@ -404,13 +408,15 @@ namespace Microsoft.IdentityModel.TestUtils
         {
             get => new List<Claim>()
             {
+                new Claim(JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString(), ClaimValueTypes.Integer64, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Aud, Audience, ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Azp, Azp, ClaimValueTypes.String, Issuer, Issuer),
                 new Claim(JwtRegisteredClaimNames.Email, "Bob@contoso.com", ClaimValueTypes.String, Issuer, Issuer),
                 new Claim(JwtRegisteredClaimNames.GivenName, "Bob", ClaimValueTypes.String, Issuer, Issuer),
                 new Claim(JwtRegisteredClaimNames.Iss, Issuer, ClaimValueTypes.String, Issuer, Issuer),
-                new Claim(JwtRegisteredClaimNames.Aud, Audience, ClaimValueTypes.String, Issuer, Issuer),
                 new Claim(JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(IssueInstant).ToString(), ClaimValueTypes.Integer64, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Jti, Jti, ClaimValueTypes.String, Issuer, Issuer),
                 new Claim(JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(NotBefore).ToString(), ClaimValueTypes.Integer64, Issuer, Issuer),
-                new Claim(JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString(), ClaimValueTypes.Integer64, Issuer, Issuer),
             };
         }
 
@@ -481,13 +487,15 @@ namespace Microsoft.IdentityModel.TestUtils
         {
             get => new Dictionary<string, object>()
             {
+                { JwtRegisteredClaimNames.Aud, Audience },
+                { JwtRegisteredClaimNames.Azp, Azp },
                 { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
+                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString() }
                 { JwtRegisteredClaimNames.GivenName, "Bob" },
                 { JwtRegisteredClaimNames.Iss, Issuer },
-                { JwtRegisteredClaimNames.Aud, Audience },
                 { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(IssueInstant).ToString() },
+                { JwtRegisteredClaimNames.Jti, Jti },
                 { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(NotBefore).ToString()},
-                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString() }
             };
         }
 

--- a/test/Microsoft.IdentityModel.TestUtils/Default.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/Default.cs
@@ -490,7 +490,7 @@ namespace Microsoft.IdentityModel.TestUtils
                 { JwtRegisteredClaimNames.Aud, Audience },
                 { JwtRegisteredClaimNames.Azp, Azp },
                 { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
-                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString() }
+                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString() },
                 { JwtRegisteredClaimNames.GivenName, "Bob" },
                 { JwtRegisteredClaimNames.Iss, Issuer },
                 { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(IssueInstant).ToString() },

--- a/test/Microsoft.IdentityModel.TestUtils/Default.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/Default.cs
@@ -408,9 +408,9 @@ namespace Microsoft.IdentityModel.TestUtils
                 new Claim(JwtRegisteredClaimNames.GivenName, "Bob", ClaimValueTypes.String, Issuer, Issuer),
                 new Claim(JwtRegisteredClaimNames.Iss, Issuer, ClaimValueTypes.String, Issuer, Issuer),
                 new Claim(JwtRegisteredClaimNames.Aud, Audience, ClaimValueTypes.String, Issuer, Issuer),
-                new Claim(JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(IssueInstant).ToString(), ClaimValueTypes.String, Issuer, Issuer),
-                new Claim(JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(NotBefore).ToString(), ClaimValueTypes.String, Issuer, Issuer),
-                new Claim(JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString(), ClaimValueTypes.String, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(IssueInstant).ToString(), ClaimValueTypes.Integer64, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(NotBefore).ToString(), ClaimValueTypes.Integer64, Issuer, Issuer),
+                new Claim(JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString(), ClaimValueTypes.Integer64, Issuer, Issuer),
             };
         }
 

--- a/test/Microsoft.IdentityModel.TestUtils/ReferenceTokens.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ReferenceTokens.cs
@@ -379,17 +379,18 @@ namespace Microsoft.IdentityModel.TestUtils
         public static string UnsignedJWSWithSingleAdditionalHeaderClaim = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIiwiaW50IjoxMjN9.eyJlbWFpbCI6IkJvYkBjb250b3NvLmNvbSIsImdpdmVuX25hbWUiOiJCb2IiLCJpc3MiOiJodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tIiwiYXVkIjoiaHR0cDovL0RlZmF1bHQuQXVkaWVuY2UuY29tIiwiaWF0IjoiMTQ4OTc3NTYxNyIsIm5iZiI6IjE0ODk3NzU2MTciLCJleHAiOiIyNTM0MDIzMDA3OTkifQ.";
 
         // the following values are separate from the one in Default.cs, so we can change the Defaults
+        // Do not change any of these values either adding new values or order or the tests will break.
         public static Dictionary<string, object> PayloadDictionary
         {
             get => new Dictionary<string, object>()
             {
-                { JwtRegisteredClaimNames.Aud, Audience },
                 { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
-                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString() },
                 { JwtRegisteredClaimNames.GivenName, "Bob" },
-                { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(IssueInstant).ToString() },
                 { JwtRegisteredClaimNames.Iss, Issuer },
+                { JwtRegisteredClaimNames.Aud, Audience },
+                { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(IssueInstant).ToString() },
                 { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(NotBefore).ToString()},
+                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString() }
             };
         }
 
@@ -397,13 +398,13 @@ namespace Microsoft.IdentityModel.TestUtils
         {
             get => new JObject()
             {
-                { JwtRegisteredClaimNames.Aud, Audience },
                 { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
-                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString() },
                 { JwtRegisteredClaimNames.GivenName, "Bob" },
-                { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(IssueInstant).ToString() },
                 { JwtRegisteredClaimNames.Iss, Issuer },
+                { JwtRegisteredClaimNames.Aud, Audience },
+                { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(IssueInstant).ToString() },
                 { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(NotBefore).ToString()},
+                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString() },
             }.ToString(Formatting.None);
         }
 

--- a/test/Microsoft.IdentityModel.TestUtils/ReferenceTokens.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ReferenceTokens.cs
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Newtonsoft.Json.Linq;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
 namespace Microsoft.IdentityModel.TestUtils
 {
     public class ReferenceTokens
@@ -370,6 +377,69 @@ namespace Microsoft.IdentityModel.TestUtils
         // This token is unsigned and includes one additional header claim:
         // { "int", 123 }.
         public static string UnsignedJWSWithSingleAdditionalHeaderClaim = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIiwiaW50IjoxMjN9.eyJlbWFpbCI6IkJvYkBjb250b3NvLmNvbSIsImdpdmVuX25hbWUiOiJCb2IiLCJpc3MiOiJodHRwOi8vRGVmYXVsdC5Jc3N1ZXIuY29tIiwiYXVkIjoiaHR0cDovL0RlZmF1bHQuQXVkaWVuY2UuY29tIiwiaWF0IjoiMTQ4OTc3NTYxNyIsIm5iZiI6IjE0ODk3NzU2MTciLCJleHAiOiIyNTM0MDIzMDA3OTkifQ.";
+
+        // the following values are separate from the one in Default.cs, so we can change the Defaults
+        public static Dictionary<string, object> PayloadDictionary
+        {
+            get => new Dictionary<string, object>()
+            {
+                { JwtRegisteredClaimNames.Aud, Audience },
+                { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
+                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString() },
+                { JwtRegisteredClaimNames.GivenName, "Bob" },
+                { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(IssueInstant).ToString() },
+                { JwtRegisteredClaimNames.Iss, Issuer },
+                { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(NotBefore).ToString()},
+            };
+        }
+
+        public static string PayloadString
+        {
+            get => new JObject()
+            {
+                { JwtRegisteredClaimNames.Aud, Audience },
+                { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
+                { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(Expires).ToString() },
+                { JwtRegisteredClaimNames.GivenName, "Bob" },
+                { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(IssueInstant).ToString() },
+                { JwtRegisteredClaimNames.Iss, Issuer },
+                { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(NotBefore).ToString()},
+            }.ToString(Formatting.None);
+        }
+
+        public static string Audience
+        {
+            get => "http://Default.Audience.com";
+        }
+        public static DateTime Expires
+        {
+            get => DateTime.Parse(ExpiresString);
+        }
+
+        public static string ExpiresString
+        {
+            get => DateTime.MaxValue.ToString("s") + "Z";
+        }
+
+        public static DateTime IssueInstant
+        {
+            get => DateTime.Parse(IssueInstantString);
+        }
+
+        public static string IssueInstantString
+        {
+            get => "2017-03-17T18:33:37.095Z";
+        }
+
+        public static string Issuer
+        {
+            get => "http://Default.Issuer.com";
+        }
+
+        public static DateTime NotBefore
+        {
+            get => DateTime.Parse("2017-03-17T18:33:37.080Z");
+        }
         #endregion
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonSerializerPrimitivesTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonSerializerPrimitivesTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                 theoryData.Add(
                     new JsonSerializerTheoryData("Dictionary<string,object>Level3")
                     {
-                        Json = $@"{{""key"":{{""l1_1"":1,""l1_2"":""level1"",""l2_dict"":{{""l2_1"":1,""l2_2"":""level2"",""l3_dict"":""System.Collections.Generic.Dictionary`2[System.String,System.Object]""}}}}}}",
+                        Json = $@"{{""key"":{{""l1_1"":1,""l1_2"":""level1"",""l2_dict"":{{""l2_1"":1,""l2_2"":""level2"",""l3_dict"":{{""l3_1"":1,""l3_2"":""level3""}}}}}}}}",
                         PropertyName = "key",
                         Object = new Dictionary<string, object> { { "l1_1", 1 }, { "l1_2", "level1" },
                                         { "l2_dict", new Dictionary<string, object> { { "l2_1", 1 }, { "l2_2", "level2" },
@@ -108,29 +108,29 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                     });
 
                 theoryData.Add(
-                    new JsonSerializerTheoryData("List<object>Level3")
+                    new JsonSerializerTheoryData("List<object>Level1")
                     {
-                        Json = $@"{{""key"":[1,""string"",1.23,[3,""stringLevel2"",6.52,""System.Collections.Generic.List`1[System.Object]""]]}}",
+                        Json = @$"{{""key"":[1,""stringLevel1"",1.11]}}",
                         PropertyName = "key",
-                        Object = new List<object> { 1, "string", 1.23,
-                                    new List<object> { 3, "stringLevel2", 6.52,
-                                        new List<object> { 3, "stringLevel2", 6.52 } } }
+                        Object = new List<object> { 1, "stringLevel1", 1.11 },
                     });
 
                 theoryData.Add(
                     new JsonSerializerTheoryData("List<object>Level2")
                     {
-                        Json = @$"{{""key"":[1,""string"",1.23,[3,""stringLevel2"",6.52]]}}",
+                        Json = @$"{{""key"":[1,""string"",1.11,[2,""stringLevel2"",2.22]]}}",
                         PropertyName = "key",
-                        Object = new List<object> { 1, "string", 1.23, new List<object> { 3, "stringLevel2", 6.52 } },
+                        Object = new List<object> { 1, "string", 1.11, new List<object> { 2, "stringLevel2", 2.22 } },
                     });
 
                 theoryData.Add(
-                    new JsonSerializerTheoryData("List<object>Level1")
+                    new JsonSerializerTheoryData("List<object>Level3")
                     {
-                        Json = @$"{{""key"":[1,""string"",1.23]}}",
+                        Json = $@"{{""key"":[1,""string"",1.11,[2,""stringLevel2"",2.22,[3,""stringLevel3"",3.33]]]}}",
                         PropertyName = "key",
-                        Object = new List<object> { 1, "string", 1.23 },
+                        Object = new List<object> { 1, "string", 1.11,
+                                                    new List<object> { 2, "stringLevel2", 2.22,
+                                                        new List<object> { 3, "stringLevel3", 3.33 } } }
                     });
 
                 return theoryData;

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonUtilities.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonUtilities.cs
@@ -137,7 +137,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
             SetAdditionalDataNumbers(dictionary);
             SetAdditionalDataValues(dictionary);
             dictionary["Object"] = CreateJsonElement(_objectData);
-            dictionary["Array"] = _arrayDataAsObjectList;
+            dictionary["Array"] = CreateJsonElement(_arrayData);
             if (key != null)
                 dictionary[key] = obj;
         }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JweUsingEchdTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JweUsingEchdTests.cs
@@ -274,7 +274,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             testData.AdditionalHeaderParams = new Dictionary<string, object>();
             testData.AdditionalHeaderParams.Add(JsonWebTokens.JwtHeaderParameterNames.Apu, testData.ApuSender);
             testData.AdditionalHeaderParams.Add(JsonWebTokens.JwtHeaderParameterNames.Apv, testData.ApvSender);
-            testData.AdditionalHeaderParams.Add(JsonWebTokens.JwtHeaderParameterNames.Epk, epkJObject);
+            testData.AdditionalHeaderParams.Add(JsonWebTokens.JwtHeaderParameterNames.Epk, epkJObject.ToString(Newtonsoft.Json.Formatting.None));
 
             return testData;
         }

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
@@ -1107,9 +1107,9 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
             expectedIdentity.AddClaim(new Claim(JwtRegisteredClaimNames.Iss, Default.Issuer, ClaimValueTypes.String, Default.Issuer));
             expectedIdentity.AddClaim(new Claim(JwtRegisteredClaimNames.Aud, Default.Audience, ClaimValueTypes.String, Default.Issuer));
-            expectedIdentity.AddClaim(new Claim(JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(expire).ToString(), ClaimValueTypes.Integer32, Default.Issuer));
-            expectedIdentity.AddClaim(new Claim(JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(utcNow).ToString(), ClaimValueTypes.Integer32, Default.Issuer));
-            expectedIdentity.AddClaim(new Claim(JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(utcNow).ToString(), ClaimValueTypes.Integer32, Default.Issuer));
+            expectedIdentity.AddClaim(new Claim(JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(expire).ToString(), ClaimValueTypes.Integer64, Default.Issuer));
+            expectedIdentity.AddClaim(new Claim(JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(utcNow).ToString(), ClaimValueTypes.Integer64, Default.Issuer));
+            expectedIdentity.AddClaim(new Claim(JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(utcNow).ToString(), ClaimValueTypes.Integer64, Default.Issuer));
 
             CompareContext context = new CompareContext { IgnoreType = true };
             IdentityComparer.AreEqual(principal.Claims, expectedIdentity.Claims, context);

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Security.Claims;
+using System.Text;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.IdentityModel.Tokens.Json;
@@ -87,6 +88,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         [Fact]
         public void JwtPayloadUnicodeMapping()
         {
+
             string issuer = "a\\b";
             List<Claim> claims = new List<Claim>();
             JwtPayload unicodePayload = new JwtPayload("a\u005Cb", "", claims, null, null);
@@ -95,7 +97,8 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             string json2 = payload.SerializeToJson();
             Assert.Equal(json, json2);
 
-            JwtPayload retrievePayload = new JwtPayload(json);
+            byte[] bytes = Encoding.UTF8.GetBytes(json);
+            JwtPayload retrievePayload = JwtPayload.CreatePayload(bytes, bytes.Length);
             Assert.Equal(retrievePayload.Iss, issuer);
 
             json = unicodePayload.Base64UrlEncode();
@@ -190,7 +193,8 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             var context = new CompareContext();
             var payload = new JwtPayload(claims);
             var payloadAsJson = payload.SerializeToJson();
-            var payloadDeserialized = new JwtPayload(payloadAsJson);
+            byte[] payloadAsBytes = Encoding.UTF8.GetBytes(payloadAsJson);
+            JwtPayload payloadDeserialized = JwtPayload.CreatePayload(payloadAsBytes, payloadAsBytes.Length);
             var instanceContext = new CompareContext
             {
                 PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
@@ -204,7 +208,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
             if (!IdentityComparer.AreEqual(payload, payloadDeserialized, instanceContext))
             {
-                instanceContext.AddDiff("payload != payloadUsingNewtonsoft");
+                instanceContext.AddDiff("payload != payloadDeserialized");
                 instanceContext.AddDiff("******************************");
             }
 
@@ -271,7 +275,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     new List<Claim>
                     {
                         new Claim("aud", "http://test.local/api/", ClaimValueTypes.String, "http://test.local/api/"),
-                        new Claim("exp", "1460647835", ClaimValueTypes.Integer32, "http://test.local/api/"),
+                        new Claim("exp", "1460647835", ClaimValueTypes.Integer64, "http://test.local/api/"),
                         new Claim("emailaddress", "user1@contoso.com", ClaimValueTypes.String, "http://test.local/api/"),
                         new Claim("emailaddress", "user2@contoso.com", ClaimValueTypes.String, "http://test.local/api/"),
                         new Claim("name", "user", ClaimValueTypes.String, "http://test.local/api/"),

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
@@ -28,8 +28,6 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 signingCredentials: creds);
 
             Assert.Equal(token.ValidTo, (new DateTime(2038,1,20)).ToUniversalTime());
-            foreach (var claim in token.Claims)
-                Console.WriteLine($"{claim}");
         }
 
         [Fact]

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
@@ -3,17 +3,35 @@
 
 using System.Collections.Generic;
 using System.Security.Claims;
+using System.Text;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
 using Xunit;
 
-#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
-
 namespace System.IdentityModel.Tokens.Jwt.Tests
 {
     public class JwtSecurityTokenTests
     {
+        [Fact]
+        public void DateTime2038Issue()
+        {
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('a', 128)));
+            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+            var claims = new[] { new Claim(ClaimTypes.NameIdentifier, "Bob") };
+            var token = new JwtSecurityToken(
+                issuer: "issuer.contoso.com",
+                audience: "audience.contoso.com",
+                claims: claims,
+                expires: (new DateTime(2038, 1, 20)).ToUniversalTime(),
+                signingCredentials: creds);
+
+            Assert.Equal(token.ValidTo, (new DateTime(2038,1,20)).ToUniversalTime());
+            foreach (var claim in token.Claims)
+                Console.WriteLine($"{claim}");
+        }
+
         [Fact]
         public void Defaults()
         {
@@ -414,5 +432,3 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
     }
 }
-
-#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant


### PR DESCRIPTION
Added to the support 'T' that were available in 6x.
Fix 2038 datetime issue with JwtSecurityToken

If possible, Json will be mapped to one of the following types:
string[], List,,Collection, object[], List, Collection, int[], long[]
Dictionary<string, string>>, Dictionary<string, string[]>, Dictionary<string, List>, Dictionary<string, Collection>
Dictionary<string, object>, Dictionary<string, object[]>

With this change 7 will not be as general as 6x but will help with common scenarios.
A general solution will require a new api.

When calling TryGetPayloadValue the priority is generally:
sting, string[], List, Collection, ...

=================================
Pattern matching is applied when possible.
Json = {“p”:[1,2,3]}
TryGetPayLoadValue<string[]>(“p”) => string[]{“1”,”2”,”3”}

Json = {“p”:”value”}
TryGetPayLoadValue<string[]>(“p”) => string[]{“value”}

Json = {“p”:{”object”:”value”}}
TryGetPayLoadValue(“p”) => “{“object”:”value”}”
This will always return a value if it was the property exists.

=====================================
We still write obj.ToString() when serializing, even if we don't understand the type, as users that are working with Newtosoft.JObject will benefit. We are open to changing this depending on feedback.