### PR TITLE
Add support for irrelevant object in OpenIdConnectConfigurationSerializer

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Json/OpenIdConnectConfigurationSerializer.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Json/OpenIdConnectConfigurationSerializer.cs
@@ -450,11 +450,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                     }
                 }
 
-                if (JsonPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartObject, true) )
-                {
-                    while(!JsonPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.EndObject, true))
-                }
-
                 if (JsonPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.EndObject, false))
                     break;
             }

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Json/OpenIdConnectConfigurationSerializer.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Json/OpenIdConnectConfigurationSerializer.cs
@@ -450,6 +450,11 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                     }
                 }
 
+                if (JsonPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartObject, true) )
+                {
+                    while(!JsonPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.EndObject, true))
+                }
+
                 if (JsonPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.EndObject, false))
                     break;
             }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
@@ -141,6 +141,17 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                                                 ""SigningKeys"":[""key1"",""key2""]
                                             }";
 
+        public static string JsonWithExtraObject = 
+                                            @"{ ""issuer"": ""https://server.example.com"",
+                                                ""authorization_endpoint"": ""https://server.example.com/authz"",
+                                                ""mtls_endpoint_aliases"":
+                                                {   ""token_endpoint"": ""https://mtls.example.com/token"",
+                                                    ""revocation_endpoint"": ""https://mtls.example.com/revo"",
+                                                    ""introspection_endpoint"": ""https://mtls.example.com/introspect""
+                                                },
+                                                ""jwks_uri"": ""https://server.example.com/jwks""
+                                            }";
+
         public static string OpenIdConnectMetadataBadX509DataString = @"{""jwks_uri"":""JsonWebKeySetBadX509Data.json""}";
         public static string OpenIdConnectMetadataBadBase64DataString = @"{""jwks_uri"":""JsonWebKeySetBadBase64Data.json""}";
         public static string OpenIdConnectMetadataBadUriKeysString = @"{""jwks_uri"":""___NoSuchFile___""}";

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationTests.cs
@@ -301,5 +301,16 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
             TestUtilities.AssertFailIfErrors(context);
         }
+        
+        [Fact]
+        public void ReadWithExtraObject()
+        {
+
+            OpenIdConnectConfiguration openIdConnectConfiguration = OpenIdConnectConfiguration.Create(OpenIdConfigData.JsonWithExtraObject);
+
+            Assert.Equal("https://server.example.com", openIdConnectConfiguration.Issuer);
+            Assert.Equal("https://server.example.com/authz", openIdConnectConfiguration.AuthorizationEndpoint);
+            Assert.Equal("https://server.example.com/jwks", openIdConnectConfiguration.JwksUri);
+        }
     }
 }


### PR DESCRIPTION
# Add support for object in OpenIdConnectConfigurationSerializer
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Error when reading .well-known/openid-configuration with an nested object.
Returns on first JsonTokenType.EndObject instead of the one at end of file.

Fixes #2407 
