### PR TITLE
Initialize list count in CreateClaims

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
@@ -44,7 +44,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
         internal List<Claim> CreateClaims(string issuer)
         {
-            var claims = new List<Claim>();
+            var claims = new List<Claim>(_jsonClaims.Count);
             foreach (KeyValuePair<string, object> kvp in _jsonClaims)
                 CreateClaimFromObject(claims, kvp.Key, kvp.Value, issuer);
 


### PR DESCRIPTION
# Initialize list count in CreateClaims

This reduces how many internal array allocations need to happen for each claim set. In my benchmark I have 17 claims, which is kind of a worst case scenario because it starts at 4 and doubles to 32 before the list is big enough.