### PR TITLE
Adding P50, P90 and P100 percentiles to benchmarks

### DIFF
--- a/benchmark/Microsoft.IdentityModel.Benchmarks/AntiVirusFriendlyConfig.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/AntiVirusFriendlyConfig.cs
@@ -1,18 +1,97 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Toolchains.InProcess.Emit;
+using BenchmarkDotNet.Reports;
+using BenchmarkDotNet.Running;
+
 
 namespace Microsoft.IdentityModel.Benchmarks
 {
+        // Define custom columns for P50 and P99 latency
+    public class P50Column : IColumn
+    {
+        public string Id => nameof(P50Column);
+        public string ColumnName => "P50";
+        public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
+        public string GetValue(Summary summary, BenchmarkCase benchmarkCase) => GetValue(summary, benchmarkCase, SummaryStyle.Default);
+        public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style)
+        {
+            // Get the statistics for the current benchmark
+            var statistics = summary[benchmarkCase].ResultStatistics;
+            // Calculate the P50 latency using the Percentile method
+            var p50 = statistics.Percentiles.P50 / style.TimeUnit.NanosecondAmount;
+            // Format the value using the style
+            return p50.ToString($"F2") + $" {style.TimeUnit.Name}";
+        }
+        public bool IsAvailable(Summary summary) => true;
+        public bool AlwaysShow => true;
+        public ColumnCategory Category => ColumnCategory.Statistics;
+        public int PriorityInCategory => 0;
+        public bool IsNumeric => true;
+        public UnitType UnitType => UnitType.Time;
+        public string Legend => "50th percentile of latency";
+    }
+
+    public class P99Column : IColumn
+    {
+        public string Id => nameof(P99Column);
+        public string ColumnName => "P99";
+        public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
+        public string GetValue(Summary summary, BenchmarkCase benchmarkCase) => GetValue(summary, benchmarkCase, SummaryStyle.Default);
+        public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style)
+        {
+            // Get the statistics for the current benchmark
+            var statistics = summary[benchmarkCase].ResultStatistics;
+            // Calculate the P99 latency using the Percentile method
+            var p99 = statistics.Percentiles.P90 / style.TimeUnit.NanosecondAmount;
+            // Format the value using the style
+            return p99.ToString($"F2") + $" {style.TimeUnit.Name}";
+        }
+        public bool IsAvailable(Summary summary) => true;
+        public bool AlwaysShow => true;
+        public ColumnCategory Category => ColumnCategory.Statistics;
+        public int PriorityInCategory => 0;
+        public bool IsNumeric => true;
+        public UnitType UnitType => UnitType.Time;
+        public string Legend => "99th percentile of latency";
+    }
+
+    public class P100Column : IColumn
+    {
+        public string Id => nameof(P100Column);
+        public string ColumnName => "P100";
+        public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
+        public string GetValue(Summary summary, BenchmarkCase benchmarkCase) => GetValue(summary, benchmarkCase, SummaryStyle.Default);
+        public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style)
+        {
+            // Get the statistics for the current benchmark
+            var statistics = summary[benchmarkCase].ResultStatistics;
+            // Calculate the P99 latency using the Percentile method
+            var p99 = statistics.Percentiles.P100 / style.TimeUnit.NanosecondAmount;
+            // Format the value using the style
+            return p99.ToString($"F2")+ $" {style.TimeUnit.Name}";
+        }
+        public bool IsAvailable(Summary summary) => true;
+        public bool AlwaysShow => true;
+        public ColumnCategory Category => ColumnCategory.Statistics;
+        public int PriorityInCategory => 0;
+        public bool IsNumeric => true;
+        public UnitType UnitType => UnitType.Time;
+        public string Legend => "100th percentile of latency";
+    }
+
+
     public class AntiVirusFriendlyConfig : ManualConfig
     {
         public AntiVirusFriendlyConfig()
         {
             AddJob(Job.MediumRun
                 .WithToolchain(InProcessEmitToolchain.Instance));
+            AddColumn(new P50Column(), new P99Column(), new P100Column());
         }
     }
 }

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/AntiVirusFriendlyConfig.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/AntiVirusFriendlyConfig.cs
@@ -36,6 +36,30 @@ namespace Microsoft.IdentityModel.Benchmarks
         public string Legend => "50th percentile of latency";
     }
 
+    public class P95Column : IColumn
+    {
+        public string Id => nameof(P99Column);
+        public string ColumnName => "P95";
+        public bool IsDefault(Summary summary, BenchmarkCase benchmarkCase) => false;
+        public string GetValue(Summary summary, BenchmarkCase benchmarkCase) => GetValue(summary, benchmarkCase, SummaryStyle.Default);
+        public string GetValue(Summary summary, BenchmarkCase benchmarkCase, SummaryStyle style)
+        {
+            // Get the statistics for the current benchmark
+            var statistics = summary[benchmarkCase].ResultStatistics;
+            // Calculate the P99 latency using the Percentile method
+            var p95 = statistics.Percentiles.P95 / style.TimeUnit.NanosecondAmount;
+            // Format the value using the style
+            return p95.ToString($"F2") + $" {style.TimeUnit.Name}";
+        }
+        public bool IsAvailable(Summary summary) => true;
+        public bool AlwaysShow => true;
+        public ColumnCategory Category => ColumnCategory.Statistics;
+        public int PriorityInCategory => 0;
+        public bool IsNumeric => true;
+        public UnitType UnitType => UnitType.Time;
+        public string Legend => "95th percentile of latency";
+    }
+
     public class P99Column : IColumn
     {
         public string Id => nameof(P99Column);
@@ -71,9 +95,9 @@ namespace Microsoft.IdentityModel.Benchmarks
             // Get the statistics for the current benchmark
             var statistics = summary[benchmarkCase].ResultStatistics;
             // Calculate the P99 latency using the Percentile method
-            var p99 = statistics.Percentiles.P100 / style.TimeUnit.NanosecondAmount;
+            var p100 = statistics.Percentiles.P100 / style.TimeUnit.NanosecondAmount;
             // Format the value using the style
-            return p99.ToString($"F2")+ $" {style.TimeUnit.Name}";
+            return p100.ToString($"F2")+ $" {style.TimeUnit.Name}";
         }
         public bool IsAvailable(Summary summary) => true;
         public bool AlwaysShow => true;
@@ -91,7 +115,7 @@ namespace Microsoft.IdentityModel.Benchmarks
         {
             AddJob(Job.MediumRun
                 .WithToolchain(InProcessEmitToolchain.Instance));
-            AddColumn(new P50Column(), new P99Column(), new P100Column());
+            AddColumn(new P50Column(), new P95Column(), new P99Column(), new P100Column());
         }
     }
 }


### PR DESCRIPTION
# Adding P50, P90 and P100 percentiles to benchmarks

Adds 3 columns to the benchmark summaries to display the P50, P90 and P100 percentiles

## Description

The benchmark summaries now contains the pecentiles

```
Runtime = ; GC =
Mean = 10.711 us, StdErr = 0.057 us (0.53%), N = 29, StdDev = 0.308 us
Min = 10.261 us, Q1 = 10.438 us, Median = 10.682 us, Q3 = 10.955 us, Max = 11.354 us
IQR = 0.517 us, LowerFence = 9.662 us, UpperFence = 11.730 us
ConfidenceInterval = [10.500 us; 10.921 us] (CI 99.9%), Margin = 0.210 us (1.96% of Mean)
Skewness = 0.36, Kurtosis = 1.97, MValue = 2
-------------------- Histogram --------------------
[10.235 us ; 10.532 us) | @@@@@@@@@
[10.532 us ; 10.795 us) | @@@@@@@@@@@
[10.795 us ; 11.203 us) | @@@@@@@@
[11.203 us ; 11.486 us) | @
---------------------------------------------------

// * Summary *

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22631.2715)
Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK=8.0.100
  [Host] : .NET 6.0.25 (6.0.2523.51912), X64 RyuJIT AVX2

Job=MediumRun  Toolchain=InProcessEmitToolchain  IterationCount=15
LaunchCount=2  WarmupCount=10
```

|                                     Method |      Mean |     Error |    StdDev |      P50 |      P99 |     P100 |   Gen0 | Allocated |
|------------------------------------------- |----------:|----------:|----------:|---------:|---------:|---------:|-------:|----------:|
|     JsonWebTokenHandler_ValidateTokenAsync |  1.471 us | 0.0600 us | 0.0898 us |  1.46 us |  1.57 us |  1.66 us | 0.2747 |   1.13 KB |
| JwtSecurityTokenHandler_ValidateTokenAsync | 10.711 us | 0.2103 us | 0.3083 us | 10.68 us | 11.15 us | 11.35 us | 0.3204 |   1.34 KB |


Fixes #2410
