### PR TITLE
Make AadIssuerValidator method ValidateAsync public.

### DIFF
--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -212,7 +212,7 @@ namespace Microsoft.IdentityModel.Validators
         /// <exception cref="ArgumentNullException"> if <paramref name="securityToken"/> is null.</exception>
         /// <exception cref="ArgumentNullException"> if <paramref name="validationParameters"/> is null.</exception>
         /// <exception cref="SecurityTokenInvalidIssuerException">if the issuer is invalid or if there is a network issue. </exception>
-        internal async ValueTask<string> ValidateAsync(
+        public async ValueTask<string> ValidateAsync(
             string issuer,
             SecurityToken securityToken,
             TokenValidationParameters validationParameters)


### PR DESCRIPTION
# Make AadIssuerValidator method ValidateAsync public.
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Making the ValidateAsync method of the AadIssuerValidator class public so it can be consumed externally. 

Related to Issue #{2556} 
