### PR TITLE
Move virtual methods to public in Signature Provider

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -195,14 +195,8 @@ namespace Microsoft.IdentityModel.Tokens
         internal override int ObjectPoolSize => _asymmetricAdapterObjectPool.Size;
 
 #if NET6_0_OR_GREATER
-        /// <summary>
-        /// This must be overridden to produce a signature over the 'input'.
-        /// </summary>
-        /// <param name="input">bytes to sign.</param>
-        /// <param name="signature">pre allocated span where signature bytes will be placed.</param>
-        /// <param name="bytesWritten">number of bytes written into the signature span.</param>
-        /// <returns>returns true if creation of signature succeeded, false otherwise.</returns>
-        internal override bool Sign(ReadOnlySpan<byte> input, Span<byte> signature, out int bytesWritten)
+        /// <inheritdoc/>
+        public override bool Sign(ReadOnlySpan<byte> input, Span<byte> signature, out int bytesWritten)
         {
             if (input == null || input.Length == 0)
                 throw LogHelper.LogArgumentNullException(nameof(input));
@@ -273,7 +267,8 @@ namespace Microsoft.IdentityModel.Tokens
             }
         }
 
-        internal override byte[] Sign(byte[] input, int offset, int count)
+        /// <inheritdoc/>
+        public override byte[] Sign(byte[] input, int offset, int count)
         {
             if (input == null || input.Length == 0)
                 throw LogHelper.LogArgumentNullException(nameof(input));

--- a/src/Microsoft.IdentityModel.Tokens/SignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SignatureProvider.cs
@@ -95,20 +95,36 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns>signed bytes</returns>
         public abstract byte[] Sign(byte[] input);
 
-        internal virtual byte[] Sign(byte[] input, int offset, int count)
+        /// <summary>
+        /// Produces a signature over the specified region of the <paramref name="input"/>.
+        /// </summary>
+        /// <param name="input">The bytes to produce a signature over.</param>
+        /// <param name="offset">The offset to specify the beginning of the region.</param>
+        /// <param name="count">The count to specify the end of the region.</param>
+        /// <returns>The signature bytes.</returns>
+        public virtual byte[] Sign(byte[] input, int offset, int count)
         {
             throw LogHelper.LogExceptionMessage(new NotImplementedException());
         }
 
 #if NET6_0_OR_GREATER
-        internal virtual bool Sign(ReadOnlySpan<byte> data, Span<byte> destination, out int bytesWritten)
+        /// <summary>
+        /// Produces a signature over the <paramref name="data"/> and writes it to <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="data">The bytes to produce a signature over.</param>
+        /// <param name="destination">The pre-allocated span where signature bytes will be placed.</param>
+        /// <param name="bytesWritten">The number of bytes written into the signature span.</param>         
+        /// <returns>returns <see langword="true"/> if creation of signature succeeded, <see langword="false"/> otherwise.</returns>
+        public virtual bool Sign(ReadOnlySpan<byte> data, Span<byte> destination, out int bytesWritten)
         {
             throw LogHelper.LogExceptionMessage(new NotImplementedException());
         }
 #endif
+        /// <summary>
         /// Verifies that the <paramref name="signature"/> over <paramref name="input"/> using the
         /// <see cref="SecurityKey"/> and <see cref="SignatureProvider.Algorithm"/> specified by this
         /// <see cref="SignatureProvider"/> are consistent.
+        /// </summary>
         /// <param name="input">the bytes that were signed.</param>
         /// <param name="signature">signature to compare against.</param>
         /// <returns>true if the computed signature matches the signature parameter, false otherwise.</returns>

--- a/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
@@ -204,7 +204,8 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
 #if NET6_0_OR_GREATER
-        internal override bool Sign(ReadOnlySpan<byte> input, Span<byte> signature, out int bytesWritten)
+        /// <inheritdoc/>
+        public override bool Sign(ReadOnlySpan<byte> input, Span<byte> signature, out int bytesWritten)
         {
             if (input == null || input.Length == 0)
                 throw LogHelper.LogArgumentNullException(nameof(input));
@@ -235,7 +236,8 @@ namespace Microsoft.IdentityModel.Tokens
         }
 #endif
 
-        internal override byte[] Sign(byte[] input, int offset, int count)
+        /// <inheritdoc/>
+        public override byte[] Sign(byte[] input, int offset, int count)
         {
             if (input == null || input.Length == 0)
                 throw LogHelper.LogArgumentNullException(nameof(input));


### PR DESCRIPTION
These methods need to be moved to public
so that the extensibility story works for user provider signature providers.

related to #2418 
