### PR TITLE
Add NotNullWhen attribute to Microsoft.IdentityModel.Tokens.CollectionUtilities.IsNullOrEmpty extension method

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/CollectionUtilities.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CollectionUtilities.cs
@@ -17,7 +17,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <typeparam name="T">The type of the <paramref name="enumerable"/>.</typeparam>
         /// <param name="enumerable">The <see cref="IEnumerable{T}"/> to be checked.</param>
         /// <returns>True if <paramref name="enumerable"/> is null or empty, false otherwise.</returns>
-        public static bool IsNullOrEmpty<T>(this IEnumerable<T> enumerable)
+        public static bool IsNullOrEmpty<T>([NotNullWhen(false)] this IEnumerable<T> enumerable)
         {
             return enumerable == null || !enumerable.Any();
         }


### PR DESCRIPTION
Added `NotNullWhen` attribute to indicate that the parameter is not `null` when the method returns `false`.