### PR TITLE
Add client certificates collection to HttpRequestData

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/HttpRequestData.cs
+++ b/src/Microsoft.IdentityModel.Protocols/HttpRequestData.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http.Headers;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 
 namespace Microsoft.IdentityModel.Protocols
 {
@@ -14,6 +16,7 @@ namespace Microsoft.IdentityModel.Protocols
     public class HttpRequestData
     {
         private IDictionary<string, IEnumerable<string>> _headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
+        private X509Certificate2Collection _clientCertificates;
 
         /// <summary>
         /// Gets or sets the http request URI. 
@@ -44,6 +47,14 @@ namespace Microsoft.IdentityModel.Protocols
                 _headers = value ?? throw new ArgumentNullException(nameof(Headers));
             }
         }
+
+        /// <summary>
+        /// Gets the certificate collection involved in authenticating the client against the server.
+        /// </summary>
+        public X509Certificate2Collection ClientCertificates => _clientCertificates ??
+            Interlocked.CompareExchange(ref _clientCertificates, [], null) ??
+            _clientCertificates;
+
         /// <summary>
         /// Gets or sets an <see cref="IDictionary{String, Object}"/> that enables custom extensibility scenarios.
         /// </summary>

--- a/test/Microsoft.IdentityModel.Protocols.Tests/HttpRequestDataTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/HttpRequestDataTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.IdentityModel.TestUtils;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Protocols.Tests
+{
+    public class HttpRequestDataTests
+    {
+        [Fact]
+        public void ClientCertificates()
+        {
+            var httpRequestData = new HttpRequestData();
+            Assert.NotNull(httpRequestData.ClientCertificates);
+            Assert.Empty(httpRequestData.ClientCertificates);
+
+            var cert = new X509Certificate2(Convert.FromBase64String(KeyingMaterial.AADCertData));
+            httpRequestData.ClientCertificates.Add(cert);
+
+            Assert.Single(httpRequestData.ClientCertificates);
+            Assert.Equal(cert, httpRequestData.ClientCertificates[0]);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces the addition of the ClientCertificates property to the HttpRequestData class, enabling the exposure of certificate collection involved in authenticating the client against the server.

Fixes #2463 