### PR TITLE
Decouple benchmark runs from test projects.

### DIFF
--- a/benchmark/Microsoft.IdentityModel.Benchmarks/BenchmarkUtils.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/BenchmarkUtils.cs
@@ -1,24 +1,113 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.IdentityModel.Tokens;
-using Microsoft.IdentityModel.TestUtils;
+using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.Benchmarks
 {
     public class BenchmarkUtils
     {
-        public static Dictionary<string, object> SimpleClaims
+        public const string Issuer = "http://www.contoso.com";
+
+        public const string Audience = "http://www.contoso.com/protected";
+
+        private static RSA _rsa;
+        private static SymmetricSecurityKey _symmetricKey;
+
+        public static RSA RSA
         {
-            get => new Dictionary<string, object>()
+            get
             {
-                { "role", new List<string>() { "role1", "Developer", "Sales"} },
-                { "email", "Bob@contoso.com" },
-                { "exp", EpochTime.GetIntDate(Default.Expires).ToString() },
-                { "nbf", EpochTime.GetIntDate(Default.NotBefore).ToString() },
-                { "iat", EpochTime.GetIntDate(Default.IssueInstant).ToString() }
-            };
+                if (_rsa == null)
+                {
+                    _rsa = RSA.Create();
+                    _rsa.KeySize = 2048;
+                }
+
+                return _rsa;
+            }
         }
+
+        public static RSAParameters RsaParameters => RSA.ExportParameters(true);
+
+        public static RSAParameters RsaParametersPublic => RSA.ExportParameters(false);
+
+        public static RsaSecurityKey RsaSecurityKey => new(RsaParameters) { KeyId = "RsaPrivate" };
+
+        public static RsaSecurityKey RsaSecurityKeyPublic => new(RsaParametersPublic) { KeyId = "RsaPublic" };
+
+        public static Dictionary<string, object> Claims
+        {
+            get
+            {
+                DateTime now = DateTime.UtcNow;
+                return new Dictionary<string, object>()
+                {
+                    { "role", new List<string>() { "role1", "Developer", "Sales"} },
+                    { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
+                    { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(now + TimeSpan.FromDays(1)) },
+                    { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(now) },
+                    { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(now) },
+                    { JwtRegisteredClaimNames.GivenName, "Bob" },
+                    { JwtRegisteredClaimNames.Iss, Issuer },
+                    { JwtRegisteredClaimNames.Aud, Audience }
+                };
+            }
+        }
+
+        public static SigningCredentials SigningCredentialsRsaSha256 => new(RsaSecurityKey, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256);
+
+        public static EncryptingCredentials EncryptingCredentialsAes256Sha512 => new(SymmetricEncryptionKey512, "dir", SecurityAlgorithms.Aes256CbcHmacSha512);
+
+        public static SymmetricSecurityKey SymmetricEncryptionKey512
+        {
+            get
+            {
+                _symmetricKey ??= new SymmetricSecurityKey(SHA512.Create().ComputeHash(Guid.NewGuid().ToByteArray()));
+                return _symmetricKey;
+            }
+        }
+
+        public static string CreateCnfClaim(RsaSecurityKey key, string algorithm)
+        {
+            return "{\"jwk\":" + CreateJwkClaim(key, algorithm) + "}";
+        }
+
+        public static string CreateJwkClaim(RsaSecurityKey key, string algorithm)
+        {
+            RSAParameters rsaParameters = ((key.Rsa == null) ? key.Parameters : key.Rsa.ExportParameters(includePrivateParameters: false));
+            return "{\"kty\":\"RSA\",\"n\":\"" +
+                    Base64UrlEncoder.Encode(rsaParameters.Modulus) +
+                    "\",\"e\":\"" +
+                    Base64UrlEncoder.Encode(rsaParameters.Exponent) +
+                    "\",\"alg\":\"" +
+                    algorithm +
+                    "\",\"kid\":\"" +
+                    key.KeyId +
+                    "\"}";
+        }
+
+        public static string CreateAccessTokenWithCnf()
+        {
+            Dictionary<string, object> claims = new Dictionary<string, object>(Claims);
+            claims.Add("cnf", CreateCnfClaim(RsaSecurityKeyPublic, SecurityAlgorithms.RsaSha256));
+            return new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+            {
+                SigningCredentials = SigningCredentialsRsaSha256,
+                Claims = claims,
+                TokenType = JwtHeaderParameterNames.Jwk
+            });
+        }
+
+        public static HttpRequestData HttpRequestData => new()
+        {
+            Method = "GET",
+            Uri = new Uri("https://www.relyingparty.com")
+        };
     }
 }

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/CreateJWETests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/CreateJWETests.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 
 using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
 using BenchmarkDotNet.Attributes;
 using Microsoft.IdentityModel.JsonWebTokens;
-using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.Benchmarks
@@ -26,10 +24,9 @@ namespace Microsoft.IdentityModel.Benchmarks
             _jwtSecurityTokenHandler = new JwtSecurityTokenHandler();
             _tokenDescriptor = new SecurityTokenDescriptor
             {
-                SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
-                EncryptingCredentials = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes256_Sha512_512,
-                Subject = new ClaimsIdentity(Default.PayloadClaims),
-                TokenType = "TokenType"
+                SigningCredentials = BenchmarkUtils.SigningCredentialsRsaSha256,
+                EncryptingCredentials = BenchmarkUtils.EncryptingCredentialsAes256Sha512,
+                Claims = BenchmarkUtils.Claims
             };
         }
 
@@ -38,5 +35,6 @@ namespace Microsoft.IdentityModel.Benchmarks
 
         [Benchmark]
         public string JwtSecurityTokenHandler_CreateJWE() => _jwtSecurityTokenHandler.CreateEncodedJwt(_tokenDescriptor);
+
     }
 }

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/CreateSignedHttpRequestTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/CreateSignedHttpRequestTests.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
-using Microsoft.IdentityModel.Protocols.SignedHttpRequest;
-using Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests;
+using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.SignedHttpRequest;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.Benchmarks
 {
@@ -20,19 +22,18 @@ namespace Microsoft.IdentityModel.Benchmarks
         {
             _signedHttpRequestHandler = new SignedHttpRequestHandler();
             _signedHttpRequestDescriptor = new SignedHttpRequestDescriptor(
-                    SignedHttpRequestTestUtils.DefaultEncodedAccessToken,
-                    new HttpRequestData(),
-                    SignedHttpRequestTestUtils.DefaultSigningCredentials,
+                    BenchmarkUtils.CreateAccessTokenWithCnf(),
+                    BenchmarkUtils.HttpRequestData,
+                    BenchmarkUtils.SigningCredentialsRsaSha256,
                     new SignedHttpRequestCreationParameters()
                     {
-                        CreateM = false,
+                        CreateM = true,
                         CreateP = false,
-                        CreateU = false
+                        CreateU = true
                     });
         }
 
         [Benchmark]
         public string SHRHandler_CreateSignedHttpRequest() => _signedHttpRequestHandler.CreateSignedHttpRequest(_signedHttpRequestDescriptor);
-
     }
 }

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/CreateTokenTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/CreateTokenTests.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Security.Claims;
 using BenchmarkDotNet.Attributes;
 using Microsoft.IdentityModel.JsonWebTokens;
-using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.Benchmarks
@@ -22,13 +20,12 @@ namespace Microsoft.IdentityModel.Benchmarks
             _jsonWebTokenHandler = new JsonWebTokenHandler();
             _tokenDescriptor = new SecurityTokenDescriptor
             {
-                Subject = new ClaimsIdentity(Default.PayloadClaims),
-                SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
+                Claims = BenchmarkUtils.Claims,
+                SigningCredentials = BenchmarkUtils.SigningCredentialsRsaSha256,
             };
         }
 
         [Benchmark]
         public string JsonWebTokenHandler_CreateToken() => _jsonWebTokenHandler.CreateToken(_tokenDescriptor);
-
     }
 }

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Microsoft.IdentityModel.Benchmarks</AssemblyName>
     <PackageId>Microsoft.IdentityModel.Benchmarks</PackageId>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(TargetNet8)' == 'True'">net6.0; net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetNet8)' == 'True'">net6.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TargetNet8)' != 'True'">net6.0</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <DelaySign>True</DelaySign>
@@ -21,12 +21,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\test\Microsoft.IdentityModel.TestUtils\Microsoft.IdentityModel.TestUtils.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.JsonWebTokens\Microsoft.IdentityModel.JsonWebTokens.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.Tokens\Microsoft.IdentityModel.Tokens.csproj" />
     <ProjectReference Include="..\..\src\System.IdentityModel.Tokens.Jwt\System.IdentityModel.Tokens.Jwt.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.Protocols.SignedHttpRequest\Microsoft.IdentityModel.Protocols.SignedHttpRequest.csproj" />
-    <ProjectReference Include="..\..\test\Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests\Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests.csproj" />
   </ItemGroup>
 
 </Project>

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/Program.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/Program.cs
@@ -1,6 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+//#define DEBUG_TESTS
+
+#if DEBUG_TESTS
+using Microsoft.IdentityModel.Protocols.SignedHttpRequest;
+using Microsoft.IdentityModel.Tokens;
+#endif
 using BenchmarkDotNet.Running;
 
 namespace Microsoft.IdentityModel.Benchmarks
@@ -9,7 +15,35 @@ namespace Microsoft.IdentityModel.Benchmarks
     {
         public static void Main(string[] args)
         {
+#if DEBUG_TESTS
+            DebugThroughTests();
+#endif
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         }
+
+#if DEBUG_TESTS
+        private static void DebugThroughTests()
+        {
+            CreateJWETests createJWETests = new CreateJWETests();
+            createJWETests.Setup();
+            string jwe = createJWETests.JsonWebTokenHandler_CreateJWE();
+
+            CreateSignedHttpRequestTests createSignedHttpRequestTests = new CreateSignedHttpRequestTests();
+            createSignedHttpRequestTests.Setup();
+            string shr = createSignedHttpRequestTests.SHRHandler_CreateSignedHttpRequest();
+
+            CreateTokenTests createTokenTests = new CreateTokenTests();
+            createTokenTests.Setup();
+            string jws = createTokenTests.JsonWebTokenHandler_CreateToken();
+
+            ValidateTokenAsyncTests validateTokenAsyncTests = new ValidateTokenAsyncTests();
+            validateTokenAsyncTests.Setup();
+            TokenValidationResult tokenValidationResult = validateTokenAsyncTests.JsonWebTokenHandler_ValidateTokenAsync().Result;
+
+            ValidateSignedHttpRequestAsyncTests validateSignedHttpRequestAsyncTests = new ValidateSignedHttpRequestAsyncTests();
+            validateSignedHttpRequestAsyncTests.Setup();
+            SignedHttpRequestValidationResult signedHttpRequestValidationResult = validateSignedHttpRequestAsyncTests.SHRHandler_ValidateSignedHttpRequestAsync().Result;
+        }
+#endif
     }
 }

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateJWEAsyncTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateJWEAsyncTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using BenchmarkDotNet.Attributes;
-using Microsoft.IdentityModel.JsonWebTokens;
-using Microsoft.IdentityModel.TestUtils;
-using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.Benchmarks
 {
@@ -19,8 +18,7 @@ namespace Microsoft.IdentityModel.Benchmarks
         private JsonWebTokenHandler _jsonWebTokenHandler;
         private JwtSecurityTokenHandler _jwtSecurityTokenHandler;
         private SecurityTokenDescriptor _tokenDescriptor;
-        private string _jweFromJsonHandler;
-        private string _jweFromJwtHandler;
+        private string _jwe;
         private TokenValidationParameters _validationParameters;
 
         [GlobalSetup]
@@ -30,26 +28,26 @@ namespace Microsoft.IdentityModel.Benchmarks
             _jwtSecurityTokenHandler = new JwtSecurityTokenHandler();
             _tokenDescriptor = new SecurityTokenDescriptor
             {
-                SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
-                EncryptingCredentials = KeyingMaterial.DefaultSymmetricEncryptingCreds_Aes256_Sha512_512,
-                Subject = new ClaimsIdentity(Default.PayloadClaims),
-                TokenType = "TokenType"
+                SigningCredentials = BenchmarkUtils.SigningCredentialsRsaSha256,
+                EncryptingCredentials = BenchmarkUtils.EncryptingCredentialsAes256Sha512,
+                Claims = BenchmarkUtils.Claims,
+                TokenType = JsonWebTokens.JwtHeaderParameterNames.Jwk
             };
-            _jweFromJsonHandler = _jsonWebTokenHandler.CreateToken(_tokenDescriptor);
-            _jweFromJwtHandler = _jwtSecurityTokenHandler.CreateEncodedJwt(_tokenDescriptor);
+
+            _jwe = _jsonWebTokenHandler.CreateToken(_tokenDescriptor);
             _validationParameters = new TokenValidationParameters
             {
-                IssuerSigningKey = KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key,
-                TokenDecryptionKey = KeyingMaterial.DefaultSymmetricSecurityKey_512,
-                ValidAudience = Default.Audience,
-                ValidIssuer = Default.Issuer
+                IssuerSigningKey = BenchmarkUtils.SigningCredentialsRsaSha256.Key,
+                TokenDecryptionKey = BenchmarkUtils.SymmetricEncryptionKey512,
+                ValidAudience = BenchmarkUtils.Audience,
+                ValidIssuer = BenchmarkUtils.Issuer
             };
         }
 
         [Benchmark]
-        public async Task<TokenValidationResult> JsonWebTokenHandler_ValidateJWEAsync() => await _jsonWebTokenHandler.ValidateTokenAsync(_jweFromJsonHandler, _validationParameters);
+        public async Task<TokenValidationResult> JsonWebTokenHandler_ValidateJWEAsync() => await _jsonWebTokenHandler.ValidateTokenAsync(_jwe, _validationParameters);
 
         [Benchmark]
-        public ClaimsPrincipal JwtSecurityTokenHandler_ValidateJWEAsync() => _jwtSecurityTokenHandler.ValidateToken(_jweFromJwtHandler, _validationParameters, out _);
+        public ClaimsPrincipal JwtSecurityTokenHandler_ValidateJWEAsync() => _jwtSecurityTokenHandler.ValidateToken(_jwe, _validationParameters, out SecurityToken _securityToken);
     }
 }

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateSignedHttpRequestAsyncTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateSignedHttpRequestAsyncTests.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using BenchmarkDotNet.Attributes;
-using Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests;
-using Microsoft.IdentityModel.Protocols.SignedHttpRequest;
-using Microsoft.IdentityModel.Protocols;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.SignedHttpRequest;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.Benchmarks
 {
@@ -15,30 +17,36 @@ namespace Microsoft.IdentityModel.Benchmarks
     public class ValidateSignedHttpRequestAsyncTests
     {
         private SignedHttpRequestHandler _signedHttpRequestHandler;
-        private SignedHttpRequestDescriptor _signedHttpRequestDescriptor;
         private SignedHttpRequestValidationContext _validationContext;
-        private string _signedHttpRequest;
 
         [GlobalSetup]
         public void Setup()
         {
-            var requestData = new HttpRequestData();
             _signedHttpRequestHandler = new SignedHttpRequestHandler();
-            _signedHttpRequestDescriptor = new SignedHttpRequestDescriptor(
-                    SignedHttpRequestTestUtils.DefaultEncodedAccessToken,
-                    requestData,
-                    SignedHttpRequestTestUtils.DefaultSigningCredentials,
-                    new SignedHttpRequestCreationParameters()
-                    {
-                        CreateM = false,
-                        CreateP = false,
-                        CreateU = false
-                    });
-            _signedHttpRequest = _signedHttpRequestHandler.CreateSignedHttpRequest(_signedHttpRequestDescriptor);
             _validationContext = new SignedHttpRequestValidationContext(
-                _signedHttpRequest,
-                requestData,
-                SignedHttpRequestTestUtils.DefaultTokenValidationParameters);
+                    _signedHttpRequestHandler.CreateSignedHttpRequest(
+                        new SignedHttpRequestDescriptor(
+                            BenchmarkUtils.CreateAccessTokenWithCnf(),
+                            BenchmarkUtils.HttpRequestData,
+                            BenchmarkUtils.SigningCredentialsRsaSha256,
+                            new SignedHttpRequestCreationParameters()
+                            {
+                                CreateM = true,
+                                CreateP = false,
+                                CreateU = true
+                            })),
+                    BenchmarkUtils.HttpRequestData,
+                    new TokenValidationParameters
+                    {
+                        IssuerSigningKey = BenchmarkUtils.SigningCredentialsRsaSha256.Key,
+                        ValidIssuer = BenchmarkUtils.Issuer,
+                        ValidAudience = BenchmarkUtils.Audience,
+                        TokenDecryptionKey = BenchmarkUtils.EncryptingCredentialsAes256Sha512.Key
+                    },
+                    new SignedHttpRequestValidationParameters
+                    {
+                        ValidateP = false
+                    });
         }
 
         [Benchmark]

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateTokenAsyncTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateTokenAsyncTests.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.IdentityModel.Tokens.Jwt;
+using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.IdentityModel.TestUtils;
-using System.IdentityModel.Tokens.Jwt;
-using System.Threading.Tasks;
 
 namespace Microsoft.IdentityModel.Benchmarks
 {
@@ -18,7 +17,7 @@ namespace Microsoft.IdentityModel.Benchmarks
         private JsonWebTokenHandler _jsonWebTokenHandler;
         private JwtSecurityTokenHandler _jwtSecurityTokenHandler;
         private SecurityTokenDescriptor _tokenDescriptor;
-        private string _jsonWebToken;
+        private string _jws;
         private TokenValidationParameters _validationParameters;
 
         [GlobalSetup]
@@ -26,38 +25,30 @@ namespace Microsoft.IdentityModel.Benchmarks
         {
             _tokenDescriptor = new SecurityTokenDescriptor
             {
-                Claims = BenchmarkUtils.SimpleClaims,
-                SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
+                Claims = BenchmarkUtils.Claims,
+                SigningCredentials = BenchmarkUtils.SigningCredentialsRsaSha256,
             };
-            _jsonWebToken = _jsonWebTokenHandler.CreateToken(_tokenDescriptor);
-            _validationParameters = new TokenValidationParameters()
-            {
-                ValidAudience = Default.Audience,
-                ValidateLifetime = true,
-                ValidIssuer = Default.Issuer,
-                IssuerSigningKey = KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key,
-            };
-        }
 
-        [GlobalSetup(Targets = new[] { nameof(JsonWebTokenHandler_ValidateTokenAsync) })]
-        public void JsonWebTokenSetup()
-        {
             _jsonWebTokenHandler = new JsonWebTokenHandler();
-            _jsonWebTokenHandler.SetDefaultTimesOnTokenCreation = false;
-        }
+            _jws = _jsonWebTokenHandler.CreateToken(_tokenDescriptor);
 
-        [Benchmark]
-        public async Task<TokenValidationResult> JsonWebTokenHandler_ValidateTokenAsync() => await _jsonWebTokenHandler.ValidateTokenAsync(_jsonWebToken, _validationParameters).ConfigureAwait(false);
-
-        [GlobalSetup(Targets = new[] { nameof(JwtSecurityTokenHandler_ValidateTokenAsync) })]
-        public void JwtSecurityTokenSetup()
-        {
             _jwtSecurityTokenHandler = new JwtSecurityTokenHandler();
             _jwtSecurityTokenHandler.SetDefaultTimesOnTokenCreation = false;
+
+            _validationParameters = new TokenValidationParameters()
+            {
+                ValidAudience = BenchmarkUtils.Audience,
+                ValidateLifetime = true,
+                ValidIssuer = BenchmarkUtils.Issuer,
+                IssuerSigningKey = BenchmarkUtils.SigningCredentialsRsaSha256.Key,
+            };
         }
 
         [Benchmark]
-        public async Task<TokenValidationResult> JwtSecurityTokenHandler_ValidateTokenAsync() => await _jwtSecurityTokenHandler.ValidateTokenAsync(_jsonWebToken, _validationParameters).ConfigureAwait(false);
+        public async Task<TokenValidationResult> JsonWebTokenHandler_ValidateTokenAsync() => await _jsonWebTokenHandler.ValidateTokenAsync(_jws, _validationParameters).ConfigureAwait(false);
+
+        [Benchmark]
+        public async Task<TokenValidationResult> JwtSecurityTokenHandler_ValidateTokenAsync() => await _jwtSecurityTokenHandler.ValidateTokenAsync(_jws, _validationParameters).ConfigureAwait(false);
 
     }
 }


### PR DESCRIPTION
Adjusted tests to use the same claims, keys and more realistic settings in runs.
Benchmark tests no longer depend on test projects for defaults as these can change when tests change.

Added simple way to debug through tests to verify settings.

