### PR TITLE
Update OpenIdConnectConfigurationSerializer.cs

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Json/OpenIdConnectConfigurationSerializer.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Json/OpenIdConnectConfigurationSerializer.cs
@@ -275,7 +275,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect
                         JsonPrimitives.ReadStrings(ref reader, config.UserInfoEndpointEncryptionEncValuesSupported, MetadataName.UserInfoEncryptionEncValuesSupported, ClassName, true);
 
                     else if (reader.ValueTextEquals(Utf8Bytes.UserInfoEndpoint))
-                        config.UserInfoEndpoint = JsonPrimitives.ReadString(ref reader, MetadataName.ScopesSupported, ClassName, true);
+                        config.UserInfoEndpoint = JsonPrimitives.ReadString(ref reader, MetadataName.UserInfoEndpoint, ClassName, true);
 
                     else if (reader.ValueTextEquals(Utf8Bytes.UserInfoSigningAlgValuesSupported))
                         JsonPrimitives.ReadStrings(ref reader, config.UserInfoEndpointSigningAlgValuesSupported, MetadataName.UserInfoSigningAlgValuesSupported, ClassName, true);


### PR DESCRIPTION
# [Bug] OpenIdConnectConfigurationSerializer Read() method does not parse UseInfoEndpoint correctly

Summary of the changes (Less than 80 chars)

## Description
Fixes parsing issue for OpenIdConnect .well-known endpoint

{Detail}

Fixes #2548 (in this specific format)
