### PR TITLE
OpenidConnectMessage serializes as 6x

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/OpenIdConnectMessage.cs
@@ -40,7 +40,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
             {
                 throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX21106, json)));
             }
-
         }
 
         /// <summary>
@@ -114,12 +113,23 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
 
             while (reader.Read())
             {
+                // propertyValue is set to match 6.x
                 if (reader.TokenType == JsonTokenType.PropertyName)
                 {
                     string propertyName = JsonPrimitives.ReadPropertyName(ref reader, ClassName, true);
                     string propertyValue = null;
                     if (reader.TokenType == JsonTokenType.String)
                         propertyValue = JsonPrimitives.ReadString(ref reader, propertyName, ClassName);
+                    else if (reader.TokenType == JsonTokenType.Number)
+                        propertyValue = (JsonPrimitives.ReadNumber(ref reader)).ToString();
+                    else if ((reader.TokenType == JsonTokenType.True) || (reader.TokenType == JsonTokenType.False))
+                        propertyValue = JsonPrimitives.ReadBoolean(ref reader, propertyName, ClassName, false).ToString();
+                    else if (reader.TokenType == JsonTokenType.Null)
+                        propertyValue = "";
+                    else if (reader.TokenType == JsonTokenType.StartArray)
+                        propertyValue = JsonPrimitives.ReadJsonElement(ref reader).GetRawText();
+                    else if (reader.TokenType == JsonTokenType.StartObject)
+                        propertyValue = JsonPrimitives.ReadJsonElement(ref reader).GetRawText();
 
                     SetParameter(propertyName, propertyValue);
                 }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -4,20 +4,18 @@
 // Ignore Spelling: Metadata Validator Retreiver
 
 using System;
-using System.CodeDom;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.IO;
 using System.Net;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.IdentityModel.Protocols.Configuration;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect.Configuration;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
 using Xunit;
-
-#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 {
@@ -26,11 +24,74 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
     /// </summary>
     public class ConfigurationManagerTests
     {
+        [Theory, MemberData(nameof(GetPublicMetadataTheoryData), DisableDiscoveryEnumeration = true)]
+        public async Task GetPublicMetadata(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            CompareContext context = TestUtilities.WriteHeader($"{this}.GetPublicMetadata", theoryData);
+            try
+            {
+                var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                    theoryData.MetadataAddress,
+                    theoryData.ConfigurationRetreiver,
+                    theoryData.DocumentRetriever,
+                    theoryData.ConfigurationValidator);
 
-        [Theory, MemberData(nameof(ConstructorTheoryData))]
+                var configuration = await configurationManager.GetConfigurationAsync(CancellationToken.None);
+
+                Assert.NotNull(configuration);
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<ConfigurationManagerTheoryData<OpenIdConnectConfiguration>> GetPublicMetadataTheoryData()
+        {
+            var theoryData = new TheoryData<ConfigurationManagerTheoryData<OpenIdConnectConfiguration>>();
+
+            theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AccountsGoogleCom")
+            {
+                ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                ConfigurationValidator = new OpenIdConnectConfigurationValidator(),
+                DocumentRetriever = new HttpDocumentRetriever(),
+                MetadataAddress = OpenIdConfigData.AccountsGoogle
+            });
+
+            theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AADCommonUrl")
+            {
+                ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                ConfigurationValidator = new OpenIdConnectConfigurationValidator(),
+                DocumentRetriever = new HttpDocumentRetriever(),
+                MetadataAddress = OpenIdConfigData.AADCommonUrl
+            });
+
+            theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AADCommonUrlV1")
+            {
+                ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                ConfigurationValidator = new OpenIdConnectConfigurationValidator(),
+                DocumentRetriever = new HttpDocumentRetriever(),
+                MetadataAddress = OpenIdConfigData.AADCommonUrlV1
+            });
+
+            theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AADCommonUrlV2")
+            {
+                ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                ConfigurationValidator = new OpenIdConnectConfigurationValidator(),
+                DocumentRetriever = new HttpDocumentRetriever(),
+                MetadataAddress = OpenIdConfigData.AADCommonUrlV2
+            });
+
+            return theoryData;
+        }
+
+        [Theory, MemberData(nameof(ConstructorTheoryData), DisableDiscoveryEnumeration = true)]
         public void OpenIdConnectConstructor(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
         {
-            TestUtilities.WriteHeader($"{this}.OpenIdConnectConstructor", theoryData);
+            var context = TestUtilities.WriteHeader($"{this}.OpenIdConnectConstructor", theoryData);
             try
             {
                 var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(theoryData.MetadataAddress, theoryData.ConfigurationRetreiver, theoryData.DocumentRetriever, theoryData.ConfigurationValidator);
@@ -40,6 +101,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             {
                 theoryData.ExpectedException.ProcessException(ex);
             }
+
+            TestUtilities.AssertFailIfErrors(context);
         }
 
         public static TheoryData<ConfigurationManagerTheoryData<OpenIdConnectConfiguration>> ConstructorTheoryData
@@ -606,6 +669,10 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
         public class ConfigurationManagerTheoryData<T> : TheoryDataBase
         {
+            public ConfigurationManagerTheoryData() {}
+
+            public ConfigurationManagerTheoryData(string testId) : base(testId) {}
+
             public TimeSpan AutomaticRefreshInterval { get; set; }
 
             public IConfigurationRetriever<T> ConfigurationRetreiver { get; set; }
@@ -633,5 +700,3 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         }
     }
 }
-
-#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
@@ -33,6 +33,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         public static OpenIdConnectConfiguration PingLabs = new OpenIdConnectConfiguration();
         public static OpenIdConnectConfiguration SingleX509Data = new OpenIdConnectConfiguration();
         public static string AADCommonUrl = "https://login.windows.net/common/.well-known/openid-configuration";
+        public static string AADCommonUrlV1 = "https://login.microsoftonline.com/common/.well-known/openid-configuration";
+        public static string AADCommonUrlV2 = "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration";
+        public static string AccountsGoogle = "https://accounts.google.com/.well-known/openid-configuration";
         public static string BadUri = "_____NoSuchfile____";
         public static string HttpsBadUri = "https://_____NoSuchfile____";
         public static string OpenIdConnectMetadataPingString = @"{""authorization_endpoint"":""https:\/\/connect-interop.pinglabs.org:9031\/as\/authorization.oauth2"",

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationRetrieverTests.cs
@@ -8,14 +8,12 @@ using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.TestUtils;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 {
     public class OpenIdConnectConfigurationRetrieverTests
     {
-
         [Fact]
         public async Task FromNetwork()
         {

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
@@ -10,7 +10,6 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect.Json.Tests;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
 #pragma warning disable SYSLIB0013 // Type or member is obsolete
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
@@ -20,29 +19,92 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
     /// </summary>
     public class OpenIdConnectMessageTests
     {
-        [Theory, MemberData(nameof(ConstructorsTheoryData))]
-        public void Constructors(OpenIdConnectMessageTheoryData theoryData)
+        [Theory, MemberData(nameof(GetMessagePropertyTheoryData), DisableDiscoveryEnumeration = true)]
+        public void GetMessageProperty(OpenIdConnectMessageTheoryData theoryData)
         {
-            TestUtilities.WriteHeader($"{this}.Constructors", theoryData);
-            var context = new CompareContext($"{this}.ReadMetadata, {theoryData.TestId}");
-            OpenIdConnectMessage messageFromJson;
-            // TODO - these local variable has been left commented out as
-            // we will need this to check a 6x -> 7x compatibility test that needs to be written.
-            //OpenIdConnectMessage messageFromJsonObj;
-            var diffs = new List<string>();
+            CompareContext context = TestUtilities.WriteHeader($"{this}.GetMessageProperty", theoryData);
             try
             {
-                messageFromJson = new OpenIdConnectMessage(theoryData.Json);
-//#pragma warning disable CS0618 // Type or member is obsolete
-//                messageFromJsonObj = new OpenIdConnectMessage6x(theoryData.JObject);
-//#pragma warning restore CS0618 // Type or member is obsolete
-                //IdentityComparer.AreEqual(messageFromJson, messageFromJsonObj, context);
-                IdentityComparer.AreEqual(messageFromJson, theoryData.Message, context);
-                theoryData.ExpectedException.ProcessNoException();
+                OpenIdConnectMessage oidcMessage = new OpenIdConnectMessage(theoryData.Json);
+                OpenIdConnectMessage6x oidcMessage6x = new OpenIdConnectMessage6x(theoryData.Json);
+                theoryData.ExpectedException.ProcessNoException(context);
+
+                IdentityComparer.AreEqual(oidcMessage.ExpiresIn, theoryData.PropertyValue, context);
+                // Note: in 6x Newtonsoft was set to format the json with /r/n and spaces, we don't do that in 7x
+                IdentityComparer.AreEqual(oidcMessage6x.ExpiresIn.Replace("\r", "").Replace("\n", "").Replace(" ", ""), theoryData.PropertyValue, context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex.InnerException, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<OpenIdConnectMessageTheoryData> GetMessagePropertyTheoryData()
+        {
+            // all of the properties are translated to strings so the single property of ExpiresIn was chosen to test.
+            // this test is to ensure that the 6x and 7x versions of the library return the same value.
+            TheoryData<OpenIdConnectMessageTheoryData> theoryData = new TheoryData<OpenIdConnectMessageTheoryData>();
+
+            theoryData.Add(new OpenIdConnectMessageTheoryData("String")
+            {
+                Json = $@"{{""expires_in"":""string""}}",
+                PropertyValue = "string"
+            });
+
+            theoryData.Add(new OpenIdConnectMessageTheoryData("Number")
+            {
+                Json = $@"{{""expires_in"":600}}",
+                PropertyValue = "600"
+            });
+
+            theoryData.Add(new OpenIdConnectMessageTheoryData("Array")
+            {
+                Json = $@"{{""expires_in"":[600,500]}}",
+                PropertyValue = "[600,500]"
+            });
+
+            theoryData.Add(new OpenIdConnectMessageTheoryData("Object")
+            {
+                Json = $@"{{""expires_in"":{{""object"":""value""}}}}",
+                PropertyValue = $@"{{""object"":""value""}}"
+            });
+
+            theoryData.Add(new OpenIdConnectMessageTheoryData("null")
+            {
+                Json = $@"{{""expires_in"":null}}",
+                PropertyValue = ""
+            });
+
+            theoryData.Add(new OpenIdConnectMessageTheoryData("true")
+            {
+                Json = $@"{{""expires_in"":true}}",
+                PropertyValue = "True"
+            });
+
+            theoryData.Add(new OpenIdConnectMessageTheoryData("false")
+            {
+                Json = $@"{{""expires_in"":false}}",
+                PropertyValue = "False"
+            });
+
+            return theoryData;
+        }
+
+        [Theory, MemberData(nameof(ConstructorsTheoryData), DisableDiscoveryEnumeration = true)]
+        public void Constructors(OpenIdConnectMessageTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.Constructors", theoryData);
+            try
+            {
+                OpenIdConnectMessage oidcMessage = new OpenIdConnectMessage(theoryData.Json);
+                IdentityComparer.AreEqual(oidcMessage, theoryData.Message, context);
+                theoryData.ExpectedException.ProcessNoException(context);
             }
             catch (Exception exception)
             {
-                theoryData.ExpectedException.ProcessException(exception);
+                theoryData.ExpectedException.ProcessException(exception, context);
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -52,6 +114,11 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         {
             return new TheoryData<OpenIdConnectMessageTheoryData>
             {
+                new OpenIdConnectMessageTheoryData("InvalidJson")
+                {
+                    ExpectedException = ExpectedException.ArgumentException("IDX21106"),
+                    Json =  @"{""response_mode"":""responseMode"";""response_mode"":""duplicateResponeMode""}"
+                },
                 new OpenIdConnectMessageTheoryData("EmptyString")
                 {
                     ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
@@ -63,10 +130,13 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 },
                 new OpenIdConnectMessageTheoryData("ResponseModeDuplicated")
                 {
-                    ExpectedException = ExpectedException.ArgumentException("IDX21106"),
-                    Json =  @"{""response_mode"":""responseMode"";""respone_mode"":""duplicateResponeMode""}"
+                    Json =  @"{""response_mode"":""responseMode"",""response_mode"":""duplicateResponseMode""}",
+                    Message = new OpenIdConnectMessage
+                    {
+                        ResponseMode = "duplicateResponseMode"
+                    }
                 },
-                new OpenIdConnectMessageTheoryData("EmptyJsonStringEmptyJobj")
+new OpenIdConnectMessageTheoryData("EmptyJsonStringEmptyJobj")
                 {
                     JObject = new JObject(),
                     Json = "{}",
@@ -618,7 +688,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             public OpenIdConnectMessageTheoryData(string testId) : base(testId) { }
 
             public OpenIdConnectMessage Message { get; set; }
-            
+
+            public string PropertyValue { get; set; }
+
             public string Json { get; set; }
 
             internal JObject JObject { get; set; }
@@ -627,4 +699,3 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 }
 
 #pragma warning restore SYSLIB0013 // Type or member is obsolete
-#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant


### PR DESCRIPTION
There were a few customers who had issues with the deserialization of the OpenidConnectMessage, particularly with numbers.
The serialization has been adjusted to match 6.x for simple types.

There is one slight change with complex types (Arrays and Objects), 6x would deserialize with formatting (\r, \n, and spaces.) 7x does not have any formatting.

A test was added to ensure the reading from Google and AAD discovery endpoints  is successful.

Fixes #2336 
