### PR TITLE
Use RSASignaturePadding.Pss by default

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -41,6 +41,8 @@ namespace Microsoft.IdentityModel.Tokens
         private VerifyDelegate _verifyFunction = VerifyNotFound;
         private VerifyUsingOffsetDelegate _verifyUsingOffsetFunction = VerifyUsingOffsetNotFound;
 
+        internal const string _enablePkcs1SignaturePaddingSwitch = "Switch.Microsoft.IdentityModel.EnablePkcs1SignaturePaddingSwitch";
+
         // Encryption algorithms do not need a HashAlgorithm, this is called by RSAKeyWrap
         internal AsymmetricAdapter(SecurityKey key, string algorithm, bool requirePrivateKey)
             : this(key, algorithm, null, requirePrivateKey)
@@ -195,8 +197,14 @@ namespace Microsoft.IdentityModel.Tokens
             }
             else
             {
-                // default RSASignaturePadding for other supported RSA algorithms is Pkcs1
-                RSASignaturePadding = RSASignaturePadding.Pkcs1;
+                if (AppContext.TryGetSwitch(_enablePkcs1SignaturePaddingSwitch, out bool enablePaddingSwitch) && enablePaddingSwitch)
+                {
+                    RSASignaturePadding = RSASignaturePadding.Pkcs1;
+                }
+                else
+                {
+                    throw new NotSupportedException(LogMessages.IDX10721);
+                }
             }
 
             RSAEncryptionPadding = (algorithm.Equals(SecurityAlgorithms.RsaOAEP) || algorithm.Equals(SecurityAlgorithms.RsaOaepKeyWrap))

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -226,6 +226,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10718 = "IDX10718: AlgorithmToValidate is not supported: '{0}'. Algorithm '{1}'.";
         public const string IDX10719 = "IDX10719: SignatureSize (in bytes) was expected to be '{0}', was '{1}'.";
         public const string IDX10720 = "IDX10720: Unable to create KeyedHashAlgorithm for algorithm '{0}', the key size must be greater than: '{1}' bits, key has '{2}' bits.";
+        public const string IDX10721 = "IDX10721: RSASignaturePadding.Pkcs1 is no longer supported. Please use one of the supported algorithms: PS256, SecurityAlgorithms.RsaSsaPssSha256Signature, PS384, SecurityAlgorithms.RsaSsaPssSha384Signature, PS512, SecurityAlgorithms.RsaSsaPssSha512Signature.";
 
         // Json specific errors
         //public const string IDX10801 = "IDX10801:"

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
@@ -51,6 +51,60 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
+        [Theory, MemberData(nameof(RSASignaturePaddingTheoryData))]
+        public void TestSupportedSignaturePaddingValues(AsymmetricAdapterTheoryData theoryData)
+        {
+            var context = new CompareContext("TestSupportedSignaturePaddingValues");
+            TestUtilities.WriteHeader($"{this}.TestSupportedSignaturePaddingValues");
+
+            try
+            {
+                AppContext.SetSwitch("Switch.Microsoft.IdentityModel.EnablePkcs1SignaturePaddingSwitch", theoryData.EnablePkcs1SignaturePaddingSwitch);
+                var asymmetricAdapter = new AsymmetricAdapter(new RsaSecurityKey(new DerivedRsa(2048)), theoryData.Algorithm, false);
+            }
+            catch(Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<AsymmetricAdapterTheoryData> RSASignaturePaddingTheoryData
+        {
+            get
+            {
+                var theoryData = new TheoryData<AsymmetricAdapterTheoryData>
+                {
+                    new AsymmetricAdapterTheoryData("AppContextSwitchFalse_UseUnsupportedAlgorithm_Exception")
+                    {
+                        Algorithm = SecurityAlgorithms.RsaSha256,
+                        EnablePkcs1SignaturePaddingSwitch = false,
+                        ExpectedException = ExpectedException.NotSupportedException("IDX10721:")
+                    },
+                    new AsymmetricAdapterTheoryData("AppContextSwitchTrue_UseUnsupportedAlgorithm_NoException")
+                    {
+                        Algorithm = SecurityAlgorithms.RsaSha256,
+                        EnablePkcs1SignaturePaddingSwitch = true,
+                        ExpectedException = ExpectedException.NoExceptionExpected
+                    }
+                };
+
+                return theoryData;
+            }
+        }
+
+        public class AsymmetricAdapterTheoryData : TheoryDataBase
+        {
+            public AsymmetricAdapterTheoryData() { }
+
+            public AsymmetricAdapterTheoryData(string testId) : base(testId) { }
+
+            public string Algorithm { get; set; }
+
+            public bool EnablePkcs1SignaturePaddingSwitch { get; set; }
+        }
+
         [Theory, MemberData(nameof(SignVerifyTheoryData))]
         public void SignVerify(SignatureProviderTheoryData theoryData)
         {

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
@@ -7,12 +7,20 @@ using System.Security.Cryptography.X509Certificates;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
-#pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
 #pragma warning disable SYSLIB0028 // Type or member is obsolete
 #pragma warning disable SYSLIB0027 // Type or member is obsolete
 
 namespace Microsoft.IdentityModel.Tokens.Tests
 {
+    /// <summary>
+    /// This class defines the test collection for all tests that set an AppContext switch.
+    /// All tests in this collection will run sequentially to prevent unexpected behavior
+    /// due to interference between tests as multiple tests set the switch.
+    /// </summary>
+    [CollectionDefinition(nameof(AppContextTestCollection), DisableParallelization = true)]
+    public class AppContextTestCollection { }
+
+    [Collection(nameof(AppContextTestCollection))]
     public class AsymmetricSignatureTests
     {
         [Fact]
@@ -92,17 +100,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
                 return theoryData;
             }
-        }
-
-        public class AsymmetricAdapterTheoryData : TheoryDataBase
-        {
-            public AsymmetricAdapterTheoryData() { }
-
-            public AsymmetricAdapterTheoryData(string testId) : base(testId) { }
-
-            public string Algorithm { get; set; }
-
-            public bool EnablePkcs1SignaturePaddingSwitch { get; set; }
         }
 
         [Theory, MemberData(nameof(SignVerifyTheoryData))]
@@ -522,8 +519,18 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
         public bool WillCreateSignatures { get; set; }
     }
+
+    public class AsymmetricAdapterTheoryData : TheoryDataBase
+    {
+        public AsymmetricAdapterTheoryData() { }
+
+        public AsymmetricAdapterTheoryData(string testId) : base(testId) { }
+
+        public string Algorithm { get; set; }
+
+        public bool EnablePkcs1SignaturePaddingSwitch { get; set; }
+    }
 }
 
 #pragma warning restore SYSLIB0027 // Type or member is obsolete
 #pragma warning restore SYSLIB0028 // Type or member is obsolete
-#pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant


### PR DESCRIPTION
**What?**
- Introduced an AppContext switch: `Switch.Microsoft.IdentityModel.EnablePkcs1SignaturePaddingSwitch`
- Change in behavior: `RSASignaturePadding.Pkcs1` is not used by default unless the above switch is enabled.

**How to Enable the AppContext Switch?**
Set the following in your code. .NET runtime will pick it up and Wilson will use it:
```csharp
AppContext.SetSwitch("Switch.Microsoft.IdentityModel.EnablePkcs1SignaturePaddingSwitch", true);
```

**Why?**
`RSASignaturePadding.Pkcs1` is no longer an approved padding scheme for RSA signing.