### PR TITLE
added langversion to benchmark csproj

### DIFF
--- a/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
@@ -11,6 +11,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <ErrorOnDuplicatePublishOutputFiles>False</ErrorOnDuplicatePublishOutputFiles>
     <IsPackable>false</IsPackable>
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <!-- Uncomment only when running EtwProfiler diagnoser on Release-->


### PR DESCRIPTION
Upping the benchmark language version to 12. Benchmarks didn't seem to see any significant difference to me it looks like noise rather than any real difference in the benchmarks.

"diff in mean" = C#v12 - C#v10  .... so negative numbers mean the upgrade ran faster and vice versa

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/JOSHLO~1/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/JOSHLO~1/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{border-top:.5pt solid #4472C4;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid #4472C4;}
.xl66
	{border-top:.5pt solid #4472C4;
	border-right:none;
	border-bottom:.5pt solid #4472C4;
	border-left:.5pt solid #4472C4;}
.xl67
	{border-top:.5pt solid #4472C4;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid #4472C4;
	white-space:normal;}
-->
</head>

<body link="#0563C1" vlink="#954F72">


Test Name | diff   in mean (μs) | margin   of error(μs) | outside margin of error
-- | -- | -- | --
JsonWebTokenHandler_CreateJWE | 2.9 | 1.62 | yes
JsonWebTokenHandler_CreateToken | -35.5 | 9.46 | yes
JsonWebTokenHandler_ValidateTokenAsync | 0.13 | 0.084 | yes
JwtSecurityTokenHandler_CreateJWE | 5.5 | 1.49 | yes
JwtSecurityTokenHandler_ValidateTokenAsync | 0.34 | 0.142 | yes
ReadJWE_FromString | -0.233 | 0.0905 | yes
SignSpanWithArrayPoolRSA | 3.3 | 2.07 | yes
JsonWebTokenHandler_ValidateJWEAsync | -0.05 | 0.854 | no
JwtSecurityTokenHandler_ValidateJWEAsync | 0.2 | 0.347 | no
ReadJWE_FromMemory | -0.037 | 0.0755 | no
ReadJWS_FromMemory | 0.034 | 0.0365 | no
ReadJWS_FromString | 0.034 | 0.0821 | no
SHRHandler_CreateSignedHttpRequest | 11 | 20.7 | no
SHRHandler_ValidateSignedHttpRequestAsync | 0.25 | 0.343 | no
SignDotnetCreatingBufferRSA | 0.6 | 1.65 | no
SignSpanWithFixedBufferRSA | -2.3 | 4.48 | no



</body>

</html>

