### PR TITLE
Adding comment for clarification 

### DIFF
--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
@@ -59,7 +59,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             Type type = typeof(JwtPayload);
             PropertyInfo[] properties = type.GetProperties();
 #if NET9_0_OR_GREATER
-            if (properties.Length != 26)
+            if (properties.Length != 26) //Additional inherited "Capacity" property from Dictionary is added in .NET 9 
                 Assert.True(false, "Number of properties has changed from 26 to: " + properties.Length + ", adjust tests");
 #else
             if (properties.Length != 25)


### PR DESCRIPTION

## Description

Adding a comment for context on previously used directive condition.

Fixes #[2551](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2551)
