### PR TITLE
Fetch configuration when validating SAML issuer and signature

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -501,7 +501,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         /// </summary>
         /// <param name="attributes"><see cref="ICollection{SamlAttribute}"/>.</param>
         /// <returns>A well formed XML string.</returns>
-        /// <remarks>The string is of the form "&lt;Actor&gt;&lt;SamlAttribute name, ns&gt;&lt;SamlAttributeValue&gt;...&lt;/SamlAttributeValue&gt;, ...&lt;/SamlAttribute&gt;...&lt;/Actor&gt;"</remarks>
+        /// <remarks>The string is of the form "&lt;Actor&gt;&lt;SamlAttribute name, ns&gt;&lt;SamlAttributeValue&gt;...&lt;/SamlAttributeValue&gt;, ...&lt;/SamlAttribute&gt;...&lt;/Actor&gt;"</remarks>        
         protected virtual string CreateXmlStringFromAttributes(ICollection<SamlAttribute> attributes)
         {
             if (attributes == null)

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -1140,7 +1140,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
             if (validationParameters == null)
                 throw LogArgumentNullException(nameof(validationParameters));
 
-            validationParameters = PopulateValidationParametersWithCurrentConfigurationAsync(validationParameters).ConfigureAwait(false).GetAwaiter()
+            validationParameters = SamlTokenUtilities.PopulateValidationParametersWithCurrentConfigurationAsync(validationParameters).ConfigureAwait(false).GetAwaiter()
                 .GetResult();
 
             var samlToken = ReadSamlToken(reader);
@@ -1167,7 +1167,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 if (token.Length > MaximumTokenSizeInBytes)
                     throw LogExceptionMessage(new ArgumentException(FormatInvariant(TokenLogMessages.IDX10209, LogHelper.MarkAsNonPII(token.Length), LogHelper.MarkAsNonPII(MaximumTokenSizeInBytes))));
 
-                validationParameters = await PopulateValidationParametersWithCurrentConfigurationAsync(validationParameters).ConfigureAwait(false);
+                validationParameters = await SamlTokenUtilities.PopulateValidationParametersWithCurrentConfigurationAsync(validationParameters).ConfigureAwait(false);
 
                 var samlToken = ValidateSignature(token, validationParameters);
                 if (samlToken == null)
@@ -1213,7 +1213,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
             if (token.Length > MaximumTokenSizeInBytes)
                 throw LogExceptionMessage(new ArgumentException(FormatInvariant(TokenLogMessages.IDX10209, LogHelper.MarkAsNonPII(token.Length), LogHelper.MarkAsNonPII(MaximumTokenSizeInBytes))));
 
-            validationParameters = PopulateValidationParametersWithCurrentConfigurationAsync(validationParameters).ConfigureAwait(false).GetAwaiter()
+            validationParameters = SamlTokenUtilities.PopulateValidationParametersWithCurrentConfigurationAsync(validationParameters).ConfigureAwait(false).GetAwaiter()
                 .GetResult();
 
             var samlToken = ValidateSignature(token, validationParameters);
@@ -1246,24 +1246,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                     LogHelper.MarkAsUnsafeSecurityArtifact(token, t => t.ToString()));
 
             return new ClaimsPrincipal(identities);
-        }
-
-        private static async Task<TokenValidationParameters> PopulateValidationParametersWithCurrentConfigurationAsync(
-            TokenValidationParameters validationParameters)
-        {
-            if (validationParameters.ConfigurationManager == null)
-            {
-                return validationParameters;
-            }
-
-            var currentConfiguration = await validationParameters.ConfigurationManager.GetBaseConfigurationAsync(CancellationToken.None).ConfigureAwait(false);
-            var validationParametersCloned = validationParameters.Clone();
-            var issuers = new[] { currentConfiguration.Issuer };
-
-            validationParametersCloned.ValidIssuers = (validationParametersCloned.ValidIssuers == null ? issuers : validationParametersCloned.ValidIssuers.Concat(issuers));
-            validationParametersCloned.IssuerSigningKeys = (validationParametersCloned.IssuerSigningKeys == null ? currentConfiguration.SigningKeys : validationParametersCloned.IssuerSigningKeys.Concat(currentConfiguration.SigningKeys));
-            return validationParametersCloned;
-
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -1251,17 +1251,19 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         private static async Task<TokenValidationParameters> PopulateValidationParametersWithCurrentConfigurationAsync(
             TokenValidationParameters validationParameters)
         {
-            if (validationParameters.ConfigurationManager != null)
+            if (validationParameters.ConfigurationManager == null)
             {
-                var currentConfiguration = await validationParameters.ConfigurationManager.GetBaseConfigurationAsync(CancellationToken.None).ConfigureAwait(false);
-                validationParameters = validationParameters.Clone();
-                var issuers = new[] { currentConfiguration.Issuer };
-
-                validationParameters.ValidIssuers = (validationParameters.ValidIssuers == null ? issuers : validationParameters.ValidIssuers.Concat(issuers));
-                validationParameters.IssuerSigningKeys = (validationParameters.IssuerSigningKeys == null ? currentConfiguration.SigningKeys : validationParameters.IssuerSigningKeys.Concat(currentConfiguration.SigningKeys));
+                return validationParameters;
             }
 
-            return validationParameters;
+            var currentConfiguration = await validationParameters.ConfigurationManager.GetBaseConfigurationAsync(CancellationToken.None).ConfigureAwait(false);
+            var validationParametersCloned = validationParameters.Clone();
+            var issuers = new[] { currentConfiguration.Issuer };
+
+            validationParametersCloned.ValidIssuers = (validationParametersCloned.ValidIssuers == null ? issuers : validationParametersCloned.ValidIssuers.Concat(issuers));
+            validationParametersCloned.IssuerSigningKeys = (validationParametersCloned.IssuerSigningKeys == null ? currentConfiguration.SigningKeys : validationParametersCloned.IssuerSigningKeys.Concat(currentConfiguration.SigningKeys));
+            return validationParametersCloned;
+
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -71,12 +71,12 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         /// <summary>
         /// Gets or set the <see cref="SamlSerializer"/> that will be used to read and write a <see cref="SamlSecurityToken"/>.
         /// </summary>
-        /// <exception cref="ArgumentNullException">'value' is null.</exception>
+        /// <exception cref="ArgumentNullException">'value' is null.</exception> 
         public SamlSerializer Serializer
         {
             get { return _serializer; }
             set { _serializer = value ?? throw LogHelper.LogArgumentNullException(nameof(value)); }
-        }
+        } 
 
         /// <summary>
         /// Gets the securityToken type supported by this handler.
@@ -132,7 +132,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 using (var sr = new StringReader(securityToken))
                 {
                     var settings = new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit };
-                    using (var reader = XmlDictionaryReader.CreateDictionaryReader(XmlReader.Create(sr, settings)))
+                    using (var reader = XmlDictionaryReader.CreateDictionaryReader(XmlReader.Create(sr, settings))) 
                     {
                         return CanReadToken(reader);
                     }
@@ -187,7 +187,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         }
 
         /// <summary>
-        /// Override this method to provide a SamlAdvice to place in the Samltoken.
+        /// Override this method to provide a SamlAdvice to place in the Samltoken. 
         /// </summary>
         /// <param name="tokenDescriptor">Contains information about the token.</param>
         /// <returns>SamlAdvice, default is null.</returns>
@@ -287,7 +287,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         }
 
         /// <summary>
-        /// Creates a SamlAuthenticationStatement for each AuthenticationInformation found in AuthenticationInformation.
+        /// Creates a SamlAuthenticationStatement for each AuthenticationInformation found in AuthenticationInformation. 
         /// Override this method to provide a custom implementation.
         /// </summary>
         /// <param name="subject">The SamlSubject of the Statement.</param>
@@ -497,7 +497,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         }
 
         /// <summary>
-        /// Builds an XML formated string from a collection of saml attributes that represent an Actor.
+        /// Builds an XML formated string from a collection of saml attributes that represent an Actor. 
         /// </summary>
         /// <param name="attributes"><see cref="ICollection{SamlAttribute}"/>.</param>
         /// <returns>A well formed XML string.</returns>
@@ -767,7 +767,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         /// <summary>
         /// Deserializes from XML a token of the type handled by this instance.
         /// </summary>
-        /// <param name="reader">An XML reader positioned at the token's start
+        /// <param name="reader">An XML reader positioned at the token's start 
         /// element.</param>
         /// <param name="validationParameters"> validation parameters for the <see cref="SamlSecurityToken"/>.</param>
         /// <returns>An instance of <see cref="SamlSecurityToken"/>.</returns>
@@ -802,7 +802,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         }
 
         /// <summary>
-        /// This method gets called when a special type of SamlAttribute is detected. The SamlAttribute passed in wraps a SamlAttribute
+        /// This method gets called when a special type of SamlAttribute is detected. The SamlAttribute passed in wraps a SamlAttribute 
         /// that contains a collection of AttributeValues, each of which are mapped to a claim.  All of the claims will be returned
         /// in an ClaimsIdentity with the specified issuer.
         /// </summary>
@@ -911,7 +911,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
             {
                 if (validationParameters.RequireAudience)
                     throw LogExceptionMessage(new SamlSecurityTokenException(LogMessages.IDX11401));
-
+               
                 return;
             }
 
@@ -980,7 +980,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         /// <exception cref="SecurityTokenValidationException">If <see cref="ReadSamlToken(string)"/> returns null"/>.</exception>
         /// <exception cref="SecurityTokenValidationException">If <see cref="TokenValidationParameters.SignatureValidator"/> returns null OR an object other than a <see cref="SamlSecurityToken"/>.</exception>
         /// <exception cref="SecurityTokenValidationException">If a signature is not found and <see cref="TokenValidationParameters.RequireSignedTokens"/> is true.</exception>
-        /// <exception cref="SecurityTokenSignatureKeyNotFoundException">If the 'token' has a key identifier and none of the <see cref="SecurityKey"/>(s) provided result in a validated signature.
+        /// <exception cref="SecurityTokenSignatureKeyNotFoundException">If the 'token' has a key identifier and none of the <see cref="SecurityKey"/>(s) provided result in a validated signature. 
         /// This can indicate that a key refresh is required.</exception>
         /// <exception cref="SecurityTokenInvalidSignatureException">If after trying all the <see cref="SecurityKey"/>(s), none result in a validated signture AND the 'token' does not have a key identifier.</exception>
         /// <returns>A <see cref="SamlSecurityToken"/> that has had the signature validated if token was signed.</returns>

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -375,7 +375,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         /// <exception cref="SecurityTokenValidationException">If <see cref="ReadSaml2Token(string)"/> return null.</exception>
         /// <exception cref="SecurityTokenValidationException">If <see cref="TokenValidationParameters.SignatureValidator"/> returns null OR an object other than a <see cref="Saml2SecurityToken"/>.</exception>
         /// <exception cref="SecurityTokenValidationException">If a signature is not found and <see cref="TokenValidationParameters.RequireSignedTokens"/> is true.</exception>
-        /// <exception cref="SecurityTokenSignatureKeyNotFoundException">If the  <paramref name="token"/> has a key identifier and none of the <see cref="SecurityKey"/>(s) provided result in a validated signature.
+        /// <exception cref="SecurityTokenSignatureKeyNotFoundException">If the  <paramref name="token"/> has a key identifier and none of the <see cref="SecurityKey"/>(s) provided result in a validated signature. 
         /// This can indicate that a key refresh is required.</exception>
         /// <exception cref="SecurityTokenInvalidSignatureException">If after trying all the <see cref="SecurityKey"/>(s), none result in a validated signature AND the 'token' does not have a key identifier.</exception>
         /// <returns>A <see cref="Saml2SecurityToken"/> that has had the signature validated if token was signed.</returns>
@@ -609,9 +609,9 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Generally, conditions should be included in assertions to limit the
-        /// impact of misuse of the assertion. Specifying the NotBefore and
-        /// NotOnOrAfter conditions can limit the period of vulnerability in
+        /// Generally, conditions should be included in assertions to limit the 
+        /// impact of misuse of the assertion. Specifying the NotBefore and 
+        /// NotOnOrAfter conditions can limit the period of vulnerability in 
         /// the case of a compromised assertion. The AudienceRestrictionCondition
         /// can be used to explicitly state the intended relying party or parties
         /// of the assertion, which coupled with appropriate audience restriction
@@ -620,8 +620,8 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         /// </para>
         /// <para>
         /// The default implementation creates NotBefore and NotOnOrAfter conditions
-        /// based on the tokenDescriptor.Lifetime. It will also generate an
-        /// AudienceRestrictionCondition limiting consumption of the assertion to
+        /// based on the tokenDescriptor.Lifetime. It will also generate an 
+        /// AudienceRestrictionCondition limiting consumption of the assertion to 
         /// tokenDescriptor.Scope.Address.
         /// </para>
         /// </remarks>
@@ -795,7 +795,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         /// <param name="actor">A <see cref="ClaimsIdentity"/> to be transformed.</param>
         /// <exception cref="ArgumentNullException">if <paramref name="actor"/> is null.</exception>
         /// <returns>A well-formed XML string.</returns>
-        /// <remarks>Normally this is called when creating a <see cref="Saml2Assertion"/> from a <see cref="ClaimsIdentity"/>. When <see cref="ClaimsIdentity.Actor"/> is not null,
+        /// <remarks>Normally this is called when creating a <see cref="Saml2Assertion"/> from a <see cref="ClaimsIdentity"/>. When <see cref="ClaimsIdentity.Actor"/> is not null, 
         /// this method is called to create an string representation to add as an attribute.
         /// <para>The string is formed: "&lt;Actor&gt;&lt;Attribute name, namespace&gt;&lt;AttributeValue&gt;...&lt;/AttributeValue&gt;, ...&lt;/Attribute&gt;...&lt;/Actor&gt;</para></remarks>
         protected string CreateActorString(ClaimsIdentity actor)
@@ -814,7 +814,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         }
 
         /// <summary>
-        /// Builds an XML formatted string from a collection of SAML attributes that represent the Actor.
+        /// Builds an XML formatted string from a collection of SAML attributes that represent the Actor. 
         /// </summary>
         /// <param name="attributes">An enumeration of Saml2Attributes.</param>
         /// <returns>A well-formed XML string.</returns>
@@ -1037,7 +1037,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
 
                 ValidateAudience(audienceRestriction.Audiences, samlToken, validationParameters);
             }
-
+            
             if (validationParameters.RequireAudience && !foundAudienceRestriction)
                 throw LogExceptionMessage(new Saml2SecurityTokenException(LogMessages.IDX13002));
         }
@@ -1053,14 +1053,14 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         }
 
         /// <summary>
-        /// This method gets called when a special type of Saml2Attribute is detected. The Saml2Attribute passed in
-        /// wraps a Saml2Attribute that contains a collection of AttributeValues, each of which will get mapped to a
+        /// This method gets called when a special type of Saml2Attribute is detected. The Saml2Attribute passed in 
+        /// wraps a Saml2Attribute that contains a collection of AttributeValues, each of which will get mapped to a 
         /// claim.  All of the claims will be returned in an ClaimsIdentity with the specified issuer.
         /// </summary>
         /// <param name="attribute">The <see cref="Saml2Attribute"/> to use.</param>
         /// <param name="identity">The <see cref="ClaimsIdentity"/> that is the subject of this token.</param>
         /// <param name="issuer">The issuer of the claim.</param>
-        /// <exception cref="InvalidOperationException">Will be thrown if the Saml2Attribute does not contain any
+        /// <exception cref="InvalidOperationException">Will be thrown if the Saml2Attribute does not contain any 
         /// valid Saml2AttributeValues.
         /// </exception>
         protected virtual void SetClaimsIdentityActorFromAttribute(Saml2Attribute attribute, ClaimsIdentity identity, string issuer)
@@ -1071,7 +1071,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
 
             Saml2Attribute actorAttribute = null;
             var claims = new Collection<Claim>();
-
+            
             // search through attribute values to see if the there is an embedded actor.
             foreach (string value in attribute.Values)
             {

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -297,18 +297,22 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
             return new ClaimsPrincipal(identity);
         }
 
-        private static async Task<TokenValidationParameters> PopulateValidationParametersWithCurrentConfigurationAsync(
-            TokenValidationParameters validationParameters)
-        {
-            if(validationParameters.ConfigurationManager != null) {
-                var currentConfiguration = await validationParameters.ConfigurationManager.GetBaseConfigurationAsync(CancellationToken.None).ConfigureAwait(false);
-                validationParameters = validationParameters.Clone();
-                var issuers = new[] { currentConfiguration.Issuer };
 
-                validationParameters.ValidIssuers = (validationParameters.ValidIssuers == null ? issuers : validationParameters.ValidIssuers.Concat(issuers));
-                validationParameters.IssuerSigningKeys = (validationParameters.IssuerSigningKeys == null ? currentConfiguration.SigningKeys : validationParameters.IssuerSigningKeys.Concat(currentConfiguration.SigningKeys));
+        private static async Task<TokenValidationParameters> PopulateValidationParametersWithCurrentConfigurationAsync(TokenValidationParameters validationParameters)
+        {
+            if (validationParameters.ConfigurationManager == null)
+            {
+                return validationParameters;
             }
-            return validationParameters;
+
+            var currentConfiguration = await validationParameters.ConfigurationManager.GetBaseConfigurationAsync(CancellationToken.None).ConfigureAwait(false);
+            var validationParametersCloned = validationParameters.Clone();
+            var issuers = new[] { currentConfiguration.Issuer };
+
+            validationParametersCloned.ValidIssuers = (validationParametersCloned.ValidIssuers == null ? issuers : validationParametersCloned.ValidIssuers.Concat(issuers));
+            validationParametersCloned.IssuerSigningKeys = (validationParametersCloned.IssuerSigningKeys == null ? currentConfiguration.SigningKeys : validationParametersCloned.IssuerSigningKeys.Concat(currentConfiguration.SigningKeys));
+            return validationParametersCloned;
+
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.WsFederation;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens.Saml.Tests;
 using Microsoft.IdentityModel.Xml;
@@ -671,6 +673,20 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                         ExpectedException = new ExpectedException(typeof(Saml2SecurityTokenReadException), "IDX13138:"),
                         Token = ReferenceTokens.Saml2Token_NoAttributes,
                         ValidationParameters = new TokenValidationParameters(),
+                    },
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_IssuerSigningKey_ConfigurationManager")
+                    {
+                        Token = ReferenceTokens.Saml2Token_Valid,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ConfigurationManager = new StaticConfigurationManager<BaseConfiguration>(new WsFederationConfiguration()
+                            {
+                                SigningKeys = { KeyingMaterial.DefaultAADSigningKey },
+                            }),
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                        }
                     },
                     new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_IssuerSigningKey_set")
                     {

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
@@ -674,6 +674,22 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                         Token = ReferenceTokens.Saml2Token_NoAttributes,
                         ValidationParameters = new TokenValidationParameters(),
                     },
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_Issuer_ConfigurationManager")
+                    {
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500:"),
+                        Token = ReferenceTokens.Saml2Token_Valid,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ConfigurationManager = new StaticConfigurationManager<BaseConfiguration>(new WsFederationConfiguration()
+                            {
+                                Issuer = "https://sts.windows.net/add29489-7269-41f4-8841-b63c95564420/",
+                            }),
+                            ValidateIssuerSigningKey = false,
+                            ValidateIssuer = true,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                        }
+                    },
                     new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_IssuerSigningKey_ConfigurationManager")
                     {
                         Token = ReferenceTokens.Saml2Token_Valid,
@@ -683,6 +699,33 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
                             {
                                 SigningKeys = { KeyingMaterial.DefaultAADSigningKey },
                             }),
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                        }
+                    },
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_IssuerSigningKey_and_Issuer_ConfigurationManager")
+                    {
+                        Token = ReferenceTokens.Saml2Token_Valid,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ConfigurationManager = new StaticConfigurationManager<BaseConfiguration>(new WsFederationConfiguration()
+                            {
+                                Issuer = "https://sts.windows.net/add29489-7269-41f4-8841-b63c95564420/",
+                                SigningKeys = { KeyingMaterial.DefaultAADSigningKey },
+                            }),
+                            ValidateIssuer = true,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                        }
+                    },
+                    new Saml2TheoryData("ReferenceTokens_Saml2Token_Valid_NoSigningKey_ConfigurationManager")
+                    {
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500:"),
+                        Token = ReferenceTokens.Saml2Token_Valid,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ConfigurationManager = new StaticConfigurationManager<BaseConfiguration>(new WsFederationConfiguration()),
                             ValidateIssuer = false,
                             ValidateAudience = false,
                             ValidateLifetime = false,

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
@@ -447,6 +447,22 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                         Token = ReferenceTokens.SamlToken_NoAttributes,
                         ValidationParameters = new TokenValidationParameters(),
                     },
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_Issuer_ConfigurationManager")
+                    {
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500:"),
+                        Token = ReferenceTokens.SamlToken_Valid,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ConfigurationManager = new StaticConfigurationManager<BaseConfiguration>(new WsFederationConfiguration()
+                            {
+                                Issuer = "http://Default.Issuer.com",
+                            }),
+                            ValidateIssuerSigningKey = false,
+                            ValidateIssuer = true,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                        }
+                    },
                     new SamlTheoryData("ReferenceTokens_SamlToken_Valid_IssuerSigningKey_ConfigurationManager")
                     {
                         Token = ReferenceTokens.SamlToken_Valid,
@@ -456,6 +472,33 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                             {
                                 SigningKeys = { KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2.Key },
                             }),
+                            ValidateIssuer = false,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                        }
+                    },
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_IssuerSigningKey_and_Issuer_ConfigurationManager")
+                    {
+                        Token = ReferenceTokens.SamlToken_Valid,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ConfigurationManager = new StaticConfigurationManager<BaseConfiguration>(new WsFederationConfiguration()
+                            {
+                                Issuer = "http://Default.Issuer.com",
+                                SigningKeys = { KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2.Key },
+                            }),
+                            ValidateIssuer = true,
+                            ValidateAudience = false,
+                            ValidateLifetime = false,
+                        }
+                    },
+                    new SamlTheoryData("ReferenceTokens_SamlToken_Valid_NoSigningKey_ConfigurationManager")
+                    {
+                        ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500:"),
+                        Token = ReferenceTokens.SamlToken_Valid,
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ConfigurationManager = new StaticConfigurationManager<BaseConfiguration>(new WsFederationConfiguration()),
                             ValidateIssuer = false,
                             ValidateAudience = false,
                             ValidateLifetime = false,

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
@@ -20,7 +20,7 @@ using Xunit;
 namespace Microsoft.IdentityModel.Tokens.Saml.Tests
 {
     /// <summary>
-    ///
+    /// 
     /// </summary>
     public class SamlSecurityTokenHandlerTests
     {


### PR DESCRIPTION
# Fetch configuration when validating SAML issuer and signature


- [X] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Fetch configuration on token validation for SAML in the same way as JwtSecurityTokenHandler

## Description

This is already done in the JwtSecurityTokenHandler and the semantics should be similar.
This caused a regression in Microsoft.AspNetCore.Authentication.WsFederation.WsFederationHandler which assumes the token handler will fetch the current configuration as part of the token validation if the ConfigurationManager is a subclass of BaseConfigurationManager.
This change makes the SamlSecurityTokenHandler and Saml2SecurityTokenHandler semantics equal to the JwtSecurityTokenHandler with regards to fetching the configuration before validation.

This discrepancy allowed the [following bug](https://github.com/dotnet/aspnetcore/issues/52099) to appear in Microsoft.AspNetCore.Authentication.WsFederation.WsFederationHandler.


Fixes #2406
