### PR TITLE
Fix AadIssuerValidator's handling of trailing forward slashes

### DIFF
--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -24,6 +24,7 @@ namespace Microsoft.IdentityModel.Validators
         private static readonly TimeSpan LastKnownGoodConfigurationLifetime = new TimeSpan(0, 24, 0, 0);
 
         internal const string V2EndpointSuffix = "/v2.0";
+        internal const string V2EndpointSuffixWithTrailingSlash = $"{V2EndpointSuffix}/";
         internal const string TenantIdTemplate = "{tenantid}";
 
         internal AadIssuerValidator(
@@ -307,7 +308,9 @@ namespace Microsoft.IdentityModel.Validators
 
         private BaseConfigurationManager GetEffectiveConfigurationManager(SecurityToken securityToken)
         {
-            return (securityToken.Issuer.EndsWith(V2EndpointSuffix, StringComparison.OrdinalIgnoreCase)) ? ConfigurationManagerV2 : ConfigurationManagerV1;
+            var isV2 = securityToken.Issuer.EndsWith(V2EndpointSuffixWithTrailingSlash, StringComparison.OrdinalIgnoreCase) ||
+                securityToken.Issuer.EndsWith(V2EndpointSuffix, StringComparison.OrdinalIgnoreCase);
+            return isV2 ? ConfigurationManagerV2 : ConfigurationManagerV1;
         }
 
         /// <summary>Gets the tenant ID from a token.</summary>

--- a/test/Microsoft.IdentityModel.Validators.Tests/MicrosoftIdentityIssuerValidatorTest.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/MicrosoftIdentityIssuerValidatorTest.cs
@@ -407,6 +407,28 @@ namespace Microsoft.IdentityModel.Validators.Tests
         }
 
         [Fact]
+        public void Validate_FromB2CAuthority_WithTokenValidateParametersValidIssuersUnspecified_ValidateSuccessfully()
+        {
+            var context = new CompareContext();
+            var issClaim = new Claim(ValidatorConstants.ClaimNameIss, ValidatorConstants.B2CIssuer);
+            var tfpClaim = new Claim(ValidatorConstants.ClaimNameTfp, ValidatorConstants.B2CSignUpSignInUserFlow);
+            var jwtSecurityToken = new JwtSecurityToken(issuer: ValidatorConstants.B2CIssuer, claims: new[] { issClaim, tfpClaim });
+
+            var validator = new AadIssuerValidator(null, ValidatorConstants.B2CAuthority);
+
+            var tokenValidationParams = new TokenValidationParameters()
+            {
+                ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(new OpenIdConnectConfiguration()
+                {
+                    Issuer = ValidatorConstants.B2CIssuer
+                })
+            };
+
+            IdentityComparer.AreEqual(ValidatorConstants.B2CIssuer, validator.Validate(ValidatorConstants.B2CIssuer, jwtSecurityToken, tokenValidationParams), context);
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Fact]
         public void Validate_FromB2CAuthority_WithTidClaim_ValidateSuccessfully()
         {
             var context = new CompareContext();

--- a/test/Microsoft.IdentityModel.Validators.Tests/ValidatorConstants.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/ValidatorConstants.cs
@@ -42,11 +42,11 @@ namespace Microsoft.IdentityModel.Validators.Tests
         public const string B2CTenant = "fabrikamb2c.onmicrosoft.com";
         public const string Tfp = "tfp";
         public const string B2CCustomDomainUserFlow = "B2C_1_signupsignin_userflow";
-        public const string B2CCustomDomainIssuer = B2CCustomDomainInstance + "/" + B2CCustomDomainTenant + "/v2.0";
+        public const string B2CCustomDomainIssuer = B2CCustomDomainInstance + "/" + B2CCustomDomainTenant + "/v2.0/";
         public const string B2CCustomDomainAuthority = B2CCustomDomainInstance + "/" + B2CCustomDomainTenant + "/" + B2CCustomDomainUserFlow;
         public const string B2CCustomDomainAuthorityWithV2 = B2CCustomDomainAuthority + "/v2.0";
-        public const string B2CIssuer = B2CInstance + "/" + B2CTenantAsGuid + "/v2.0";
-        public const string B2CIssuer2 = B2CInstance2 + "/" + B2CTenantAsGuid + "/v2.0";
+        public const string B2CIssuer = B2CInstance + "/" + B2CTenantAsGuid + "/v2.0/";
+        public const string B2CIssuer2 = B2CInstance2 + "/" + B2CTenantAsGuid + "/v2.0/";
         public const string B2CAuthority = B2CInstance + "/" + B2CTenant + "/" + B2CSignUpSignInUserFlow;
         public const string B2CAuthorityWithV2 = B2CAuthority + "/v2.0";
         public const string B2CIssuerTfp = B2CInstance + "/" + Tfp + "/" + B2CTenantAsGuid + "/" + B2CSignUpSignInUserFlow + "/v2.0";


### PR DESCRIPTION
This fixes errors like the following reported by multiple customers at https://github.com/dotnet/aspnetcore/issues/51005 when they tried to upgrade their app using `AddMicrosoftIdentityWebApp` to .NET 8.

> Issuer: 'https://munsonpickles3.b2clogin.com/f6c04159-d728-43cd-8ae1-c1f3793844d5/v2.0/', does not match any of the valid issuers provided for this application.

While `https://login.microsoftonline.com/{TenantId}/v2.0/.well-known/openid-configuration`, responds with `"issuer": "https://login.microsoftonline.com/{TenantId}/v2.0"` and issues JWTs with `iss` claims containing no trailing slashes, if you use a custom B2C authority like `https://{TenantName}.b2clogin.com/{TenantName}.onmicrosoft.com/B2C_1_SignUpSignIn/v2.0/.well-known/openid-configuration` you will get `"issuer": "https://TenantName}.b2clogin.com/{TenantId}/v2.0/"` responses and `iss` claims with trailing slashes.

This is causing upgrades of Azure B2C customers to .NET 8 to fail because `AadIssuerValidator.GetEffectiveConfigurationManager()` does not account for trailing slashes. This causes it to query V1 metadata for a V2 token, which causes a mismatch because the V1 metadata does not include a trailing forward slash for the issuer while the V2 token does include a trailing forward slash.

While it looks like this bug has been around for a while, I think the reason customers haven't seen this until upgrading to .NET 8 is because the `OpenIdConnectHandler` has stopped setting `TokenValidationParameters.ValidIssuers`. It is now expected expected setting `TokenValidationParameters.ConfigurationMager` is sufficient as of https://github.com/dotnet/aspnetcore/pull/49542.

In the particular case of people using `AadIssuerValidator`, this PR is sufficient to fix regression because `AadIssuerValidator.Validate` falls back to querying the `ConfigurationManager` itself rather than completely rely on  `OpenIdConnectHandler.HandleRemoteAuthenticateAsync()` having done that already.

However, I am concerned that there could be other custom `TokenHander` or `TokenValidationParameters.IssuerValidator` callbacks that read from `TokenValidationParameters.ValidIssuers` other than `AadIssuerValidator`, and that don't have the logic to query the `ConfigurationManager` itself since it was never before necessary.

I'm wondering if we shouldn't also just update the `else if (_configuration != null)` to be `if (_configuration != null)` in [OpenIdConnectHandler.ValidateTokenUsingHandlerAsync](https://github.com/dotnet/aspnetcore/blob/cbfc558b6dd2676b47c8009e2453ddce5725c8d7/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs#L1332), [JwtBearerHandler.SetupTokenValidationParametersAsync](https://github.com/dotnet/aspnetcore/blob/cbfc558b6dd2676b47c8009e2453ddce5725c8d7/src/Security/Authentication/JwtBearer/src/JwtBearerHandler.cs#L248-L250) and [WsFederationHandler.SetupTokenValidationParametersAsync](https://github.com/dotnet/aspnetcore/blob/cbfc558b6dd2676b47c8009e2453ddce5725c8d7/src/Security/Authentication/WsFederation/src/WsFederationHandler.cs#L381-L383) to be extra safe. I assume this would have perf implications though.

@jennyf19 @keegan-caruso @brentschmaltz @eerhardt @mkArtak