### PR TITLE
Fixes index out-of-range error

### DIFF
--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -397,6 +397,11 @@ namespace Microsoft.IdentityModel.Validators
                 if (!validIssuerTemplateSpan.Slice(0, indexOfTenantIdTemplate).SequenceEqual(actualIssuerSpan.Slice(0, indexOfTenantIdTemplate)))
                     return false;
 
+                // Ensure actualIssuer is long enough to match the validIssuerTemplate with tenantId replaced.
+                // This prevents index out-of-range errors in the next step.
+                if (actualIssuer.Length <= indexOfTenantIdTemplate + tenantId.Length)
+                    return false;
+
                 // ensure that actualIssuer contains the tenantId from indexOfTenantIdTemplate for the length of tenantId.Length
                 if (!actualIssuerSpan.Slice(indexOfTenantIdTemplate, tenantId.Length).SequenceEqual(tenantId.AsSpan()))
                     return false;

--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -390,8 +390,10 @@ namespace Microsoft.IdentityModel.Validators
             ReadOnlySpan<char> validIssuerTemplateSpan = validIssuerTemplate.AsSpan();
             ReadOnlySpan<char> actualIssuerSpan = actualIssuer.AsSpan();
             int indexOfTenantIdTemplate = validIssuerTemplate.IndexOf(TenantIdTemplate, StringComparison.Ordinal);
+            int indexOfTenantIdInActualIssuer = actualIssuer.IndexOf(TenantIdTemplate, StringComparison.Ordinal);
+            bool actualIssuerTemplated = indexOfTenantIdInActualIssuer >= 0;
 
-            if (indexOfTenantIdTemplate >= 0 && actualIssuer.Length > indexOfTenantIdTemplate)
+            if (!actualIssuerTemplated && indexOfTenantIdTemplate >= 0 && actualIssuer.Length > indexOfTenantIdTemplate)
             {
                 // ensure the first part of the validIssuerTemplate matches the first part of actualIssuer
                 if (!validIssuerTemplateSpan.Slice(0, indexOfTenantIdTemplate).SequenceEqual(actualIssuerSpan.Slice(0, indexOfTenantIdTemplate)))

--- a/src/Microsoft.IdentityModel.Validators/AadTokenValidationParametersExtension.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadTokenValidationParametersExtension.cs
@@ -76,9 +76,13 @@ namespace Microsoft.IdentityModel.Validators
 #if NET6_0_OR_GREATER
                 if (!string.IsNullOrEmpty(tokenIssuer) && !tokenIssuer.Contains(tenantIdFromToken, StringComparison.Ordinal))
                     throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidIssuerException(LogHelper.FormatInvariant(LogMessages.IDX40004, LogHelper.MarkAsNonPII(tokenIssuer), LogHelper.MarkAsNonPII(tenantIdFromToken))));
+
+                var v2TokenIssuer = openIdConnectConfiguration.Issuer?.Replace(AadIssuerValidator.TenantIdTemplate, tenantIdFromToken, StringComparison.Ordinal);
 #else
                 if (!string.IsNullOrEmpty(tokenIssuer) && !tokenIssuer.Contains(tenantIdFromToken))
                     throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidIssuerException(LogHelper.FormatInvariant(LogMessages.IDX40004, LogHelper.MarkAsNonPII(tokenIssuer), LogHelper.MarkAsNonPII(tenantIdFromToken))));
+
+                var v2TokenIssuer = openIdConnectConfiguration.Issuer?.Replace(AadIssuerValidator.TenantIdTemplate, tenantIdFromToken);
 #endif
                 // comparing effectiveSigningKeyIssuer with v2TokenIssuer is required because of the following scenario:
                 // 1. service trusts /common/v2.0 endpoint 
@@ -86,7 +90,7 @@ namespace Microsoft.IdentityModel.Validators
                 // 3. signing key issuers will never match sts.windows.net as v1 endpoint doesn't have issuers attached to keys
                 // v2TokenIssuer is the representation of Token.Issuer (if it was a v2 issuer)
                 if (!AadIssuerValidator.IsValidIssuer(signingKeyIssuer, tenantIdFromToken, tokenIssuer)
-                    && !AadIssuerValidator.IsValidIssuer(signingKeyIssuer, tenantIdFromToken, openIdConnectConfiguration.Issuer))
+                    && !AadIssuerValidator.IsValidIssuer(signingKeyIssuer, tenantIdFromToken, v2TokenIssuer))
                 {
                     int templateStartIndex = signingKeyIssuer.IndexOf(AadIssuerValidator.TenantIdTemplate, StringComparison.Ordinal);
                     string effectiveSigningKeyIssuer = templateStartIndex > -1 ? CreateIssuer(signingKeyIssuer, AadIssuerValidator.TenantIdTemplate, tenantIdFromToken, templateStartIndex) : signingKeyIssuer;

--- a/src/Microsoft.IdentityModel.Validators/AadTokenValidationParametersExtension.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadTokenValidationParametersExtension.cs
@@ -77,12 +77,10 @@ namespace Microsoft.IdentityModel.Validators
                 if (!string.IsNullOrEmpty(tokenIssuer) && !tokenIssuer.Contains(tenantIdFromToken, StringComparison.Ordinal))
                     throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidIssuerException(LogHelper.FormatInvariant(LogMessages.IDX40004, LogHelper.MarkAsNonPII(tokenIssuer), LogHelper.MarkAsNonPII(tenantIdFromToken))));
 
-                var v2TokenIssuer = openIdConnectConfiguration.Issuer?.Replace(AadIssuerValidator.TenantIdTemplate, tenantIdFromToken, StringComparison.Ordinal);
 #else
                 if (!string.IsNullOrEmpty(tokenIssuer) && !tokenIssuer.Contains(tenantIdFromToken))
                     throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidIssuerException(LogHelper.FormatInvariant(LogMessages.IDX40004, LogHelper.MarkAsNonPII(tokenIssuer), LogHelper.MarkAsNonPII(tenantIdFromToken))));
 
-                var v2TokenIssuer = openIdConnectConfiguration.Issuer?.Replace(AadIssuerValidator.TenantIdTemplate, tenantIdFromToken);
 #endif
                 // comparing effectiveSigningKeyIssuer with v2TokenIssuer is required because of the following scenario:
                 // 1. service trusts /common/v2.0 endpoint 
@@ -90,7 +88,7 @@ namespace Microsoft.IdentityModel.Validators
                 // 3. signing key issuers will never match sts.windows.net as v1 endpoint doesn't have issuers attached to keys
                 // v2TokenIssuer is the representation of Token.Issuer (if it was a v2 issuer)
                 if (!AadIssuerValidator.IsValidIssuer(signingKeyIssuer, tenantIdFromToken, tokenIssuer)
-                    && !AadIssuerValidator.IsValidIssuer(signingKeyIssuer, tenantIdFromToken, v2TokenIssuer))
+                    && !AadIssuerValidator.IsValidIssuer(signingKeyIssuer, tenantIdFromToken, openIdConnectConfiguration.Issuer))
                 {
                     int templateStartIndex = signingKeyIssuer.IndexOf(AadIssuerValidator.TenantIdTemplate, StringComparison.Ordinal);
                     string effectiveSigningKeyIssuer = templateStartIndex > -1 ? CreateIssuer(signingKeyIssuer, AadIssuerValidator.TenantIdTemplate, tenantIdFromToken, templateStartIndex) : signingKeyIssuer;

--- a/test/Microsoft.IdentityModel.Validators.Tests/AadIssuerValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/AadIssuerValidatorTests.cs
@@ -1,24 +1,127 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
 namespace Microsoft.IdentityModel.Validators.Tests
 {
     public class AadIssuerValidatorTests
     {
-        [Theory]
-        [InlineData(ValidatorConstants.AadInstance + AadIssuerValidator.TenantIdTemplate, ValidatorConstants.AadInstance + ValidatorConstants.TenantIdAsGuid, true)]
-        [InlineData(ValidatorConstants.AadInstancePPE + AadIssuerValidator.TenantIdTemplate, ValidatorConstants.AadInstance + ValidatorConstants.TenantIdAsGuid, false)]
-        [InlineData(ValidatorConstants.AadInstance + AadIssuerValidator.TenantIdTemplate, ValidatorConstants.AadInstance + ValidatorConstants.B2CTenantAsGuid, false)]
-        [InlineData("", ValidatorConstants.AadInstance + ValidatorConstants.TenantIdAsGuid, false)]
-        [InlineData(ValidatorConstants.AadInstance + AadIssuerValidator.TenantIdTemplate, "", false)]
-        public static void IsValidIssuer_CanValidateTemplatedIssuers(string templatedIssuer, string issuer, bool expectedResult)
+        [Theory, MemberData(nameof(AadIssuerValidationTestCases))]
+        public static void IsValidIssuer_CanValidateTemplatedIssuers(AadIssuerValidatorTheoryData theoryData)
         {
             // act
-            var result = AadIssuerValidator.IsValidIssuer(templatedIssuer, ValidatorConstants.TenantIdAsGuid, issuer);
+            var result = AadIssuerValidator.IsValidIssuer(theoryData.TemplatedIssuer, theoryData.TenantIdClaim, theoryData.TokenIssuer);
 
             // assert
-            Assert.Equal(expectedResult, result);
+            Assert.Equal(theoryData.ExpectedResult, result);
         }
+
+        public static TheoryData<AadIssuerValidatorTheoryData> AadIssuerValidationTestCases()
+        {
+            var theoryData = new TheoryData<AadIssuerValidatorTheoryData>
+            {
+                new AadIssuerValidatorTheoryData("CompareTokenIssuer_V1TemplateWithV1Issuer_Success")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV1CommonAuthority,
+                    TokenIssuer = ValidatorConstants.V1Issuer,
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = true,
+                },
+                new AadIssuerValidatorTheoryData("ValidateIssuer_V1TemplateWithV2Issuer_Failure")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV1CommonAuthority,
+                    TokenIssuer = ValidatorConstants.AadIssuer,
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = false,
+                },
+                new AadIssuerValidatorTheoryData("ValidateIssuer_V2TemplateWithV1Issuer_Failure")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV2CommonAuthority,
+                    TokenIssuer = ValidatorConstants.V1Issuer,
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = false,
+                },
+                new AadIssuerValidatorTheoryData("ValidateIssuer_V2TemplateWithV2Issuer_Success")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV2CommonAuthority,
+                    TokenIssuer = ValidatorConstants.AadIssuer,
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = true,
+                },
+                new AadIssuerValidatorTheoryData("ValidateIssuer_NullTemplate_Failure")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV1CommonAuthority,
+                    TokenIssuer = "",
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = false,
+                },
+
+                new AadIssuerValidatorTheoryData("ValidateIssuer_NullIssuer_Failure")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV1CommonAuthority,
+                    TokenIssuer = "",
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = false,
+                },
+                new AadIssuerValidatorTheoryData("ValidateIssuer_NullTenantId_Failure")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV1CommonAuthority,
+                    TokenIssuer = ValidatorConstants.AadIssuer,
+                    TenantIdClaim = "",
+                    ExpectedResult = false,
+                },
+                new AadIssuerValidatorTheoryData("ValidateIssuer_PPETemplateWithV1Issuer_Failure")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadInstancePPE + "/" + AadIssuerValidator.TenantIdTemplate,
+                    TokenIssuer =  ValidatorConstants.AadInstance + "/" + ValidatorConstants.TenantIdAsGuid,
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = false,
+                },
+                new AadIssuerValidatorTheoryData("ValidateIssuerSigningKey_V2SigningKeyIssuer_V1TokenIssuer_Failure")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV2CommonAuthority,
+                    TokenIssuer =  ValidatorConstants.V1Issuer,
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = false,
+                },
+                new AadIssuerValidatorTheoryData("ValidateIssuerSigningKey_V2SigningKeyIssuer_V2TokenIssuer_Success")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV2CommonAuthority,
+                    TokenIssuer =  ValidatorConstants.AadIssuer,
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = true,
+                },
+                new AadIssuerValidatorTheoryData("ValidateIssuerSigningKey_MalformedV2TokenIssuer_Failure")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV2CommonAuthority,
+                    TokenIssuer =  "https://login.microsoftonline.com/{tenantid}/v2.0",
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = false,
+                }
+            };
+
+            return theoryData;
+        }
+    }
+
+    public class AadIssuerValidatorTheoryData : TheoryDataBase
+    {
+        public AadIssuerValidatorTheoryData()
+        {
+        }
+
+        public AadIssuerValidatorTheoryData(string testId) : base(testId)
+        {
+        }
+
+        public string TemplatedIssuer { get; set; }
+
+        public string TokenIssuer { get; set; }
+
+        public string TenantIdClaim { get; set; }
+
+        public bool ExpectedResult { get; set; }
     }
 }

--- a/test/Microsoft.IdentityModel.Validators.Tests/AadIssuerValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/AadIssuerValidatorTests.cs
@@ -50,6 +50,27 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
                     ExpectedResult = true,
                 },
+                new AadIssuerValidatorTheoryData("ValidateIssuer_V11TemplateWithV11Issuer_Success")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV11CommonAuthority,
+                    TokenIssuer =  ValidatorConstants.AadIssuerV11,
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = true,
+                },
+                new AadIssuerValidatorTheoryData("ValidateIssuer_V11TemplateWithV1Issuer_Failure")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV11CommonAuthority,
+                    TokenIssuer =  ValidatorConstants.V1Issuer,
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = false,
+                },
+                new AadIssuerValidatorTheoryData("ValidateIssuer_V11TemplateWithV2Issuer_Failure")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV11CommonAuthority,
+                    TokenIssuer =  ValidatorConstants.AadIssuer,
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = false,
+                },
                 new AadIssuerValidatorTheoryData("ValidateIssuer_NullTemplate_Failure")
                 {
                     TemplatedIssuer = ValidatorConstants.AadIssuerV1CommonAuthority,
@@ -57,7 +78,6 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
                     ExpectedResult = false,
                 },
-
                 new AadIssuerValidatorTheoryData("ValidateIssuer_NullIssuer_Failure")
                 {
                     TemplatedIssuer = ValidatorConstants.AadIssuerV1CommonAuthority,
@@ -99,7 +119,14 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     TokenIssuer =  "https://login.microsoftonline.com/{tenantid}/v2.0",
                     TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
                     ExpectedResult = false,
-                }
+                },
+                new AadIssuerValidatorTheoryData("ValidateIssuerSigningKey_MalformedV2TokenIssuer_Failure")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV2CommonAuthority,
+                    TokenIssuer =  "https://login.microsoftonline.com/{tenantid}/v2.0",
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = false,
+                },
             };
 
             return theoryData;

--- a/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
@@ -289,6 +289,19 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     OpenIdConnectConfiguration = mockConfiguration
                 });
 
+                jwk = KeyingMaterial.JsonWebKeyP256;
+                jwk.AdditionalData.Add(OpenIdProviderMetadataNames.Issuer, ValidatorConstants.AadIssuerV2CommonAuthority);
+                mockConfiguration.JsonWebKeySet.Keys.Add(jwk);
+                mockConfiguration.Issuer = ValidatorConstants.AadIssuerV2CommonAuthority;
+                var jwtSecurityTokenV1Issuer = new JwtSecurityToken(issuer: ValidatorConstants.V1Issuer, claims: new[] { issClaim, tidClaim });
+                theoryData.Add(new AadSigningKeyIssuerTheoryData
+                {
+                    TestId = "HappyPath_V2AuthorityV1TokenIssuer_Matches_SigningKeyIssuer",
+                    SecurityKey = KeyingMaterial.JsonWebKeyP256,
+                    SecurityToken = jwtSecurityTokenV1Issuer,
+                    OpenIdConnectConfiguration = mockConfiguration
+                });
+
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
                 {
                     TestId = "MissingTenantIdClaimInToken",


### PR DESCRIPTION
Why?
The issuer signing key validation logic was updated to use AadIssuerValidator.IsValidIssuer(..). In this process, the existing logic was modified to compare the signing key issuer template (https://login.microsoftonline.com/{tenantid}/v2.0) with the templated issuer in the OpenIdConnect configuration (https://login.microsoftonline.com/{tenantid}/v2.0). This led to an index out-of-range error because IsValidIssuer expects the actualIssuer from the token to contain a GUID for tid rather than a {tenantid} template.

How?
Restored logic to generate the effective token issuer by replacing the {tenantid} template with the actual tenant ID from the token. Added an additional check to ensure the actual issuer is long enough to match the validIssuerTemplate with the tenant ID replaced, preventing out-of-range errors.

Added tests to cover both issuer validation and issuer signing key validation.