### PR TITLE
Adjust uppercase json serialization tests

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -32,7 +32,7 @@
 
   <!-- Wilson version  -->
   <PropertyGroup>
-    <WilsonCurrentVersion>7.4.0</WilsonCurrentVersion>
+    <WilsonCurrentVersion>7.4.1</WilsonCurrentVersion>
 
     <PreviewVersionSuffix Condition="'$(PreviewVersionSuffix)' == '' and '$(BuildingInsideVisualStudio)' != 'true'">preview-$([System.DateTime]::Now.AddYears(-2019).Year)$([System.DateTime]::Now.ToString("MMddHHmmss"))</PreviewVersionSuffix>
     <!--VS re-evaluates the variables, so having seconds or minutes creates an infinite loop of package updates-->

--- a/buildPack.bat
+++ b/buildPack.bat
@@ -1,3 +1,2 @@
 dotnet build /r Product.proj
-dotnet test --no-restore --no-build Product.proj
 dotnet pack --no-restore -o artifacts --no-build Product.proj

--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
@@ -635,7 +635,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
 
             if (!IsReaderAtTokenType(ref reader, JsonTokenType.String, false))
                 throw LogHelper.LogExceptionMessage(
-                    CreateJsonReaderExceptionInvalidType(ref reader, "JsonTokenType.StartArray", className, propertyName));
+                    CreateJsonReaderExceptionInvalidType(ref reader, "JsonTokenType.String", className, propertyName));
 
             string retval = reader.GetString();
 

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConfigData.cs
@@ -172,7 +172,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         #endregion
 
         #region GOOGLE 2/2/2024 https://accounts.google.com/.well-known/openid-configuration
-        public static string AccountsGoogleCom =>
+        public static string AccountsGoogleComJson =>
                 $$"""
                 {
                 "issuer": "https://accounts.google.com",
@@ -225,7 +225,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         #endregion
 
         #region AADCommonV1 2/2/2024 https://login.microsoftonline.com/common/.well-known/openid-configuration 
-        public static string AADCommonV1 =>
+        public static string AADCommonV1Json =>
                 """
                 {
                 "token_endpoint": "https://login.microsoftonline.com/common/oauth2/token",
@@ -294,7 +294,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         #endregion
 
         #region AADCommonV2 2/2/2024 https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration
-        public static string AADCommonV2 =>
+        public static string AADCommonV2Json =>
             """
             {
             "token_endpoint": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
@@ -322,6 +322,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             "rbac_url": "https://pas.windows.net"
             }
             """;
+
         public static OpenIdConnectConfiguration AADCommonV2Config
         {
             get

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectSerializationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectSerializationTests.cs
@@ -41,22 +41,24 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             {
                 TheoryData<OpenIdConnectTheoryData> theoryData = new TheoryData<OpenIdConnectTheoryData>();
 
-                theoryData.Add(new OpenIdConnectTheoryData("AADCommonV1Config")
+                // the reason to replace AdditionalData with upper case is because the test deserializes uppercase and lowercase.
+                // we wanted to leave the data sets in original form from discovery to be used in other tests.
+                theoryData.Add(new OpenIdConnectTheoryData("AADCommonV1")
                 {
-                    CompareTo = OpenIdConfigData.AADCommonV1Config,
-                    Json = OpenIdConfigData.AADCommonV1
+                    CompareTo = JsonUtilities.SetAdditionalDataKeysToUpperCase(OpenIdConfigData.AADCommonV1Config),
+                    Json = JsonUtilities.SetAdditionalDataKeysToUpperCase(OpenIdConfigData.AADCommonV1Json, OpenIdConfigData.AADCommonV1Config)
                 });
 
-                theoryData.Add(new OpenIdConnectTheoryData("AADCommonV2Config")
+                theoryData.Add(new OpenIdConnectTheoryData("AADCommonV2")
                 {
-                    CompareTo = OpenIdConfigData.AADCommonV2Config,
-                    Json = OpenIdConfigData.AADCommonV2
+                    CompareTo = JsonUtilities.SetAdditionalDataKeysToUpperCase(OpenIdConfigData.AADCommonV2Config),
+                    Json = JsonUtilities.SetAdditionalDataKeysToUpperCase(OpenIdConfigData.AADCommonV2Json, OpenIdConfigData.AADCommonV2Config)
                 });
 
                 theoryData.Add(new OpenIdConnectTheoryData("AccountsGoogleCom")
                 {
-                    CompareTo = OpenIdConfigData.AccountsGoogleComConfig,
-                    Json = OpenIdConfigData.AccountsGoogleCom
+                    CompareTo = JsonUtilities.SetAdditionalDataKeysToUpperCase(OpenIdConfigData.AccountsGoogleComConfig),
+                    Json = JsonUtilities.SetAdditionalDataKeysToUpperCase(OpenIdConfigData.AccountsGoogleComJson, OpenIdConfigData.AccountsGoogleComConfig)
                 });
 
                 theoryData.Add(new OpenIdConnectTheoryData("FrontChannelFalse")

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.JsonWebTokens\Microsoft.IdentityModel.JsonWebTokens.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.Protocols.SignedHttpRequest\Microsoft.IdentityModel.Protocols.SignedHttpRequest.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.Tokens\Microsoft.IdentityModel.Tokens.csproj" />
+    <ProjectReference Include="..\Microsoft.IdentityModel.Tokens.Tests\Microsoft.IdentityModel.Tokens.Tests.csproj" />
     <ProjectReference Include="..\Microsoft.IdentityModel.TestUtils\Microsoft.IdentityModel.TestUtils.csproj" />
   </ItemGroup>
   

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Json.Tests;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;

--- a/test/Microsoft.IdentityModel.Tokens.Tests/BaseConfigurationComparerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/BaseConfigurationComparerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens.Json.Tests;
 using Xunit;
 
 namespace Microsoft.IdentityModel.Tokens.Tests

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/DataSets.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/DataSets.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using Microsoft.IdentityModel.Tokens;
 
 /// <summary>
 /// Data sets for testing 
 /// </summary>
-namespace Microsoft.IdentityModel.TestUtils
+namespace Microsoft.IdentityModel.Tokens.Json.Tests
 {
     public class DataSets
     {
@@ -360,7 +359,7 @@ namespace Microsoft.IdentityModel.TestUtils
         public static string JsonWebKeySetUseNoKtyString = @"{ ""keys"":[" + JsonWebKeyNoKtyString + "]}";
 
         #region GOOGLE 2/2/2024 https://www.googleapis.com/oauth2/v3/certs
-        public static string AccountsGoogle =
+        public static string AccountsGoogleJson =
             """
             {
                 "keys": [
@@ -430,7 +429,7 @@ namespace Microsoft.IdentityModel.TestUtils
         #endregion
 
         #region AADCommonV1 2/2/2024 https://login.microsoftonline.com/common/discovery/keys
-        public static string AADCommonKeySetString_V1 =
+        public static string AADCommonV1KeySetJson =
             """
             {
                 "keys": [
@@ -471,7 +470,7 @@ namespace Microsoft.IdentityModel.TestUtils
             }
             """;
 
-        public static JsonWebKey AADCommonKey1_V1
+        public static JsonWebKey AADCommonV1Key1
         {
             get
             {
@@ -489,7 +488,7 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
-        public static JsonWebKey AADCommonKey2_V1
+        public static JsonWebKey AADCommonV1Key2
         {
             get
             {
@@ -507,7 +506,7 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
-        public static JsonWebKey AADCommonKey3_V1
+        public static JsonWebKey AADCommonV1Key3
         {
             get
             {
@@ -525,7 +524,7 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
-        public static JsonWebKeySet AADCommonKeySet_V1
+        public static JsonWebKeySet AADCommonV1KeySet
         {
             get
             {
@@ -533,21 +532,21 @@ namespace Microsoft.IdentityModel.TestUtils
                 {
                     Keys = new List<JsonWebKey>
                     {
-                        AADCommonKey1_V1,
-                        AADCommonKey2_V1,
-                        AADCommonKey3_V1
+                        AADCommonV1Key1,
+                        AADCommonV1Key2,
+                        AADCommonV1Key3
                     }
                 };
             }
         }
-
         #endregion
 
         #region AADCommonV2 2/2/2024 https://login.microsoftonline.com/common/discovery/v2.0/keys
-        public static string AADCommonKeySetString_V2 =
+        public static string AADCommonV2KeySetJson =
             """
-                        {
-                "keys": [
+            {
+                "keys":
+                [
                     {
                         "kty": "RSA",
                         "use": "sig",
@@ -612,7 +611,7 @@ namespace Microsoft.IdentityModel.TestUtils
             }
             """;
 
-        public static JsonWebKey AADCommonKey1_V2
+        public static JsonWebKey AADCommonV2Key1
         {
             get
             {
@@ -631,7 +630,7 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
-        public static JsonWebKey AADCommonKey2_V2
+        public static JsonWebKey AADCommonV2Key2
         {
             get
             {
@@ -650,7 +649,7 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
-        public static JsonWebKey AADCommonKey3_V2
+        public static JsonWebKey AADCommonV2Key3
         {
             get
             {
@@ -669,7 +668,7 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
-        public static JsonWebKey AADCommonKey4_V2
+        public static JsonWebKey AADCommonV2Key4
         {
             get
             {
@@ -688,7 +687,7 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
-        public static JsonWebKey AADCommonKey5_V2
+        public static JsonWebKey AADCommonV2Key5
         {
             get
             {
@@ -707,7 +706,7 @@ namespace Microsoft.IdentityModel.TestUtils
             }
         }
 
-        public static JsonWebKeySet AADCommonKeySet_V2
+        public static JsonWebKeySet AADCommonV2KeySet
         {
             get
             {
@@ -715,11 +714,11 @@ namespace Microsoft.IdentityModel.TestUtils
                 {
                     Keys = new List<JsonWebKey>
                     {
-                        AADCommonKey1_V2,
-                        AADCommonKey2_V2,
-                        AADCommonKey3_V2,
-                        AADCommonKey4_V2,
-                        AADCommonKey5_V2
+                        AADCommonV2Key1,
+                        AADCommonV2Key2,
+                        AADCommonV2Key3,
+                        AADCommonV2Key4,
+                        AADCommonV2Key5
                     }
                 };
             }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonData.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonData.cs
@@ -11,13 +11,14 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
     public static class JsonData
     {
         // Create a unique string for each property, to avoid collisions
-        public static string ArrayProperty = Guid.NewGuid().ToString();
-        public static string ObjectProperty = Guid.NewGuid().ToString();
-        public static string FalseProperty = Guid.NewGuid().ToString();
-        public static string TrueProperty = Guid.NewGuid().ToString();
-        public static string StringProperty = Guid.NewGuid().ToString();
-        public static string StringValue = Guid.NewGuid().ToString();
-        public static string NullProperty = Guid.NewGuid().ToString();
+        // Moved these to UpperInvariant so test that perform uppercase to lowercase will work.
+        public static string ArrayProperty = Guid.NewGuid().ToString().ToUpperInvariant();
+        public static string ObjectProperty = Guid.NewGuid().ToString().ToUpperInvariant();
+        public static string FalseProperty = Guid.NewGuid().ToString().ToUpperInvariant();
+        public static string TrueProperty = Guid.NewGuid().ToString().ToUpperInvariant();
+        public static string StringProperty = Guid.NewGuid().ToString().ToUpperInvariant();
+        public static string StringValue = Guid.NewGuid().ToString().ToUpperInvariant();
+        public static string NullProperty = Guid.NewGuid().ToString().ToUpperInvariant();
 
         // Json strings are name:value (claim) pairs inside an object
         // The naming here is:
@@ -47,7 +48,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
 
         public static string ObjectValue =
             $$"""
-            {"object":["ObjectValue1","ObjectValue2"]}
+            {"OBJECT":["ObjectValue1","ObjectValue2"]}
             """;
 
         public static string ObjectClaim =

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonUtilities.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonUtilities.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.Json;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.IdentityModel.Tokens.Json.Tests
@@ -212,7 +213,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                     string propertyName = reader.GetString();
                     if (propertyName != null)
                     {
-                        json = json.Replace(propertyName + ":", propertyName.ToUpperInvariant() + ":");
+                        json = json.Replace("\"" + propertyName + "\":", "\"" + propertyName.ToUpperInvariant() + "\":");
                     }
                 }
             }
@@ -220,5 +221,82 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
             return json;
         }
 
+        /// <summary>
+        /// json is used in a test to create the OpenIdConnectConfiguration, all values found in the json that match keys in AdditionalData are set to upper case.
+        /// </summary>
+        /// <param name="json"></param>
+        /// <param name="configuration"></param>
+        /// <returns></returns>
+        public static string SetAdditionalDataKeysToUpperCase(string json, OpenIdConnectConfiguration configuration)
+        {
+            foreach (string key in configuration.AdditionalData.Keys)
+                json = json.Replace("\"" + key + "\":", "\"" + key.ToUpperInvariant() + "\":");
+
+            return json;
+        }
+
+        public static OpenIdConnectConfiguration SetAdditionalDataKeysToUpperCase(OpenIdConnectConfiguration configuration)
+        {
+            SetAdditionalDataKeysToUpperCase(configuration.AdditionalData);
+            return configuration;
+        }
+
+        public static JsonWebKeySet SetAdditionalDataKeysToUpperCase(JsonWebKeySet jsonWebKeySet)
+        {
+            SetAdditionalDataKeysToUpperCase(jsonWebKeySet.AdditionalData);
+            foreach (JsonWebKey jsonWebKey in jsonWebKeySet.Keys)
+                SetAdditionalDataKeysToUpperCase(jsonWebKey);
+
+            return jsonWebKeySet;
+        }
+
+        public static JsonWebKey SetAdditionalDataKeysToUpperCase(JsonWebKey jsonWebKey)
+        {
+            SetAdditionalDataKeysToUpperCase(jsonWebKey.AdditionalData);
+            return jsonWebKey;
+        }
+
+        /// <summary>
+        /// json is used to create the JsonWebKeySet, all values found in the json that match keys in AdditionalData are set to upper case.
+        /// </summary>
+        /// <param name="json"></param>
+        /// <param name="jsonWebKeySet"></param>
+        /// <returns></returns>
+        public static string SetAdditionalDataKeysToUpperCase(string json, JsonWebKeySet jsonWebKeySet)
+        {
+            foreach (string key in jsonWebKeySet.AdditionalData.Keys)
+                json = json.Replace("\"" + key + "\":", "\"" + key.ToUpperInvariant() + "\":");
+
+            foreach (JsonWebKey jsonWebKey in jsonWebKeySet.Keys)
+                json = SetAdditionalDataKeysToUpperCase(json, jsonWebKey);
+
+            return json;
+        }
+
+        /// <summary>
+        /// json is used to create the JsonWebKey, all values found in the json that match keys in AdditionalData are set to upper case.
+        /// </summary>
+        /// <param name="json"></param>
+        /// <param name="jsonWebKey"></param>
+        /// <returns></returns>
+        public static string SetAdditionalDataKeysToUpperCase(string json, JsonWebKey jsonWebKey)
+        {
+            foreach (string key in jsonWebKey.AdditionalData.Keys)
+                json = json.Replace("\"" + key + "\":", "\"" + key.ToUpperInvariant() + "\":");
+
+            return json;
+        }
+
+        public static void SetAdditionalDataKeysToUpperCase(IDictionary<string,object> additionalData)
+        {
+            List<string> keys = [.. additionalData.Keys];
+
+            for (int i = 0; i < keys.Count; i++)
+            {
+                string key = keys[i];
+                additionalData[key.ToUpperInvariant()] = additionalData[key];
+                additionalData.Remove(key);
+            }
+        }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySetSerializationTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySetSerializationTests.cs
@@ -119,19 +119,22 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
 
                 theoryData.Add(new JsonWebKeySetTheoryData("AADCommonV1")
                 {
-                    Json = DataSets.AADCommonKeySetString_V1,
-                    JsonWebKeySet = DataSets.AADCommonKeySet_V1
+                    Json = DataSets.AADCommonV1KeySetJson,
+                    JsonWebKeySet = DataSets.AADCommonV1KeySet
                 });
 
+                // the reason to replace "issuer" with "ISSUER" is because the test deserializes uppercase and lowercase.
+                // since "issuer" is not a property of JsonWebKeySet the value ends up in the AdditionalData dictionary, which is case sensitive.
+                // we wanted to leave the data sets as they were obtained from metadata so they can be used in other tests.
                 theoryData.Add(new JsonWebKeySetTheoryData("AADCommonV2")
                 {
-                    Json = DataSets.AADCommonKeySetString_V2,
-                    JsonWebKeySet = DataSets.AADCommonKeySet_V2
+                    Json = JsonUtilities.SetAdditionalDataKeysToUpperCase(DataSets.AADCommonV2KeySetJson, DataSets.AADCommonV2KeySet),
+                    JsonWebKeySet = JsonUtilities.SetAdditionalDataKeysToUpperCase(DataSets.AADCommonV2KeySet)
                 });
 
                 theoryData.Add(new JsonWebKeySetTheoryData("AccountsGoogleCom")
                 {
-                    Json = DataSets.AccountsGoogle,
+                    Json = DataSets.AccountsGoogleJson,
                     JsonWebKeySet = DataSets.AccountsGoogleKeySet
                 });
 

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtHeaderTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtHeaderTests.cs
@@ -8,9 +8,8 @@ using System.Text.Json;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Json.Tests;
 using Xunit;
-
-#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
 
 namespace System.IdentityModel.Tokens.Jwt.Tests
 {
@@ -248,5 +247,3 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         public SigningCredentials SigningCredentials { get; set; }
    }
 }
-
-#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant


### PR DESCRIPTION
The serialization tests for mixed case for OpenIdConnectConfiguration, JsonWebKey, JsonWebKeySet relied on a test method that was not working.

This code fixes the test, makes some renaming changes for consistency, and moves a file.
