### PR TITLE
Remove dotnet.xunitextensions

### DIFF
--- a/build/commonTest.props
+++ b/build/commonTest.props
@@ -29,10 +29,6 @@
     <NoWarn>$(NoWarn);SYSLIB0051</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'net6.0' Or '$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.DotNet.XUnitExtensions" Version="$(MicrosoftDotNetXUnitExtensionsVersion)" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftVersion)" />

--- a/build/dependenciesTest.props
+++ b/build/dependenciesTest.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <DotNetCoreAppRuntimeVersion>2.1.30</DotNetCoreAppRuntimeVersion>
     <MicrosoftAzureKeyVaultCryptographyVersion>2.0.5</MicrosoftAzureKeyVaultCryptographyVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>2.4.0-prerelease-63213-02</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftNETTestSdkVersion>16.10.0</MicrosoftNETTestSdkVersion>
     <NetStandardVersion>2.0.3</NetStandardVersion>
     <NewtonsoftVersion>13.0.3</NewtonsoftVersion>

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AuthenticatedEncryptionProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AuthenticatedEncryptionProviderTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
@@ -63,38 +64,35 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     /// </summary>
     public class AuthenticatedEncryptionProviderTests
     {
-#if NET_CORE
-        [PlatformSpecific(TestPlatforms.Linux | TestPlatforms.OSX)]
-        [Fact(Skip = "Adjustment needed")]
-        public void AesGcmEncryptionOnLinuxAndMac()
-        {
-            Assert.Throws<PlatformNotSupportedException>(() => new AuthenticatedEncryptionProvider(Default.SymmetricEncryptionKey256, SecurityAlgorithms.Aes256Gcm));
-        }
-#endif
-
-#if NET_CORE
-        [PlatformSpecific(TestPlatforms.Windows)]
-#endif
         [Fact]
         public void AesGcmEncryptionOnWindows()
         {
-            var context = new CompareContext();
-            try
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var provider = new AuthenticatedEncryptionProvider(Default.SymmetricEncryptionKey256, SecurityAlgorithms.Aes256Gcm);
+                Assert.Throws<PlatformNotSupportedException>(() => new AuthenticatedEncryptionProvider(Default.SymmetricEncryptionKey256, SecurityAlgorithms.Aes256Gcm));
             }
-            catch (Exception ex)
-            {
-                context.AddDiff($"AuthenticatedEncryptionProvider is not supposed to throw an exception, Exception:{ ex.ToString()}");
+            else
+            { 
+                var context = new CompareContext();
+                try
+                {
+                    var provider = new AuthenticatedEncryptionProvider(Default.SymmetricEncryptionKey256, SecurityAlgorithms.Aes256Gcm);
+                }
+                catch (Exception ex)
+                {
+                    context.AddDiff($"AuthenticatedEncryptionProvider is not supposed to throw an exception, Exception:{ex.ToString()}");
+                }
+                TestUtilities.AssertFailIfErrors(context);
             }
-            TestUtilities.AssertFailIfErrors(context);
         }
 
 #if NET_CORE
-        [PlatformSpecific(TestPlatforms.Windows)]
         [Fact]
         public void AesGcm_Dispose()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                Assert.Throws<PlatformNotSupportedException>(() => new AuthenticatedEncryptionProvider(Default.SymmetricEncryptionKey256, SecurityAlgorithms.Aes256Gcm));
+
             AuthenticatedEncryptionProvider encryptionProvider = new AuthenticatedEncryptionProvider(Default.SymmetricEncryptionKey256, SecurityAlgorithms.Aes256Gcm);
             encryptionProvider.Dispose();
             var expectedException = ExpectedException.ObjectDisposedException;


### PR DESCRIPTION
MIcrosoft.Dotnet.XunitExtensions is a prerelease dependency that is hardly used; replace it with something that has an official release and does the same effective work.