### PR TITLE
Reduce Allocations in ValidateSignature

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
@@ -1311,7 +1311,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 }
                     
                 if (key != null)
-                    keys = new List<SecurityKey> { key };
+                    keys = [key];
             }
 
             // on decryption for ECDH-ES, we get the public key from the EPK value see: https://datatracker.ietf.org/doc/html/rfc7518#appendix-C

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -901,7 +901,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 if (key != null)
                 {
                     kidMatched = true;
-                    keys = new List<SecurityKey> { key };
+                    keys = [key];
                 }
             }
 

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -1037,7 +1037,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 {
                     // remember that key was matched for throwing exception SecurityTokenSignatureKeyNotFoundException
                     keyMatched = true;
-                    keys = new List<SecurityKey> { securityKey };
+                    keys = [securityKey];
                 }
             }
 

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlTokenUtilities.cs
@@ -48,44 +48,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         }
 
         /// <summary>
-        /// Returns all <see cref="SecurityKey"/> to use when validating the signature of a token.
-        /// </summary>
-        /// <param name="token">The <see cref="string"/> representation of the token that is being validated.</param>
-        /// <param name="samlToken">The <see cref="SecurityToken"/> that is being validated.</param>
-        /// <param name="tokenKeyInfo">The <see cref="KeyInfo"/> field of the token being validated</param>
-        /// <param name="validationParameters">A <see cref="TokenValidationParameters"/> required for validation.</param>
-        /// <param name="keyMatched">A <see cref="bool"/> to represent if a a issuer signing key matched with token kid or x5t</param>
-        /// <returns>Returns all <see cref="SecurityKey"/> to use for signature validation.</returns>
-        internal static IEnumerable<SecurityKey> GetKeysForTokenSignatureValidation(string token, SecurityToken samlToken, KeyInfo tokenKeyInfo, TokenValidationParameters validationParameters, out bool keyMatched)
-        {
-            keyMatched = false;
-
-            if (validationParameters.IssuerSigningKeyResolver != null)
-            {
-                return validationParameters.IssuerSigningKeyResolver(token, samlToken, tokenKeyInfo?.Id, validationParameters);
-            }
-            else
-            {
-                SecurityKey key = ResolveTokenSigningKey(tokenKeyInfo, validationParameters);
-
-                if (key != null)
-                {
-                    keyMatched = true;
-                    return new List<SecurityKey> { key };
-                }
-                else
-                {
-                    keyMatched = false;
-                    if (validationParameters.TryAllIssuerSigningKeys)
-                    {
-                        return TokenUtilities.GetAllSigningKeys(validationParameters: validationParameters);
-                    }
-                }
-            }
-            return null;
-        }
-
-        /// <summary>
         /// Creates <see cref="Claim"/>'s from <paramref name="claimsCollection"/>.
         /// </summary>
         /// <param name="claimsCollection"> A dictionary that represents a set of claims.</param>

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -430,7 +430,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                 {
                     // remember that key was matched for throwing exception SecurityTokenSignatureKeyNotFoundException
                     keyMatched = true;
-                    keys = new List<SecurityKey> { key };
+                    keys = [key];
                 }
             }
 

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1344,7 +1344,7 @@ namespace System.IdentityModel.Tokens.Jwt
                 if (key != null)
                 {
                     kidMatched = true;
-                    keys = new List<SecurityKey> { key };
+                    keys = [key];
                 }
             }
 
@@ -1812,7 +1812,7 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 var key = ResolveTokenDecryptionKey(jwtToken.RawData, jwtToken, validationParameters);
                 if (key != null)
-                    keys = new List<SecurityKey> { key };
+                    keys = [key];
             }
 
             // control gets here if:


### PR DESCRIPTION
When we need to create an enumerable with a single element in it, we are allocating a `new List<SecurityKey> { key }`. This allocates both the list, and then allocates a 4 element array backing the list (because this syntax is C# sugar for just calling Add on the collection).

Instead, use a collection expression which optimizes the single element case.

There was one method in Saml that had this pattern in it, but was unused. I opted to remove it. Please let me know if it should be preserved for some reason.

Using an internal benchmark with 1,000 iterations, these allocations will be cut in half:

![image](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/assets/8291187/0bce9d30-1444-4dc4-be68-21b35ef23265)
