### PR TITLE
Adds an AppContext switch to control HMAC key size verification.

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -19,7 +19,9 @@ namespace Microsoft.IdentityModel.Tokens
         private static object _cacheLock = new object();
         private static int _defaultSignatureProviderObjectPoolCacheSize = Environment.ProcessorCount * 4;
         private int _signatureProviderObjectPoolCacheSize = _defaultSignatureProviderObjectPoolCacheSize;
-
+#if !NET45
+        internal const string _skipValidationOfHmacKeySizes = "Switch.Microsoft.IdentityModel.UnsafeRelaxHmacKeySizeValidation";
+#endif
         /// <summary>
         /// Returns the default <see cref="CryptoProviderFactory"/> instance.
         /// </summary>
@@ -489,6 +491,10 @@ namespace Microsoft.IdentityModel.Tokens
 
         private static void ValidateKeySize(byte[] keyBytes, string algorithm, int expectedNumberOfBytes)
         {
+#if !NET45
+            if (AppContext.TryGetSwitch(_skipValidationOfHmacKeySizes, out bool skipValidationOfHmacKeySize) && skipValidationOfHmacKeySize)
+                return;
+#endif
             if (keyBytes.Length < expectedNumberOfBytes)
                 throw LogHelper.LogExceptionMessage(
                     new ArgumentOutOfRangeException(

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -223,7 +223,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10717 = "IDX10717: '{0} + {1}' must not be greater than {2}, '{3} + {4} > {5}'.";
         public const string IDX10718 = "IDX10718: AlgorithmToValidate is not supported: '{0}'. Algorithm '{1}'.";
         public const string IDX10719 = "IDX10719: SignatureSize (in bytes) was expected to be '{0}', was '{1}'.";
-        public const string IDX10720 = "IDX10720: Unable to create KeyedHashAlgorithm for algorithm '{0}', the key size must be greater than: '{1}' bits, key has '{2}' bits.";
+        public const string IDX10720 = "IDX10720: Unable to create KeyedHashAlgorithm for algorithm '{0}', the key size must be greater than: '{1}' bits, key has '{2}' bits. See https://aka.ms/IdentityModel/UnsafeRelaxHmacKeySizeValidation";
 
         // Json specific errors
         //public const string IDX10801 = "IDX10801:"

--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.IdentityModel.Validators
         private static readonly TimeSpan LastKnownGoodConfigurationLifetime = new TimeSpan(0, 24, 0, 0);
 
         internal const string V2EndpointSuffix = "/v2.0";
-        internal const string V2EndpointSuffixWithTrailingSlash = $"{V2EndpointSuffix}/";
+        internal const string V2EndpointSuffixWithTrailingSlash = "/v2.0/";
         internal const string TenantIdTemplate = "{tenantid}";
 
         internal AadIssuerValidator(

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     /// SymmetricSignatureProvider
     /// AsymmetricSignatureProvider
     /// </summary>
+    [Collection("Sequential")]
     public class SignatureProviderTests
     {
         [Theory, MemberData(nameof(SignatureProviderConstructorParamsTheoryData))]
@@ -740,6 +741,34 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
+#if !NET452
+        [Theory, MemberData(nameof(SymmetricSecurityKeySizesVerifyOFFTheoryData))]
+        public void SymmetricSecurityKeySizesVerifyOFF(SymmetricSignatureProviderTheoryData theoryData)
+        {
+            AppContext.SetSwitch(CryptoProviderFactory._skipValidationOfHmacKeySizes, true);
+            var context = TestUtilities.WriteHeader($"{this}.SymmetricSecurityKeySizes", theoryData);
+            try
+            {
+                var provider = new SymmetricSignatureProvider(theoryData.SecurityKey, theoryData.Algorithm);
+                provider.Verify(new byte[32], new byte[32]);
+
+                theoryData.ExpectedException.ProcessNoException(context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            AppContext.SetSwitch(CryptoProviderFactory._skipValidationOfHmacKeySizes, false);
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<SymmetricSignatureProviderTheoryData> SymmetricSecurityKeySizesVerifyOFFTheoryData()
+        {
+            return AddSymmetricSecurityKeySizesTheoryData(false);
+        }
+#endif
+
         [Theory, MemberData(nameof(SymmetricSecurityKeySizesTheoryData))]
         public void SymmetricSecurityKeySizesVerify(SymmetricSignatureProviderTheoryData theoryData)
         {
@@ -761,20 +790,25 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
         public static TheoryData<SymmetricSignatureProviderTheoryData> SymmetricSecurityKeySizesTheoryData()
         {
+            return AddSymmetricSecurityKeySizesTheoryData(true);
+        }
+
+        private static TheoryData<SymmetricSignatureProviderTheoryData> AddSymmetricSecurityKeySizesTheoryData(bool addException)
+        {
             var theoryData = new TheoryData<SymmetricSignatureProviderTheoryData>();
 
             theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha256Signature")
             {
                 SecurityKey = new SymmetricSecurityKey(new byte[16]),
                 Algorithm = ALG.HmacSha256Signature,
-                ExpectedException = EE.ArgumentOutOfRangeException("IDX10720:")
+                ExpectedException = addException ? EE.ArgumentOutOfRangeException("IDX10720:") : EE.NoExceptionExpected
             });
 
             theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha256")
             {
                 SecurityKey = new SymmetricSecurityKey(new byte[16]),
                 Algorithm = ALG.HmacSha256,
-                ExpectedException = EE.ArgumentOutOfRangeException("IDX10720:")
+                ExpectedException = addException ? EE.ArgumentOutOfRangeException("IDX10720:") : EE.NoExceptionExpected
             });
 
             theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha256_32")
@@ -787,14 +821,14 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             {
                 SecurityKey = new SymmetricSecurityKey(new byte[32]),
                 Algorithm = ALG.HmacSha384Signature,
-                ExpectedException = EE.ArgumentOutOfRangeException("IDX10720:")
+                ExpectedException = addException ? EE.ArgumentOutOfRangeException("IDX10720:") : EE.NoExceptionExpected
             });
 
             theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha384")
             {
                 SecurityKey = new SymmetricSecurityKey(new byte[32]),
                 Algorithm = ALG.HmacSha384,
-                ExpectedException = EE.ArgumentOutOfRangeException("IDX10720:")
+                ExpectedException = addException ? EE.ArgumentOutOfRangeException("IDX10720:") : EE.NoExceptionExpected
             });
 
             theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha384_48")
@@ -807,14 +841,14 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             {
                 SecurityKey = new SymmetricSecurityKey(new byte[48]),
                 Algorithm = ALG.HmacSha512Signature,
-                ExpectedException = EE.ArgumentOutOfRangeException("IDX10720:")
+                ExpectedException = addException ? EE.ArgumentOutOfRangeException("IDX10720:") : EE.NoExceptionExpected
             });
 
             theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha512")
             {
                 SecurityKey = new SymmetricSecurityKey(new byte[48]),
                 Algorithm = ALG.HmacSha512,
-                ExpectedException = EE.ArgumentOutOfRangeException("IDX10720:")
+                ExpectedException = addException ? EE.ArgumentOutOfRangeException("IDX10720:") : EE.NoExceptionExpected
             });
 
             theoryData.Add(new SymmetricSignatureProviderTheoryData("HmacSha512_64")


### PR DESCRIPTION
Conforming with https://datatracker.ietf.org/doc/html/rfc7518#section-3.2 causes some users to fault.
The AppContext switch "Switch.Microsoft.IdentityModel.UnsafeRelaxHmacKeySizeValidation" can be used bypass this new check.

HMAC will still require a minimum of 128 bits.
