### PR TITLE
make CollectionUtilities internal

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/CollectionUtilities.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CollectionUtilities.cs
@@ -9,7 +9,7 @@ namespace Microsoft.IdentityModel.Tokens
     /// <summary>
     /// A class which contains useful methods for processing collections.
     /// </summary>
-    public static class CollectionUtilities
+    static class CollectionUtilities
     {
         /// <summary>
         /// Checks whether <paramref name="enumerable"/> is null or empty.


### PR DESCRIPTION
You should not extend types you dont own

also CollectionUtilities.IsNullOrEmpty  is not a safe general purpose method. if the IEnumerable is a forward only approach, then this method will consume the first value effectively creating a bug.