### PR TITLE
Revert to 6x behavior where users can clear.

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <summary>
         /// Default claim type mapping for inbound claims.
         /// </summary>
-        public static readonly Dictionary<string, string> DefaultInboundClaimTypeMap = new Dictionary<string, string>(ClaimTypeMapping.InboundClaimTypeMap);
+        public static IDictionary<string, string> DefaultInboundClaimTypeMap = new Dictionary<string, string>(ClaimTypeMapping.InboundClaimTypeMap);
 
         /// <summary>
         /// Default value for the flag that determines whether or not the InboundClaimTypeMap is used.


### PR DESCRIPTION
6x has this exposed as an IDictionary, since it is static and rarely used there would be very small perf hit.