### PR TITLE
Use invariant culture when formatting claims in JwtSecurityToken

### DIFF
--- a/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
@@ -529,7 +529,14 @@ namespace System.IdentityModel.Tokens.Jwt
                             claims.Add(new Claim(keyValuePair.Key, "false", ClaimValueTypes.Boolean, issuer, issuer));
                     }
                     else if (keyValuePair.Value != null)
-                        claims.Add(new Claim(keyValuePair.Key, keyValuePair.Value.ToString(), GetClaimValueType(keyValuePair.Value), issuer, issuer));
+                    {
+                        var value = keyValuePair.Value;
+                        var claimValueType = GetClaimValueType(value);
+                        if (value is IConvertible convertible)
+                            claims.Add(new Claim(keyValuePair.Key, convertible.ToString(CultureInfo.InvariantCulture), claimValueType, issuer, issuer));
+                        else
+                            claims.Add(new Claim(keyValuePair.Key, value.ToString(), claimValueType, issuer, issuer));
+                    }
                 }
 
                 return claims;

--- a/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
@@ -532,8 +532,8 @@ namespace System.IdentityModel.Tokens.Jwt
                     {
                         var value = keyValuePair.Value;
                         var claimValueType = GetClaimValueType(value);
-                        if (value is IConvertible convertible)
-                            claims.Add(new Claim(keyValuePair.Key, convertible.ToString(CultureInfo.InvariantCulture), claimValueType, issuer, issuer));
+                        if (value is IFormattable formattable)
+                            claims.Add(new Claim(keyValuePair.Key, formattable.ToString(null, CultureInfo.InvariantCulture), claimValueType, issuer, issuer));
                         else
                             claims.Add(new Claim(keyValuePair.Key, value.ToString(), claimValueType, issuer, issuer));
                     }

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
@@ -12,7 +12,7 @@ using System.Linq;
 using System.Reflection;
 using System.Security.Claims;
 using System.Text;
-using System.Text.Json;
+using System.Threading;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.IdentityModel.Tokens.Json.Tests;
@@ -1630,6 +1630,25 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             string jsonEncoded = Base64UrlEncoder.Encode("{}") + "." + Base64UrlEncoder.Encode(json) + ".";
             JsonWebToken encodedToken = new JsonWebToken(jsonEncoded);
             _ = encodedToken.Claims;
+        }
+
+        [Fact]
+        public void DifferentCultureJsonWebToken()
+        {
+            string result = string.Empty;
+
+            var thread = new Thread(() =>
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+                var token = new JsonWebToken(JsonUtilities.CreateUnsignedToken("numericClaim", 10.9d));
+                var claim = token.Claims.First(c => c.Type == "numericClaim");
+                result = claim.Value;
+            });
+
+            thread.Start();
+            thread.Join();
+
+            Assert.Equal("10.9", result);
         }
     }
 

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
 using System.Text;
+using System.Threading;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
@@ -452,6 +454,35 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 return theoryData;
             }
 
+        }
+
+        [Fact]
+        public void DifferentCultureJwtSecurityToken()
+        {
+            string result = string.Empty;
+
+            var thread = new Thread(() =>
+            {
+                CultureInfo.CurrentCulture = new CultureInfo("fr-FR");
+
+                var handler = new JwtSecurityTokenHandler();
+                var token = handler.CreateJwtSecurityToken(new SecurityTokenDescriptor
+                {
+                    Claims = new Dictionary<string, object>
+                    {
+                        { "numericClaim", 10.9d }
+                    }
+                });
+
+                var claim = token.Claims.First(c => c.Type == "numericClaim");
+                result = claim.Value;
+
+            });
+
+            thread.Start();
+            thread.Join();
+
+            Assert.Equal("10.9", result);
         }
     }
 }


### PR DESCRIPTION
# Use invariant culture when formatting claims in JwtSecurityToken

## Description

Verified JSONWebToken handles this correctly already.

Fixes #2409
