### PR TITLE
Improve build.sh speed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ build() {
   echo -e "Build ...... "
   echo -e "===========================================================\n"
 
-  dotnet build WilsonUnix.sln
+  dotnet build --no-restore WilsonUnix.sln
   echo -e "\n"
 }
 
@@ -30,7 +30,7 @@ pack() {
   echo -e "Pack ...... "
   echo -e "===========================================================\n"
 
-  dotnet pack WilsonUnix.sln
+  dotnet pack --no-build WilsonUnix.sln
   
   echo -e "\n"
   echo -e "==========================================================="


### PR DESCRIPTION
# Improve build.sh speed

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [ ] **NA** You've included unit or integration tests for your change, where applicable.
- [ ] **NA** You've included inline docs for your change, where applicable.
- [ ] **NA** If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [ ] **NA** There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

By default build and pack will trigger restore and build respectively. Considering it was just built and restored, no need to repeat these steps. Thus adding option to disable this in each step.
