### PR TITLE
Add back support for Guid values in JwtPayload...

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
@@ -941,6 +941,8 @@ namespace Microsoft.IdentityModel.Tokens.Json
                 writer.WriteNumber(key, d);
             else if (obj is float f)
                 writer.WriteNumber(key, f);
+            else if (obj is Guid g)
+                writer.WriteString(key, g);
             else
                 throw LogHelper.LogExceptionMessage(
                     new ArgumentException(

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonSerializerPrimitivesTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonSerializerPrimitivesTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
         [Fact]
         public void CheckMaxDepthReading()
         {
-            var document = JsonDocument.Parse(@"{""key"":" + new string('[', 62) +  @"""value""" + new string(']', 62) + "}");
+            var document = JsonDocument.Parse(@"{""key"":" + new string('[', 62) + @"""value""" + new string(']', 62) + "}");
 
             Dictionary<string, object> value;
             JsonSerializerPrimitives.TryCreateTypeFromJsonElement(document.RootElement, out value);
@@ -76,7 +76,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
 
             json.Append('{');
 
-            foreach(var i in Enumerable.Range(0, 100))
+            foreach (var i in Enumerable.Range(0, 100))
             {
                 json.Append($@"""key-{i}"":""value-{i}""");
                 if (i != 99)
@@ -135,7 +135,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                     IdentityComparer.AreEqual(json, theoryData.Json, context);
                     theoryData.ExpectedException.ProcessNoException(context);
                 }
-                catch (Exception ex )
+                catch (Exception ex)
                 {
                     theoryData.ExpectedException.ProcessException(ex, context);
                 }
@@ -248,7 +248,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                     Json = json,
                     PropertyName = "key",
                     Object = result,
-                    ExpectedException = new ExpectedException(typeExpected:typeof(InvalidOperationException))
+                    ExpectedException = new ExpectedException(typeExpected: typeof(InvalidOperationException))
                 });
 
                 (json, result) = CreateJsonSerializerTheoryData(50);
@@ -259,7 +259,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                 var mergedObjects = new Dictionary<string, object>
                 {
                     ["key1"] = new Dictionary<string, object> { ["key"] = result },
-                    ["key2"] = new Dictionary<string, object> { ["key"] =  result2 },
+                    ["key2"] = new Dictionary<string, object> { ["key"] = result2 },
                 };
 
                 theoryData.Add(new JsonSerializerTheoryData($"MultipleObjects")
@@ -338,7 +338,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                 jsonIdentityModel = JsonConvert.DeserializeObject<JsonTestClass>(theoryData.Json);
                 theoryData.IdentityModelSerializerExpectedException.ProcessNoException(serializationContext);
             }
-            catch (Exception ex )
+            catch (Exception ex)
             {
                 theoryData.IdentityModelSerializerExpectedException.ProcessException(ex, serializationContext);
             }
@@ -586,6 +586,11 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                     JsonTestClass = CreateJsonTestClass("String")
                 });
 
+                theoryData.Add(new JsonSerializerTheoryData("Guid")
+                {
+                    JsonTestClass = CreateJsonTestClass("Guid")
+                });
+
                 return theoryData;
             }
         }
@@ -617,6 +622,9 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
 
             if (propertiesToSet == "*" || propertiesToSet.Contains("String"))
                 jsonTestClass.String = "string";
+
+            if (propertiesToSet == "*" || propertiesToSet.Contains("Guid"))
+                jsonTestClass.Guid = Guid.NewGuid();
 
             return jsonTestClass;
         }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonTestClass.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonTestClass.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.IdentityModel.Logging;
 
@@ -39,6 +40,8 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
 
         public string String { get; set; }
 
+        public Guid? Guid { get; set; }
+
         public bool ShouldSerializeAdditionalData()
         {
             return AdditionalData.Count > 0;
@@ -70,6 +73,11 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
         public bool ShouldSerializeString()
         {
             return String != null;
+        }
+
+        public bool ShouldSerializeGuid()
+        {
+            return Guid.HasValue;
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonTestClassSerializer.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonTestClassSerializer.cs
@@ -216,6 +216,9 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
             if (!string.IsNullOrEmpty(jsonTestClass.String))
                 writer.WriteString("String", jsonTestClass.String);
 
+            if (jsonTestClass.Guid.HasValue)
+                writer.WriteString("Guid", jsonTestClass.Guid.Value);
+
             if (jsonTestClass.AdditionalData != null && jsonTestClass.AdditionalData.Count > 0)
             {
                 foreach (var item in jsonTestClass.AdditionalData)

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
@@ -521,5 +521,15 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             var issuer = jwtPayload.Iss;
             Assert.True(issuer == null);
         }
+
+        [Fact]
+        public void TestGuidClaim()
+        {
+            JwtPayload jwtPayload = new JwtPayload();
+            Guid guid = Guid.NewGuid();
+            string expected = $"{{\"appid\":\"{guid}\"}}";
+            jwtPayload.Add("appid", guid);
+            Assert.Equal(expected, jwtPayload.SerializeToJson());
+        }
     }
 }


### PR DESCRIPTION
# Add back support for Guid values in JwtPayload...

Changes `JsonSerializerPrimitves` to serialize claim values of type `Guid` as `string` (rather than throwing an Exception)...

## Description

In versions of `Microsoft.IdentityModel.Tokens` < 7.0.0-preview4, claim values could have values of type `Guid` and would be serialized successfully. This appears to have been regressed with the rewrite of the serializer implementation.

I checked the round-trip behavior with older versions, and it seems that the serialized strings are subsequently deserialized as `string` (by `JwtPayload.Deserialize`), so I left the behavior asymmetric (rather than try-parsing all string values as `Guid`).

Fixes #2439
