### PR TITLE
Cache context switches

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -609,7 +609,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
         internal static string GetStringClaimValueType(string str, string claimType)
         {
-            if (!string.IsNullOrEmpty(claimType) && !JsonSerializerPrimitives.TryAllStringClaimsAsDateTime() && JsonSerializerPrimitives.IsKnownToNotBeDateTime(claimType))
+            if (!string.IsNullOrEmpty(claimType) && !AppContextSwitches.TryAllStringClaimsAsDateTime && JsonSerializerPrimitives.IsKnownToNotBeDateTime(claimType))
                 return ClaimValueTypes.String;
 
             if (DateTime.TryParse(str, out DateTime dateTimeValue))

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -21,15 +21,6 @@ namespace Microsoft.IdentityModel.Tokens
         internal static bool UseClaimsIdentityType => _useClaimsIdentity ??= (AppContext.TryGetSwitch(UseClaimsIdentityTypeSwitch, out bool useClaimsIdentityType) && useClaimsIdentityType);
 
         /// <summary>
-        /// Used for testing to reset the <see cref="UseClaimsIdentityType"/> switch to its default value.
-        /// </summary>
-        internal static void ResetUseClaimsIdentityTypeSwitch()
-        {
-            _useClaimsIdentity = null;
-            AppContext.SetSwitch(UseClaimsIdentityTypeSwitch, false);
-        }
-
-        /// <summary>
         /// When validating the issuer signing key, specifies whether to fail if the 'tid' claim is missing.
         /// </summary>
         internal const string DoNotFailOnMissingTidSwitch = "Switch.Microsoft.IdentityModel.DontFailOnMissingTidValidateIssuerSigning";
@@ -37,15 +28,6 @@ namespace Microsoft.IdentityModel.Tokens
         private static bool? _doNotFailOnMissingTid;
 
         internal static bool DontFailOnMissingTid => _doNotFailOnMissingTid ??= (AppContext.TryGetSwitch(DoNotFailOnMissingTidSwitch, out bool doNotFailOnMissingTid) && doNotFailOnMissingTid);
-
-        /// <summary>
-        /// Used for testing to reset the <see cref="UseClaimsIdentityType"/> switch to its default value.
-        /// </summary>
-        internal static void ResetDoNotFailOnMissingTidSwitch()
-        {
-            _doNotFailOnMissingTid = null;
-            AppContext.SetSwitch(DoNotFailOnMissingTidSwitch, false);
-        }
 
         /// <summary>
         /// When reading claims from the token, specifies whether to try to convert all string claims to DateTime.
@@ -58,10 +40,16 @@ namespace Microsoft.IdentityModel.Tokens
         internal static bool TryAllStringClaimsAsDateTime => _tryAllStringClaimsAsDateTime ??= (AppContext.TryGetSwitch(TryAllStringClaimsAsDateTimeSwitch, out bool tryAsDateTime) && tryAsDateTime);
 
         /// <summary>
-        /// Used for testing to reset the <see cref="UseClaimsIdentityType"/> switch to its default value.
+        /// Used for testing to reset all switches to its default value.
         /// </summary>
-        internal static void ResetTryAllStringClaimsAsDateTimeSwitch()
+        internal static void ResetAllSwitches()
         {
+            _useClaimsIdentity = null;
+            AppContext.SetSwitch(UseClaimsIdentityTypeSwitch, false);
+
+            _doNotFailOnMissingTid = null;
+            AppContext.SetSwitch(DoNotFailOnMissingTidSwitch, false);
+
             _tryAllStringClaimsAsDateTime = null;
             AppContext.SetSwitch(TryAllStringClaimsAsDateTimeSwitch, false);
         }

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -14,41 +14,56 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Enables a fallback to the previous behavior of using <see cref="ClaimsIdentity"/> instead of <see cref="CaseSensitiveClaimsIdentity"/> globally.
         /// </summary>
-        private const string UseClaimsIdentityTypeSwitch = "Microsoft.IdentityModel.Tokens.UseClaimsIdentityType";
+        internal const string UseClaimsIdentityTypeSwitch = "Microsoft.IdentityModel.Tokens.UseClaimsIdentityType";
 
         private static bool? _useClaimsIdentity;
 
-        internal static bool UseClaimsIdentityType
+        internal static bool UseClaimsIdentityType => _useClaimsIdentity ??= (AppContext.TryGetSwitch(UseClaimsIdentityTypeSwitch, out bool useClaimsIdentityType) && useClaimsIdentityType);
+
+        /// <summary>
+        /// Used for testing to reset the <see cref="UseClaimsIdentityType"/> switch to its default value.
+        /// </summary>
+        internal static void ResetUseClaimsIdentityTypeSwitch()
         {
-            get => _useClaimsIdentity ??= (AppContext.TryGetSwitch(UseClaimsIdentityTypeSwitch, out bool useClaimsIdentityType) && useClaimsIdentityType);
-            set => _useClaimsIdentity = value;
+            _useClaimsIdentity = null;
+            AppContext.SetSwitch(UseClaimsIdentityTypeSwitch, false);
         }
 
         /// <summary>
         /// When validating the issuer signing key, specifies whether to fail if the 'tid' claim is missing.
         /// </summary>
-        private const string DontFailOnMissingTidSwitch = "Switch.Microsoft.IdentityModel.DontFailOnMissingTidValidateIssuerSigning";
+        internal const string DontFailOnMissingTidSwitch = "Switch.Microsoft.IdentityModel.DontFailOnMissingTidValidateIssuerSigning";
 
         private static bool? _dontFailOnMissingTid;
 
-        internal static bool DontFailOnMissingTid
+        internal static bool DontFailOnMissingTid => _dontFailOnMissingTid ??= (AppContext.TryGetSwitch(DontFailOnMissingTidSwitch, out bool dontFailOnMissingTid) && dontFailOnMissingTid);
+
+        /// <summary>
+        /// Used for testing to reset the <see cref="UseClaimsIdentityType"/> switch to its default value.
+        /// </summary>
+        internal static void ResetDontFailOnMissingTidSwitch()
         {
-            get => _dontFailOnMissingTid ??= (AppContext.TryGetSwitch(DontFailOnMissingTidSwitch, out bool dontFailOnMissingTid) && dontFailOnMissingTid);
-            set => _dontFailOnMissingTid = value;
+            _dontFailOnMissingTid = null;
+            AppContext.SetSwitch(DontFailOnMissingTidSwitch, false);
         }
 
         /// <summary>
         /// When reading claims from the token, specifies whether to try to convert all string claims to DateTime.
         /// Some claims are known not to be DateTime, so conversion is skipped.
         /// </summary>
-        private const string TryAllStringClaimsAsDateTimeSwitch = "Switch.Microsoft.IdentityModel.TryAllStringClaimsAsDateTime";
+        internal const string TryAllStringClaimsAsDateTimeSwitch = "Switch.Microsoft.IdentityModel.TryAllStringClaimsAsDateTime";
 
         private static bool? _tryAllStringClaimsAsDateTime;
 
-        internal static bool TryAllStringClaimsAsDateTime
+        internal static bool TryAllStringClaimsAsDateTime => _tryAllStringClaimsAsDateTime ??= (AppContext.TryGetSwitch(TryAllStringClaimsAsDateTimeSwitch, out bool tryAsDateTime) && tryAsDateTime);
+
+        /// <summary>
+        /// Used for testing to reset the <see cref="UseClaimsIdentityType"/> switch to its default value.
+        /// </summary>
+        internal static void ResetTryAllStringClaimsAsDateTimeSwitch()
         {
-            get => _tryAllStringClaimsAsDateTime ??= (AppContext.TryGetSwitch(TryAllStringClaimsAsDateTimeSwitch, out bool tryAsDateTime) && tryAsDateTime);
-            set => _tryAllStringClaimsAsDateTime = value;
+            _tryAllStringClaimsAsDateTime = null;
+            AppContext.SetSwitch(TryAllStringClaimsAsDateTimeSwitch, false);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -32,19 +32,19 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// When validating the issuer signing key, specifies whether to fail if the 'tid' claim is missing.
         /// </summary>
-        internal const string DontFailOnMissingTidSwitch = "Switch.Microsoft.IdentityModel.DontFailOnMissingTidValidateIssuerSigning";
+        internal const string DoNotFailOnMissingTidSwitch = "Switch.Microsoft.IdentityModel.DontFailOnMissingTidValidateIssuerSigning";
 
-        private static bool? _dontFailOnMissingTid;
+        private static bool? _doNotFailOnMissingTid;
 
-        internal static bool DontFailOnMissingTid => _dontFailOnMissingTid ??= (AppContext.TryGetSwitch(DontFailOnMissingTidSwitch, out bool dontFailOnMissingTid) && dontFailOnMissingTid);
+        internal static bool DontFailOnMissingTid => _doNotFailOnMissingTid ??= (AppContext.TryGetSwitch(DoNotFailOnMissingTidSwitch, out bool doNotFailOnMissingTid) && doNotFailOnMissingTid);
 
         /// <summary>
         /// Used for testing to reset the <see cref="UseClaimsIdentityType"/> switch to its default value.
         /// </summary>
-        internal static void ResetDontFailOnMissingTidSwitch()
+        internal static void ResetDoNotFailOnMissingTidSwitch()
         {
-            _dontFailOnMissingTid = null;
-            AppContext.SetSwitch(DontFailOnMissingTidSwitch, false);
+            _doNotFailOnMissingTid = null;
+            AppContext.SetSwitch(DoNotFailOnMissingTidSwitch, false);
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -14,8 +14,41 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Enables a fallback to the previous behavior of using <see cref="ClaimsIdentity"/> instead of <see cref="CaseSensitiveClaimsIdentity"/> globally.
         /// </summary>
-        internal const string UseClaimsIdentityTypeSwitch = "Microsoft.IdentityModel.Tokens.UseClaimsIdentityType";
+        private const string UseClaimsIdentityTypeSwitch = "Microsoft.IdentityModel.Tokens.UseClaimsIdentityType";
 
-        internal static bool UseClaimsIdentityType() => (AppContext.TryGetSwitch(UseClaimsIdentityTypeSwitch, out bool useClaimsIdentityType) && useClaimsIdentityType);
+        private static bool? _useClaimsIdentity;
+
+        internal static bool UseClaimsIdentityType
+        {
+            get => _useClaimsIdentity ??= (AppContext.TryGetSwitch(UseClaimsIdentityTypeSwitch, out bool useClaimsIdentityType) && useClaimsIdentityType);
+            set => _useClaimsIdentity = value;
+        }
+
+        /// <summary>
+        /// When validating the issuer signing key, specifies whether to fail if the 'tid' claim is missing.
+        /// </summary>
+        private const string DontFailOnMissingTidSwitch = "Switch.Microsoft.IdentityModel.DontFailOnMissingTidValidateIssuerSigning";
+
+        private static bool? _dontFailOnMissingTid;
+
+        internal static bool DontFailOnMissingTid
+        {
+            get => _dontFailOnMissingTid ??= (AppContext.TryGetSwitch(DontFailOnMissingTidSwitch, out bool dontFailOnMissingTid) && dontFailOnMissingTid);
+            set => _dontFailOnMissingTid = value;
+        }
+
+        /// <summary>
+        /// When reading claims from the token, specifies whether to try to convert all string claims to DateTime.
+        /// Some claims are known not to be DateTime, so conversion is skipped.
+        /// </summary>
+        private const string TryAllStringClaimsAsDateTimeSwitch = "Switch.Microsoft.IdentityModel.TryAllStringClaimsAsDateTime";
+
+        private static bool? _tryAllStringClaimsAsDateTime;
+
+        internal static bool TryAllStringClaimsAsDateTime
+        {
+            get => _tryAllStringClaimsAsDateTime ??= (AppContext.TryGetSwitch(TryAllStringClaimsAsDateTimeSwitch, out bool tryAsDateTime) && tryAsDateTime);
+            set => _tryAllStringClaimsAsDateTime = value;
+        }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/ClaimsIdentityFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ClaimsIdentityFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.IdentityModel.Tokens
     {
         internal static ClaimsIdentity Create(IEnumerable<Claim> claims)
         {
-            if (AppContextSwitches.UseClaimsIdentityType())
+            if (AppContextSwitches.UseClaimsIdentityType)
                 return new ClaimsIdentity(claims);
 
             return new CaseSensitiveClaimsIdentity(claims);
@@ -21,7 +21,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         internal static ClaimsIdentity Create(IEnumerable<Claim> claims, string authenticationType)
         {
-            if (AppContextSwitches.UseClaimsIdentityType())
+            if (AppContextSwitches.UseClaimsIdentityType)
                 return new ClaimsIdentity(claims, authenticationType);
 
             return new CaseSensitiveClaimsIdentity(claims, authenticationType);
@@ -29,7 +29,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         internal static ClaimsIdentity Create(string authenticationType, string nameType, string roleType, SecurityToken securityToken)
         {
-            if (AppContextSwitches.UseClaimsIdentityType())
+            if (AppContextSwitches.UseClaimsIdentityType)
                 return new ClaimsIdentity(authenticationType: authenticationType, nameType: nameType, roleType: roleType);
 
             return new CaseSensitiveClaimsIdentity(authenticationType: authenticationType, nameType: nameType, roleType: roleType)

--- a/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Json/JsonSerializerPrimitives.cs
@@ -146,7 +146,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
 
             if (jsonElement.ValueKind == JsonValueKind.String)
             {
-                if (!string.IsNullOrEmpty(claimType) && !TryAllStringClaimsAsDateTime() && IsKnownToNotBeDateTime(claimType))
+                if (!string.IsNullOrEmpty(claimType) && !AppContextSwitches.TryAllStringClaimsAsDateTime && IsKnownToNotBeDateTime(claimType))
                     return jsonElement.GetString();
 
                 if (DateTime.TryParse(jsonElement.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTime dateTime))
@@ -705,13 +705,6 @@ namespace Microsoft.IdentityModel.Tokens.Json
             return retVal;
         }
 
-        internal const string TryToCreateDateTimeClaimsSwitch = "Switch.Microsoft.IdentityModel.TryAllStringClaimsAsDateTime";
-
-        public static bool TryAllStringClaimsAsDateTime()
-        {
-            return (AppContext.TryGetSwitch(TryToCreateDateTimeClaimsSwitch, out bool tryAsDateTime) && tryAsDateTime);
-        }
-
         /// <summary>
         /// This is a non-exhaustive list of claim types that are not expected to be DateTime values
         /// sourced from expected Entra V1 and V2 claims, OpenID Connect claims, and a selection of
@@ -833,7 +826,7 @@ namespace Microsoft.IdentityModel.Tokens.Json
 
             string originalString = reader.GetString();
 
-            if (!TryAllStringClaimsAsDateTime() && IsKnownToNotBeDateTime(propertyName))
+            if (!AppContextSwitches.TryAllStringClaimsAsDateTime && IsKnownToNotBeDateTime(propertyName))
             {
                 reader.Read();
                 return originalString;

--- a/src/Microsoft.IdentityModel.Validators/AadTokenValidationParametersExtension.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadTokenValidationParametersExtension.cs
@@ -45,13 +45,6 @@ namespace Microsoft.IdentityModel.Validators
             };
         }
 
-        internal const string DontFailOnMissingTidSwitch = "Switch.Microsoft.IdentityModel.DontFailOnMissingTidValidateIssuerSigning";
-
-        private static bool DontFailOnMissingTid()
-        {
-            return (AppContext.TryGetSwitch(DontFailOnMissingTidSwitch, out bool dontFailOnMissingTid) && dontFailOnMissingTid);
-        }
-
         /// <summary>
         /// Validates the issuer signing key.
         /// </summary>
@@ -81,7 +74,7 @@ namespace Microsoft.IdentityModel.Validators
                 var tenantIdFromToken = GetTid(securityToken);
                 if (string.IsNullOrEmpty(tenantIdFromToken))
                 {
-                    if (DontFailOnMissingTid())
+                    if (AppContextSwitches.DontFailOnMissingTid)
                         return true; 
                     
                     throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidIssuerException(LogMessages.IDX40009));

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerClaimsIdentityTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerClaimsIdentityTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         [Fact]
         public void CreateClaimsIdentity_ReturnsClaimsIdentity_WithAppContextSwitch()
         {
-            AppContext.SetSwitch(AppContextSwitches.UseClaimsIdentityTypeSwitch, true);
+            AppContextSwitches.UseClaimsIdentityType = true;
 
             var handler = new DerivedJsonWebTokenHandler();
             var jsonWebToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor()));
@@ -54,7 +54,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             handler.MapInboundClaims = true;
             Assert.IsType<ClaimsIdentity>(handler.CreateClaimsIdentityInternal(jsonWebToken, tokenValidationParameters, Default.Issuer));
 
-            AppContext.SetSwitch(AppContextSwitches.UseClaimsIdentityTypeSwitch, false);
+            AppContextSwitches.UseClaimsIdentityType = false;
         }
 
         private class DerivedJsonWebTokenHandler : JsonWebTokenHandler

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerClaimsIdentityTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerClaimsIdentityTests.cs
@@ -36,6 +36,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             actualClaimsIdentity = handler.CreateClaimsIdentityInternal(jsonWebToken, tokenValidationParameters, Default.Issuer);
             Assert.IsType<CaseSensitiveClaimsIdentity>(actualClaimsIdentity);
             Assert.NotNull(((CaseSensitiveClaimsIdentity)actualClaimsIdentity).SecurityToken);
+
+            AppContextSwitches.ResetAllSwitches();
         }
 
         [Fact]

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerClaimsIdentityTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerClaimsIdentityTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             handler.MapInboundClaims = true;
             Assert.IsType<ClaimsIdentity>(handler.CreateClaimsIdentityInternal(jsonWebToken, tokenValidationParameters, Default.Issuer));
 
-            AppContextSwitches.ResetUseClaimsIdentityTypeSwitch();
+            AppContextSwitches.ResetAllSwitches();
         }
 
         private class DerivedJsonWebTokenHandler : JsonWebTokenHandler

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerClaimsIdentityTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerClaimsIdentityTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         [Fact]
         public void CreateClaimsIdentity_ReturnsClaimsIdentity_WithAppContextSwitch()
         {
-            AppContextSwitches.UseClaimsIdentityType = true;
+            AppContext.SetSwitch(AppContextSwitches.UseClaimsIdentityTypeSwitch, true);
 
             var handler = new DerivedJsonWebTokenHandler();
             var jsonWebToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor()));
@@ -54,7 +54,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             handler.MapInboundClaims = true;
             Assert.IsType<ClaimsIdentity>(handler.CreateClaimsIdentityInternal(jsonWebToken, tokenValidationParameters, Default.Issuer));
 
-            AppContextSwitches.UseClaimsIdentityType = false;
+            AppContextSwitches.ResetUseClaimsIdentityTypeSwitch();
         }
 
         private class DerivedJsonWebTokenHandler : JsonWebTokenHandler

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ClaimsIdentityFactoryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ClaimsIdentityFactoryTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         [InlineData(false)]
         public void Create_FromTokenValidationParameters_ReturnsCorrectClaimsIdentity(bool useClaimsIdentity)
         {
-            AppContextSwitches.UseClaimsIdentityType = useClaimsIdentity;
+            AppContext.SetSwitch(AppContextSwitches.UseClaimsIdentityTypeSwitch, useClaimsIdentity);
 
             var jsonWebToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor()));
             var tokenValidationParameters = new TokenValidationParameters();
@@ -42,7 +42,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 Assert.Equal(jsonWebToken, ((CaseSensitiveClaimsIdentity)actualClaimsIdentity).SecurityToken);
             }
 
-            AppContextSwitches.UseClaimsIdentityType = false;
+            AppContextSwitches.ResetUseClaimsIdentityTypeSwitch();
         }
 
         [Theory]

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ClaimsIdentityFactoryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ClaimsIdentityFactoryTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 Assert.Equal(jsonWebToken, ((CaseSensitiveClaimsIdentity)actualClaimsIdentity).SecurityToken);
             }
 
-            AppContextSwitches.ResetUseClaimsIdentityTypeSwitch();
+            AppContextSwitches.ResetAllSwitches();
         }
 
         [Theory]

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ClaimsIdentityFactoryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ClaimsIdentityFactoryTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         [InlineData(false)]
         public void Create_FromTokenValidationParameters_ReturnsCorrectClaimsIdentity(bool useClaimsIdentity)
         {
-            AppContext.SetSwitch(AppContextSwitches.UseClaimsIdentityTypeSwitch, useClaimsIdentity);
+            AppContextSwitches.UseClaimsIdentityType = useClaimsIdentity;
 
             var jsonWebToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor()));
             var tokenValidationParameters = new TokenValidationParameters();
@@ -42,7 +42,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 Assert.Equal(jsonWebToken, ((CaseSensitiveClaimsIdentity)actualClaimsIdentity).SecurityToken);
             }
 
-            AppContext.SetSwitch(AppContextSwitches.UseClaimsIdentityTypeSwitch, false);
+            AppContextSwitches.UseClaimsIdentityType = false;
         }
 
         [Theory]

--- a/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
@@ -345,8 +345,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityKey = KeyingMaterial.JsonWebKeyP256,
                     SecurityToken = new JwtSecurityToken(),
                     OpenIdConnectConfiguration = mockConfiguration,
-                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DontFailOnMissingTidSwitch, true),
-                    TearDownAction = () => AppContextSwitches.ResetDontFailOnMissingTidSwitch(),
+                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, true),
+                    TearDownAction = () => AppContextSwitches.ResetDoNotFailOnMissingTidSwitch(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -356,8 +356,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityToken = new JwtSecurityToken(),
                     OpenIdConnectConfiguration = mockConfiguration,
                     ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX40009"),
-                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DontFailOnMissingTidSwitch, false),
-                    TearDownAction = () => AppContextSwitches.ResetDontFailOnMissingTidSwitch(),
+                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, false),
+                    TearDownAction = () => AppContextSwitches.ResetDoNotFailOnMissingTidSwitch(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -366,8 +366,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityKey = KeyingMaterial.JsonWebKeyP256,
                     SecurityToken = new JwtSecurityToken(),
                     OpenIdConnectConfiguration = mockConfiguration,
-                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DontFailOnMissingTidSwitch, true),
-                    TearDownAction = () => AppContextSwitches.ResetDontFailOnMissingTidSwitch(),
+                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, true),
+                    TearDownAction = () => AppContextSwitches.ResetDoNotFailOnMissingTidSwitch(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -377,8 +377,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor(Default.SymmetricSigningCredentials, [issClaim]))),
                     OpenIdConnectConfiguration = mockConfiguration,
                     ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX40009"),
-                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DontFailOnMissingTidSwitch, false),
-                    TearDownAction = () => AppContextSwitches.ResetDontFailOnMissingTidSwitch(),
+                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, false),
+                    TearDownAction = () => AppContextSwitches.ResetDoNotFailOnMissingTidSwitch(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -387,8 +387,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityKey = KeyingMaterial.JsonWebKeyP256,
                     SecurityToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor(Default.SymmetricSigningCredentials, [issClaim]))),
                     OpenIdConnectConfiguration = mockConfiguration,
-                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DontFailOnMissingTidSwitch, true),
-                    TearDownAction = () => AppContextSwitches.ResetDontFailOnMissingTidSwitch(),
+                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, true),
+                    TearDownAction = () => AppContextSwitches.ResetDoNotFailOnMissingTidSwitch(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData

--- a/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
@@ -345,8 +345,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityKey = KeyingMaterial.JsonWebKeyP256,
                     SecurityToken = new JwtSecurityToken(),
                     OpenIdConnectConfiguration = mockConfiguration,
-                    SetupAction = () => AppContext.SetSwitch(AadTokenValidationParametersExtension.DontFailOnMissingTidSwitch, true),
-                    TearDownAction = () => AppContext.SetSwitch(AadTokenValidationParametersExtension.DontFailOnMissingTidSwitch, false)
+                    SetupAction = () => AppContextSwitches.DontFailOnMissingTid = true,
+                    TearDownAction = () => AppContextSwitches.DontFailOnMissingTid = false,
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -356,8 +356,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityToken = new JwtSecurityToken(),
                     OpenIdConnectConfiguration = mockConfiguration,
                     ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX40009"),
-                    SetupAction = () => AppContext.SetSwitch(AadTokenValidationParametersExtension.DontFailOnMissingTidSwitch, false),
-                    TearDownAction = () => AppContext.SetSwitch(AadTokenValidationParametersExtension.DontFailOnMissingTidSwitch, isEnabled: false)
+                    SetupAction = () => AppContextSwitches.DontFailOnMissingTid = false,
+                    TearDownAction = () => AppContextSwitches.DontFailOnMissingTid = false,
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -366,8 +366,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityKey = KeyingMaterial.JsonWebKeyP256,
                     SecurityToken = new JwtSecurityToken(),
                     OpenIdConnectConfiguration = mockConfiguration,
-                    SetupAction = () => AppContext.SetSwitch(AadTokenValidationParametersExtension.DontFailOnMissingTidSwitch, true),
-                    TearDownAction = () => AppContext.SetSwitch(AadTokenValidationParametersExtension.DontFailOnMissingTidSwitch, false)
+                    SetupAction = () => AppContextSwitches.DontFailOnMissingTid = true,
+                    TearDownAction = () => AppContextSwitches.DontFailOnMissingTid = false,
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -377,8 +377,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor(Default.SymmetricSigningCredentials, [issClaim]))),
                     OpenIdConnectConfiguration = mockConfiguration,
                     ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX40009"),
-                    SetupAction = () => AppContext.SetSwitch(AadTokenValidationParametersExtension.DontFailOnMissingTidSwitch, false),
-                    TearDownAction = () => AppContext.SetSwitch(AadTokenValidationParametersExtension.DontFailOnMissingTidSwitch, isEnabled: false)
+                    SetupAction = () => AppContextSwitches.DontFailOnMissingTid = false,
+                    TearDownAction = () => AppContextSwitches.DontFailOnMissingTid = false,
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -387,8 +387,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityKey = KeyingMaterial.JsonWebKeyP256,
                     SecurityToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor(Default.SymmetricSigningCredentials, [issClaim]))),
                     OpenIdConnectConfiguration = mockConfiguration,
-                    SetupAction = () => AppContext.SetSwitch(AadTokenValidationParametersExtension.DontFailOnMissingTidSwitch, true),
-                    TearDownAction = () => AppContext.SetSwitch(AadTokenValidationParametersExtension.DontFailOnMissingTidSwitch, false)
+                    SetupAction = () => AppContextSwitches.DontFailOnMissingTid = true,
+                    TearDownAction = () => AppContextSwitches.DontFailOnMissingTid = false,
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData

--- a/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
@@ -345,8 +345,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityKey = KeyingMaterial.JsonWebKeyP256,
                     SecurityToken = new JwtSecurityToken(),
                     OpenIdConnectConfiguration = mockConfiguration,
-                    SetupAction = () => AppContextSwitches.DontFailOnMissingTid = true,
-                    TearDownAction = () => AppContextSwitches.DontFailOnMissingTid = false,
+                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DontFailOnMissingTidSwitch, true),
+                    TearDownAction = () => AppContextSwitches.ResetDontFailOnMissingTidSwitch(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -356,8 +356,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityToken = new JwtSecurityToken(),
                     OpenIdConnectConfiguration = mockConfiguration,
                     ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX40009"),
-                    SetupAction = () => AppContextSwitches.DontFailOnMissingTid = false,
-                    TearDownAction = () => AppContextSwitches.DontFailOnMissingTid = false,
+                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DontFailOnMissingTidSwitch, false),
+                    TearDownAction = () => AppContextSwitches.ResetDontFailOnMissingTidSwitch(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -366,8 +366,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityKey = KeyingMaterial.JsonWebKeyP256,
                     SecurityToken = new JwtSecurityToken(),
                     OpenIdConnectConfiguration = mockConfiguration,
-                    SetupAction = () => AppContextSwitches.DontFailOnMissingTid = true,
-                    TearDownAction = () => AppContextSwitches.DontFailOnMissingTid = false,
+                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DontFailOnMissingTidSwitch, true),
+                    TearDownAction = () => AppContextSwitches.ResetDontFailOnMissingTidSwitch(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -377,8 +377,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor(Default.SymmetricSigningCredentials, [issClaim]))),
                     OpenIdConnectConfiguration = mockConfiguration,
                     ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX40009"),
-                    SetupAction = () => AppContextSwitches.DontFailOnMissingTid = false,
-                    TearDownAction = () => AppContextSwitches.DontFailOnMissingTid = false,
+                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DontFailOnMissingTidSwitch, false),
+                    TearDownAction = () => AppContextSwitches.ResetDontFailOnMissingTidSwitch(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -387,8 +387,8 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityKey = KeyingMaterial.JsonWebKeyP256,
                     SecurityToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor(Default.SymmetricSigningCredentials, [issClaim]))),
                     OpenIdConnectConfiguration = mockConfiguration,
-                    SetupAction = () => AppContextSwitches.DontFailOnMissingTid = true,
-                    TearDownAction = () => AppContextSwitches.DontFailOnMissingTid = false,
+                    SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DontFailOnMissingTidSwitch, true),
+                    TearDownAction = () => AppContextSwitches.ResetDontFailOnMissingTidSwitch(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData

--- a/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
@@ -346,7 +346,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityToken = new JwtSecurityToken(),
                     OpenIdConnectConfiguration = mockConfiguration,
                     SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, true),
-                    TearDownAction = () => AppContextSwitches.ResetDoNotFailOnMissingTidSwitch(),
+                    TearDownAction = () => AppContextSwitches.ResetAllSwitches(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -357,7 +357,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     OpenIdConnectConfiguration = mockConfiguration,
                     ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX40009"),
                     SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, false),
-                    TearDownAction = () => AppContextSwitches.ResetDoNotFailOnMissingTidSwitch(),
+                    TearDownAction = () => AppContextSwitches.ResetAllSwitches(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -367,7 +367,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityToken = new JwtSecurityToken(),
                     OpenIdConnectConfiguration = mockConfiguration,
                     SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, true),
-                    TearDownAction = () => AppContextSwitches.ResetDoNotFailOnMissingTidSwitch(),
+                    TearDownAction = () => AppContextSwitches.ResetAllSwitches(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -378,7 +378,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     OpenIdConnectConfiguration = mockConfiguration,
                     ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX40009"),
                     SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, false),
-                    TearDownAction = () => AppContextSwitches.ResetDoNotFailOnMissingTidSwitch(),
+                    TearDownAction = () => AppContextSwitches.ResetAllSwitches(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -388,7 +388,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor(Default.SymmetricSigningCredentials, [issClaim]))),
                     OpenIdConnectConfiguration = mockConfiguration,
                     SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, true),
-                    TearDownAction = () => AppContextSwitches.ResetDoNotFailOnMissingTidSwitch(),
+                    TearDownAction = () => AppContextSwitches.ResetAllSwitches(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData

--- a/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
             }
             finally
             {
-                theoryData.TearDownAction?.Invoke();
+                AppContextSwitches.ResetAllSwitches();
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -346,7 +346,6 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityToken = new JwtSecurityToken(),
                     OpenIdConnectConfiguration = mockConfiguration,
                     SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, true),
-                    TearDownAction = () => AppContextSwitches.ResetAllSwitches(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -357,7 +356,6 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     OpenIdConnectConfiguration = mockConfiguration,
                     ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX40009"),
                     SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, false),
-                    TearDownAction = () => AppContextSwitches.ResetAllSwitches(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -367,7 +365,6 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityToken = new JwtSecurityToken(),
                     OpenIdConnectConfiguration = mockConfiguration,
                     SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, true),
-                    TearDownAction = () => AppContextSwitches.ResetAllSwitches(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -378,7 +375,6 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     OpenIdConnectConfiguration = mockConfiguration,
                     ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX40009"),
                     SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, false),
-                    TearDownAction = () => AppContextSwitches.ResetAllSwitches(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -388,7 +384,6 @@ namespace Microsoft.IdentityModel.Validators.Tests
                     SecurityToken = new JsonWebToken(Default.Jwt(Default.SecurityTokenDescriptor(Default.SymmetricSigningCredentials, [issClaim]))),
                     OpenIdConnectConfiguration = mockConfiguration,
                     SetupAction = () => AppContext.SetSwitch(AppContextSwitches.DoNotFailOnMissingTidSwitch, true),
-                    TearDownAction = () => AppContextSwitches.ResetAllSwitches(),
                 });
 
                 theoryData.Add(new AadSigningKeyIssuerTheoryData
@@ -454,8 +449,6 @@ namespace Microsoft.IdentityModel.Validators.Tests
             public bool SetDelegateWithoutConfig { get; set; } = false;
 
             public Action SetupAction { get; set; }
-
-            public Action TearDownAction { get; set; }
         }
     }
 }


### PR DESCRIPTION
Fixes #2722.

- Caches context switch values.
- Moves all context switches into one file.
- Adds a method reset all context switches for testing.

Perf results for validation and claims creation which ends up hitting two switches: UseClaimsIdentityTypeSwitch, TryAllStringClaimsAsDateTimeSwitch.

Without caching:

| Method                                              | Mean     | Error    | StdDev   | P90      | P95      | P100     | Gen0   | Allocated |
|---------------------------------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| JsonWebTokenHandler_ValidateTokenAsync_CreateClaims | 36.41 μs | 0.136 μs | 0.299 μs | 36.84 μs | 36.93 μs | 37.06 μs | 0.9766 |  16.52 KB |

With caching:

| Method                                              | Mean     | Error    | StdDev   | P90      | P95      | P100     | Gen0   | Allocated |
|---------------------------------------------------- |---------:|---------:|---------:|---------:|---------:|---------:|-------:|----------:|
| JsonWebTokenHandler_ValidateTokenAsync_CreateClaims | 35.13 μs | 0.047 μs | 0.100 μs | 35.26 μs | 35.28 μs | 35.34 μs | 0.9766 |  16.52 KB |

