### PR TITLE
Support 6x where JsonWebToken.GetPayloadValue<string>("aud") succeeds

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
@@ -216,7 +216,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 if (objType == typeof(DateTime))
                     return (T)((object)((DateTime)obj).ToString("o", CultureInfo.InvariantCulture));
 
-               return (T)((object)obj.ToString());
+                if (obj is List<string> list)
+                {
+                    if (list.Count == 1)
+                        return (T)((object)(list[0]));
+                }
+                else
+                    return (T)((object)obj.ToString());
             }
             else if (typeof(T) == typeof(bool))
             {

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/GetPayloadValueTheoryData.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/GetPayloadValueTheoryData.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.IdentityModel.TestUtils;
-using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 {
@@ -12,11 +11,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         public GetPayloadValueTheoryData(string testId) : base(testId)
         { }
 
-        public SecurityTokenDescriptor SecurityTokenDescriptor { get; set; }
+        public object ClaimValue { get; set; }
 
         public string PropertyName { get; set; }
-
-        public Type PropertyOut { get; set; }
 
         public Type PropertyType { get; set; }
 


### PR DESCRIPTION
6x supported JsonWebToken.GetPayloadValue<string>("aud").
This change supports that.

Throws if multiple audiences exist.