### PR TITLE
Marcinzo/issuervalidatormetadata

### DIFF
--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -284,7 +284,7 @@ namespace Microsoft.IdentityModel.Validators
         /// </code></example>
         /// <returns>A <see cref="AadIssuerValidator"/> for the aadAuthority.</returns>
         /// <exception cref="ArgumentNullException">if <paramref name="aadAuthority"/> is null or empty.</exception>
-        public static AadIssuerValidator GetAadIssuerValidator(string aadAuthority, HttpClient httpClient, Func<string, BaseConfigurationManager> configurationManagerProvider)
+        internal static AadIssuerValidator GetAadIssuerValidator(string aadAuthority, HttpClient httpClient, Func<string, BaseConfigurationManager> configurationManagerProvider)
         {
             if (string.IsNullOrEmpty(aadAuthority))
                 throw LogHelper.LogArgumentNullException(nameof(aadAuthority));

--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/IssuerLastKnownGood.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/IssuerLastKnownGood.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.IdentityModel.Validators
+{
+    /// <summary>
+    /// Class representing the last known good for issuer.
+    /// </summary>
+    internal class IssuerLastKnownGood
+    {
+        private string _issuer;
+        private TimeSpan _lastKnownGoodLifetime;
+        private DateTime? _lastKnownGoodConfigFirstUse = null;
+
+        /// <summary>
+        /// Gets or sets the issuer value.
+        /// </summary>
+        public string Issuer
+        {
+            get
+            {
+                return _issuer;
+            }
+            set
+            {
+                if (value == null)
+                    throw LogHelper.LogArgumentNullException(nameof(value));
+
+                _lastKnownGoodConfigFirstUse = DateTime.UtcNow;
+                _issuer = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the last known good lifetime.
+        /// </summary>
+        public TimeSpan LastKnownGoodLifetime
+        {
+            get { return _lastKnownGoodLifetime; }
+            set
+            {
+                if (value < TimeSpan.Zero)
+                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), LogHelper.FormatInvariant(LogMessages.IDX40008, value)));
+
+                _lastKnownGoodLifetime = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets an indicator whether the value is still within its lifetime and is valid.
+        /// </summary>
+        public bool IsValid
+        {
+            get
+            {
+                return _lastKnownGoodConfigFirstUse + LastKnownGoodLifetime > DateTime.UtcNow;
+            }
+        }
+
+    }
+}

--- a/src/Microsoft.IdentityModel.Validators/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Validators/LogMessages.cs
@@ -23,5 +23,6 @@ namespace Microsoft.IdentityModel.Validators
         public const string IDX40004 = "IDX40004: Token issuer: '{0}', does not contain the `tid` or `tenantId` claim present in the token: '{1}'.";
         public const string IDX40005 = "IDX40005: Token issuer: '{0}', does not match the signing key issuer: '{1}'.";
         public const string IDX40007 = "IDX40007: RequireSignedTokens property on ValidationParameters is set to true, but the issuer signing key is null.";
+        public const string IDX40008 = "IDX40008: When setting LastKnownGoodLifetime, the value must be greater than or equal to zero. value: '{0}'.";
     }
 }

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -3475,6 +3475,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWSWithConfigAsync", theoryData);
             try
             {
+                // clear up static state.
+                AadIssuerValidator.s_issuerValidators[Default.AadV1Authority] = new AadIssuerValidator(null, Default.AadV1Authority);
+
+                // previous instance is captured in a closure during theorydata set setup.
+                if (theoryData.ValidationParameters.IssuerValidator != null)
+                    theoryData.ValidationParameters.IssuerValidator = AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).Validate;
+
                 var handler = new JsonWebTokenHandler();
                 var jwt = handler.ReadJsonWebToken(theoryData.Token);
                 AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).ConfigurationManagerV1 = theoryData.ValidationParameters.ConfigurationManager;

--- a/test/Microsoft.IdentityModel.TestUtils/MockConfigurationManager.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/MockConfigurationManager.cs
@@ -21,6 +21,15 @@ namespace Microsoft.IdentityModel.TestUtils
         private Exception _exToThrowOnFirstGet;
 
         /// <summary>
+        /// Gets or sets the refreshed configuration. Use with RequestRefresh to simulate data transmission.
+        /// </summary>
+        public T RefreshedConfiguration
+        {
+            get { return _refreshedConfiguration; }
+            set { _refreshedConfiguration = value; }
+        }
+
+        /// <summary>
         /// Initializes an new instance of <see cref="MockConfigurationManager{T}"/> with a Configuration instance.
         /// </summary>
         /// <param name="configuration">Configuration of type OpenIdConnectConfiguration or OpenIdConnectConfiguration.</param>

--- a/test/Microsoft.IdentityModel.Validators.Tests/ValidatorConstants.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/ValidatorConstants.cs
@@ -31,6 +31,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
         public const string UsGovIssuer = "https://login.microsoftonline.us/" + UsGovTenantId + "/v2.0";
         public const string UsGovTenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";
         public const string V1Issuer = "https://sts.windows.net/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/";
+        public const string AadIssuerV1CommonAuthority = "https://sts.windows.net/{tenantid}/";
         public const string AadIssuerV2CommonAuthority = AadInstance + "/{tenantid}/v2.0";
 
         public const string B2CSignUpSignInUserFlow = "b2c_1_susi";

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -2218,8 +2218,38 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
             try
             {
+                // clear up static state.
+                AadIssuerValidator.s_issuerValidators[Default.AadV1Authority] = new AadIssuerValidator(null, Default.AadV1Authority);
+
+                // previous instance is captured in a closure during theorydata set setup.
+                if (theoryData.ValidationParameters.IssuerValidator != null)
+                    theoryData.ValidationParameters.IssuerValidator = AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).Validate;
+
+                var handler = new JwtSecurityTokenHandler();
+
+                if (theoryData.SetupIssuerLkg)
+                {
+                    // make a valid pass to initiate issuer LKG.
+                    var issuerValidator = AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority);
+                    issuerValidator.ConfigurationManagerV1 = theoryData.SetupIssuerLkgConfigurationManager;
+
+                    var previousValidateWithLKG = theoryData.ValidationParameters.ValidateWithLKG;
+                    theoryData.ValidationParameters.ValidateWithLKG = false;
+
+                    var setupValidationResult = handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
+
+                    theoryData.ValidationParameters.ValidateWithLKG = previousValidateWithLKG;
+
+                    if (setupValidationResult.Exception != null)
+                    {
+                        if (setupValidationResult.IsValid)
+                            context.AddDiff("setupValidationResult.IsValid, setupValidationResult.Exception != null");
+                        throw setupValidationResult.Exception;
+                    }
+                }
+
                 AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).ConfigurationManagerV1 = theoryData.ValidationParameters.ConfigurationManager;
-                new JwtSecurityTokenHandler().ValidateToken(theoryData.Token, theoryData.ValidationParameters, out _);
+                handler.ValidateToken(theoryData.Token, theoryData.ValidationParameters, out _);
                 theoryData.ExpectedException.ProcessNoException(context);
             }
             catch (Exception ex)
@@ -2239,8 +2269,38 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
             try
             {
+                // clear up static state.
+                AadIssuerValidator.s_issuerValidators[Default.AadV1Authority] = new AadIssuerValidator(null, Default.AadV1Authority);
+
+                // previous instance is captured in a closure during theorydata set setup.
+                if (theoryData.ValidationParameters.IssuerValidator != null)
+                    theoryData.ValidationParameters.IssuerValidator = AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).Validate;
+
+                var handler = new JwtSecurityTokenHandler();
+
+                if (theoryData.SetupIssuerLkg)
+                {
+                    // make a valid pass to initiate issuer LKG.
+                    var issuerValidator = AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority);
+                    issuerValidator.ConfigurationManagerV1 = theoryData.SetupIssuerLkgConfigurationManager;
+
+                    var previousValidateWithLKG = theoryData.ValidationParameters.ValidateWithLKG;
+                    theoryData.ValidationParameters.ValidateWithLKG = false;
+
+                    var setupValidationResult = handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
+
+                    theoryData.ValidationParameters.ValidateWithLKG = previousValidateWithLKG;
+
+                    if (setupValidationResult.Exception != null)
+                    {
+                        if (setupValidationResult.IsValid)
+                            context.AddDiff("setupValidationResult.IsValid, setupValidationResult.Exception != null");
+                        throw setupValidationResult.Exception;
+                    }
+                }
+
                 AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).ConfigurationManagerV1 = theoryData.ValidationParameters.ConfigurationManager;
-                new JwtSecurityTokenHandler().ValidateToken(theoryData.Token, theoryData.ValidationParameters, out _);
+                handler.ValidateToken(theoryData.Token, theoryData.ValidationParameters, out _);
                 theoryData.ExpectedException.ProcessNoException(context);
             }
             catch (Exception ex)

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtTestDatasets.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtTestDatasets.cs
@@ -556,6 +556,8 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     {
                         TestId = nameof(Default.AsymmetricJws) + "_ConfigIssuerInvalid_AadIssuerValidatorThrow_LKGValid",
                         Token = Default.AadAsymmetricJws,
+                        SetupIssuerLkg = true,
+                        SetupIssuerLkgConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(validConfig),
                         ValidationParameters = new TokenValidationParameters
                         {
                             ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(invalidIssuerConfig, validConfig),
@@ -650,6 +652,8 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     {
                         TestId = nameof(Default.AsymmetricJws) + "_ConfigInvalid_AadIssuerValidatorThrow_LKGSucceeds_RequestRefreshIssuerInvalid",
                         Token = Default.AadAsymmetricJws,
+                        SetupIssuerLkg = true,
+                        SetupIssuerLkgConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(validConfig),
                         ValidationParameters = new TokenValidationParameters
                         {
                             ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(invalidIssuerConfig, validConfig, invalidIssuerConfig),
@@ -962,6 +966,8 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     {
                         TestId = nameof(aadJwe) + "_ConfigIssuerInvalid_AadIssuerValidatorThrow_LKGValid",
                         Token = aadJwe,
+                        SetupIssuerLkg = true,
+                        SetupIssuerLkgConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(validConfig),
                         ValidationParameters = new TokenValidationParameters
                         {
                             ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(invalidIssuerConfig, validConfig),
@@ -1047,6 +1053,8 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     {
                         TestId = nameof(aadJwe) + "_ConfigInvalid_AadIssuerValidatorThrow_LKGSucceeds_RequestRefreshIssuerInvalid",
                         Token = aadJwe,
+                        SetupIssuerLkg = true,
+                        SetupIssuerLkgConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(validConfig),
                         ValidationParameters = new TokenValidationParameters
                         {
                             ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(invalidIssuerConfig, validConfig, invalidIssuerConfig),

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtTheoryData.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtTheoryData.cs
@@ -34,5 +34,9 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         public string TokenTypeHeader { get; set; }
 
         public bool ShouldSetLastKnownConfiguration { get; set; }
+
+        public bool SetupIssuerLkg { get; set; } = false;
+
+        public BaseConfigurationManager SetupIssuerLkgConfigurationManager { get; set; }
     }
 }


### PR DESCRIPTION
# PoC injecting metadata configuration managers from outside for single point cache management
This PR adds injection point to AadIssuerValidator for ConfigurationManager

## Description
This PR allows for centralized cache management, including http policies, lifetime policies, etc. and reduces the amount of copies 
of cached data.

This is a conservative change, that still utilizes prev mechanism for a fallback in case the cache cannot be retrieved.

{Detail}

Fixes #{bug number} (in this specific format)
