### PR TITLE
MSBuild target to override Project Ref versions

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -63,4 +63,12 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubVersion)" PrivateAssets="All"/>
   </ItemGroup>
 
+  <Target Name="_GetProjectReferenceVersionRanges" AfterTargets="_GetProjectReferenceVersions">
+    <ItemGroup>
+      <_ProjectReferencesWithVersions Condition="'%(ProjectVersion)' != ''">
+        <ProjectVersion>[%(ProjectVersion)]</ProjectVersion>
+      </_ProjectReferencesWithVersions>
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
# MSBuild target to override Project Ref versions

## Description

Adds a msbuild target to override project references to use an exact version.
