### PR TITLE
Add meaningful error message when virtual is not overridden.

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Tokens/BaseConfigurationManager.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -88,7 +87,12 @@ namespace Microsoft.IdentityModel.Tokens
         /// as it is meant to be overridden by the class that extends it.</remarks>
         public virtual Task<BaseConfiguration> GetBaseConfigurationAsync(CancellationToken cancel)
         {
-            throw new NotImplementedException();
+            throw LogHelper.LogExceptionMessage(
+                new NotImplementedException(
+                    LogHelper.FormatInvariant(
+                        LogMessages.IDX10267,
+                        LogHelper.MarkAsNonPII("public virtual Task<BaseConfiguration> GetBaseConfigurationAsync(CancellationToken cancel)"),
+                        LogHelper.MarkAsNonPII(GetType().FullName))));
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -81,7 +81,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10264 = "IDX10264: Reading issuer signing keys from validation parameters and configuration.";
         public const string IDX10265 = "IDX10265: Reading issuer signing keys from configuration.";
         //public const string IDX10266 = "IDX10266: Unable to validate issuer. validationParameters.ValidIssuer is null or whitespace, validationParameters.ValidIssuers is null or empty and ConfigurationManager is null.";
-        public const string IDX10267 = "IDX10267: '{0}' has been called by a derived class: '{1}' which has not implemented this method. For this call graph to succeed, '{1}' will need to implement: '{0}'.";
+        public const string IDX10267 = "IDX10267: '{0}' has been called by a derived class '{1}' which has not implemented this method. For this call graph to succeed, '{1}' will need to implement '{0}'.";
 
 
         // 10500 - SignatureValidation

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -81,6 +81,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10264 = "IDX10264: Reading issuer signing keys from validation parameters and configuration.";
         public const string IDX10265 = "IDX10265: Reading issuer signing keys from configuration.";
         //public const string IDX10266 = "IDX10266: Unable to validate issuer. validationParameters.ValidIssuer is null or whitespace, validationParameters.ValidIssuers is null or empty and ConfigurationManager is null.";
+        public const string IDX10267 = "IDX10267: '{0}' has been called by a derived class: '{1}' which has not implemented this method. For this call graph to succeed, '{1}' will need to implement: '{0}'.";
 
 
         // 10500 - SignatureValidation

--- a/src/Microsoft.IdentityModel.Tokens/SignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SignatureProvider.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.IdentityModel.Logging;
 using System;
 using System.Threading;
+using Microsoft.IdentityModel.Logging;
 
 namespace Microsoft.IdentityModel.Tokens
 {
@@ -104,7 +104,13 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns>The signature bytes.</returns>
         public virtual byte[] Sign(byte[] input, int offset, int count)
         {
-            throw LogHelper.LogExceptionMessage(new NotImplementedException());
+            throw LogHelper.LogExceptionMessage(
+                new NotImplementedException(
+                    LogHelper.FormatInvariant(
+                        LogMessages.IDX10267,
+                        LogHelper.MarkAsNonPII("public virtual byte[] Sign(byte[] input, int offset, int count)"),
+                        LogHelper.MarkAsNonPII(GetType().FullName))));
+
         }
 
 #if NET6_0_OR_GREATER
@@ -117,7 +123,12 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns>returns <see langword="true"/> if creation of signature succeeded, <see langword="false"/> otherwise.</returns>
         public virtual bool Sign(ReadOnlySpan<byte> data, Span<byte> destination, out int bytesWritten)
         {
-            throw LogHelper.LogExceptionMessage(new NotImplementedException());
+            throw LogHelper.LogExceptionMessage(
+                new NotImplementedException(
+                    LogHelper.FormatInvariant(
+                        LogMessages.IDX10267,
+                        LogHelper.MarkAsNonPII("public virtual bool Sign(ReadOnlySpan<byte> data, Span<byte> destination, out int bytesWritten)"),
+                        LogHelper.MarkAsNonPII(GetType().FullName))));
         }
 #endif
         /// <summary>
@@ -149,7 +160,12 @@ namespace Microsoft.IdentityModel.Tokens
         /// <exception cref="ObjectDisposedException"><see cref="Dispose(bool)"/> has been called.</exception>
         public virtual bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength)
         {
-            throw LogHelper.LogExceptionMessage(new NotImplementedException());
+            throw LogHelper.LogExceptionMessage(
+                new NotImplementedException(
+                    LogHelper.FormatInvariant(
+                        LogMessages.IDX10267,
+                        LogHelper.MarkAsNonPII("public virtual bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength)"),
+                        LogHelper.MarkAsNonPII(GetType().FullName))));
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/TokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.IdentityModel.Logging;
 using System;
 using System.ComponentModel;
 using System.Security.Claims;
@@ -32,7 +31,7 @@ namespace Microsoft.IdentityModel.Tokens
         public virtual int MaximumTokenSizeInBytes
         {
             get => _maximumTokenSizeInBytes; 
-            set => _maximumTokenSizeInBytes =  (value < 1) ? throw LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), FormatInvariant(LogMessages.IDX10101, LogHelper.MarkAsNonPII(value)))) : value;
+            set => _maximumTokenSizeInBytes =  (value < 1) ? throw LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), FormatInvariant(LogMessages.IDX10101, MarkAsNonPII(value)))) : value;
         }
 
         /// <summary>
@@ -50,7 +49,7 @@ namespace Microsoft.IdentityModel.Tokens
         public int TokenLifetimeInMinutes
         {
             get => _defaultTokenLifetimeInMinutes;
-            set => _defaultTokenLifetimeInMinutes = (value < 1) ? throw LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), FormatInvariant(LogMessages.IDX10104, LogHelper.MarkAsNonPII(value)))) : value;
+            set => _defaultTokenLifetimeInMinutes = (value < 1) ? throw LogExceptionMessage(new ArgumentOutOfRangeException(nameof(value), FormatInvariant(LogMessages.IDX10104, MarkAsNonPII(value)))) : value;
         }
 
         #region methods
@@ -63,7 +62,15 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="token">The token to be validated.</param>
         /// <param name="validationParameters">A <see cref="TokenValidationParameters"/> required for validation.</param>
         /// <returns>A <see cref="TokenValidationResult"/></returns>
-        public virtual Task<TokenValidationResult> ValidateTokenAsync(string token, TokenValidationParameters validationParameters) => throw new NotImplementedException();
+        public virtual Task<TokenValidationResult> ValidateTokenAsync(string token, TokenValidationParameters validationParameters)
+        {
+            throw LogExceptionMessage(
+                new NotImplementedException(
+                    FormatInvariant(
+                        LogMessages.IDX10267,
+                        MarkAsNonPII("public virtual Task<TokenValidationResult> ValidateTokenAsync(string token, TokenValidationParameters validationParameters)"),
+                        MarkAsNonPII(GetType().FullName))));
+        }
 
         /// <summary>
         /// Validates a token.
@@ -73,7 +80,15 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="token">The <see cref="SecurityToken"/> to be validated.</param>
         /// <param name="validationParameters">A <see cref="TokenValidationParameters"/> required for validation.</param>
         /// <returns>A <see cref="TokenValidationResult"/></returns>
-        public virtual Task<TokenValidationResult> ValidateTokenAsync(SecurityToken token, TokenValidationParameters validationParameters) => throw new NotImplementedException();
+        public virtual Task<TokenValidationResult> ValidateTokenAsync(SecurityToken token, TokenValidationParameters validationParameters)
+        {
+            throw LogExceptionMessage(
+                new NotImplementedException(
+                    FormatInvariant(
+                        LogMessages.IDX10267,
+                        MarkAsNonPII("public virtual Task<TokenValidationResult> ValidateTokenAsync(SecurityToken token, TokenValidationParameters validationParameters)"),
+                        MarkAsNonPII(GetType().FullName))));
+        }
 
         /// <summary>
         /// Converts a string into an instance of <see cref="SecurityToken"/>.
@@ -82,7 +97,15 @@ namespace Microsoft.IdentityModel.Tokens
         /// <exception cref="ArgumentNullException"><paramref name="token"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">'token.Length' is greater than <see cref="TokenHandler.MaximumTokenSizeInBytes"/>.</exception>
         /// <returns>A <see cref="SecurityToken"/>.</returns>
-        public virtual SecurityToken ReadToken(string token) => throw new NotImplementedException();
+        public virtual SecurityToken ReadToken(string token)
+        {
+            throw LogExceptionMessage(
+                new NotImplementedException(
+                    FormatInvariant(
+                        LogMessages.IDX10267,
+                        MarkAsNonPII("public virtual SecurityToken ReadToken(string token)"),
+                        MarkAsNonPII(GetType().FullName))));
+        }
 
         /// <summary>
         /// Called by base class to create a <see cref="ClaimsIdentity"/>.
@@ -93,8 +116,15 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="issuer">the 'issuer' to use by default when creating a Claim.</param>
         /// <returns>A <see cref="ClaimsIdentity"/>.</returns>
         /// <exception cref="NotImplementedException"></exception>
-        internal virtual ClaimsIdentity CreateClaimsIdentityInternal(SecurityToken securityToken, TokenValidationParameters tokenValidationParameters, string issuer) => throw new NotImplementedException();
-
+        internal virtual ClaimsIdentity CreateClaimsIdentityInternal(SecurityToken securityToken, TokenValidationParameters tokenValidationParameters, string issuer)
+        {
+            throw LogExceptionMessage(
+                new NotImplementedException(
+                    FormatInvariant(
+                        LogMessages.IDX10267,
+                        MarkAsNonPII("internal virtual ClaimsIdentity CreateClaimsIdentityInternal(SecurityToken securityToken, TokenValidationParameters tokenValidationParameters, string issuer)"),
+                        MarkAsNonPII(GetType().FullName))));
+        }
         #endregion
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AbstractVirtualsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AbstractVirtualsTests.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.TestUtils;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Tokens.Tests
+{
+    /// <summary>
+    /// This class tests abstract virtual methods that were added to abstract classes as virtuals and throw NotImplementedException to ensure the exception message makes sense.
+    /// </summary>
+    public class AbstractVirtualsTests
+    {
+        #region BaseConfigurationManager
+        [Fact]
+        public void BaseConfigurationManager_GetBaseConfigurationAsync()
+        {
+            TestUtilities.WriteHeader($"{this}.BaseConfigurationManager_GetBaseConfigurationAsync");
+
+            try
+            {
+                new DerivedBaseConfigurationManager().GetBaseConfigurationAsync(default).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                Assert.Contains("IDX10267: 'public virtual Task<BaseConfiguration> GetBaseConfigurationAsync(CancellationToken cancel)'", ex.Message);
+            }
+        }
+        #endregion
+
+        #region SignatureProvider
+        [Fact]
+        public void SignatureProvider_Sign()
+        {
+            TestUtilities.WriteHeader($"{this}.SignatureProvider_Sign");
+
+            try
+            {
+                new DerivedSignatureProvider(KeyingMaterial.RsaSecurityKey1, "RS256").Sign(new byte[1], 0, 0);
+            }
+            catch (Exception ex)
+            {
+                Assert.Contains("IDX10267: 'public virtual byte[] Sign(byte[] input, int offset, int count)'", ex.Message);
+            }
+        }
+
+        #if NET6_0_OR_GREATER
+        [Fact]
+        public void SignatureProvider_Sign_Offset()
+        {
+            TestUtilities.WriteHeader($"{this}.SignatureProvider_Sign_Offset");
+
+            try
+            {
+                new DerivedSignatureProvider(KeyingMaterial.RsaSecurityKey1, "RS256").Sign((new byte[1]).AsSpan(), (new byte[1]).AsSpan(), out int bytesOut);
+            }
+            catch (Exception ex)
+            {
+                Assert.Contains("IDX10267: 'public virtual bool Sign(ReadOnlySpan<byte> data, Span<byte> destination, out int bytesWritten)'", ex.Message);
+            }
+        }
+        #endif
+
+        [Fact]
+        public void SignatureProvider_Verify_Offset()
+        {
+            TestUtilities.WriteHeader($"{this}.SignatureProvider_Verify_Offset");
+
+            try
+            {
+                new DerivedSignatureProvider(KeyingMaterial.RsaSecurityKey1, "RS256").Verify(new byte[1], 0, 0, new byte[1], 0, 0);
+            }
+            catch (Exception ex)
+            {
+                Assert.Contains("IDX10267: 'public virtual bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength)'", ex.Message);
+            }
+        }
+        #endregion
+
+        #region TokenHandler
+        [Fact]
+        public void TokenHandler_ReadToken()
+        {
+            TestUtilities.WriteHeader($"{this}.TokenHandler_ReadToken");
+
+            try
+            {
+                new DerivedTokenHandler().ReadToken("");
+            }
+            catch (Exception ex)
+            {
+                Assert.Contains("IDX10267: 'public virtual SecurityToken ReadToken(string token)'", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void TokenHandler_CreateClaimsIdentityInternal()
+        {
+            TestUtilities.WriteHeader($"{this}.TokenHandler_CreateClaimsIdentityInternal");
+
+            try
+            {
+                new DerivedTokenHandler().CreateClaimsIdentityInternal(new DerivedSecurityToken(), new TokenValidationParameters(), "");
+            }
+            catch (Exception ex)
+            {
+                Assert.Contains("IDX10267: 'internal virtual ClaimsIdentity CreateClaimsIdentityInternal(SecurityToken securityToken, TokenValidationParameters tokenValidationParameters, string issuer)'", ex.Message);
+            }
+        }
+        [Fact]
+        public async Task TokenHandler_ValidateTokenAsyncString()
+        {
+            TestUtilities.WriteHeader($"{this}.TokenHandler_ValidateTokenAsyncString");
+
+            try
+            {
+                await new DerivedTokenHandler().ValidateTokenAsync("token", new TokenValidationParameters()).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Assert.Contains("IDX10267: 'public virtual Task<TokenValidationResult> ValidateTokenAsync(string token, TokenValidationParameters validationParameters)'", ex.Message);
+            }
+        }
+
+        [Fact]
+        public async Task TokenHandler_ValidateTokenAsyncToken()
+        {
+            TestUtilities.WriteHeader($"{this}.TokenHandler_ValidateTokenAsyncToken");
+
+            try
+            {
+                await new DerivedTokenHandler().ValidateTokenAsync(new DerivedSecurityToken(), new TokenValidationParameters()).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Assert.Contains("IDX10267: 'public virtual Task<TokenValidationResult> ValidateTokenAsync(SecurityToken token, TokenValidationParameters validationParameters)'", ex.Message);
+            }
+        }
+        #endregion
+    }
+
+    public class DerivedBaseConfigurationManager : BaseConfigurationManager
+    {
+        public override void RequestRefresh() => throw new NotImplementedException();
+    }
+
+    public class DerivedSignatureProvider : SignatureProvider
+    {
+        public DerivedSignatureProvider(SecurityKey key, string algorithm) : base(key, algorithm)
+        {
+        }
+
+        protected override void Dispose(bool disposing) => throw new NotImplementedException();
+
+        public override byte[] Sign(byte[] input) => throw new NotImplementedException();
+
+        public override bool Verify(byte[] input, byte[] signature) => throw new NotImplementedException();
+    }
+
+    public class DerivedTokenHandler : TokenHandler
+    {
+    }
+}


### PR DESCRIPTION
## Description
When we added virtuals to abstract methods that threw in the base class, we then called those methods that were implemented in user derived classes. The user code would fault with a NotImplementedException.
These changes add a messages that the user can act on to fix the issue.

Fixes https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/1970