### PR TITLE
Package version is set by scripts.

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -35,7 +35,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageVersion>7.1.0</PackageVersion>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>7.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>


### PR DESCRIPTION
Currently our builds set the package version by script.
We will be changing to a different model, but other dependencies require we continue for a while.