### PR TITLE
Initial work to reduce memory in GetCacheKey

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
+++ b/src/Microsoft.IdentityModel.Tokens/InMemoryCryptoProviderCache.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.Logging;
@@ -103,7 +102,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         private static string GetCacheKeyPrivate(SecurityKey securityKey, string algorithm, string typeofProvider)
         {
-            return $"{securityKey.GetType()}-{securityKey.InternalId}-{algorithm}-{typeofProvider}";
+            return securityKey.GetCryptoProviderCacheKey(algorithm, typeofProvider);
         }
 
         /// <summary>


### PR DESCRIPTION
# Reduce memory in get cache key

Still some more testing to be done to look at all the cases.

Need to understand perf of non-typical cases better where multiple keys are used

Difference is within the error for throughput

memory -~7%

Before:

|                                     Method |     Mean |    Error |   StdDev |   Median |      P90 |      P95 |     P100 |   Gen0 | Allocated |
|------------------------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
|     JsonWebTokenHandler_ValidateTokenAsync | 29.89 us | 0.329 us | 0.715 us | 29.66 us | 31.17 us | 31.46 us | 31.60 us | 0.1221 |    4.3 KB |
| JwtSecurityTokenHandler_ValidateTokenAsync | 33.42 us | 0.676 us | 1.455 us | 32.83 us | 36.17 us | 36.30 us | 36.89 us | 0.4272 |  11.75 KB |

After:

|                                     Method |     Mean |    Error |   StdDev |   Median |      P90 |      P95 |     P100 |   Gen0 | Allocated |
|------------------------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
|     JsonWebTokenHandler_ValidateTokenAsync | 29.77 us | 0.286 us | 0.621 us | 29.57 us | 30.70 us | 31.40 us | 31.69 us | 0.1221 |   3.97 KB |
| JwtSecurityTokenHandler_ValidateTokenAsync | 33.07 us | 0.685 us | 1.460 us | 32.28 us | 35.70 us | 36.17 us | 37.12 us | 0.4272 |  11.42 KB |
