### PR TITLE
Call TVP.CreateClaimsIdentity to support users that have overloaded.

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -212,7 +212,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             _ = validationParameters ?? throw LogHelper.LogArgumentNullException(nameof(validationParameters));
 
-            ClaimsIdentity identity = ClaimsIdentityFactory.Create(jwtToken, validationParameters, issuer);
+            ClaimsIdentity identity = validationParameters.CreateClaimsIdentity(jwtToken, issuer);
             foreach (Claim jwtClaim in jwtToken.Claims)
             {
                 bool wasMapped = _inboundClaimTypeMap.TryGetValue(jwtClaim.Type, out string claimType);
@@ -281,7 +281,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             _ = validationParameters ?? throw LogHelper.LogArgumentNullException(nameof(validationParameters));
 
-            ClaimsIdentity identity = ClaimsIdentityFactory.Create(jwtToken, validationParameters, issuer);
+            ClaimsIdentity identity = validationParameters.CreateClaimsIdentity(jwtToken, issuer);
             foreach (Claim jwtClaim in jwtToken.Claims)
             {
                 string claimType = jwtClaim.Type;

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -677,7 +677,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
 
                 if (!identityDict.TryGetValue(statement.Subject, out ClaimsIdentity identity))
                 {
-                    identity = ClaimsIdentityFactory.Create(samlToken, validationParameters, issuer);
+                    identity = validationParameters.CreateClaimsIdentity(samlToken, issuer);
                     ProcessSubject(statement.Subject, identity, issuer);
                     identityDict.Add(statement.Subject, identity);
                 }

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -1314,7 +1314,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                 actualIssuer = ClaimsIdentity.DefaultIssuer;
             }
 
-            var identity = ClaimsIdentityFactory.Create(samlToken, validationParameters, issuer);
+            var identity = validationParameters.CreateClaimsIdentity(samlToken, issuer);
 
             ProcessSubject(samlToken.Assertion.Subject, identity, actualIssuer);
             ProcessStatements(samlToken.Assertion.Statements, identity, actualIssuer);

--- a/src/Microsoft.IdentityModel.Tokens/ClaimsIdentityFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ClaimsIdentityFactory.cs
@@ -37,45 +37,5 @@ namespace Microsoft.IdentityModel.Tokens
                 SecurityToken = securityToken,
             };
         }
-
-        internal static ClaimsIdentity Create(SecurityToken securityToken, TokenValidationParameters validationParameters, string issuer)
-        {
-            ClaimsIdentity claimsIdentity = validationParameters.CreateClaimsIdentity(securityToken, issuer);
-
-            // Set the SecurityToken in cases where derived TokenValidationParameters created a CaseSensitiveClaimsIdentity.
-            if (claimsIdentity is CaseSensitiveClaimsIdentity caseSensitiveClaimsIdentity && caseSensitiveClaimsIdentity.SecurityToken == null)
-            {
-                caseSensitiveClaimsIdentity.SecurityToken = securityToken;
-            }
-            else if (claimsIdentity is not CaseSensitiveClaimsIdentity && !AppContextSwitches.UseClaimsIdentityType())
-            {
-                claimsIdentity = new CaseSensitiveClaimsIdentity(claimsIdentity)
-                {
-                    SecurityToken = securityToken,
-                };
-            }
-
-            return claimsIdentity;
-        }
-
-        internal static ClaimsIdentity Create(TokenHandler tokenHandler, SecurityToken securityToken, TokenValidationParameters validationParameters, string issuer)
-        {
-            ClaimsIdentity claimsIdentity = tokenHandler.CreateClaimsIdentityInternal(securityToken, validationParameters, issuer);
-
-            // Set the SecurityToken in cases where derived TokenHandler created a CaseSensitiveClaimsIdentity.
-            if (claimsIdentity is CaseSensitiveClaimsIdentity caseSensitiveClaimsIdentity && caseSensitiveClaimsIdentity.SecurityToken == null)
-            {
-                caseSensitiveClaimsIdentity.SecurityToken = securityToken;
-            }
-            else if (claimsIdentity is not CaseSensitiveClaimsIdentity && !AppContextSwitches.UseClaimsIdentityType())
-            {
-                claimsIdentity = new CaseSensitiveClaimsIdentity(claimsIdentity)
-                {
-                    SecurityToken = securityToken,
-                };
-            }
-
-            return claimsIdentity;
-        }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/TokenValidationResult.cs
@@ -135,7 +135,7 @@ namespace Microsoft.IdentityModel.Tokens
 
                     if (_validationParameters != null && SecurityToken != null && _tokenHandler != null && Issuer != null)
                     {
-                        _claimsIdentity = ClaimsIdentityFactory.Create(_tokenHandler, SecurityToken, _validationParameters, Issuer);
+                        _claimsIdentity = _tokenHandler.CreateClaimsIdentityInternal(SecurityToken, _validationParameters, Issuer);
                     }
 
                     _claimsIdentityInitialized = true;

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1527,7 +1527,7 @@ namespace System.IdentityModel.Tokens.Jwt
 
         private ClaimsIdentity CreateClaimsIdentityWithMapping(JwtSecurityToken jwtToken, string actualIssuer, TokenValidationParameters validationParameters)
         {
-            ClaimsIdentity identity = ClaimsIdentityFactory.Create(jwtToken, validationParameters, actualIssuer);
+            ClaimsIdentity identity = validationParameters.CreateClaimsIdentity(jwtToken, actualIssuer);
             foreach (Claim jwtClaim in jwtToken.Claims)
             {
                 if (_inboundClaimFilter.Contains(jwtClaim.Type))
@@ -1573,7 +1573,7 @@ namespace System.IdentityModel.Tokens.Jwt
 
         private ClaimsIdentity CreateClaimsIdentityWithoutMapping(JwtSecurityToken jwtToken, string actualIssuer, TokenValidationParameters validationParameters)
         {
-            ClaimsIdentity identity = ClaimsIdentityFactory.Create(jwtToken, validationParameters, actualIssuer);
+            ClaimsIdentity identity = validationParameters.CreateClaimsIdentity(jwtToken, actualIssuer);
             foreach (Claim jwtClaim in jwtToken.Claims)
             {
                 if (_inboundClaimFilter.Contains(jwtClaim.Type))

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/json/JsonWebTokenHandler.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/json/JsonWebTokenHandler.cs
@@ -806,7 +806,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         {
             _ = validationParameters ?? throw LogHelper.LogArgumentNullException(nameof(validationParameters));
 
-            ClaimsIdentity identity = ClaimsIdentityFactory.Create(jwtToken, validationParameters, issuer);
+            ClaimsIdentity identity = validationParameters.CreateClaimsIdentity(jwtToken, issuer);
             foreach (Claim jwtClaim in jwtToken.Claims)
             {
                 bool wasMapped = _inboundClaimTypeMap.TryGetValue(jwtClaim.Type, out string claimType);
@@ -875,7 +875,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         {
             _ = validationParameters ?? throw LogHelper.LogArgumentNullException(nameof(validationParameters));
 
-            ClaimsIdentity identity = ClaimsIdentityFactory.Create(jwtToken, validationParameters, issuer);
+            ClaimsIdentity identity = validationParameters.CreateClaimsIdentity(jwtToken, issuer);
             foreach (Claim jwtClaim in jwtToken.Claims)
             {
                 string claimType = jwtClaim.Type;

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ClaimsIdentityFactoryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ClaimsIdentityFactoryTests.cs
@@ -45,48 +45,39 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             AppContext.SetSwitch(AppContextSwitches.UseClaimsIdentityTypeSwitch, false);
         }
 
-        [Fact]
-        public void Create_FromDerivedTokenValidationParameters_HonorsSetSecurityToken()
-        {
-            var jsonWebToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor()));
-            var tokenValidationParameters = new DerivedTokenValidationParameters(returnCaseSensitiveClaimsIdentityWithToken: true);
-            tokenValidationParameters.AuthenticationType = "custom-authentication-type";
-            tokenValidationParameters.NameClaimType = "custom-name";
-            tokenValidationParameters.RoleClaimType = "custom-role";
-
-            var actualClaimsIdentity = tokenValidationParameters.CreateClaimsIdentity(jsonWebToken, Default.Issuer);
-
-            // The SecurityToken set in derived TokenValidationParameters is honored.
-            Assert.IsType<CaseSensitiveClaimsIdentity>(actualClaimsIdentity);
-
-            var securityToken = ((CaseSensitiveClaimsIdentity)actualClaimsIdentity).SecurityToken;
-            Assert.NotNull(securityToken);
-            Assert.IsType<TvpJsonWebToken>(securityToken);
-            Assert.NotEqual(jsonWebToken, securityToken);
-
-            Assert.Equal(tokenValidationParameters.AuthenticationType, actualClaimsIdentity.AuthenticationType);
-            Assert.Equal(tokenValidationParameters.NameClaimType, actualClaimsIdentity.NameClaimType);
-            Assert.Equal(tokenValidationParameters.RoleClaimType, actualClaimsIdentity.RoleClaimType);
-        }
-
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Create_FromDerivedTokenValidationParameters_ReturnsCorrectClaimsIdentity(bool tvpReturnsCaseSensitiveClaimsIdentityWithoutToken)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Create_FromDerivedTokenValidationParameters_ReturnsCorrectClaimsIdentity(bool tvpReturnsCaseSensitiveClaimsIdentity, bool tvpReturnsCaseSensitiveClaimsIdentityWithToken)
         {
             var jsonWebToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor()));
-            var tokenValidationParameters = new DerivedTokenValidationParameters(returnCaseSensitiveClaimsIdentityWithoutToken: tvpReturnsCaseSensitiveClaimsIdentityWithoutToken);
+            var tokenValidationParameters = new DerivedTokenValidationParameters(tvpReturnsCaseSensitiveClaimsIdentity, tvpReturnsCaseSensitiveClaimsIdentityWithToken);
             tokenValidationParameters.AuthenticationType = "custom-authentication-type";
             tokenValidationParameters.NameClaimType = "custom-name";
             tokenValidationParameters.RoleClaimType = "custom-role";
 
             var actualClaimsIdentity = tokenValidationParameters.CreateClaimsIdentity(jsonWebToken, Default.Issuer);
 
-            Assert.IsType<CaseSensitiveClaimsIdentity>(actualClaimsIdentity);
-
-            var securityToken = ((CaseSensitiveClaimsIdentity)actualClaimsIdentity).SecurityToken;
-            Assert.NotNull(securityToken);
-            Assert.Equal(jsonWebToken, securityToken);
+            if (tvpReturnsCaseSensitiveClaimsIdentity)
+            {
+                Assert.IsType<CaseSensitiveClaimsIdentity>(actualClaimsIdentity);
+                if (tvpReturnsCaseSensitiveClaimsIdentityWithToken)
+                {
+                    var securityToken = ((CaseSensitiveClaimsIdentity)actualClaimsIdentity).SecurityToken;
+                    Assert.NotNull(securityToken);
+                    Assert.IsType<TvpJsonWebToken>(securityToken);
+                    Assert.NotEqual(jsonWebToken, securityToken);
+                }
+                else
+                {
+                    Assert.Null(((CaseSensitiveClaimsIdentity)actualClaimsIdentity).SecurityToken);
+                }
+            }
+            else
+            {
+                Assert.IsType<ClaimsIdentity>(actualClaimsIdentity);
+            }
 
             Assert.Equal(tokenValidationParameters.AuthenticationType, actualClaimsIdentity.AuthenticationType);
             Assert.Equal(tokenValidationParameters.NameClaimType, actualClaimsIdentity.NameClaimType);
@@ -97,28 +88,30 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
         private class DerivedTokenValidationParameters : TokenValidationParameters
         {
+            private bool _returnCaseSensitiveClaimsIdentity;
             private bool _returnCaseSensitiveClaimsIdentityWithToken;
-            private bool _returnCaseSensitiveClaimsIdentityWithoutToken;
 
-            public DerivedTokenValidationParameters(bool returnCaseSensitiveClaimsIdentityWithToken = false, bool returnCaseSensitiveClaimsIdentityWithoutToken = false)
+            public DerivedTokenValidationParameters(bool returnCaseSensitiveClaimsIdentity = false, bool returnCaseSensitiveClaimsIdentityWithToken = false)
             {
+                _returnCaseSensitiveClaimsIdentity = returnCaseSensitiveClaimsIdentity;
                 _returnCaseSensitiveClaimsIdentityWithToken = returnCaseSensitiveClaimsIdentityWithToken;
-                _returnCaseSensitiveClaimsIdentityWithoutToken = returnCaseSensitiveClaimsIdentityWithoutToken;
             }
 
             public override ClaimsIdentity CreateClaimsIdentity(SecurityToken securityToken, string issuer)
             {
-                if (_returnCaseSensitiveClaimsIdentityWithToken)
+                if (_returnCaseSensitiveClaimsIdentity)
                 {
-                    return new CaseSensitiveClaimsIdentity(AuthenticationType, NameClaimType, RoleClaimType)
+                    if (_returnCaseSensitiveClaimsIdentityWithToken)
                     {
-                        SecurityToken = new TvpJsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor())),
-                    };
-                }
-
-                if (_returnCaseSensitiveClaimsIdentityWithoutToken)
-                {
-                    return new CaseSensitiveClaimsIdentity(AuthenticationType, NameClaimType, RoleClaimType);
+                        return new CaseSensitiveClaimsIdentity(AuthenticationType, NameClaimType, RoleClaimType)
+                        {
+                            SecurityToken = new TvpJsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor())),
+                        };
+                    }
+                    else
+                    {
+                        return new CaseSensitiveClaimsIdentity(AuthenticationType, NameClaimType, RoleClaimType);
+                    }
                 }
 
                 return new ClaimsIdentity(AuthenticationType, NameClaimType, RoleClaimType);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ClaimsIdentityFactoryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ClaimsIdentityFactoryTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             tokenValidationParameters.NameClaimType = "custom-name";
             tokenValidationParameters.RoleClaimType = "custom-role";
 
-            var actualClaimsIdentity = ClaimsIdentityFactory.Create(jsonWebToken, tokenValidationParameters, Default.Issuer);
+            var actualClaimsIdentity = tokenValidationParameters.CreateClaimsIdentity(jsonWebToken, Default.Issuer);
 
             Assert.Equal(tokenValidationParameters.AuthenticationType, actualClaimsIdentity.AuthenticationType);
             Assert.Equal(tokenValidationParameters.NameClaimType, actualClaimsIdentity.NameClaimType);
@@ -54,7 +54,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             tokenValidationParameters.NameClaimType = "custom-name";
             tokenValidationParameters.RoleClaimType = "custom-role";
 
-            var actualClaimsIdentity = ClaimsIdentityFactory.Create(jsonWebToken, tokenValidationParameters, Default.Issuer);
+            var actualClaimsIdentity = tokenValidationParameters.CreateClaimsIdentity(jsonWebToken, Default.Issuer);
 
             // The SecurityToken set in derived TokenValidationParameters is honored.
             Assert.IsType<CaseSensitiveClaimsIdentity>(actualClaimsIdentity);
@@ -80,7 +80,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             tokenValidationParameters.NameClaimType = "custom-name";
             tokenValidationParameters.RoleClaimType = "custom-role";
 
-            var actualClaimsIdentity = ClaimsIdentityFactory.Create(jsonWebToken, tokenValidationParameters, Default.Issuer);
+            var actualClaimsIdentity = tokenValidationParameters.CreateClaimsIdentity(jsonWebToken, Default.Issuer);
 
             Assert.IsType<CaseSensitiveClaimsIdentity>(actualClaimsIdentity);
 


### PR DESCRIPTION
Call TVP.CreateClaimsIdentity to maintain back compat for users that have overloaded TVP.CreateClaimsIdentity.