### PR TITLE
Fix flaky test

### DIFF
--- a/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
@@ -765,10 +765,10 @@ namespace Microsoft.IdentityModel.TestUtils
             if (!ContinueCheckingEquality(lifetimeValidationResult1, lifetimeValidationResult2, localContext))
                 return context.Merge(localContext);
 
-            if (lifetimeValidationResult1.NotBefore != lifetimeValidationResult2.NotBefore)
+            if (AreDatesEqualWithEpsilon(lifetimeValidationResult1.NotBefore, lifetimeValidationResult2.NotBefore, 1))
                 localContext.Diffs.Add($"LifetimeValidationResult1.NotBefore: '{lifetimeValidationResult1.NotBefore}' != LifetimeValidationResult2.NotBefore: '{lifetimeValidationResult2.NotBefore}'");
 
-            if (lifetimeValidationResult1.Expires != lifetimeValidationResult2.Expires)
+            if (AreDatesEqualWithEpsilon(lifetimeValidationResult1.Expires, lifetimeValidationResult2.Expires, 1))
                 localContext.Diffs.Add($"LifetimeValidationResult1.Expires: '{lifetimeValidationResult1.Expires}' != LifetimeValidationResult2.Expires: '{lifetimeValidationResult2.Expires}'");
 
             if (lifetimeValidationResult1.IsValid != lifetimeValidationResult2.IsValid)
@@ -1669,5 +1669,14 @@ namespace Microsoft.IdentityModel.TestUtils
             else
                 return string.Format(CultureInfo.InvariantCulture, "{0}", (str ?? "null"));
         }
+
+        public static bool AreDatesEqualWithEpsilon(DateTime? dateTime1, DateTime? dateTime2, int epsilon)
+        {
+            if (dateTime1 is DateTime date1 && dateTime2 is DateTime date2)
+                return Math.Abs((date1 - date2).TotalSeconds) <= epsilon;
+
+            return dateTime1 == dateTime2;
+        }
+
     }
 }

--- a/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
@@ -765,10 +765,10 @@ namespace Microsoft.IdentityModel.TestUtils
             if (!ContinueCheckingEquality(lifetimeValidationResult1, lifetimeValidationResult2, localContext))
                 return context.Merge(localContext);
 
-            if (AreDatesEqualWithEpsilon(lifetimeValidationResult1.NotBefore, lifetimeValidationResult2.NotBefore, 1))
+            if (!AreDatesEqualWithEpsilon(lifetimeValidationResult1.NotBefore, lifetimeValidationResult2.NotBefore, 1))
                 localContext.Diffs.Add($"LifetimeValidationResult1.NotBefore: '{lifetimeValidationResult1.NotBefore}' != LifetimeValidationResult2.NotBefore: '{lifetimeValidationResult2.NotBefore}'");
 
-            if (AreDatesEqualWithEpsilon(lifetimeValidationResult1.Expires, lifetimeValidationResult2.Expires, 1))
+            if (!AreDatesEqualWithEpsilon(lifetimeValidationResult1.Expires, lifetimeValidationResult2.Expires, 1))
                 localContext.Diffs.Add($"LifetimeValidationResult1.Expires: '{lifetimeValidationResult1.Expires}' != LifetimeValidationResult2.Expires: '{lifetimeValidationResult2.Expires}'");
 
             if (lifetimeValidationResult1.IsValid != lifetimeValidationResult2.IsValid)


### PR DESCRIPTION
# Fix flaky test
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Modified date comparison method in unit tests to fix flaky test.

## Description
Added method to IdentityComparer to compare two dates against an epsilon value to avoid flakiness.

Fixes #2683 