### PR TITLE
Don't always test string claims for Date Time

### DIFF
--- a/benchmark/Microsoft.IdentityModel.Benchmarks/BenchmarkUtils.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/BenchmarkUtils.cs
@@ -60,6 +60,43 @@ namespace Microsoft.IdentityModel.Benchmarks
             }
         }
 
+        public static Dictionary<string, object> ClaimsExtendedExample
+        {
+            get
+            {
+                DateTime now = DateTime.UtcNow;
+                return new Dictionary<string, object>()
+                {
+                    { "acct", 0 },
+                    { "aio", Guid.NewGuid().ToString() },
+                    { "amr", new List<string>() { "pwd", "mfa" } },
+                    { "app_displayname", "MyApp" },
+                    { "appidacr", 0 },
+                    { "azpacr", 0 },
+                    { "azp", Guid.NewGuid().ToString() },
+                    { "groups", new List<string>() { "group1", "group2" } },
+                    { "name", "Bob" },
+                    { "oid", Guid.NewGuid().ToString() },
+                    { "rh", Guid.NewGuid().ToString() },
+                    { "scp", "access_as_user" },
+                    { JwtRegisteredClaimNames.Sub, Guid.NewGuid().ToString() },
+                    { "tid", Guid.NewGuid().ToString() },
+                    { "family_name", "Smith" },
+                    { "ver", "2.0" },
+                    { "wids", new List<string>() { Guid.NewGuid().ToString() } },
+                    { "xms_cc", Guid.NewGuid().ToString() },
+                    { "role", new List<string>() { "role1", "Developer", "Sales"} },
+                    { JwtRegisteredClaimNames.Email, "Bob@contoso.com" },
+                    { JwtRegisteredClaimNames.Exp, EpochTime.GetIntDate(now + TimeSpan.FromDays(1)) },
+                    { JwtRegisteredClaimNames.Nbf, EpochTime.GetIntDate(now) },
+                    { JwtRegisteredClaimNames.Iat, EpochTime.GetIntDate(now) },
+                    { JwtRegisteredClaimNames.GivenName, "Bob" },
+                    { JwtRegisteredClaimNames.Iss, Issuer },
+                    { JwtRegisteredClaimNames.Aud, Audience }
+                };
+            }
+        }
+
         public static SigningCredentials SigningCredentialsRsaSha256 => new(RsaSecurityKey, SecurityAlgorithms.RsaSha256, SecurityAlgorithms.Sha256);
 
         public static EncryptingCredentials EncryptingCredentialsAes256Sha512 => new(SymmetricEncryptionKey512, "dir", SecurityAlgorithms.Aes256CbcHmacSha512);

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/Program.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/Program.cs
@@ -49,6 +49,7 @@ namespace Microsoft.IdentityModel.Benchmarks
             ValidateTokenAsyncTests validateTokenAsyncTests = new ValidateTokenAsyncTests();
             validateTokenAsyncTests.Setup();
             TokenValidationResult tokenValidationResult = validateTokenAsyncTests.JsonWebTokenHandler_ValidateTokenAsync().Result;
+            var claims = validateTokenAsyncTests.JsonWebTokenHandler_ValidateTokenAsync_CreateClaims();
 
             ValidateSignedHttpRequestAsyncTests validateSignedHttpRequestAsyncTests = new ValidateSignedHttpRequestAsyncTests();
             validateSignedHttpRequestAsyncTests.Setup();

--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
@@ -55,7 +55,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             // Json.net recognized DateTime by default.
             if (value is string str)
-                claims.Add(new Claim(claimType, str, JwtTokenUtilities.GetStringClaimValueType(str), issuer, issuer));
+                claims.Add(new Claim(claimType, str, JwtTokenUtilities.GetStringClaimValueType(claimType, str), issuer, issuer));
             else if (value is int i)
                 claims.Add(new Claim(claimType, i.ToString(CultureInfo.InvariantCulture), ClaimValueTypes.Integer32, issuer, issuer));
             else if (value is long l)
@@ -107,7 +107,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (jsonElement.ValueKind == JsonValueKind.String)
             {
                 string claimValue = jsonElement.ToString();
-                return new Claim(claimType, claimValue, JwtTokenUtilities.GetStringClaimValueType(claimValue), issuer, issuer);
+                return new Claim(claimType, claimValue, JwtTokenUtilities.GetStringClaimValueType(claimType, claimValue), issuer, issuer);
             }
             else if (jsonElement.ValueKind == JsonValueKind.Null)
                 return new Claim(claimType, string.Empty, JsonClaimValueTypes.JsonNull, issuer, issuer);

--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
@@ -55,7 +55,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             // Json.net recognized DateTime by default.
             if (value is string str)
-                claims.Add(new Claim(claimType, str, JwtTokenUtilities.GetStringClaimValueType(claimType, str), issuer, issuer));
+                claims.Add(new Claim(claimType, str, JwtTokenUtilities.GetStringClaimValueType(str, claimType), issuer, issuer));
             else if (value is int i)
                 claims.Add(new Claim(claimType, i.ToString(CultureInfo.InvariantCulture), ClaimValueTypes.Integer32, issuer, issuer));
             else if (value is long l)
@@ -107,7 +107,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (jsonElement.ValueKind == JsonValueKind.String)
             {
                 string claimValue = jsonElement.ToString();
-                return new Claim(claimType, claimValue, JwtTokenUtilities.GetStringClaimValueType(claimType, claimValue), issuer, issuer);
+                return new Claim(claimType, claimValue, JwtTokenUtilities.GetStringClaimValueType(claimValue, claimType), issuer, issuer);
             }
             else if (jsonElement.ValueKind == JsonValueKind.Null)
                 return new Claim(claimType, string.Empty, JsonClaimValueTypes.JsonNull, issuer, issuer);

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -604,10 +604,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         // breaking compatibility.
         internal static string GetStringClaimValueType(string str)
         {
-            return GetStringClaimValueType(string.Empty, str);
+            return GetStringClaimValueType(str, string.Empty);
         }
 
-        internal static string GetStringClaimValueType(string claimType, string str)
+        internal static string GetStringClaimValueType(string str, string claimType)
         {
             if (!string.IsNullOrEmpty(claimType) && !JsonSerializerPrimitives.TryAllStringClaimsAsDateTime() && JsonSerializerPrimitives.IsKnownToNotBeDateTime(claimType))
                 return ClaimValueTypes.String;

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -12,6 +12,7 @@ using System.Text.RegularExpressions;
 using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Json;
 
 using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
 
@@ -599,8 +600,18 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         }
 
         // If a string is in IS8061 format, assume a DateTime is in UTC
+        // Because this is a friend class, we can't remove this method without
+        // breaking compatibility.
         internal static string GetStringClaimValueType(string str)
         {
+            return GetStringClaimValueType(string.Empty, str);
+        }
+
+        internal static string GetStringClaimValueType(string claimType, string str)
+        {
+            if (!string.IsNullOrEmpty(claimType) && !JsonSerializerPrimitives.TryAllStringClaimsAsDateTime() && JsonSerializerPrimitives.KnownNonDateTimesClaimTypes.Contains(claimType))
+                return ClaimValueTypes.String;
+
             if (DateTime.TryParse(str, out DateTime dateTimeValue))
             {
                 string dtUniversal = dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture);

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -609,7 +609,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
         internal static string GetStringClaimValueType(string claimType, string str)
         {
-            if (!string.IsNullOrEmpty(claimType) && !JsonSerializerPrimitives.TryAllStringClaimsAsDateTime() && JsonSerializerPrimitives.KnownNonDateTimesClaimTypes.Contains(claimType))
+            if (!string.IsNullOrEmpty(claimType) && !JsonSerializerPrimitives.TryAllStringClaimsAsDateTime() && JsonSerializerPrimitives.IsKnownToNotBeDateTime(claimType))
                 return ClaimValueTypes.String;
 
             if (DateTime.TryParse(str, out DateTime dateTimeValue))

--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
@@ -130,13 +130,13 @@ namespace Microsoft.IdentityModel.Tokens.Json
 
         internal static object CreateObjectFromJsonElement(JsonElement jsonElement, int currentDepth)
         {
-            return CreateObjectFromJsonElement(string.Empty, jsonElement, currentDepth);
+            return CreateObjectFromJsonElement(jsonElement, currentDepth, string.Empty);
         }
 
         /// <remarks>
         /// <paramref name="claimType"/> is not considered on recursive calls.
         /// </remarks>
-        internal static object CreateObjectFromJsonElement(string claimType, JsonElement jsonElement, int currentDepth)
+        internal static object CreateObjectFromJsonElement(JsonElement jsonElement, int currentDepth, string claimType)
         {
             if (currentDepth >= MaxDepth)
                 throw new InvalidOperationException(LogHelper.FormatInvariant(
@@ -186,7 +186,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                 int index = 0;
                 foreach (JsonElement j in jsonElement.EnumerateArray())
                 {
-                    items[index++] = CreateObjectFromJsonElement(string.Empty, j, currentDepth + 1);
+                    items[index++] = CreateObjectFromJsonElement(j, currentDepth + 1, string.Empty);
                 }
 
                 return items;
@@ -201,7 +201,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                 KeyValuePair<string, object>[] kvps = new KeyValuePair<string, object>[numItems];
                 foreach (JsonProperty property in jsonElement.EnumerateObject())
                 {
-                    kvps[index++] = new KeyValuePair<string, object>(property.Name, CreateObjectFromJsonElement(string.Empty, property.Value, currentDepth + 1));
+                    kvps[index++] = new KeyValuePair<string, object>(property.Name, CreateObjectFromJsonElement(property.Value, currentDepth + 1, string.Empty));
                 }
 
                 return kvps;
@@ -306,7 +306,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     Dictionary<string, object> dictionary = new();
                     foreach (JsonProperty property in jsonElement.EnumerateObject())
                     {
-                        dictionary[property.Name] = CreateObjectFromJsonElement(string.Empty, property.Value, currentDepth + 1);
+                        dictionary[property.Name] = CreateObjectFromJsonElement(property.Value, currentDepth + 1, string.Empty);
                     }
 
                     t = (T)(object)dictionary;
@@ -397,7 +397,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     numItems = 0;
                     foreach (JsonElement j in jsonElement.EnumerateArray())
                     {
-                        items[numItems++] = CreateObjectFromJsonElement(string.Empty, j, currentDepth + 1);
+                        items[numItems++] = CreateObjectFromJsonElement(j, currentDepth + 1, string.Empty);
                     }
 
                     t = (T)(object)items;
@@ -408,7 +408,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     List<object> items = new();
                     foreach (JsonElement j in jsonElement.EnumerateArray())
                     {
-                        items.Add(CreateObjectFromJsonElement(string.Empty, j, currentDepth + 1));
+                        items.Add(CreateObjectFromJsonElement(j, currentDepth + 1, string.Empty));
                     }
 
                     t = (T)(object)items;
@@ -419,7 +419,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     Collection<object> items = new();
                     foreach (JsonElement j in jsonElement.EnumerateArray())
                     {
-                        items.Add(CreateObjectFromJsonElement(string.Empty, j, currentDepth + 1));
+                        items.Add(CreateObjectFromJsonElement(j, currentDepth + 1, string.Empty));
                     }
 
                     t = (T)(object)items;
@@ -718,7 +718,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
         /// sourced from expected Entra V1 and V2 claims, OpenID Connect claims, and a selection of
         /// restricted claim names.
         /// </summary>
-        private static HashSet<string> KnownNonDateTimesClaimTypes = new(StringComparer.Ordinal)
+        private static readonly HashSet<string> s_knownNonDateTimeClaimTypes = new(StringComparer.Ordinal)
         {
             // Header Values.
             "alg",
@@ -816,7 +816,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
             if (string.IsNullOrEmpty(claimType))
                 return true;
 
-            if (KnownNonDateTimesClaimTypes.Contains(claimType))
+            if (s_knownNonDateTimeClaimTypes.Contains(claimType))
                 return true;
 
             return false;

--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
@@ -130,6 +130,14 @@ namespace Microsoft.IdentityModel.Tokens.Json
 
         internal static object CreateObjectFromJsonElement(JsonElement jsonElement, int currentDepth)
         {
+            return CreateObjectFromJsonElement(string.Empty, jsonElement, currentDepth);
+        }
+
+        /// <remarks>
+        /// <paramref name="claimType"/> is not considered on recursive calls.
+        /// </remarks>
+        internal static object CreateObjectFromJsonElement(string claimType, JsonElement jsonElement, int currentDepth)
+        {
             if (currentDepth >= MaxDepth)
                 throw new InvalidOperationException(LogHelper.FormatInvariant(
                     LogMessages.IDX10815,
@@ -138,6 +146,9 @@ namespace Microsoft.IdentityModel.Tokens.Json
 
             if (jsonElement.ValueKind == JsonValueKind.String)
             {
+                if (!string.IsNullOrEmpty(claimType) && !TryAllStringClaimsAsDateTime() && KnownNonDateTimesClaimTypes.Contains(claimType))
+                    return jsonElement.GetString();
+
                 if (DateTime.TryParse(jsonElement.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime dateTime))
                     return dateTime;
 
@@ -175,7 +186,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                 int index = 0;
                 foreach (JsonElement j in jsonElement.EnumerateArray())
                 {
-                    items[index++] = CreateObjectFromJsonElement(j, currentDepth + 1);
+                    items[index++] = CreateObjectFromJsonElement(string.Empty, j, currentDepth + 1);
                 }
 
                 return items;
@@ -190,7 +201,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                 KeyValuePair<string, object>[] kvps = new KeyValuePair<string, object>[numItems];
                 foreach (JsonProperty property in jsonElement.EnumerateObject())
                 {
-                    kvps[index++] = new KeyValuePair<string, object>(property.Name, CreateObjectFromJsonElement(property.Value, currentDepth + 1));
+                    kvps[index++] = new KeyValuePair<string, object>(property.Name, CreateObjectFromJsonElement(string.Empty, property.Value, currentDepth + 1));
                 }
 
                 return kvps;
@@ -295,7 +306,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     Dictionary<string, object> dictionary = new();
                     foreach (JsonProperty property in jsonElement.EnumerateObject())
                     {
-                        dictionary[property.Name] = CreateObjectFromJsonElement(property.Value, currentDepth + 1);
+                        dictionary[property.Name] = CreateObjectFromJsonElement(string.Empty, property.Value, currentDepth + 1);
                     }
 
                     t = (T)(object)dictionary;
@@ -386,7 +397,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     numItems = 0;
                     foreach (JsonElement j in jsonElement.EnumerateArray())
                     {
-                        items[numItems++] = CreateObjectFromJsonElement(j, currentDepth + 1);
+                        items[numItems++] = CreateObjectFromJsonElement(string.Empty, j, currentDepth + 1);
                     }
 
                     t = (T)(object)items;
@@ -397,7 +408,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     List<object> items = new();
                     foreach (JsonElement j in jsonElement.EnumerateArray())
                     {
-                        items.Add(CreateObjectFromJsonElement(j, currentDepth + 1));
+                        items.Add(CreateObjectFromJsonElement(string.Empty, j, currentDepth + 1));
                     }
 
                     t = (T)(object)items;
@@ -408,7 +419,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     Collection<object> items = new();
                     foreach (JsonElement j in jsonElement.EnumerateArray())
                     {
-                        items.Add(CreateObjectFromJsonElement(j, currentDepth + 1));
+                        items.Add(CreateObjectFromJsonElement(string.Empty, j, currentDepth + 1));
                     }
 
                     t = (T)(object)items;
@@ -695,6 +706,98 @@ namespace Microsoft.IdentityModel.Tokens.Json
             return retVal;
         }
 
+        internal const string TryToCreateDateTimeClaimsSwitch = "Switch.Microsoft.IdentityModel.TryAllStringClaimsAsDateTime";
+
+        public static bool TryAllStringClaimsAsDateTime()
+        {
+            return (AppContext.TryGetSwitch(TryToCreateDateTimeClaimsSwitch, out bool tryAsDateTime) && tryAsDateTime);
+        }
+
+        /// <summary>
+        /// This is a non-exhaustive list of claim types that are not expected to be DateTime values
+        /// sourced from expected Entra V1 and V2 claims, OpenID Connect claims, and a selection of
+        /// restricted claim names.
+        /// </summary>
+        public static HashSet<string> KnownNonDateTimesClaimTypes = new(StringComparer.Ordinal)
+        {
+            "acr",
+            "acrs",
+            "access_token",
+            "account_type",
+            "acct",
+            "actor",
+            "actort",
+            "actortoken",
+            "aio",
+            "altsecid",
+            "amr",
+            "app_displayname",
+            "appid",
+            "appidacr",
+            "at_hash",
+            "aud",
+            "authorization_code",
+            "azp",
+            "azpacr",
+            "c_hash",
+            "cnf",
+            "capolids",
+            "ctry",
+            "email",
+            "family_name",
+            "fwd",
+            "gender",
+            "given_name",
+            "groups",
+            "hasgroups",
+            "idp",
+            "idtyp",
+            "in_corp",
+            "ipaddr",
+            "iss",
+            "jti",
+            "jwk",
+            "login_hint",
+            "name",
+            "nameid",
+            "nickname",
+            "nonce",
+            "oid",
+            "onprem_sid",
+            "phone_number",
+            "phone_number_verified",
+            "pop_jwk",
+            "preferred_username",
+            "prn",
+            "puid",
+            "pwd_url",
+            "rh",
+            "role",
+            "roles",
+            "secaud",
+            "sid",
+            "sub",
+            "tenant_ctry",
+            "tenant_region_scope",
+            "tid",
+            "typ",
+            "unique_name",
+            "upn",
+            "uti",
+            "ver",
+            "verified_primary_email",
+            "verified_secondary_email",
+            "vnet",
+            "website",
+            "wids",
+            "xms_cc",
+            "xms_edov",
+            "xms_pdl",
+            "xms_pl",
+            "xms_tpl",
+            "ztdid"
+        };
+
         internal static object ReadStringAsObject(ref Utf8JsonReader reader, string propertyName, string className, bool read = false)
         {
             // returning null keeps the same logic as JsonSerialization.ReadObject
@@ -706,6 +809,13 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     CreateJsonReaderException(ref reader, "JsonTokenType.String", className, propertyName));
 
             string originalString = reader.GetString();
+
+            if (!TryAllStringClaimsAsDateTime() && KnownNonDateTimesClaimTypes.Contains(propertyName))
+            {
+                reader.Read();
+                return originalString;
+            }
+
 #pragma warning disable CA1031 // Do not catch general exception types
             try
             {

--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
@@ -720,6 +720,21 @@ namespace Microsoft.IdentityModel.Tokens.Json
         /// </summary>
         private static HashSet<string> KnownNonDateTimesClaimTypes = new(StringComparer.Ordinal)
         {
+            // Header Values.
+            "alg",
+            "cty",
+            "crit",
+            "enc",
+            "jku",
+            "jwk",
+            "kid",
+            "typ",
+            "x5c",
+            "x5t",
+            "x5t#S256",
+            "x5u",
+            "zip",
+            // JWT claims.
             "acr",
             "acrs",
             "access_token",
@@ -756,7 +771,6 @@ namespace Microsoft.IdentityModel.Tokens.Json
             "ipaddr",
             "iss",
             "jti",
-            "jwk",
             "login_hint",
             "name",
             "nameid",
@@ -780,7 +794,6 @@ namespace Microsoft.IdentityModel.Tokens.Json
             "tenant_ctry",
             "tenant_region_scope",
             "tid",
-            "typ",
             "unique_name",
             "upn",
             "uti",

--- a/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
@@ -672,7 +672,7 @@ namespace System.IdentityModel.Tokens.Jwt
             Type objType = value.GetType();
 
             if (value is string str)
-                return JwtTokenUtilities.GetStringClaimValueType(claimType, str);
+                return JwtTokenUtilities.GetStringClaimValueType(str, claimType);
             else if (objType == typeof(int))
                 return ClaimValueTypes.Integer32;
             else if (objType == typeof(long))

--- a/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtPayload.cs
@@ -508,7 +508,7 @@ namespace System.IdentityModel.Tokens.Jwt
                         claims.Add(new Claim(keyValuePair.Key, string.Empty, JsonClaimValueTypes.JsonNull, issuer, issuer));
 
                     else if (keyValuePair.Value is string str)
-                        claims.Add(new Claim(keyValuePair.Key, str, GetClaimValueType(str), issuer, issuer));
+                        claims.Add(new Claim(keyValuePair.Key, str, GetClaimValueType(keyValuePair.Key, str), issuer, issuer));
 
                     else if (keyValuePair.Value is JsonElement j)
                         AddClaimsFromJsonElement(keyValuePair.Key, issuer, j, claims);
@@ -521,7 +521,7 @@ namespace System.IdentityModel.Tokens.Jwt
                     {
                         foreach (var item in dictionary)
                             if (item.Value != null)
-                                claims.Add(new Claim(keyValuePair.Key, "{" + item.Key + ":" + item.Value.ToString() + "}", GetClaimValueType(item.Value), issuer, issuer));
+                                claims.Add(new Claim(keyValuePair.Key, "{" + item.Key + ":" + item.Value.ToString() + "}", GetClaimValueType(item.Key, item.Value), issuer, issuer));
                     }
                     else if (keyValuePair.Value is DateTime dateTime)
                         claims.Add(new Claim(keyValuePair.Key, dateTime.ToString("o", CultureInfo.InvariantCulture), ClaimValueTypes.DateTime, issuer, issuer));
@@ -536,7 +536,7 @@ namespace System.IdentityModel.Tokens.Jwt
                     else if (keyValuePair.Value != null)
                     {
                         var value = keyValuePair.Value;
-                        var claimValueType = GetClaimValueType(value);
+                        var claimValueType = GetClaimValueType(keyValuePair.Key, value);
                         if (value is IFormattable formattable)
                             claims.Add(new Claim(keyValuePair.Key, formattable.ToString(null, CultureInfo.InvariantCulture), claimValueType, issuer, issuer));
                         else
@@ -569,7 +569,7 @@ namespace System.IdentityModel.Tokens.Jwt
                     AddListofObjects(key, innerObjects, claims, issuer);
                 else
                 {
-                    var claimValueType = GetClaimValueType(obj);
+                    var claimValueType = GetClaimValueType(key, obj);
                     if (obj is IFormattable formattable)
                         claims.Add(new Claim(key, formattable.ToString(null, CultureInfo.InvariantCulture), claimValueType, issuer, issuer));
                     else
@@ -664,7 +664,7 @@ namespace System.IdentityModel.Tokens.Jwt
                 this[kvp.Key] = kvp.Value;
         }
 
-        internal static string GetClaimValueType(object value)
+        private static string GetClaimValueType(string claimType, object value)
         {
             if (value == null)
                 return JsonClaimValueTypes.JsonNull;
@@ -672,7 +672,7 @@ namespace System.IdentityModel.Tokens.Jwt
             Type objType = value.GetType();
 
             if (value is string str)
-                return JwtTokenUtilities.GetStringClaimValueType(str);
+                return JwtTokenUtilities.GetStringClaimValueType(claimType, str);
             else if (objType == typeof(int))
                 return ClaimValueTypes.Integer32;
             else if (objType == typeof(long))


### PR DESCRIPTION
# Don't always test string claims for Date Time

## Description

Cannot remove APIs in in these internal methods as they are friends

There are serveral claim types that should never
be a datetime value. This changes introduces
a list of claim types that will not be tested if they are a Date Time format. 
This list of claim types is not exhaustive.

Added test data for a test token with more claims
and a benchmark using this data.

Benchmark results:

BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3593/23H2/2023Update/SunValley3) (Hyper-V)
Intel Xeon Platinum 8370C CPU 2.80GHz, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.301
  [Host]    : .NET 8.0.6 (8.0.624.26715), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI
  MediumRun : .NET 8.0.6 (8.0.624.26715), X64 RyuJIT AVX-512F+CD+BW+DQ+VL+VBMI

Job=MediumRun  MaxAbsoluteError=10.0000 ms  IterationCount=15
LaunchCount=4  WarmupCount=10

| Method                                                                | Mean     | Error    | StdDev   | P90      | P95      | P100     | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|---------------------------------------------------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
| JsonWebTokenHandler_ValidateTokenAsync_CreateClaims                   | 45.71 us | 0.565 us | 1.227 us | 47.23 us | 47.35 us | 47.46 us |  1.10 |    0.03 | 0.6104 |  17.63 KB |        1.04 |
| JsonWebTokenHandler_ValidateTokenAsync_CreateClaims_WithOptimizations | 41.50 us | 0.195 us | 0.416 us | 42.06 us | 42.14 us | 42.72 us |  1.00 |    0.00 | 0.6104 |  16.88 KB |        1.00 |

Fixes #2615 
