### PR TITLE
Adjust benchmark, PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+# {PR title}
+<!-- Thank you for submitting a pull request to our repo. -->
+
+<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
+below to ensure a smooth review and merge process for your PR. -->
+
+- [ ] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+- [ ] You've included unit or integration tests for your change, where applicable.
+- [ ] You've included inline docs for your change, where applicable.
+- [ ] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
+- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.
+
+<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->
+
+Summary of the changes (Less than 80 chars)
+
+## Description
+
+{Detail}
+
+Fixes #{bug number} (in this specific format)

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/CreateTokenTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/CreateTokenTests.cs
@@ -9,6 +9,7 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.Benchmarks
 {
+    [HideColumns("Type", "Job", "WarmupCount", "LaunchCount")]
     public class CreateTokenTests
     {
         JsonWebTokenHandler jsonWebTokenHandler;

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateTokenAsyncTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateTokenAsyncTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 namespace Microsoft.IdentityModel.Benchmarks
 {
     [Config(typeof(AntiVirusFriendlyConfig))]
+    [HideColumns("Type", "Job", "WarmupCount", "LaunchCount")]
     public class ValidateTokenAsyncTests
     {
         JsonWebTokenHandler jsonWebTokenHandler;

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/identitymodel.benchmarks.yml
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/identitymodel.benchmarks.yml
@@ -5,6 +5,7 @@ jobs:
   benchmarks:
     source:
       repository: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet
+      branchOrCommit: dev7
       project: benchmark\Microsoft.IdentityModel.Benchmarks\Microsoft.IdentityModel.Benchmarks.csproj
     variables:
       filterArg: "*"

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/identitymodel.benchmarks.yml
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/identitymodel.benchmarks.yml
@@ -15,11 +15,12 @@ jobs:
       benchmarkDotNet: true
     
 scenarios:
-  ValidateTokenAsyncTests:
-    application:
-      job: benchmarks
 
-  CreateTokenTests:
+  ValidateToken:
     application:
-      job: benchmarks
+      job: "*ValidateTokenAsyncTests*"
+
+  CreateToken:
+    application:
+      job: "*CreateTokenTests*"
 


### PR DESCRIPTION
For crank, the command must use dev7 until the benchmark app is merged into dev. 

In the crank output for the microbenchmarks, several noisy columns are displayed. This change hides them.

Create a PR template that refers people to the [benchmarking wiki page](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)