### PR TITLE
Serialize byte arrays as base64 strings in Json Tokens

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
@@ -1129,6 +1129,10 @@ namespace Microsoft.IdentityModel.Tokens.Json
 
                 writer.WriteEndObject();
             }
+            else if ((typeof(byte[])).IsAssignableFrom(objType))
+            {
+                writer.WriteBase64String(key, (byte[])obj);
+            }
             else if (typeof(IList).IsAssignableFrom(objType))
             {
                 IList list = (IList)obj;

--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
@@ -1118,6 +1118,8 @@ namespace Microsoft.IdentityModel.Tokens.Json
                 writer.WriteBoolean(key, b);
             else if (obj is DateTime dt)
                 writer.WriteString(key, dt.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture));
+            else if (obj is byte[] byteArray)
+                writer.WriteBase64String(key, byteArray);
             else if (typeof(IDictionary).IsAssignableFrom(objType))
             {
                 IDictionary dictionary = (IDictionary)obj;
@@ -1128,10 +1130,6 @@ namespace Microsoft.IdentityModel.Tokens.Json
                     WriteObject(ref writer, k.ToString(), dictionary[k]);
 
                 writer.WriteEndObject();
-            }
-            else if ((typeof(byte[])).IsAssignableFrom(objType))
-            {
-                writer.WriteBase64String(key, (byte[])obj);
             }
             else if (typeof(IList).IsAssignableFrom(objType))
             {

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
@@ -44,6 +44,33 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         };
 
         [Fact]
+        public void ByteArrayClaimsEncodedAsExpected()
+        {
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('a', 128)));
+            var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+            var value = new byte[] { 0x21, 0x62, 0x36, 0x34 };
+
+            SecurityTokenDescriptor tokenDescriptor = new SecurityTokenDescriptor
+            {
+                SigningCredentials = creds,
+                Claims = new Dictionary<string, object>
+                {
+                    ["byteArray"] = value
+                },
+            };
+
+            JsonWebTokenHandler handler = new();
+            string tokenString = handler.CreateToken(tokenDescriptor);
+            JsonWebToken jsonWebToken = new JsonWebToken(tokenString);
+            var claimSet = jsonWebToken.Claims;
+            var expectedValue = System.Text.Json.JsonSerializer.Serialize(value).Trim('"');
+
+            // Will throw if can't find.
+            var testClaim = claimSet.First(c => c.Type == "byteArray");
+            Assert.Equal(expectedValue, testClaim.Value);
+        }
+
+        [Fact]
         public void BoolClaimsEncodedAsExpected()
         {
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('a', 128)));

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
@@ -17,6 +17,28 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
     public class JwtSecurityTokenTests
     {
         [Fact]
+        public void ByteArrayClaimsEncodedAsExpected()
+        {
+            var value = new byte[] { 0x21, 0x62, 0x36, 0x34 };
+            var tokenPayload = new JwtPayload
+            {
+                ["byteArray"] = value,
+            };
+
+            var token = new JwtSecurityToken(new JwtHeader(), tokenPayload);
+
+            var handler = new JwtSecurityTokenHandler();
+
+            var tokenString = handler.WriteToken(token);
+            var parsedToken = new JwtSecurityToken(tokenString);
+            var expectedValue = System.Text.Json.JsonSerializer.Serialize(value).Trim('"');
+
+            // Will throw if can't find.
+            var testClaim = parsedToken.Claims.First(c => c.Type == "byteArray");
+            Assert.Equal(expectedValue, testClaim.Value);
+        }
+
+        [Fact]
         public void BoolClaimsEncodedAsExpected()
         {
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('a', 128)));


### PR DESCRIPTION
# Serialize byte arrays as base64 strings in Json Tokens

## Description

Serialize byte arrays as base64 strings in Json tokens. This was the behavior in 6.x releases.

Fixes #2524
