### PR TITLE
[Backport] Fix AadIssuerValidator's handling of trailing forward slashes

### DIFF
--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -24,6 +24,7 @@ namespace Microsoft.IdentityModel.Validators
         private static readonly TimeSpan LastKnownGoodConfigurationLifetime = new TimeSpan(0, 24, 0, 0);
 
         internal const string V2EndpointSuffix = "/v2.0";
+        internal const string V2EndpointSuffixWithTrailingSlash = $"{V2EndpointSuffix}/";
         internal const string TenantIdTemplate = "{tenantid}";
 
         internal AadIssuerValidator(
@@ -304,7 +305,9 @@ namespace Microsoft.IdentityModel.Validators
 
         private BaseConfigurationManager GetEffectiveConfigurationManager(SecurityToken securityToken)
         {
-            return (securityToken.Issuer.EndsWith(V2EndpointSuffix, StringComparison.OrdinalIgnoreCase)) ? ConfigurationManagerV2 : ConfigurationManagerV1;
+            var isV2 = securityToken.Issuer.EndsWith(V2EndpointSuffixWithTrailingSlash, StringComparison.OrdinalIgnoreCase) ||
+                securityToken.Issuer.EndsWith(V2EndpointSuffix, StringComparison.OrdinalIgnoreCase);
+            return isV2 ? ConfigurationManagerV2 : ConfigurationManagerV1;
         }
 
         /// <summary>Gets the tenant ID from a token.</summary>

--- a/test/Microsoft.IdentityModel.Validators.Tests/MicrosoftIdentityIssuerValidatorTest.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/MicrosoftIdentityIssuerValidatorTest.cs
@@ -407,6 +407,28 @@ namespace Microsoft.IdentityModel.Validators.Tests
         }
 
         [Fact]
+        public void Validate_FromB2CAuthority_WithTokenValidateParametersValidIssuersUnspecified_ValidateSuccessfully()
+        {
+            var context = new CompareContext();
+            var issClaim = new Claim(ValidatorConstants.ClaimNameIss, ValidatorConstants.B2CIssuer);
+            var tfpClaim = new Claim(ValidatorConstants.ClaimNameTfp, ValidatorConstants.B2CSignUpSignInUserFlow);
+            var jwtSecurityToken = new JwtSecurityToken(issuer: ValidatorConstants.B2CIssuer, claims: new[] { issClaim, tfpClaim });
+
+            var validator = new AadIssuerValidator(null, ValidatorConstants.B2CAuthority);
+
+            var tokenValidationParams = new TokenValidationParameters()
+            {
+                ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(new OpenIdConnectConfiguration()
+                {
+                    Issuer = ValidatorConstants.B2CIssuer
+                })
+            };
+
+            IdentityComparer.AreEqual(ValidatorConstants.B2CIssuer, validator.Validate(ValidatorConstants.B2CIssuer, jwtSecurityToken, tokenValidationParams), context);
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Fact]
         public void Validate_FromB2CAuthority_WithTidClaim_ValidateSuccessfully()
         {
             var context = new CompareContext();

--- a/test/Microsoft.IdentityModel.Validators.Tests/ValidatorConstants.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/ValidatorConstants.cs
@@ -42,11 +42,11 @@ namespace Microsoft.IdentityModel.Validators.Tests
         public const string B2CTenant = "fabrikamb2c.onmicrosoft.com";
         public const string Tfp = "tfp";
         public const string B2CCustomDomainUserFlow = "B2C_1_signupsignin_userflow";
-        public const string B2CCustomDomainIssuer = B2CCustomDomainInstance + "/" + B2CCustomDomainTenant + "/v2.0";
+        public const string B2CCustomDomainIssuer = B2CCustomDomainInstance + "/" + B2CCustomDomainTenant + "/v2.0/";
         public const string B2CCustomDomainAuthority = B2CCustomDomainInstance + "/" + B2CCustomDomainTenant + "/" + B2CCustomDomainUserFlow;
         public const string B2CCustomDomainAuthorityWithV2 = B2CCustomDomainAuthority + "/v2.0";
-        public const string B2CIssuer = B2CInstance + "/" + B2CTenantAsGuid + "/v2.0";
-        public const string B2CIssuer2 = B2CInstance2 + "/" + B2CTenantAsGuid + "/v2.0";
+        public const string B2CIssuer = B2CInstance + "/" + B2CTenantAsGuid + "/v2.0/";
+        public const string B2CIssuer2 = B2CInstance2 + "/" + B2CTenantAsGuid + "/v2.0/";
         public const string B2CAuthority = B2CInstance + "/" + B2CTenant + "/" + B2CSignUpSignInUserFlow;
         public const string B2CAuthorityWithV2 = B2CAuthority + "/v2.0";
         public const string B2CIssuerTfp = B2CInstance + "/" + Tfp + "/" + B2CTenantAsGuid + "/" + B2CSignUpSignInUserFlow + "/v2.0";


### PR DESCRIPTION
This is a backport of #2361 since some customers are running into this issue when using the Microsoft.IdentityModel.Validators 6.x packages with ASP.NET Core 8.

This can happen even if developers are referencing the latest Microsoft.Identity.Web NuGet package but happen to be doing it from a net7.0 or earlier project that is then referenced by net8.0 project. See https://github.com/dotnet/aspnetcore/issues/52283#issuecomment-1823625562 for background

@jmprieur @jennyf19 