### PR TITLE
Fix typo in TokenValidationParameters

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -855,7 +855,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Gets or sets a boolean that controls the validation order of the payload and signature during token validation.
         /// </summary>
-        /// <remarks>If <see cref= "ValidateSignatureLast" /> is set to ture, it will validate payload ahead of signature .
+        /// <remarks>If <see cref= "ValidateSignatureLast" /> is set to true, it will validate payload ahead of signature.
         /// The default is <c>false</c>.
         /// </remarks>
         [DefaultValue(false)]


### PR DESCRIPTION
# Fix typo in TokenValidationParameters

The description of the `ValidateSignatureLast` has been updated to fix the typo of "ture" to true.

## Description

The description of the `ValidateSignatureLast` field in the `TokenValidationParameters` class has a small typo in the Remark section. Specifically, the description of the `ValidateSignatureLast` field in the TokenValidationParameters class has a typo of "ture" to true. This change will fix the typo.

This change does not affect any behavior changes, but rather improve the [Documentation](https://learn.microsoft.com/en-us/dotnet/api/microsoft.identitymodel.tokens.tokenvalidationparameters.validatesignaturelast?view=msal-web-dotnet-latest#microsoft-identitymodel-tokens-tokenvalidationparameters-validatesignaturelast).
