### PR TITLE
Update benchmark config

### DIFF
--- a/benchmark/Microsoft.IdentityModel.Benchmarks/AsymmetricAdapterSignatures.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/AsymmetricAdapterSignatures.cs
@@ -15,9 +15,6 @@ namespace Microsoft.IdentityModel.Benchmarks
 {
     // dotnet run -c release -f net8.0 --filter Microsoft.IdentityModel.Benchmarks.AsymmetricAdapterSignatures.*
 
-    [Config(typeof(BenchmarkConfig))]
-    [HideColumns("Type", "Job", "WarmupCount", "LaunchCount")]
-    [MemoryDiagnoser]
     public class AsymmetricAdapterSignatures
     {
         private byte[] _bytesToSign;
@@ -46,7 +43,7 @@ namespace Microsoft.IdentityModel.Benchmarks
         }
 
         /// <summary>
-        /// In this case, dotnet creates a buffer to hold the signature.
+        /// In this case, .NET creates a buffer to hold the signature.
         /// ArrayPool is not used, because the buffer is created by the framework and not the user.
         /// The buffer is not returned to the pool, and must be garbage collected.
         /// </summary>
@@ -57,7 +54,7 @@ namespace Microsoft.IdentityModel.Benchmarks
         }
 
         /// <summary>
-        /// In this case, the user obatins a buffer to hold the signature frm the array pool.
+        /// In this case, the user obtains a buffer to hold the signature from the array pool.
         /// A new api available in .NET 5.0+ is used to provide the buffer to place the signature.
         /// The size of the bytes written is returned in the out parameter, size.
         /// </summary>

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/BenchmarkConfig.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/BenchmarkConfig.cs
@@ -3,8 +3,9 @@
 
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Jobs;
-using BenchmarkDotNet.Toolchains.InProcess.Emit;
+using BenchmarkDotNet.Order;
 using Perfolizer.Horology;
 
 namespace Microsoft.IdentityModel.Benchmarks
@@ -14,12 +15,16 @@ namespace Microsoft.IdentityModel.Benchmarks
         public BenchmarkConfig()
         {
             AddJob(Job.MediumRun
-                .WithToolchain(InProcessEmitToolchain.Instance)
                 .WithLaunchCount(4)
                 .WithMaxAbsoluteError(TimeInterval.FromMilliseconds(10)))
-                // uncomment to disable validation to enable debuging through benchmarks
+                // uncomment to disable validation to enable debugging through benchmarks
                 //.WithOption(ConfigOptions.DisableOptimizationsValidator, true)
-                .AddColumn(StatisticColumn.P90, StatisticColumn.P95, StatisticColumn.P100);
+                .AddColumn(StatisticColumn.P90, StatisticColumn.P95, StatisticColumn.P100)
+                .WithOrderer(new DefaultOrderer(SummaryOrderPolicy.Method))
+                .HideColumns(Column.WarmupCount, Column.Type, Column.Job)
+                .AddDiagnoser(MemoryDiagnoser.Default); // https://benchmarkdotnet.org/articles/configs/diagnosers.html
+                //.AddDiagnoser(new EtwProfiler()) // Uncomment to generate traces / flame graphs. Doc: https://adamsitnik.com/ETW-Profiler/
         }
+    }
     }
 }

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/BenchmarkConfig.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/BenchmarkConfig.cs
@@ -26,5 +26,4 @@ namespace Microsoft.IdentityModel.Benchmarks
                 //.AddDiagnoser(new EtwProfiler()) // Uncomment to generate traces / flame graphs. Doc: https://adamsitnik.com/ETW-Profiler/
         }
     }
-    }
 }

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/CreateJWETests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/CreateJWETests.cs
@@ -10,9 +10,6 @@ namespace Microsoft.IdentityModel.Benchmarks
 {
     // dotnet run -c release -f net8.0 --filter Microsoft.IdentityModel.Benchmarks.CreateJWETests*
 
-    [Config(typeof(BenchmarkConfig))]
-    [HideColumns("Type", "Job", "WarmupCount", "LaunchCount")]
-    [MemoryDiagnoser]
     public class CreateJWETests
     {
         private JsonWebTokenHandler _jsonWebTokenHandler;

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/CreateSignedHttpRequestTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/CreateSignedHttpRequestTests.cs
@@ -8,9 +8,6 @@ namespace Microsoft.IdentityModel.Benchmarks
 {
     // dotnet run -c release -f net8.0 --filter Microsoft.IdentityModel.Benchmarks.CreateSignedHttpRequestTests*
 
-    [Config(typeof(BenchmarkConfig))]
-    [HideColumns("Type", "Job", "WarmupCount", "LaunchCount")]
-    [MemoryDiagnoser]
     public class CreateSignedHttpRequestTests
     {
         private SignedHttpRequestHandler _signedHttpRequestHandler;

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/CreateTokenTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/CreateTokenTests.cs
@@ -10,9 +10,6 @@ namespace Microsoft.IdentityModel.Benchmarks
 {
     // dotnet run -c release -f net8.0 --filter Microsoft.IdentityModel.Benchmarks.CreateTokenTests*
 
-    [Config(typeof(BenchmarkConfig))]
-    [HideColumns("Type", "Job", "WarmupCount", "LaunchCount")]
-    [MemoryDiagnoser]
     public class CreateTokenTests
     {
         private JsonWebTokenHandler _jsonWebTokenHandler;

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
@@ -11,8 +11,16 @@
     <ErrorOnDuplicatePublishOutputFiles>False</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
 
+  <!-- Uncomment only when running EtwProfiler diagnoser on Release-->
+  <!-- https://learn.microsoft.com/en-us/visualstudio/msbuild/common-msbuild-project-properties -->
+  <!--<PropertyGroup>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>-->
+  
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
@@ -16,11 +16,13 @@
   <!--<PropertyGroup>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>-->
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
+  </ItemGroup>-->
   
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/Program.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/Program.cs
@@ -4,6 +4,7 @@
 using Microsoft.IdentityModel.Protocols.SignedHttpRequest;
 using Microsoft.IdentityModel.Tokens;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Configs;
 
 namespace Microsoft.IdentityModel.Benchmarks
 {
@@ -13,7 +14,13 @@ namespace Microsoft.IdentityModel.Benchmarks
         {
             //DebugThroughTests();
 
-            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+#if DEBUG
+            var benchmarkConfig = ManualConfig.Union(DefaultConfig.Instance, new DebugInProcessConfig()); // Allows debugging into benchmarks
+#else
+            var benchmarkConfig = ManualConfig.Union(DefaultConfig.Instance, new BenchmarkConfig());
+#endif
+
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, benchmarkConfig);
         }
         private static void DebugThroughTests()
         {

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateJWEAsyncTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateJWEAsyncTests.cs
@@ -12,9 +12,6 @@ namespace Microsoft.IdentityModel.Benchmarks
 {
     // dotnet run -c release -f net8.0 --filter Microsoft.IdentityModel.Benchmarks.ValidateJWEAsyncTests*
 
-    [Config(typeof(BenchmarkConfig))]
-    [HideColumns("Type", "Job", "WarmupCount", "LaunchCount")]
-    [MemoryDiagnoser]
     public class ValidateJWEAsyncTests
     {
         private JsonWebTokenHandler _jsonWebTokenHandler;

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateSignedHttpRequestAsyncTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateSignedHttpRequestAsyncTests.cs
@@ -11,9 +11,6 @@ namespace Microsoft.IdentityModel.Benchmarks
 {
     // dotnet run -c release -f net8.0 --filter Microsoft.IdentityModel.Benchmarks.ValidateSignedHttpRequestAsyncTests*
 
-    [Config(typeof(BenchmarkConfig))]
-    [HideColumns("Type", "Job", "WarmupCount", "LaunchCount")]
-    [MemoryDiagnoser]
     public class ValidateSignedHttpRequestAsyncTests
     {
         private SignedHttpRequestHandler _signedHttpRequestHandler;

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateTokenAsyncTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateTokenAsyncTests.cs
@@ -11,9 +11,6 @@ namespace Microsoft.IdentityModel.Benchmarks
 {
     // dotnet run -c release -f net8.0 --filter Microsoft.IdentityModel.Benchmarks.ValidateTokenAsyncTests*
 
-    [Config(typeof(BenchmarkConfig))]
-    [HideColumns("Type", "Job", "WarmupCount", "LaunchCount")]
-    [MemoryDiagnoser]
     public class ValidateTokenAsyncTests
     {
         private JsonWebTokenHandler _jsonWebTokenHandler;


### PR DESCRIPTION
Fixes #2472

- Update benchmarks config to match SAL.
- Use out-of-process BDN toolchain instead of in-process one.
- Move the configuration from class attributes into `BenchmarkConfig` to reduce code duplication.
- Add a debug flag to allow debugging into benchmarks.
- Enable EtwProfiler (should be commented out for prod).