### PR TITLE
Token Type validation: Remove exceptions

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -73,6 +73,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10256 = "IDX10256: Unable to validate the token type. TokenValidationParameters.ValidTypes is set, but the 'typ' header claim is null or empty.";
         public const string IDX10257 = "IDX10257: Token type validation failed. Type: '{0}'. Did not match: validationParameters.TokenTypes: '{1}'.";
         public const string IDX10258 = "IDX10258: Token type validated. Type: '{0}'.";
+        public const string IDX10259 = "IDX10259: Unable to validate the token type, delegate threw an exception";
         // public const string IDX10260 = "IDX10260:";
         public const string IDX10261 = "IDX10261: Unable to retrieve configuration from authority: '{0}'. \nProceeding with token validation in case the relevant properties have been set manually on the TokenValidationParameters. Exception caught: \n {1}. See https://aka.ms/validate-using-configuration-manager for additional information.";
         public const string IDX10262 = "IDX10262: One of the issuers in TokenValidationParameters.ValidIssuers was null or an empty string. See https://aka.ms/wilson/tokenvalidation for details.";

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -73,7 +73,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10256 = "IDX10256: Unable to validate the token type. TokenValidationParameters.ValidTypes is set, but the 'typ' header claim is null or empty.";
         public const string IDX10257 = "IDX10257: Token type validation failed. Type: '{0}'. Did not match: validationParameters.TokenTypes: '{1}'.";
         public const string IDX10258 = "IDX10258: Token type validated. Type: '{0}'.";
-        public const string IDX10259 = "IDX10259: Unable to validate the token type, delegate threw an exception";
+        public const string IDX10259 = "IDX10259: Unable to validate the token type, delegate threw an exception.";
         // public const string IDX10260 = "IDX10260:";
         public const string IDX10261 = "IDX10261: Unable to retrieve configuration from authority: '{0}'. \nProceeding with token validation in case the relevant properties have been set manually on the TokenValidationParameters. Exception caught: \n {1}. See https://aka.ms/validate-using-configuration-manager for additional information.";
         public const string IDX10262 = "IDX10262: One of the issuers in TokenValidationParameters.ValidIssuers was null or an empty string. See https://aka.ms/wilson/tokenvalidation for details.";

--- a/src/Microsoft.IdentityModel.Tokens/Validation/TokenTypeValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/TokenTypeValidationResult.cs
@@ -13,14 +13,23 @@ namespace Microsoft.IdentityModel.Tokens
     {
         private Exception? _exception;
 
+        /// <summary>
+        /// Creates an instance of <see cref="TokenTypeValidationResult"/>.
+        /// </summary>
+        /// <paramref name="type"/> is the type against which the token was validated.
         public TokenTypeValidationResult(string? type)
             : base(ValidationFailureType.ValidationSucceeded)
         {
             Type = type;
             IsValid = true;
-
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="TokenTypeValidationResult"/>
+        /// </summary>
+        /// <paramref name="type"/> is the type against which the token was validated.
+        /// <paramref name="validationFailure"/> is the <see cref="ValidationFailureType"/> that occurred during validation.
+        /// <paramref name="exceptionDetail"/> is the <see cref="ExceptionDetail"/> that occurred during validation.
         public TokenTypeValidationResult(string? type, ValidationFailureType validationFailure, ExceptionDetail exceptionDetail)
             : base(validationFailure, exceptionDetail)
         {

--- a/src/Microsoft.IdentityModel.Tokens/Validation/TokenTypeValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/TokenTypeValidationResult.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+#nullable enable
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Contains the result of validating the TokenType of a <see cref="SecurityToken"/>.
+    /// The <see cref="TokenValidationResult"/> contains a collection of <see cref="ValidationResult"/> for each step in the token validation.
+    /// </summary>
+    internal class TokenTypeValidationResult : ValidationResult
+    {
+        private Exception? _exception;
+
+        public TokenTypeValidationResult(string? type)
+            : base(ValidationFailureType.ValidationSucceeded)
+        {
+            Type = type;
+            IsValid = true;
+
+        }
+
+        public TokenTypeValidationResult(string? type, ValidationFailureType validationFailure, ExceptionDetail exceptionDetail)
+            : base(validationFailure, exceptionDetail)
+        {
+            Type = type;
+            IsValid = false;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Exception"/> that occurred during validation.
+        /// </summary>
+        public override Exception? Exception
+        {
+            get
+            {
+                if (_exception != null || ExceptionDetail == null)
+                    return _exception;
+
+                HasValidOrExceptionWasRead = true;
+                _exception = ExceptionDetail.GetException();
+                if (_exception is SecurityTokenInvalidTypeException securityTokenInvalidTypeException)
+                {
+                    securityTokenInvalidTypeException.InvalidType = Type;
+                    securityTokenInvalidTypeException.Source = "Microsoft.IdentityModel.Tokens";
+                }
+
+                return _exception;
+            }
+        }
+
+        /// <summary>
+        /// Gets the security token type.
+        /// </summary>
+        public string? Type { get; }
+
+    }
+}
+#nullable restore

--- a/src/Microsoft.IdentityModel.Tokens/Validation/TokenTypeValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/TokenTypeValidationResult.cs
@@ -12,6 +12,7 @@ namespace Microsoft.IdentityModel.Tokens
     internal class TokenTypeValidationResult : ValidationResult
     {
         private Exception? _exception;
+        private const string TokenSource = "Microsoft.IdentityModel.Tokens";
 
         /// <summary>
         /// Creates an instance of <see cref="TokenTypeValidationResult"/>.
@@ -52,7 +53,7 @@ namespace Microsoft.IdentityModel.Tokens
                 if (_exception is SecurityTokenInvalidTypeException securityTokenInvalidTypeException)
                 {
                     securityTokenInvalidTypeException.InvalidType = Type;
-                    securityTokenInvalidTypeException.Source = "Microsoft.IdentityModel.Tokens";
+                    securityTokenInvalidTypeException.Source = TokenSource;
                 }
 
                 return _exception;

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
@@ -40,6 +40,12 @@ namespace Microsoft.IdentityModel.Tokens
         private class AudienceValidationFailure : ValidationFailureType { internal AudienceValidationFailure(string name) : base(name) { } }
 
         /// <summary>
+        /// Defines a type that represents that token type validation failed.
+        /// </summary>
+        public static readonly ValidationFailureType TokenTypeValidationFailed = new TokenTypeValidationFailure("TokenTypeValidationFailure");
+        private class TokenTypeValidationFailure : ValidationFailureType { internal TokenTypeValidationFailure(string name) : base(name) { } }
+
+        /// <summary>
         /// Defines a type that represents that signing key validation failed.
         /// </summary>
         public static readonly ValidationFailureType SigningKeyValidationFailed = new SigningKeyValidationFailure("SigningKeyValidationFailed");

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
@@ -42,7 +42,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Defines a type that represents that token type validation failed.
         /// </summary>
-        public static readonly ValidationFailureType TokenTypeValidationFailed = new TokenTypeValidationFailure("TokenTypeValidationFailure");
+        public static readonly ValidationFailureType TokenTypeValidationFailed = new TokenTypeValidationFailure("TokenTypeValidationFailed");
         private class TokenTypeValidationFailure : ValidationFailureType { internal TokenTypeValidationFailure(string name) : base(name) { } }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Defines a type that represents that lifetime validation failed.
         /// </summary>
-        public static readonly ValidationFailureType LifetimeValidationFailed = new LifetimeValidationFailure("LifetimeValidationFailure");
+        public static readonly ValidationFailureType LifetimeValidationFailed = new LifetimeValidationFailure("LifetimeValidationFailed");
         private class LifetimeValidationFailure : ValidationFailureType { internal LifetimeValidationFailure(string name) : base(name) { } }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
@@ -90,6 +90,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
 
             if (validationParameters == null)
+            {
                 return new TokenTypeValidationResult(
                     type,
                     ValidationFailureType.NullArgument,
@@ -99,6 +100,7 @@ namespace Microsoft.IdentityModel.Tokens
                             LogHelper.MarkAsNonPII(nameof(validationParameters))),
                         typeof(ArgumentNullException),
                         new StackFrame(true)));
+            }
 
             if (validationParameters.TypeValidator == null && (validationParameters.ValidTypes == null || !validationParameters.ValidTypes.Any()))
             {
@@ -141,7 +143,9 @@ namespace Microsoft.IdentityModel.Tokens
             }
 
             if (LogHelper.IsEnabled(EventLogLevel.Informational))
+            {
                 LogHelper.LogInformation(LogMessages.IDX10258, LogHelper.MarkAsNonPII(type));
+            }
 
             return new TokenTypeValidationResult(type);
         }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.Logging;
 
+#nullable enable
 namespace Microsoft.IdentityModel.Tokens
 {
     public static partial class Validators
@@ -57,5 +59,103 @@ namespace Microsoft.IdentityModel.Tokens
 
             return type;
         }
+
+#pragma warning disable CA1801 // TODO: remove pragma disable once callContext is used for logging
+        internal static TokenTypeValidationResult ValidateTokenType(string? type, SecurityToken? securityToken, TokenValidationParameters validationParameters, CallContext callContext)
+#pragma warning restore CA1801 // TODO: remove pragma disable once callContext is used for logging
+        {
+            if (securityToken == null)
+            {
+                return new TokenTypeValidationResult(
+                    type,
+                    ValidationFailureType.NullArgument,
+                    new ExceptionDetail(
+                        new MessageDetail(
+                            LogMessages.IDX10000,
+                            LogHelper.MarkAsNonPII(nameof(securityToken))),
+                        typeof(ArgumentNullException),
+                        new StackFrame(true)));
+            }
+
+            if (validationParameters == null)
+                return new TokenTypeValidationResult(
+                    type,
+                    ValidationFailureType.NullArgument,
+                    new ExceptionDetail(
+                        new MessageDetail(
+                            LogMessages.IDX10000,
+                            LogHelper.MarkAsNonPII(nameof(validationParameters))),
+                        typeof(ArgumentNullException),
+                        new StackFrame(true)));
+
+            if (validationParameters.TypeValidator == null && (validationParameters.ValidTypes == null || !validationParameters.ValidTypes.Any()))
+            {
+                LogHelper.LogVerbose(LogMessages.IDX10255);
+                return new TokenTypeValidationResult(type);
+            }
+
+            if (validationParameters.TypeValidator != null)
+            {
+                return ValidateTokenTypeUsingDelegate(type, securityToken, validationParameters);
+            }
+
+            if (string.IsNullOrEmpty(type))
+            {
+                return new TokenTypeValidationResult(
+                    type,
+                    ValidationFailureType.NullArgument,
+                    new ExceptionDetail(
+                        new MessageDetail(
+                            LogMessages.IDX10256,
+                            LogHelper.MarkAsNonPII(nameof(type))),
+                        typeof(ArgumentNullException),
+                        new StackFrame(true)));
+            }
+
+            if (!validationParameters.ValidTypes.Contains(type, StringComparer.Ordinal))
+            {
+                return new TokenTypeValidationResult(
+                     type,
+                     ValidationFailureType.TokenTypeValidationFailed,
+                     new ExceptionDetail(
+                         new MessageDetail(
+                             LogMessages.IDX10257,
+                             LogHelper.MarkAsNonPII(nameof(type)),
+                             LogHelper.MarkAsNonPII(Utility.SerializeAsSingleCommaDelimitedString(validationParameters.ValidTypes))),
+                         typeof(SecurityTokenInvalidTypeException),
+                         new StackFrame(true)));
+            }
+
+            if (LogHelper.IsEnabled(EventLogLevel.Informational))
+                LogHelper.LogInformation(LogMessages.IDX10258, LogHelper.MarkAsNonPII(type));
+
+            return new TokenTypeValidationResult(type);
+        }
+
+        private static TokenTypeValidationResult ValidateTokenTypeUsingDelegate(string? type, SecurityToken securityToken, TokenValidationParameters validationParameters)
+        {
+            try
+            {
+                var validatedType = validationParameters.TypeValidator(type, securityToken, validationParameters);
+                return new TokenTypeValidationResult(validatedType);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return new TokenTypeValidationResult(
+                    type,
+                    ValidationFailureType.TokenTypeValidationFailed,
+                    new ExceptionDetail(
+                        new MessageDetail(
+                            LogMessages.IDX10259,
+                            LogHelper.MarkAsNonPII(nameof(validationParameters.TypeValidator)),
+                            LogHelper.MarkAsNonPII(ex.Message)),
+                        ex.GetType(),
+                        new StackFrame(true),
+                        ex));
+            }
+        }
     }
 }
+#nullable restore

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
@@ -60,6 +60,18 @@ namespace Microsoft.IdentityModel.Tokens
             return type;
         }
 
+        /// <summary>
+        /// Validates the type of the token.
+        /// </summary>
+        /// <param name="type">The token type or <c>null</c> if it couldn't be resolved (e.g from the 'typ' header for a JWT).</param>
+        /// <param name="securityToken">The <see cref="SecurityToken"/> that is being validated.</param>
+        /// <param name="validationParameters"><see cref="TokenValidationParameters"/> required for validation.</param>
+        /// <param name="callContext"></param>
+        /// <exception cref="ArgumentNullException">If <paramref name="validationParameters"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="securityToken"/> is null.</exception>
+        /// <exception cref="SecurityTokenInvalidTypeException">If <paramref name="type"/> is null or whitespace and <see cref="TokenValidationParameters.ValidTypes"/> is not null.</exception>
+        /// <exception cref="SecurityTokenInvalidTypeException">If <paramref name="type"/> failed to match <see cref="TokenValidationParameters.ValidTypes"/>.</exception>
+        /// <remarks>An EXACT match is required. <see cref="StringComparison.Ordinal"/> (case sensitive) is used for comparing <paramref name="type"/> against <see cref="TokenValidationParameters.ValidTypes"/>.</remarks>
 #pragma warning disable CA1801 // TODO: remove pragma disable once callContext is used for logging
         internal static TokenTypeValidationResult ValidateTokenType(string? type, SecurityToken? securityToken, TokenValidationParameters validationParameters, CallContext callContext)
 #pragma warning restore CA1801 // TODO: remove pragma disable once callContext is used for logging
@@ -99,16 +111,18 @@ namespace Microsoft.IdentityModel.Tokens
                 return ValidateTokenTypeUsingDelegate(type, securityToken, validationParameters);
             }
 
+            // Note: don't return an invalid TokenTypeValidationResult for a null or empty token type when a user-defined delegate is set
+            // to allow it to extract the actual token type from a different location (e.g from the claims).
             if (string.IsNullOrEmpty(type))
             {
                 return new TokenTypeValidationResult(
                     type,
-                    ValidationFailureType.NullArgument,
+                    ValidationFailureType.TokenTypeValidationFailed,
                     new ExceptionDetail(
                         new MessageDetail(
                             LogMessages.IDX10256,
                             LogHelper.MarkAsNonPII(nameof(type))),
-                        typeof(ArgumentNullException),
+                        typeof(SecurityTokenInvalidTypeException),
                         new StackFrame(true)));
             }
 

--- a/test/Microsoft.IdentityModel.TestUtils/ExpectedException.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ExpectedException.cs
@@ -265,6 +265,11 @@ namespace Microsoft.IdentityModel.TestUtils
             return new ExpectedException(typeof(SecurityTokenInvalidSignatureException), substringExpected, innerTypeExpected);
         }
 
+        public static ExpectedException SecurityTokenInvalidTypeException(string substringExpected = null, Type innerTypeExpected = null)
+        {
+            return new ExpectedException(typeof(SecurityTokenInvalidTypeException), substringExpected, innerTypeExpected);
+        }
+
         public static ExpectedException SecurityTokenNoExpirationException(string substringExpected = null, Type innerTypeExpected = null)
         {
             return new ExpectedException(typeof(SecurityTokenNoExpirationException), substringExpected, innerTypeExpected);

--- a/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
@@ -873,6 +873,72 @@ namespace Microsoft.IdentityModel.TestUtils
             return context.Merge(localContext);
         }
 
+        public static bool AreTokenTypeValidationResultsEqual(object object1, object object2, CompareContext context)
+        {
+            var localContext = new CompareContext(context);
+            if (!ContinueCheckingEquality(object1, object2, context))
+                return context.Merge(localContext);
+
+            return AreTokenTypeValidationResultsEqual(
+                object1 as TokenTypeValidationResult,
+                object2 as TokenTypeValidationResult,
+                "TokenTypeValidationResult1",
+                "TokenTypeValidationResult2",
+                null,
+                context);
+        }
+
+        internal static bool AreTokenTypeValidationResultsEqual(
+            TokenTypeValidationResult tokenTypeValidationResult1,
+            TokenTypeValidationResult tokenTypeValidationResult2,
+            string name1,
+            string name2,
+            string stackPrefix,
+            CompareContext context)
+        {
+            var localContext = new CompareContext(context);
+            if (!ContinueCheckingEquality(tokenTypeValidationResult1, tokenTypeValidationResult2, localContext))
+                return context.Merge(localContext);
+
+            if (tokenTypeValidationResult1.Type != tokenTypeValidationResult2.Type)
+                localContext.Diffs.Add($"TokenTypeValidationResult1.Type: '{tokenTypeValidationResult1.Type}' != TokenTypeValidationResult2.ExpirationTime: '{tokenTypeValidationResult2.Type}'");
+
+            if (tokenTypeValidationResult1.IsValid != tokenTypeValidationResult2.IsValid)
+                localContext.Diffs.Add($"TokenTypeValidationResult1.IsValid: {tokenTypeValidationResult1.IsValid} != TokenTypeValidationResult2.IsValid: {tokenTypeValidationResult2.IsValid}");
+
+            if (tokenTypeValidationResult1.ValidationFailureType != tokenTypeValidationResult2.ValidationFailureType)
+                localContext.Diffs.Add($"TokenTypeValidationResult1.ValidationFailureType: {tokenTypeValidationResult1.ValidationFailureType} != TokenTypeValidationResult2.ValidationFailureType: {tokenTypeValidationResult2.ValidationFailureType}");
+
+            // true => both are not null.
+            if (ContinueCheckingEquality(tokenTypeValidationResult1.Exception, tokenTypeValidationResult2.Exception, localContext))
+            {
+                AreStringsEqual(
+                    tokenTypeValidationResult1.Exception.Message,
+                    tokenTypeValidationResult2.Exception.Message,
+                    $"({name1}).Exception.Message",
+                    $"({name2}).Exception.Message",
+                    localContext);
+
+                AreStringsEqual(
+                    tokenTypeValidationResult1.Exception.Source,
+                    tokenTypeValidationResult2.Exception.Source,
+                    $"({name1}).Exception.Source",
+                    $"({name2}).Exception.Source",
+                    localContext);
+
+                if (!string.IsNullOrEmpty(stackPrefix))
+                    AreStringPrefixesEqual(
+                        tokenTypeValidationResult1.Exception.StackTrace.Trim(),
+                        tokenTypeValidationResult2.Exception.StackTrace.Trim(),
+                        $"({name1}).Exception.StackTrace",
+                        $"({name2}).Exception.StackTrace",
+                        stackPrefix.Trim(),
+                        localContext);
+            }
+
+            return context.Merge(localContext);
+        }
+
         public static bool AreJArraysEqual(object object1, object object2, CompareContext context)
         {
             var localContext = new CompareContext(context);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/TokenTypeValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/TokenTypeValidationResultTests.cs
@@ -1,0 +1,216 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens.Json.Tests;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Logging;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Tokens.Validation.Tests
+{
+    public class TokenTypeValidationResultTests
+    {
+        [Theory, MemberData(nameof(TokenTypeValidationTestCases), DisableDiscoveryEnumeration = true)]
+        public void ValidateTokenType(TokenTypeTheoryData theoryData)
+        {
+            CompareContext context = TestUtilities.WriteHeader($"{this}.TokenTypeValidationResultTests", theoryData);
+
+            TokenTypeValidationResult tokenTypeValidationResult = Validators.ValidateTokenType(
+                theoryData.Type,
+                theoryData.SecurityToken,
+                theoryData.ValidationParameters,
+                new CallContext());
+
+            if (tokenTypeValidationResult.Exception != null)
+                theoryData.ExpectedException.ProcessException(tokenTypeValidationResult.Exception);
+            else
+                theoryData.ExpectedException.ProcessNoException();
+
+            IdentityComparer.AreTokenTypeValidationResultsEqual(
+                tokenTypeValidationResult,
+                theoryData.TokenTypeValidationResult,
+                context);
+
+            TestUtilities.AssertFailIfErrors(context);
+
+        }
+
+        public static TheoryData<TokenTypeTheoryData> TokenTypeValidationTestCases
+        {
+            get
+            {
+                String[] validTypesNoJwt = { "ID Token", "Refresh Token", "Access Token" };
+                String[] validTypesWithJwt = { "ID Token", "Refresh Token", "Access Token", "JWT" }; 
+
+                return new TheoryData<TokenTypeTheoryData>
+                {
+                    new TokenTypeTheoryData
+                    {
+                        TestId = "Valid_DefaultTokenTypeValidation",
+                        Type = "JWT",
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, "JWT"),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidTypes = validTypesWithJwt
+                        },
+                        TokenTypeValidationResult = new TokenTypeValidationResult("JWT")
+                    },
+                    new TokenTypeTheoryData
+                    {
+                        TestId = "Invalid_SecurityTokenIsNull",
+                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        Type = "JWT",
+                        SecurityToken = null,
+                        ValidationParameters = null,
+                        TokenTypeValidationResult = new TokenTypeValidationResult(
+                            "JWT",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10000,
+                                    LogHelper.MarkAsNonPII("securityToken")),
+                                typeof(ArgumentNullException),
+                                new StackFrame(true)))
+                    },
+                    new TokenTypeTheoryData
+                    {
+                        TestId = "Invalid_ValidationParametersAreNull",
+                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        Type = "JWT",
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, "JWT"),
+                        ValidationParameters = null,
+                        TokenTypeValidationResult = new TokenTypeValidationResult(
+                            "JWT",
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10000,
+                                    LogHelper.MarkAsNonPII("validationParameters")),
+                                typeof(ArgumentNullException),
+                                new StackFrame(true)))
+                    },
+                    new TokenTypeTheoryData
+                    {
+                        TestId = "Valid_ValidateTokenTypeUsingDelegate",
+                        Type = "JWT",
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, "JWT"),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            TypeValidator = (Type, SecurityToken, TokenValidationParameters) => "JWT"
+                        },
+                        TokenTypeValidationResult = new TokenTypeValidationResult("JWT")
+                    },
+                    new TokenTypeTheoryData
+                    {
+                        TestId = "Invalid_ValidateTokenTypeUsingDelegate",
+                        ExpectedException = ExpectedException.SecurityTokenInvalidTypeException(substringExpected: "IDX10259:", innerTypeExpected: typeof(SecurityTokenInvalidTypeException)),
+                        Type = "JWT",
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, "JWT"),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            TypeValidator = (Type, SecurityToken, TokenValidationParameters) => throw new SecurityTokenInvalidTypeException()
+                        },
+                        TokenTypeValidationResult = new TokenTypeValidationResult(
+                            "JWT",
+                            ValidationFailureType.TokenTypeValidationFailed,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10259,
+                                    LogHelper.MarkAsNonPII("TypeValidator"),
+                                    LogHelper.MarkAsNonPII("Delegate message")),
+                                typeof(SecurityTokenInvalidTypeException),
+                                new StackFrame(true),
+                                new SecurityTokenInvalidTypeException()))
+                    },
+                    new TokenTypeTheoryData
+                    {
+                        TestId = "Valid_TokenValidationParametersTypeValidatorAndValidTypesAreNull",
+                        Type = "JWT",
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, "JWT"),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            TypeValidator = null,
+                            ValidTypes = null
+                        },
+                        TokenTypeValidationResult = new TokenTypeValidationResult("JWT")
+                    },
+                    new TokenTypeTheoryData
+                    {
+                        TestId = "Invalid_TokenTypeIsEmpty",
+                        ExpectedException = ExpectedException.ArgumentNullException("IDX10256:"),
+                        Type = String.Empty,
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, String.Empty),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidTypes = validTypesNoJwt
+                        },
+                        TokenTypeValidationResult = new TokenTypeValidationResult(
+                            string.Empty,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10256,
+                                    LogHelper.MarkAsNonPII("type")),
+                                typeof(ArgumentNullException),
+                                new StackFrame(true)))
+                    },
+                    new TokenTypeTheoryData
+                    {
+                        TestId = "Invalid_TokenTypeIsNull",
+                        ExpectedException = ExpectedException.ArgumentNullException("IDX10256:"),
+                        Type = null,
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, null),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidTypes = validTypesNoJwt
+                        },
+                        TokenTypeValidationResult = new TokenTypeValidationResult(
+                            null,
+                            ValidationFailureType.NullArgument,
+                            new ExceptionDetail(
+                                new MessageDetail(
+                                    LogMessages.IDX10256,
+                                    LogHelper.MarkAsNonPII("type")),
+                                typeof(ArgumentNullException),
+                                new StackFrame(true)))
+                    },
+                    new TokenTypeTheoryData
+                    {
+                        TestId = "Invalid_TokenValidationParametersValidTypesDoesNotSupportType",
+                        ExpectedException = ExpectedException.SecurityTokenInvalidTypeException("IDX10257:"),
+                        Type = "JWT",
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, "JWT"),
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            ValidTypes = validTypesNoJwt
+                        },
+                        TokenTypeValidationResult = new TokenTypeValidationResult(
+                            "JWT",
+                            ValidationFailureType.TokenTypeValidationFailed,
+                            new ExceptionDetail(
+                                 new MessageDetail(
+                                     LogMessages.IDX10257,
+                                     LogHelper.MarkAsNonPII("type"),
+                                     LogHelper.MarkAsNonPII(Utility.SerializeAsSingleCommaDelimitedString(validTypesNoJwt))),
+                                 typeof(SecurityTokenInvalidTypeException),
+                                 new StackFrame(true)))
+                    }
+                };
+            }
+        }
+
+        public class TokenTypeTheoryData : TheoryDataBase
+        {
+            public string Type { get; set; }
+
+            public SecurityToken SecurityToken { get; set; }
+
+            public TokenValidationParameters ValidationParameters { get; set; }
+
+            internal TokenTypeValidationResult TokenTypeValidationResult { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/TokenTypeValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/TokenTypeValidationResultTests.cs
@@ -140,7 +140,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     new TokenTypeTheoryData
                     {
                         TestId = "Invalid_TokenTypeIsEmpty",
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10256:"),
+                        ExpectedException = ExpectedException.SecurityTokenInvalidTypeException("IDX10256:"),
                         Type = String.Empty,
                         SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, String.Empty),
                         ValidationParameters = new TokenValidationParameters
@@ -149,18 +149,18 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         },
                         TokenTypeValidationResult = new TokenTypeValidationResult(
                             string.Empty,
-                            ValidationFailureType.NullArgument,
+                            ValidationFailureType.TokenTypeValidationFailed,
                             new ExceptionDetail(
                                 new MessageDetail(
                                     LogMessages.IDX10256,
                                     LogHelper.MarkAsNonPII("type")),
-                                typeof(ArgumentNullException),
+                                typeof(SecurityTokenInvalidTypeException),
                                 new StackFrame(true)))
                     },
                     new TokenTypeTheoryData
                     {
                         TestId = "Invalid_TokenTypeIsNull",
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10256:"),
+                        ExpectedException = ExpectedException.SecurityTokenInvalidTypeException("IDX10256:"),
                         Type = null,
                         SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, null),
                         ValidationParameters = new TokenValidationParameters
@@ -169,12 +169,12 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         },
                         TokenTypeValidationResult = new TokenTypeValidationResult(
                             null,
-                            ValidationFailureType.NullArgument,
+                            ValidationFailureType.TokenTypeValidationFailed,
                             new ExceptionDetail(
                                 new MessageDetail(
                                     LogMessages.IDX10256,
                                     LogHelper.MarkAsNonPII("type")),
-                                typeof(ArgumentNullException),
+                                typeof(SecurityTokenInvalidTypeException),
                                 new StackFrame(true)))
                     },
                     new TokenTypeTheoryData


### PR DESCRIPTION
# Token Type validation:  Remove exceptions

## Description

- Implemented new (internal momentarily) method for token type validation which replaces exception throwing with a return of the new TokenTypeValidationResult containing the exception information.
- Added tests around all the previous cases.
