### PR TITLE
Improve bypassing token signature validation

### DIFF
--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1343,12 +1343,12 @@ namespace System.IdentityModel.Tokens.Jwt
             bool kidMatched = false;
             IEnumerable<SecurityKey> keys = null;
 
+            if (validationParameters.RequireSignedTokens)
+                return jwtToken;
+
             if (string.IsNullOrEmpty(jwtToken.RawSignature))
             {
-                if (validationParameters.RequireSignedTokens)
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10504, jwtToken)));
-                else
-                    return jwtToken;
+                throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10504, jwtToken)));
             }
 
             if (validationParameters.IssuerSigningKeyResolverUsingConfiguration != null)

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1343,7 +1343,7 @@ namespace System.IdentityModel.Tokens.Jwt
             bool kidMatched = false;
             IEnumerable<SecurityKey> keys = null;
 
-            if (validationParameters.RequireSignedTokens)
+            if (validationParameters.RequireSignedTokens == false)
                 return jwtToken;
 
             if (string.IsNullOrEmpty(jwtToken.RawSignature))


### PR DESCRIPTION
# Improve bypassing token signature validation

Signature key will be processed while bypassing token signature validation. This code change ensures that the whole validation of signature block is skipped when the bypass flag is set.

