### PR TITLE
Audience validation: remove exceptions

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -880,7 +880,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
         /// <param name="audiences"><see cref="IEnumerable{String}"/>.</param>
         /// <param name="securityToken">The <see cref="SamlSecurityToken"/> being validated.</param>
         /// <param name="validationParameters"><see cref="TokenValidationParameters"/> required for validation.</param>
-        /// <remarks>see <see cref="Validators.ValidateAudience"/> for additional details.</remarks>
+        /// <remarks>see <see cref="Validators.ValidateAudience(IEnumerable{string}, SecurityToken, TokenValidationParameters)"/> for additional details.</remarks>
         protected virtual void ValidateAudience(IEnumerable<string> audiences, SecurityToken securityToken, TokenValidationParameters validationParameters)
         {
             Validators.ValidateAudience(audiences, securityToken, validationParameters);

--- a/src/Microsoft.IdentityModel.Tokens/Validation/AudienceValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/AudienceValidationResult.cs
@@ -63,6 +63,6 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Gets the audience that was validated or intended to be validated.
         /// </summary>
-        public string Audience { get; } = "null";
+        public string Audience { get; };
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/AudienceValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/AudienceValidationResult.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Contains the result of validating the audiences from a <see cref="SecurityToken"/>.
+    /// The <see cref="TokenValidationResult"/> contains a collection of <see cref="ValidationResult"/> for each step in the token validation.
+    /// </summary>
+    internal class AudienceValidationResult : ValidationResult
+    {
+        private Exception _exception;
+
+        /// <summary>
+        /// Creates an instance of <see cref="AudienceValidationResult"/>.
+        /// </summary>
+        /// <paramref name="audience"/> is the audience that was validated successfully.
+        public AudienceValidationResult(string audience) : base(ValidationFailureType.ValidationSucceeded)
+        {
+            IsValid = true;
+            Audience = audience;
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="IssuerValidationResult"/>
+        /// </summary>
+        /// <paramref name="audience"/> is the audience that was intended to be validated.
+        /// <paramref name="validationFailure"/> is the <see cref="ValidationFailureType"/> that occurred during validation.
+        /// <paramref name="exceptionDetail"/> is the <see cref="ExceptionDetail"/> that occurred during validation.
+        public AudienceValidationResult(string audience, ValidationFailureType validationFailure, ExceptionDetail exceptionDetail)
+            : base(validationFailure, exceptionDetail)
+        {
+            IsValid = false;
+            Audience = audience;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Exception"/> that occurred during validation.
+        /// </summary>
+        public override Exception Exception
+        {
+            get
+            {
+                if (_exception != null || ExceptionDetail == null)
+                    return _exception;
+
+                HasValidOrExceptionWasRead = true;
+                _exception = ExceptionDetail.GetException();
+                SecurityTokenInvalidAudienceException securityTokenInvalidAudienceException = _exception as SecurityTokenInvalidAudienceException;
+                if (securityTokenInvalidAudienceException != null)
+                {
+                    securityTokenInvalidAudienceException.InvalidAudience = Audience;
+                    securityTokenInvalidAudienceException.ExceptionDetail = ExceptionDetail;
+                    securityTokenInvalidAudienceException.Source = "Microsoft.IdentityModel.Tokens";
+                }
+
+                return _exception;
+            }
+        }
+
+        /// <summary>
+        /// Gets the audience that was validated or intended to be validated.
+        /// </summary>
+        public string Audience { get; } = "null";
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/Validation/AudienceValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/AudienceValidationResult.cs
@@ -48,8 +48,7 @@ namespace Microsoft.IdentityModel.Tokens
 
                 HasValidOrExceptionWasRead = true;
                 _exception = ExceptionDetail.GetException();
-                SecurityTokenInvalidAudienceException securityTokenInvalidAudienceException = _exception as SecurityTokenInvalidAudienceException;
-                if (securityTokenInvalidAudienceException != null)
+                if (_exception is SecurityTokenInvalidAudienceException securityTokenInvalidAudienceException)
                 {
                     securityTokenInvalidAudienceException.InvalidAudience = Audience;
                     securityTokenInvalidAudienceException.ExceptionDetail = ExceptionDetail;

--- a/src/Microsoft.IdentityModel.Tokens/Validation/AudienceValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/AudienceValidationResult.cs
@@ -63,6 +63,6 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Gets the audience that was validated or intended to be validated.
         /// </summary>
-        public string Audience { get; };
+        public string Audience { get; }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
@@ -34,6 +34,12 @@ namespace Microsoft.IdentityModel.Tokens
         private class IssuerValidationFailure : ValidationFailureType { internal IssuerValidationFailure(string name) : base(name) { } }
 
         /// <summary>
+        /// Defines a type that represents that audience validation failed.
+        /// </summary>
+        public static readonly ValidationFailureType AudienceValidationFailed = new AudienceValidationFailure("AudienceValidationFailed");
+        private class AudienceValidationFailure : ValidationFailureType { internal AudienceValidationFailure(string name) : base(name) { } }
+
+        /// <summary>
         /// Defines a type that represents that no evaluation has taken place.
         /// </summary>
         public static readonly ValidationFailureType ValidationNotEvaluated = new NotEvaluated("NotEvaluated");

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Audience.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Audience.cs
@@ -3,12 +3,30 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
+using System.Threading;
 using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.Logging;
 
 namespace Microsoft.IdentityModel.Tokens
 {
+    /// <summary>
+    /// Definition for delegate that will validate the audiences value in a token.
+    /// </summary>
+    /// <param name="audiences">The audiences to validate.</param>
+    /// <param name="securityToken">The <see cref="SecurityToken"/> that is being validated.</param>
+    /// <param name="validationParameters"><see cref="TokenValidationParameters"/> required for validation.</param>
+    /// <param name="callContext"></param>
+    /// <returns>A <see cref="IssuerValidationResult"/>that contains the results of validating the issuer.</returns>
+    /// <remarks>This delegate is not expected to throw.</remarks>
+    internal delegate AudienceValidationResult ValidateAudience(
+        IEnumerable<string> audiences,
+        SecurityToken securityToken,
+        TokenValidationParameters validationParameters,
+        CallContext callContext);
+
     /// <summary>
     /// Partial class for Audience Validation.
     /// </summary>
@@ -88,7 +106,121 @@ namespace Microsoft.IdentityModel.Tokens
             throw LogHelper.LogExceptionMessage(ex);
         }
 
+
+#nullable enable
+        /// <summary>
+        /// Determines if the audiences found in a <see cref="SecurityToken"/> are valid.
+        /// </summary>
+        /// <param name="audiences">The audiences found in the <see cref="SecurityToken"/>.</param>
+        /// <param name="securityToken">The <see cref="SecurityToken"/> being validated.</param>
+        /// <param name="validationParameters"><see cref="TokenValidationParameters"/> required for validation.</param>
+        /// <param name="callContext"></param>
+        /// <exception cref="ArgumentNullException">If 'validationParameters' is null.</exception>
+        /// <exception cref="ArgumentNullException">If 'audiences' is null and <see cref="TokenValidationParameters.ValidateAudience"/> is true.</exception>
+        /// <exception cref="SecurityTokenInvalidAudienceException">If <see cref="TokenValidationParameters.ValidAudience"/> is null or whitespace and <see cref="TokenValidationParameters.ValidAudiences"/> is null.</exception>
+        /// <exception cref="SecurityTokenInvalidAudienceException">If none of the 'audiences' matched either <see cref="TokenValidationParameters.ValidAudience"/> or one of <see cref="TokenValidationParameters.ValidAudiences"/>.</exception>
+        /// <remarks>An EXACT match is required.</remarks>
+#pragma warning disable CA1801 // TODO: remove pragma disable once callContext is used for logging
+        internal static AudienceValidationResult ValidateAudience(IEnumerable<string> audiences, SecurityToken securityToken, TokenValidationParameters validationParameters, CallContext callContext)
+#pragma warning restore CA1801
+        {
+            if (validationParameters == null)
+                return new AudienceValidationResult(
+                    Utility.SerializeAsSingleCommaDelimitedString(audiences),
+                    ValidationFailureType.NullArgument,
+                    new ExceptionDetail(
+                        new MessageDetail(
+                            LogMessages.IDX10000,
+                            LogHelper.MarkAsNonPII(nameof(validationParameters))),
+                        typeof(ArgumentNullException),
+                        new StackFrame(true)));
+
+            if (!validationParameters.ValidateAudience)
+            {
+                LogHelper.LogWarning(LogMessages.IDX10233);
+                return new AudienceValidationResult(Utility.SerializeAsSingleCommaDelimitedString(audiences));
+            }
+
+            if (securityToken == null)
+                return new AudienceValidationResult(
+                    Utility.SerializeAsSingleCommaDelimitedString(audiences),
+                    ValidationFailureType.NullArgument,
+                    new ExceptionDetail(
+                        new MessageDetail(
+                            LogMessages.IDX10000,
+                            LogHelper.MarkAsNonPII(nameof(securityToken))),
+                        typeof(ArgumentNullException),
+                        new StackFrame(true),
+                        null));
+
+            if (audiences == null)
+                return new AudienceValidationResult(
+                    Utility.SerializeAsSingleCommaDelimitedString(audiences),
+                    ValidationFailureType.NullArgument,
+                    new ExceptionDetail(
+                        new MessageDetail(
+                            LogMessages.IDX10207,
+                            null),
+                        typeof(SecurityTokenInvalidAudienceException),
+                        new StackFrame(true)));
+
+            if (string.IsNullOrWhiteSpace(validationParameters.ValidAudience) && (validationParameters.ValidAudiences == null))
+                return new AudienceValidationResult(
+                    Utility.SerializeAsSingleCommaDelimitedString(audiences),
+                    ValidationFailureType.NullArgument,
+                    new ExceptionDetail(
+                        new MessageDetail(
+                            LogMessages.IDX10208,
+                            null),
+                        typeof(SecurityTokenInvalidAudienceException),
+                        new StackFrame(true)));
+
+            if (!audiences.Any())
+                return new AudienceValidationResult(
+                    Utility.SerializeAsSingleCommaDelimitedString(audiences),
+                    ValidationFailureType.NullArgument,
+                    new ExceptionDetail(
+                        new MessageDetail(
+                            LogMessages.IDX10206,
+                            null),
+                        typeof(SecurityTokenInvalidAudienceException),
+                        new StackFrame(true)));
+
+            // create enumeration of all valid audiences from validationParameters
+            IEnumerable<string> validationParametersAudiences;
+
+            if (validationParameters.ValidAudiences == null)
+                validationParametersAudiences = new[] { validationParameters.ValidAudience };
+            else if (string.IsNullOrWhiteSpace(validationParameters.ValidAudience))
+                validationParametersAudiences = validationParameters.ValidAudiences;
+            else
+                validationParametersAudiences = validationParameters.ValidAudiences.Concat(new[] { validationParameters.ValidAudience });
+
+            string? validAudience = AudienceIsValidReturning(audiences, validationParameters, validationParametersAudiences);
+            if (validAudience != null)
+            {
+                return new AudienceValidationResult(validAudience);
+            }
+
+            return new AudienceValidationResult(
+                    Utility.SerializeAsSingleCommaDelimitedString(audiences),
+                    ValidationFailureType.AudienceValidationFailed,
+                    new ExceptionDetail(
+                        new MessageDetail(
+                            LogMessages.IDX10214,
+                            LogHelper.MarkAsNonPII(Utility.SerializeAsSingleCommaDelimitedString(audiences)),
+                            LogHelper.MarkAsNonPII(validationParameters.ValidAudience ?? "null"),
+                            LogHelper.MarkAsNonPII(Utility.SerializeAsSingleCommaDelimitedString(validationParameters.ValidAudiences))),
+                        typeof(SecurityTokenInvalidAudienceException),
+                        new StackFrame(true)));
+        }
+
         private static bool AudienceIsValid(IEnumerable<string> audiences, TokenValidationParameters validationParameters, IEnumerable<string> validationParametersAudiences)
+        {
+            return AudienceIsValidReturning(audiences, validationParameters, validationParametersAudiences) != null;
+        }
+
+        private static string? AudienceIsValidReturning(IEnumerable<string> audiences, TokenValidationParameters validationParameters, IEnumerable<string> validationParametersAudiences)
         {
             foreach (string tokenAudience in audiences)
             {
@@ -105,13 +237,14 @@ namespace Microsoft.IdentityModel.Tokens
                         if (LogHelper.IsEnabled(EventLogLevel.Informational))
                             LogHelper.LogInformation(LogMessages.IDX10234, LogHelper.MarkAsNonPII(tokenAudience));
 
-                        return true;
+                        return validAudience;
                     }
                 }
             }
 
-            return false;
+            return null;
         }
+#nullable disable
 
         private static bool AudiencesMatch(TokenValidationParameters validationParameters, string tokenAudience, string validAudience)
         {

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Audience.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Audience.cs
@@ -188,17 +188,20 @@ namespace Microsoft.IdentityModel.Tokens
 
         private static string? AudienceIsValidReturning(IEnumerable<string> audiences, TokenValidationParameters validationParameters)
         {
+            if (audiences is not List<string> internalAudiences)
+                internalAudiences = audiences.ToList();
+
             string? validAudience = null;
             if (!string.IsNullOrWhiteSpace(validationParameters.ValidAudience))
-                validAudience = AudiencesMatchSingle(audiences, validationParameters.ValidAudience, validationParameters.IgnoreTrailingSlashWhenValidatingAudience);
+                validAudience = AudiencesMatchSingle(internalAudiences, validationParameters.ValidAudience, validationParameters.IgnoreTrailingSlashWhenValidatingAudience);
 
             if (validAudience == null && validationParameters.ValidAudiences != null)
-                validAudience = AudiencesMatchList(audiences, validationParameters.ValidAudiences, validationParameters.IgnoreTrailingSlashWhenValidatingAudience);
+                validAudience = AudiencesMatchList(internalAudiences, validationParameters.ValidAudiences, validationParameters.IgnoreTrailingSlashWhenValidatingAudience);
 
             return validAudience;
         }
 
-        private static string? AudiencesMatchSingle(IEnumerable<string> audiences, string validAudience, bool ignoreTrailingSlashWhenValidatingAudience)
+        private static string? AudiencesMatchSingle(List<string> audiences, string validAudience, bool ignoreTrailingSlashWhenValidatingAudience)
         {
             foreach (string tokenAudience in audiences)
             {
@@ -217,7 +220,7 @@ namespace Microsoft.IdentityModel.Tokens
             return null;
         }
 
-        private static string? AudiencesMatchList(IEnumerable<string> audiences, IEnumerable<string> validAudiences, bool ignoreTrailingSlashWhenValidatingAudience)
+        private static string? AudiencesMatchList(List<string> audiences, IEnumerable<string> validAudiences, bool ignoreTrailingSlashWhenValidatingAudience)
         {
             foreach (string tokenAudience in audiences)
             {

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Audience.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Audience.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.Logging;
 
+#nullable enable
 namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
@@ -23,7 +24,7 @@ namespace Microsoft.IdentityModel.Tokens
     /// <remarks>This delegate is not expected to throw.</remarks>
     internal delegate AudienceValidationResult ValidateAudience(
         IEnumerable<string> audiences,
-        SecurityToken securityToken,
+        SecurityToken? securityToken,
         TokenValidationParameters validationParameters,
         CallContext callContext);
 
@@ -107,7 +108,6 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
 
-#nullable enable
         /// <summary>
         /// Determines if the audiences found in a <see cref="SecurityToken"/> are valid.
         /// </summary>
@@ -121,7 +121,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <exception cref="SecurityTokenInvalidAudienceException">If none of the 'audiences' matched either <see cref="TokenValidationParameters.ValidAudience"/> or one of <see cref="TokenValidationParameters.ValidAudiences"/>.</exception>
         /// <remarks>An EXACT match is required.</remarks>
 #pragma warning disable CA1801 // TODO: remove pragma disable once callContext is used for logging
-        internal static AudienceValidationResult ValidateAudience(IEnumerable<string> audiences, SecurityToken securityToken, TokenValidationParameters validationParameters, CallContext callContext)
+        internal static AudienceValidationResult ValidateAudience(IEnumerable<string> audiences, SecurityToken? securityToken, TokenValidationParameters validationParameters, CallContext callContext)
 #pragma warning restore CA1801
         {
             if (validationParameters == null)
@@ -140,18 +140,6 @@ namespace Microsoft.IdentityModel.Tokens
                 LogHelper.LogWarning(LogMessages.IDX10233);
                 return new AudienceValidationResult(Utility.SerializeAsSingleCommaDelimitedString(audiences));
             }
-
-            if (securityToken == null)
-                return new AudienceValidationResult(
-                    Utility.SerializeAsSingleCommaDelimitedString(audiences),
-                    ValidationFailureType.NullArgument,
-                    new ExceptionDetail(
-                        new MessageDetail(
-                            LogMessages.IDX10000,
-                            LogHelper.MarkAsNonPII(nameof(securityToken))),
-                        typeof(ArgumentNullException),
-                        new StackFrame(true),
-                        null));
 
             if (audiences == null)
                 return new AudienceValidationResult(
@@ -285,3 +273,4 @@ namespace Microsoft.IdentityModel.Tokens
 
     }
 }
+#nullable disable

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1639,7 +1639,7 @@ namespace System.IdentityModel.Tokens.Jwt
         /// <param name="audiences">The audiences found in the <see cref="JwtSecurityToken"/>.</param>
         /// <param name="jwtToken">The <see cref="JwtSecurityToken"/> being validated.</param>
         /// <param name="validationParameters"><see cref="TokenValidationParameters"/> required for validation.</param>
-        /// <remarks>See <see cref="Validators.ValidateAudience"/> for additional details.</remarks>
+        /// <remarks>See <see cref="Validators.ValidateAudience(IEnumerable{string}, SecurityToken, TokenValidationParameters)"/> for additional details.</remarks>
         protected virtual void ValidateAudience(IEnumerable<string> audiences, JwtSecurityToken jwtToken, TokenValidationParameters validationParameters)
         {
             Validators.ValidateAudience(audiences, jwtToken, validationParameters);

--- a/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
@@ -574,6 +574,9 @@ namespace Microsoft.IdentityModel.TestUtils
             if (issuerValidationResult1.Issuer != issuerValidationResult2.Issuer)
                 localContext.Diffs.Add($"IssuerValidationResult1.Issuer: {issuerValidationResult1.Issuer} != IssuerValidationResult2.Issuer: {issuerValidationResult2.Issuer}");
 
+            if (issuerValidationResult1.IsValid != issuerValidationResult2.IsValid)
+                localContext.Diffs.Add($"IssuerValidationResult1.IsValid: {issuerValidationResult1.IsValid} != IssuerValidationResult2.IsValid: {issuerValidationResult2.IsValid}");
+
             if (issuerValidationResult1.Source != issuerValidationResult2.Source)
                 localContext.Diffs.Add($"IssuerValidationResult1.Source: {issuerValidationResult1.Source} != IssuerValidationResult2.Source: {issuerValidationResult2.Source}");
 
@@ -600,6 +603,69 @@ namespace Microsoft.IdentityModel.TestUtils
                         issuerValidationResult2.Exception.StackTrace.Trim(),
                         $"({name1})issuerValidationResult1.Exception.StackTrace",
                         $"({name2})issuerValidationResult2.Exception.StackTrace",
+                        stackPrefix.Trim(),
+                        localContext);
+            }
+
+            return context.Merge(localContext);
+        }
+
+        public static bool AreAudienceValidationResultsEqual(object object1, object object2, CompareContext context)
+        {
+            var localContext = new CompareContext(context);
+            if (!ContinueCheckingEquality(object1, object2, context))
+                return context.Merge(localContext);
+
+            return AreAudienceValidationResultsEqual(
+                object1 as AudienceValidationResult,
+                object2 as AudienceValidationResult,
+                "AudienceValidationResult1",
+                "AudienceValidationResult2",
+                null,
+                context);
+        }
+
+        internal static bool AreAudienceValidationResultsEqual(
+            AudienceValidationResult audienceValidationResult1,
+            AudienceValidationResult audienceValidationResult2,
+            string name1,
+            string name2,
+            string stackPrefix,
+            CompareContext context)
+        {
+            var localContext = new CompareContext(context);
+            if (!ContinueCheckingEquality(audienceValidationResult1, audienceValidationResult2, localContext))
+                return context.Merge(localContext);
+
+            if (audienceValidationResult1.Audience != audienceValidationResult2.Audience)
+                localContext.Diffs.Add($"AudienceValidationResult1.Audience: '{audienceValidationResult1.Audience}' != AudienceValidationResult2.Audience: '{audienceValidationResult2.Audience}'");
+
+            if (audienceValidationResult1.IsValid != audienceValidationResult2.IsValid)
+                localContext.Diffs.Add($"AudienceValidationResult1.IsValid: {audienceValidationResult1.IsValid} != AudienceValidationResult2.IsValid: {audienceValidationResult2.IsValid}");
+
+            // true => both are not null.
+            if (ContinueCheckingEquality(audienceValidationResult1.Exception, audienceValidationResult2.Exception, localContext))
+            {
+                AreStringsEqual(
+                    audienceValidationResult1.Exception.Message,
+                    audienceValidationResult2.Exception.Message,
+                    $"({name1})audienceValidationResult1.Exception.Message",
+                    $"({name2})audienceValidationResult2.Exception.Message",
+                    localContext);
+
+                AreStringsEqual(
+                    audienceValidationResult1.Exception.Source,
+                    audienceValidationResult2.Exception.Source,
+                    $"({name1})audienceValidationResult1.Exception.Source",
+                    $"({name2})audienceValidationResult2.Exception.Source",
+                    localContext);
+
+                if (!string.IsNullOrEmpty(stackPrefix))
+                    AreStringPrefixesEqual(
+                        audienceValidationResult1.Exception.StackTrace.Trim(),
+                        audienceValidationResult2.Exception.StackTrace.Trim(),
+                        $"({name1})audienceValidationResult1.Exception.StackTrace",
+                        $"({name2})audienceValidationResult2.Exception.StackTrace",
                         stackPrefix.Trim(),
                         localContext);
             }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
@@ -1,0 +1,640 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens.Json.Tests;
+using Xunit;
+using System.Collections.Generic;
+
+namespace Microsoft.IdentityModel.Tokens.Validation.Tests
+{
+    public class AudienceValidationResultTests
+    {
+        [Theory, MemberData(nameof(ValidateAudienceParametersTestCases), DisableDiscoveryEnumeration = true)]
+        public void ValidateAudienceParameters(AudienceValidationTheoryData theoryData)
+        {
+            CompareContext context = TestUtilities.WriteHeader($"{this}.AudienceValidatorResultTests", theoryData);
+
+            AudienceValidationResult audienceValidationResult = Validators.ValidateAudience(
+                theoryData.Audiences,
+                theoryData.SecurityToken,
+                theoryData.ValidationParameters,
+                new CallContext());
+
+            if (audienceValidationResult.Exception == null)
+                theoryData.ExpectedException.ProcessNoException();
+            else
+                theoryData.ExpectedException.ProcessException(audienceValidationResult.Exception, context);
+
+            IdentityComparer.AreAudienceValidationResultsEqual(
+                audienceValidationResult,
+                theoryData.AudienceValidationResult,
+                context);
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<AudienceValidationTheoryData> ValidateAudienceParametersTestCases
+        {
+            get
+            {
+                return new TheoryData<AudienceValidationTheoryData>
+                {
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = new List<string> { "audience1" },
+                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        TestId = "ValidationParametersNull",
+                        ValidationParameters = null,
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            "audience1",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10000,
+                                    LogHelper.MarkAsNonPII("validationParameters")),
+                                typeof(ArgumentNullException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = new List<string> { "audience1" },
+                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        TestId = "SecurityTokenNull",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = "audience"},
+                        SecurityToken = null,
+                        AudienceValidationResult = new AudienceValidationResult(
+                            "audience1",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10000,
+                                    LogHelper.MarkAsNonPII("securityToken")),
+                                typeof(ArgumentNullException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = new List<string> { "" },
+                        ExpectedException =  ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "AudiencesEmptyString",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = "audience"},
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            "",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(""),
+                                    LogHelper.MarkAsNonPII("audience"),
+                                    LogHelper.MarkAsNonPII("null")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = new List<string> { "    " },
+                        ExpectedException =  ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "AudiencesWhiteSpace",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = "audience"},
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            "    ",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII("    "),
+                                    LogHelper.MarkAsNonPII("audience"),
+                                    LogHelper.MarkAsNonPII("null")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = null,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10207:"),
+                        TestId = "AudiencesNull",
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            "null",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10207,
+                                    null),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = new List<string>{ },
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10206:"),
+                        TestId = "AudiencesEmptyList",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = "audience"},
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            "empty",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10206,
+                                    null),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = new List<string>{ },
+                        TestId = "ValidateAudienceFalseAudiencesEmptyList",
+                        ValidationParameters = new TokenValidationParameters{ ValidateAudience = false },
+                        AudienceValidationResult = new AudienceValidationResult("empty")
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = null,
+                        TestId = "ValidateAudienceFalseAudiencesNull",
+                        ValidationParameters = new TokenValidationParameters{ ValidateAudience = false },
+                        AudienceValidationResult = new AudienceValidationResult("null")
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = new List<string> { "audience1" },
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208:"),
+                        TestId = "ValidAudienceEmptyString",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = "" },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            "audience1",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10208,
+                                    null),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = new List<string> { "audience1" },
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208:"),
+                        TestId = "ValidAudienceWhiteSpace",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = "    " },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            "audience1",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10208,
+                                    null),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = new List<string> { "audience1" },
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "ValidAudiencesEmptyString",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudiences = new List<string>{ "" } },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            "audience1",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII("audience1"),
+                                    LogHelper.MarkAsNonPII("null"),
+                                    LogHelper.MarkAsNonPII("")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = new List<string> { "audience1" },
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "ValidAudiencesWhiteSpace",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudiences = new List<string>{ "    " } },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            "audience1",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII("audience1"),
+                                    LogHelper.MarkAsNonPII("null"),
+                                    LogHelper.MarkAsNonPII("    ")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = new List<string> { "audience1" },
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208:"),
+                        TestId = "ValidateAudienceTrueValidAudienceAndValidAudiencesNull",
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            "audience1",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10208,
+                                    null),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    }
+                };
+            }
+        }
+
+        [Theory, MemberData(nameof(ValidateAudienceTheoryData))]
+        public void ValidateAudience(AudienceValidationTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.ValidateAudience", theoryData);
+            AudienceValidationResult audienceValidationResult = Validators.ValidateAudience(
+                theoryData.Audiences,
+                theoryData.SecurityToken,
+                theoryData.ValidationParameters,
+                new CallContext());
+
+            if (audienceValidationResult.Exception != null)
+                theoryData.ExpectedException.ProcessException(audienceValidationResult.Exception);
+            else
+                theoryData.ExpectedException.ProcessNoException(context);
+
+            IdentityComparer.AreAudienceValidationResultsEqual(
+                audienceValidationResult,
+                theoryData.AudienceValidationResult,
+                context);
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<AudienceValidationTheoryData> ValidateAudienceTheoryData
+        {
+            get
+            {
+                var audience1 = "http://audience1.com";
+                var audience2 = "http://audience2.com";
+                List<string> audiences1 = new List<string> { "", audience1 };
+                List<string> audiences1WithSlash = new List<string> { "", audience1 + "/" };
+                List<string> audiences1WithTwoSlashes = new List<string> { "", audience1 + "//" };
+                List<string> audiences2 = new List<string> { "", audience2 };
+                List<string> audiences2WithSlash = new List<string> { "", audience2 + "/" };
+
+                var commaAudience1 = ", " + audience1;
+                var commaAudience2 = ", " + audience2;
+                var audience1Slash = audience1 + "/";
+                var audience2Slash = audience2 + "/";
+                var commaAudience1Slash = commaAudience1 + "/";
+                var commaAudience2Slash = commaAudience2 + "/";
+
+                return new TheoryData<AudienceValidationTheoryData>
+                {
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1,
+                        TestId = "SameLengthMatched",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(audience1)
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "SameLengthNotMatched",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = audience2 },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            commaAudience1,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(commaAudience1),
+                                    LogHelper.MarkAsNonPII(audience2),
+                                    LogHelper.MarkAsNonPII("null")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1,
+                        TestId = "NoMatchTVPValidateFalse",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = audience2, ValidateAudience = false },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(commaAudience1)
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "AudiencesValidAudienceWithSlashNotMatched",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = audience2 + "/" },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            commaAudience1,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(commaAudience1),
+                                    LogHelper.MarkAsNonPII(audience2Slash),
+                                    LogHelper.MarkAsNonPII("null")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences2WithSlash,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "AudiencesWithSlashValidAudienceSameLengthNotMatched",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            commaAudience2Slash,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(commaAudience2Slash),
+                                    LogHelper.MarkAsNonPII(audience1),
+                                    LogHelper.MarkAsNonPII("null")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "ValidAudienceWithSlashTVPFalse",
+                        ValidationParameters = new TokenValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false, ValidAudience = audience1 + "/" },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            commaAudience1,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(commaAudience1),
+                                    LogHelper.MarkAsNonPII(audience1Slash),
+                                    LogHelper.MarkAsNonPII("null")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1,
+                        TestId = "ValidAudienceWithSlashTVPTrue",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 + "/" },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(audience1Slash)
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "ValidAudiencesWithSlashTVPFalse",
+                        ValidationParameters = new TokenValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false, ValidAudiences = audiences1WithSlash },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            commaAudience1,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(commaAudience1),
+                                    LogHelper.MarkAsNonPII("null"),
+                                    LogHelper.MarkAsNonPII(commaAudience1Slash)),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1,
+                        TestId = "ValidAudiencesWithSlashTVPTrue",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudiences = audiences1WithSlash },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(audience1Slash)
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "ValidAudienceWithExtraChar",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 + "A" },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            commaAudience1,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(commaAudience1),
+                                    LogHelper.MarkAsNonPII(audience1 + "A"),
+                                    LogHelper.MarkAsNonPII("null")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "ValidAudienceWithDoubleSlashTVPTrue",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 + "//" },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            commaAudience1,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(commaAudience1),
+                                    LogHelper.MarkAsNonPII(audience1 + "//"),
+                                    LogHelper.MarkAsNonPII("null")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "ValidAudiencesWithDoubleSlashTVPTrue",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudiences = audiences1WithTwoSlashes },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            commaAudience1,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(commaAudience1),
+                                    LogHelper.MarkAsNonPII("null"),
+                                    LogHelper.MarkAsNonPII(commaAudience1 + "//")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1WithSlash,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "TokenAudienceWithSlashTVPFalse",
+                        ValidationParameters = new TokenValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false, ValidAudience = audience1 },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            commaAudience1Slash,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(commaAudience1Slash),
+                                    LogHelper.MarkAsNonPII(audience1),
+                                    LogHelper.MarkAsNonPII("null")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1WithSlash,
+                        TestId = "TokenAudienceWithSlashTVPTrue",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(audience1)
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences2WithSlash,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "TokenAudienceWithSlashNotEqual",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            commaAudience2Slash,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(commaAudience2Slash),
+                                    LogHelper.MarkAsNonPII(audience1),
+                                    LogHelper.MarkAsNonPII("null")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1WithSlash,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "TokenAudiencesWithSlashTVPFalse",
+                        ValidationParameters = new TokenValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false, ValidAudience = audience1 },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            commaAudience1Slash,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(commaAudience1Slash),
+                                    LogHelper.MarkAsNonPII(audience1),
+                                    LogHelper.MarkAsNonPII("null")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1WithSlash,
+                        TestId = "TokenAudiencesWithSlashTVPTrue",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(audience1)
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1WithSlash,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "TokenAudiencesWithSlashValidAudiencesNotMatchedTVPTrue",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudiences = audiences2 },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            commaAudience1Slash,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(commaAudience1Slash),
+                                    LogHelper.MarkAsNonPII("null"),
+                                    LogHelper.MarkAsNonPII(commaAudience2)),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    },
+                    new AudienceValidationTheoryData
+                    {
+                        Audiences = audiences1WithTwoSlashes,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TestId = "TokenAudienceWithTwoSlashesTVPTrue",
+                        ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        AudienceValidationResult = new AudienceValidationResult(
+                            commaAudience1 + "//",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10214,
+                                    LogHelper.MarkAsNonPII(commaAudience1 + "//"),
+                                    LogHelper.MarkAsNonPII(audience1),
+                                    LogHelper.MarkAsNonPII("null")),
+                                typeof(SecurityTokenInvalidAudienceException),
+                                new StackFrame(true),
+                                null)),
+                    }
+                };
+            }
+        }
+
+        public class AudienceValidationTheoryData : TheoryDataBase
+        {
+            public List<string> Audiences { get; set; }
+
+            internal AudienceValidationResult AudienceValidationResult { get; set; }
+
+            public SecurityToken SecurityToken { get; set; }
+
+            public TokenValidationParameters ValidationParameters { get; set; } = new TokenValidationParameters();
+
+            internal ValidationFailureType ValidationFailureType { get; set; }
+        }
+
+
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
@@ -381,7 +381,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         Audiences = audiences1,
                         TestId = "ValidAudienceWithSlashTVPTrue",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 + "/" },
-                        AudienceValidationResult = new AudienceValidationResult(audience1Slash)
+                        AudienceValidationResult = new AudienceValidationResult(audience1)
                     },
                     new AudienceValidationTheoryData
                     {
@@ -407,7 +407,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         Audiences = audiences1,
                         TestId = "ValidAudiencesWithSlashTVPTrue",
                         ValidationParameters = new TokenValidationParameters{ ValidAudiences = audiences1WithSlash },
-                        AudienceValidationResult = new AudienceValidationResult(audience1Slash)
+                        AudienceValidationResult = new AudienceValidationResult(audience1)
                     },
                     new AudienceValidationTheoryData
                     {
@@ -490,7 +490,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         Audiences = audiences1WithSlash,
                         TestId = "TokenAudienceWithSlashTVPTrue",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
-                        AudienceValidationResult = new AudienceValidationResult(audience1)
+                        AudienceValidationResult = new AudienceValidationResult(audience1Slash)
                     },
                     new AudienceValidationTheoryData
                     {
@@ -535,7 +535,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         Audiences = audiences1WithSlash,
                         TestId = "TokenAudiencesWithSlashTVPTrue",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
-                        AudienceValidationResult = new AudienceValidationResult(audience1)
+                        AudienceValidationResult = new AudienceValidationResult(audience1Slash)
                     },
                     new AudienceValidationTheoryData
                     {

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
@@ -50,7 +50,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
                         TestId = "ValidationParametersNull",
                         ValidationParameters = null,
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             "audience1",
                             ValidationFailureType.NullArgument,
@@ -64,29 +63,10 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData
                     {
-                        Audiences = new List<string> { "audience1" },
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
-                        TestId = "SecurityTokenNull",
-                        ValidationParameters = new TokenValidationParameters{ ValidAudience = "audience"},
-                        SecurityToken = null,
-                        AudienceValidationResult = new AudienceValidationResult(
-                            "audience1",
-                            ValidationFailureType.NullArgument,
-                            new ExceptionDetail(
-                                new MessageDetail(
-                                    LogMessages.IDX10000,
-                                    LogHelper.MarkAsNonPII("securityToken")),
-                                typeof(ArgumentNullException),
-                                new StackFrame(true),
-                                null)),
-                    },
-                    new AudienceValidationTheoryData
-                    {
                         Audiences = new List<string> { "" },
                         ExpectedException =  ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "AudiencesEmptyString",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = "audience"},
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             "",
                             ValidationFailureType.NullArgument,
@@ -106,7 +86,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException =  ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "AudiencesWhiteSpace",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = "audience"},
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             "    ",
                             ValidationFailureType.NullArgument,
@@ -125,7 +104,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         Audiences = null,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10207:"),
                         TestId = "AudiencesNull",
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             "null",
                             ValidationFailureType.NullArgument,
@@ -143,7 +121,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10206:"),
                         TestId = "AudiencesEmptyList",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = "audience"},
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             "empty",
                             ValidationFailureType.NullArgument,
@@ -175,7 +152,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208:"),
                         TestId = "ValidAudienceEmptyString",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = "" },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             "audience1",
                             ValidationFailureType.NullArgument,
@@ -193,7 +169,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208:"),
                         TestId = "ValidAudienceWhiteSpace",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = "    " },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             "audience1",
                             ValidationFailureType.NullArgument,
@@ -211,7 +186,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "ValidAudiencesEmptyString",
                         ValidationParameters = new TokenValidationParameters{ ValidAudiences = new List<string>{ "" } },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             "audience1",
                             ValidationFailureType.NullArgument,
@@ -231,7 +205,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "ValidAudiencesWhiteSpace",
                         ValidationParameters = new TokenValidationParameters{ ValidAudiences = new List<string>{ "    " } },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             "audience1",
                             ValidationFailureType.NullArgument,
@@ -250,7 +223,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         Audiences = new List<string> { "audience1" },
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208:"),
                         TestId = "ValidateAudienceTrueValidAudienceAndValidAudiencesNull",
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             "audience1",
                             ValidationFailureType.NullArgument,
@@ -372,7 +344,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "AudiencesWithSlashValidAudienceSameLengthNotMatched",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             commaAudience2Slash,
                             ValidationFailureType.NullArgument,
@@ -392,7 +363,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "ValidAudienceWithSlashTVPFalse",
                         ValidationParameters = new TokenValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false, ValidAudience = audience1 + "/" },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             commaAudience1,
                             ValidationFailureType.NullArgument,
@@ -411,7 +381,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         Audiences = audiences1,
                         TestId = "ValidAudienceWithSlashTVPTrue",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 + "/" },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(audience1Slash)
                     },
                     new AudienceValidationTheoryData
@@ -420,7 +389,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "ValidAudiencesWithSlashTVPFalse",
                         ValidationParameters = new TokenValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false, ValidAudiences = audiences1WithSlash },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             commaAudience1,
                             ValidationFailureType.NullArgument,
@@ -439,7 +407,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         Audiences = audiences1,
                         TestId = "ValidAudiencesWithSlashTVPTrue",
                         ValidationParameters = new TokenValidationParameters{ ValidAudiences = audiences1WithSlash },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(audience1Slash)
                     },
                     new AudienceValidationTheoryData
@@ -448,7 +415,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "ValidAudienceWithExtraChar",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 + "A" },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             commaAudience1,
                             ValidationFailureType.NullArgument,
@@ -468,7 +434,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "ValidAudienceWithDoubleSlashTVPTrue",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 + "//" },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             commaAudience1,
                             ValidationFailureType.NullArgument,
@@ -488,7 +453,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "ValidAudiencesWithDoubleSlashTVPTrue",
                         ValidationParameters = new TokenValidationParameters{ ValidAudiences = audiences1WithTwoSlashes },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             commaAudience1,
                             ValidationFailureType.NullArgument,
@@ -508,7 +472,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "TokenAudienceWithSlashTVPFalse",
                         ValidationParameters = new TokenValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false, ValidAudience = audience1 },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             commaAudience1Slash,
                             ValidationFailureType.NullArgument,
@@ -527,7 +490,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         Audiences = audiences1WithSlash,
                         TestId = "TokenAudienceWithSlashTVPTrue",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(audience1)
                     },
                     new AudienceValidationTheoryData
@@ -536,7 +498,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "TokenAudienceWithSlashNotEqual",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             commaAudience2Slash,
                             ValidationFailureType.NullArgument,
@@ -556,7 +517,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "TokenAudiencesWithSlashTVPFalse",
                         ValidationParameters = new TokenValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false, ValidAudience = audience1 },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             commaAudience1Slash,
                             ValidationFailureType.NullArgument,
@@ -575,7 +535,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         Audiences = audiences1WithSlash,
                         TestId = "TokenAudiencesWithSlashTVPTrue",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(audience1)
                     },
                     new AudienceValidationTheoryData
@@ -584,7 +543,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "TokenAudiencesWithSlashValidAudiencesNotMatchedTVPTrue",
                         ValidationParameters = new TokenValidationParameters{ ValidAudiences = audiences2 },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             commaAudience1Slash,
                             ValidationFailureType.NullArgument,
@@ -604,7 +562,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TestId = "TokenAudienceWithTwoSlashesTVPTrue",
                         ValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         AudienceValidationResult = new AudienceValidationResult(
                             commaAudience1 + "//",
                             ValidationFailureType.NullArgument,

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/IssuerValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/IssuerValidationResultTests.cs
@@ -32,6 +32,8 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
 
                 if (issuerValidationResult.Exception != null)
                     theoryData.ExpectedException.ProcessException(issuerValidationResult.Exception, context);
+                else
+                    theoryData.ExpectedException.ProcessNoException();
 
                 IdentityComparer.AreIssuerValidationResultsEqual(
                     issuerValidationResult,


### PR DESCRIPTION
# Audience validation: Remove exceptions
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Removed exceptions thrown as part of audience validation.

## Description
- Implemented new (internal momentarily) method for audience validation which replaces exception throwing with a return of the new AudienceValidationResult containing the exception information.
- Added new delegate signature for audience validation
- Added tests around all the previous cases.
- Updated ambiguous references in documentation to specify the old version of ValidateAudience.
