### PR TITLE
Use Base64.DecodeFromUtf8InPlace

### DIFF
--- a/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>-->
   
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -570,15 +570,16 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         internal JsonClaimSet CreateClaimSet(ReadOnlySpan<char> strSpan, int startIndex, int length, bool createHeaderClaimSet)
         {
             int outputSize = Base64UrlEncoding.ValidateAndGetOutputSize(strSpan, startIndex, length);
+
             byte[] output = ArrayPool<byte>.Shared.Rent(outputSize);
             try
             {
-                Base64UrlEncoding.Decode(strSpan, startIndex, length, output);
+                Base64UrlEncoder.UnsafeDecode(strSpan.Slice(startIndex, length), output);
                 return createHeaderClaimSet ? CreateHeaderClaimSet(output.AsSpan()) : CreatePayloadClaimSet(output.AsSpan());
             }
             finally
             {
-                ArrayPool<byte>.Shared.Return(output);
+                ArrayPool<byte>.Shared.Return(output, true);
             }
         }
 

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -504,7 +504,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
                 try
                 {
-                    Header = CreateHeaderClaimSet(Base64UrlEncoder.UnsafeDecode(headerSpan).AsSpan());
+                    Header = CreateHeaderClaimSet(Base64UrlEncoder.Decode(headerSpan).AsSpan());
                 }
                 catch (Exception ex)
                 {
@@ -518,7 +518,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 ReadOnlySpan<char> encryptedKeyBytes = encodedTokenSpan.Slice(Dot1 + 1, Dot2 - Dot1 - 1);
                 if (!encryptedKeyBytes.IsEmpty)
                 {
-                    EncryptedKeyBytes = Base64UrlEncoder.UnsafeDecode(encryptedKeyBytes);
+                    EncryptedKeyBytes = Base64UrlEncoder.Decode(encryptedKeyBytes);
                     _encryptedKey = encryptedKeyBytes.ToString();
                 }
                 else
@@ -532,7 +532,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
                 try
                 {
-                    InitializationVectorBytes = Base64UrlEncoder.UnsafeDecode(initializationVectorSpan);
+                    InitializationVectorBytes = Base64UrlEncoder.Decode(initializationVectorSpan);
                 }
                 catch (Exception ex)
                 {
@@ -545,7 +545,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
                 try
                 {
-                    AuthenticationTagBytes = Base64UrlEncoder.UnsafeDecode(authTagSpan);
+                    AuthenticationTagBytes = Base64UrlEncoder.Decode(authTagSpan);
                 }
                 catch (Exception ex)
                 {
@@ -558,7 +558,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
                 try
                 {
-                    CipherTextBytes = Base64UrlEncoder.UnsafeDecode(cipherTextSpan);
+                    CipherTextBytes = Base64UrlEncoder.Decode(cipherTextSpan);
                 }
                 catch (Exception ex)
                 {
@@ -574,7 +574,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             byte[] output = ArrayPool<byte>.Shared.Rent(outputSize);
             try
             {
-                Base64UrlEncoder.UnsafeDecode(strSpan.Slice(startIndex, length), output);
+                Base64UrlEncoder.Decode(strSpan.Slice(startIndex, length), output);
                 return createHeaderClaimSet ? CreateHeaderClaimSet(output.AsSpan()) : CreatePayloadClaimSet(output.AsSpan());
             }
             finally

--- a/src/Microsoft.IdentityModel.Tokens/Base64UrlEncoder.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Base64UrlEncoder.cs
@@ -176,10 +176,7 @@ namespace Microsoft.IdentityModel.Tokens
             return UnsafeDecode(str.AsSpan());
         }
 
-#if NET6_0_OR_GREATER
-        [SkipLocalsInit]
-#endif
-        internal static unsafe byte[] UnsafeDecode(ReadOnlySpan<char> strSpan)
+        internal static byte[] UnsafeDecode(ReadOnlySpan<char> strSpan)
         {
             int mod = strSpan.Length % 4;
             if (mod == 1)
@@ -189,11 +186,38 @@ namespace Microsoft.IdentityModel.Tokens
             int decodedLength = strSpan.Length + (4 - mod) % 4;
 
 #if NET6_0_OR_GREATER
+            return Decode(strSpan, needReplace, decodedLength);
+#else
+            return UnsafeDecode(strSpan, needReplace, decodedLength);
+#endif
+        }
+
+        internal static unsafe void UnsafeDecode(ReadOnlySpan<char> strSpan, Span<byte> output)
+        {
+            int mod = strSpan.Length % 4;
+            if (mod == 1)
+                throw LogHelper.LogExceptionMessage(new FormatException(LogHelper.FormatInvariant(LogMessages.IDX10400, strSpan.ToString())));
+
+            bool needReplace = strSpan.IndexOfAny(base64UrlCharacter62, base64UrlCharacter63) >= 0;
+            int decodedLength = strSpan.Length + (4 - mod) % 4;
+
+#if NET6_0_OR_GREATER
+            Decode(strSpan, output, needReplace, decodedLength);
+#else
+            UnsafeDecode(strSpan, output, needReplace, decodedLength);
+#endif
+        }
+
+#if NET6_0_OR_GREATER
+
+        [SkipLocalsInit]
+        private static byte[] Decode(ReadOnlySpan<char> strSpan, bool needReplace, int decodedLength)
+        {
             // If the incoming chars don't contain any of the base64url characters that need to be replaced,
             // and if the incoming chars are of the exact right length, then we'll be able to just pass the
-            // incoming chars directly to Convert.TryFromBase64Chars. Otherwise, rent an array, copy all the
+            // incoming chars directly to DecodeFromUtf8InPlace. Otherwise, rent an array, copy all the
             // data into it, and do whatever fixups are necessary on that copy, then pass that copy into
-            // Convert.TryFromBase64Chars.
+            // DecodeFromUtf8InPlace.
 
             const int StackAllocThreshold = 512;
             char[] arrayPoolChars = null;
@@ -207,28 +231,7 @@ namespace Microsoft.IdentityModel.Tokens
                     arrayPoolChars = ArrayPool<char>.Shared.Rent(decodedLength);
                 charsSpan = charsSpan.Slice(0, decodedLength);
 
-                source.CopyTo(charsSpan);
-                if (source.Length < charsSpan.Length)
-                {
-                    charsSpan[source.Length] = base64PadCharacter;
-                    if (source.Length + 1 < charsSpan.Length)
-                    {
-                        charsSpan[source.Length + 1] = base64PadCharacter;
-                    }
-                }
-
-                if (needReplace)
-                {
-                    Span<char> remaining = charsSpan;
-                    int pos;
-                    while ((pos = remaining.IndexOfAny(base64UrlCharacter62, base64UrlCharacter63)) >= 0)
-                    {
-                        remaining[pos] = (remaining[pos] == base64UrlCharacter62) ? base64Character62 : base64Character63;
-                        remaining = remaining.Slice(pos + 1);
-                    }
-                }
-
-                source = charsSpan;
+                source = HandlePaddingAndReplace(charsSpan, source, needReplace);
             }
 
             byte[] arrayPoolBytes = null;
@@ -236,24 +239,123 @@ namespace Microsoft.IdentityModel.Tokens
                 stackalloc byte[StackAllocThreshold] :
                 arrayPoolBytes = ArrayPool<byte>.Shared.Rent(decodedLength);
 
-            bool converted = Convert.TryFromBase64Chars(source, bytesSpan, out int bytesWritten);
-            Debug.Assert(converted, "Expected TryFromBase64Chars to be successful");
-            byte[] result = bytesSpan.Slice(0, bytesWritten).ToArray();
+            int length = Encoding.UTF8.GetBytes(source, bytesSpan);
+            Span<byte> utf8Span = bytesSpan.Slice(0, length);
 
-            if (arrayPoolBytes is not null)
+            byte[] result = null;
+
+            try
             {
-                bytesSpan.Clear();
-                ArrayPool<byte>.Shared.Return(arrayPoolBytes);
+                OperationStatus status = System.Buffers.Text.Base64.DecodeFromUtf8InPlace(utf8Span, out int bytesWritten);
+                if (status != OperationStatus.Done)
+                    throw LogHelper.LogExceptionMessage(new FormatException(LogHelper.FormatInvariant(LogMessages.IDX10400, strSpan.ToString())));
+
+                result = bytesSpan.Slice(0, bytesWritten).ToArray();
             }
-
-            if (arrayPoolChars is not null)
+            finally
             {
-                charsSpan.Clear();
-                ArrayPool<char>.Shared.Return(arrayPoolChars);
+                if (arrayPoolBytes is not null)
+                {
+                    bytesSpan.Clear();
+                    ArrayPool<byte>.Shared.Return(arrayPoolBytes);
+                }
+
+                if (arrayPoolChars is not null)
+                {
+                    charsSpan.Clear();
+                    ArrayPool<char>.Shared.Return(arrayPoolChars);
+                }
             }
 
             return result;
+        }
+
+        [SkipLocalsInit]
+        private static void Decode(ReadOnlySpan<char> strSpan, Span<byte> output, bool needReplace, int decodedLength)
+        {
+            // If the incoming chars don't contain any of the base64url characters that need to be replaced,
+            // and if the incoming chars are of the exact right length, then we'll be able to just pass the
+            // incoming chars directly to DecodeFromUtf8InPlace. Otherwise, rent an array, copy all the
+            // data into it, and do whatever fixups are necessary on that copy, then pass that copy into
+            // DecodeFromUtf8InPlace.
+
+            const int StackAllocThreshold = 512;
+            char[] arrayPoolChars = null;
+            scoped Span<char> charsSpan = default;
+            scoped ReadOnlySpan<char> source = strSpan;
+
+            if (needReplace || decodedLength != source.Length)
+            {
+                charsSpan = decodedLength <= StackAllocThreshold ?
+                    stackalloc char[StackAllocThreshold] :
+                    arrayPoolChars = ArrayPool<char>.Shared.Rent(decodedLength);
+                charsSpan = charsSpan.Slice(0, decodedLength);
+
+                source = HandlePaddingAndReplace(charsSpan, source, needReplace);
+            }
+
+            byte[] arrayPoolBytes = null;
+            Span<byte> bytesSpan = decodedLength <= StackAllocThreshold ?
+                stackalloc byte[StackAllocThreshold] :
+                arrayPoolBytes = ArrayPool<byte>.Shared.Rent(decodedLength);
+
+            int length = Encoding.UTF8.GetBytes(source, bytesSpan);
+            Span<byte> utf8Span = bytesSpan.Slice(0, length);
+
+            try
+            {
+                OperationStatus status = System.Buffers.Text.Base64.DecodeFromUtf8InPlace(utf8Span, out int bytesWritten);
+                if (status != OperationStatus.Done)
+                    throw LogHelper.LogExceptionMessage(new FormatException(LogHelper.FormatInvariant(LogMessages.IDX10400, strSpan.ToString())));
+
+                utf8Span.Slice(0, bytesWritten).CopyTo(output);
+            }
+            finally
+            {
+                if (arrayPoolBytes is not null)
+                {
+                    bytesSpan.Clear();
+                    ArrayPool<byte>.Shared.Return(arrayPoolBytes);
+                }
+
+                if (arrayPoolChars is not null)
+                {
+                    charsSpan.Clear();
+                    ArrayPool<char>.Shared.Return(arrayPoolChars);
+                }
+            }
+        }
+
+        private static ReadOnlySpan<char> HandlePaddingAndReplace(Span<char> charsSpan, ReadOnlySpan<char> source, bool needReplace)
+        {
+            source.CopyTo(charsSpan);
+            if (source.Length < charsSpan.Length)
+            {
+                charsSpan[source.Length] = base64PadCharacter;
+                if (source.Length + 1 < charsSpan.Length)
+                {
+                    charsSpan[source.Length + 1] = base64PadCharacter;
+                }
+            }
+
+            if (needReplace)
+            {
+                Span<char> remaining = charsSpan;
+                int pos;
+                while ((pos = remaining.IndexOfAny(base64UrlCharacter62, base64UrlCharacter63)) >= 0)
+                {
+                    remaining[pos] = (remaining[pos] == base64UrlCharacter62) ? base64Character62 : base64Character63;
+                    remaining = remaining.Slice(pos + 1);
+                }
+            }
+
+            return charsSpan;
+        }
+
 #else
+
+        private static unsafe byte[] UnsafeDecode(ReadOnlySpan<char> strSpan, bool needReplace, int decodedLength)
+        {
             if (needReplace)
             {
                 string decodedString = new(char.MinValue, decodedLength);
@@ -298,8 +400,14 @@ namespace Microsoft.IdentityModel.Tokens
                     return Convert.FromBase64String(decodedString);
                 }
             }
-#endif
         }
+
+        private static unsafe void UnsafeDecode(ReadOnlySpan<char> strSpan, Span<byte> output, bool needReplace, int decodedLength)
+        {
+            byte[] result = UnsafeDecode(strSpan, needReplace, decodedLength);
+            result.CopyTo(output);
+        }
+#endif
 
         /// <summary>
         /// Decodes the string from Base64UrlEncoded to UTF8.


### PR DESCRIPTION
# Use Base64.DecodeFromUtf8InPlace for base64 decode

## Description

Base64.DecodeFromUtf8InPlace is SIMD aware.

CPU: ~ -12% on token read time

before:

| Method             | Mean     | Error     | StdDev    | Median   | P90      | P95      | P100     | Gen0   | Allocated |
|------------------- |---------:|----------:|----------:|---------:|---------:|---------:|---------:|-------:|----------:|
| ReadJWS_FromMemory | 3.487 us | 0.0287 us | 0.0612 us | 3.465 us | 3.601 us | 3.604 us | 3.605 us | 0.1068 |   2.67 KB |
| ReadJWS_FromString | 3.492 us | 0.0101 us | 0.0217 us | 3.490 us | 3.524 us | 3.529 us | 3.545 us | 0.1068 |   2.67 KB |

after:

| Method             | Mean     | Error     | StdDev    | P90      | P95      | P100     | Gen0   | Allocated |
|------------------- |---------:|----------:|----------:|---------:|---------:|---------:|-------:|----------:|
| ReadJWS_FromMemory | 3.068 us | 0.0139 us | 0.0303 us | 3.094 us | 3.117 us | 3.151 us | 0.1068 |   2.67 KB |
| ReadJWS_FromString | 3.076 us | 0.0134 us | 0.0292 us | 3.113 us | 3.121 us | 3.127 us | 0.1068 |   2.67 KB |

Note: this was run with a cpu with the following intrinsics: AVX-512F+CD+BW+DQ+VL+VBMI