### PR TITLE
Revert to 6x behavior with GetPayloadClaim<object>("aud")

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonWebToken.PayloadClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonWebToken.PayloadClaimSet.cs
@@ -44,9 +44,14 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                         else
                         {
                             if (reader.TokenType != JsonTokenType.Null)
+                            {
                                 _audiences.Add(JsonSerializerPrimitives.ReadString(ref reader, JwtRegisteredClaimNames.Aud, ClassName));
-
-                            claims[JwtRegisteredClaimNames.Aud] = _audiences;
+                                claims[JwtRegisteredClaimNames.Aud] = _audiences[0];
+                            }
+                            else
+                            {
+                                claims[JwtRegisteredClaimNames.Aud] = _audiences;
+                            }
                         }
                     }
                     else if (reader.ValueTextEquals(JwtPayloadUtf8Bytes.Azp))

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
@@ -275,6 +275,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             {
                 var theoryData = new TheoryData<GetPayloadValueTheoryData>();
 
+                theoryData.Add(new GetPayloadValueTheoryData("stringFromSingleAsObject")
+                {
+                    ClaimValue = "audience",
+                    PropertyName = "aud",
+                    PropertyType = typeof(object),
+                    PropertyValue = new List<string> { "audience" },
+                    Json = JsonUtilities.CreateUnsignedToken("aud", "audience")
+                });
+
                 theoryData.Add(new GetPayloadValueTheoryData("stringFromSingleInList")
                 {
                     ClaimValue = "audience",


### PR DESCRIPTION
In 6x, GetPayloadClaim<object>("aud") will return a single string when aud was a single value.
The changes in 7 resulted in a List<string> with one value, which broke some users.

This change returns to the same behavior as 6x.

Note: GetPayloadClaim<string>("aud") would return a string.

JsonWebToken.Audiences is a better approach to access the 'aud' values as during the deserialization of the JWT, the audience values are deserialized.

Addresses: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2328