### PR TITLE
Remove Delegate Checks in Multiple Validators and Prevents Null Setting of Delegates

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -73,7 +73,6 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10256 = "IDX10256: Unable to validate the token type. TokenValidationParameters.ValidTypes is set, but the 'typ' header claim is null or empty.";
         public const string IDX10257 = "IDX10257: Token type validation failed. Type: '{0}'. Did not match: validationParameters.TokenTypes: '{1}'.";
         public const string IDX10258 = "IDX10258: Token type validated. Type: '{0}'.";
-        public const string IDX10259 = "IDX10259: Unable to validate the token type, delegate threw an exception.";
         // public const string IDX10260 = "IDX10260:";
         public const string IDX10261 = "IDX10261: Unable to retrieve configuration from authority: '{0}'. \nProceeding with token validation in case the relevant properties have been set manually on the TokenValidationParameters. Exception caught: \n {1}. See https://aka.ms/validate-using-configuration-manager for additional information.";
         public const string IDX10262 = "IDX10262: One of the issuers in TokenValidationParameters.ValidIssuers was null or an empty string. See https://aka.ms/wilson/tokenvalidation for details.";

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
@@ -491,12 +491,12 @@ namespace Microsoft.IdentityModel.Tokens
         public IList<string> ValidIssuers { get; }
 
         /// <summary>
-        /// Gets the <see cref="IList{String}"/> that contains valid types that will be used to check against the JWT header's 'typ' claim.
+        /// Gets or sets the <see cref="IList{String}"/> that contains valid types that will be used to check against the JWT header's 'typ' claim.
         /// If this property is not set, the 'typ' header claim will not be validated and all types will be accepted.
         /// In the case of a JWE, this property will ONLY apply to the inner token header.
         /// The default is <c>null</c>.
         /// </summary>
-        public IList<string> ValidTypes { get; }
+        public IList<string> ValidTypes { get; set; }
 
         public bool ValidateActor { get; set; }
     }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
@@ -440,16 +440,16 @@ namespace Microsoft.IdentityModel.Tokens
         public TokenReplayValidator TokenReplayValidator { get; set; }
 
         /// <summary>
-        /// Gets or sets a delegate that will be used to validate the type of the token.
-        /// If the token type cannot be validated, an exception MUST be thrown by the delegate.
+        /// Allows overriding the delegate that will be used to validate the type of the token.
+        /// If the token type cannot be validated, a <see cref="TokenTypeValidationResult"/> MUST be returned by the delegate.
         /// Note: the 'type' parameter may be null if it couldn't be extracted from its usual location.
         /// Implementations that need to resolve it from a different location can use the 'token' parameter.
         /// </summary>
         /// <remarks>
-        /// If set, this delegate will be called to validate the 'type' of the token, instead of default processing.
-        /// This means that no default 'type' validation will occur.
+        /// If no delegate is set, the default implementation will be used. The default checks the type
+        /// against the <see cref="ValidTypes"/> property, if it's present then, it will succeed.
         /// </remarks>
-        public TypeValidator TypeValidator { get; set; }
+        public TypeValidatorDelegate TypeValidator { get; set; } = Validators.ValidateTokenType;
 
         /// <summary>
         /// Gets or sets a boolean to control if the LKG configuration will be used for token validation.

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
@@ -556,10 +556,15 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns>The <see cref="IList{String}"/> that contains valid token types that will be used to check against the token's 'typ' claim.</returns>
         public IList<string> ValidTypes
         {
-            get => _validTokenTypes ?? Interlocked.CompareExchange(ref _validTokenTypes, new List<string>(), null);
-            set => _validTokenTypes = value ?? throw new ArgumentNullException(nameof(value));
+            get
+            {
+                return _validTokenTypes;
+            }
+            set
+            {
+                _validTokenTypes = value ?? throw new ArgumentNullException(nameof(value));
+            }
         }
-
 
         public bool ValidateActor { get; set; }
     }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Algorithm.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Algorithm.cs
@@ -17,7 +17,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="algorithm">The algorithm to be validated.</param>
         /// <param name="securityKey">The <see cref="SecurityKey"/> that signed the <see cref="SecurityToken"/>.</param>
         /// <param name="securityToken">The <see cref="SecurityToken"/> being validated.</param>
-        /// <param name="validationParameters"><see cref="TokenValidationParameters"/> required for validation.</param>
+        /// <param name="validationParameters"><see cref="ValidationParameters"/> required for validation.</param>
         /// <param name="callContext"></param>
 #pragma warning disable CA1801 // TODO: remove pragma disable once callContext is used for logging
         internal static AlgorithmValidationResult ValidateAlgorithm(

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Audience.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Audience.cs
@@ -20,7 +20,7 @@ namespace Microsoft.IdentityModel.Tokens
     /// <param name="callContext"></param>
     /// <returns>A <see cref="IssuerValidationResult"/>that contains the results of validating the issuer.</returns>
     /// <remarks>This delegate is not expected to throw.</remarks>
-    internal delegate AudienceValidationResult ValidateAudience(
+    internal delegate AudienceValidationResult AudienceValidatorDelegate(
         IEnumerable<string> audiences,
         SecurityToken? securityToken,
         TokenValidationParameters validationParameters,

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenReplay.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenReplay.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.Logging;
 
 namespace Microsoft.IdentityModel.Tokens
@@ -16,14 +12,14 @@ namespace Microsoft.IdentityModel.Tokens
     /// </summary>
     /// <param name="expirationTime">When does the <see cref="SecurityToken"/> expire..</param>
     /// <param name="securityToken">The security token that is being validated.</param>
-    /// <param name="validationParameters">The <see cref="TokenValidationParameters"/> to be used for validating the token.</param>
+    /// <param name="validationParameters">The <see cref="ValidationParameters"/> to be used for validating the token.</param>
     /// <param name="callContext"></param>
     /// <returns>A <see cref="ReplayValidationResult"/>that contains the results of validating the token.</returns>
     /// <remarks>This delegate is not expected to throw.</remarks>
-    internal delegate ReplayValidationResult ValidateTokenReplay(
+    internal delegate ReplayValidationResult TokenReplayValidatorDelegate(
         DateTime? expirationTime,
         string securityToken,
-        TokenValidationParameters validationParameters,
+        ValidationParameters validationParameters,
         CallContext callContext);
 
     /// <summary>
@@ -36,15 +32,15 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         /// <param name="expirationTime">When does the security token expire.</param>
         /// <param name="securityToken">The <see cref="SecurityToken"/> being validated.</param>
-        /// <param name="validationParameters">The <see cref="TokenValidationParameters"/> to be used for validating the token.</param>
+        /// <param name="validationParameters">The <see cref="ValidationParameters"/> to be used for validating the token.</param>
         /// <param name="callContext"></param>
         /// <exception cref="ArgumentNullException">If 'securityToken' is null or whitespace.</exception>
         /// <exception cref="ArgumentNullException">If 'validationParameters' is null or whitespace.</exception>
-        /// <exception cref="SecurityTokenNoExpirationException">If <see cref="TokenValidationParameters.TokenReplayCache"/> is not null and expirationTime.HasValue is false. When a TokenReplayCache is set, tokens require an expiration time.</exception>
+        /// <exception cref="SecurityTokenNoExpirationException">If <see cref="ValidationParameters.TokenReplayCache"/> is not null and expirationTime.HasValue is false. When a TokenReplayCache is set, tokens require an expiration time.</exception>
         /// <exception cref="SecurityTokenReplayDetectedException">If the 'securityToken' is found in the cache.</exception>
-        /// <exception cref="SecurityTokenReplayAddFailedException">If the 'securityToken' could not be added to the <see cref="TokenValidationParameters.TokenReplayCache"/>.</exception>
+        /// <exception cref="SecurityTokenReplayAddFailedException">If the 'securityToken' could not be added to the <see cref="ValidationParameters.TokenReplayCache"/>.</exception>
 #pragma warning disable CA1801 // Review unused parameters
-        internal static ReplayValidationResult ValidateTokenReplay(DateTime? expirationTime, string securityToken, TokenValidationParameters validationParameters, CallContext callContext)
+        internal static ReplayValidationResult ValidateTokenReplay(DateTime? expirationTime, string securityToken, ValidationParameters validationParameters, CallContext callContext)
 #pragma warning restore CA1801 // Review unused parameters
         {
             if (string.IsNullOrWhiteSpace(securityToken))
@@ -70,18 +66,6 @@ namespace Microsoft.IdentityModel.Tokens
                         typeof(ArgumentNullException),
                         new StackFrame(),
                         null));
-
-            if (validationParameters.TokenReplayValidator != null)
-            {
-                return ValidateTokenReplayUsingDelegate(expirationTime, securityToken, validationParameters);
-            }
-
-            if (!validationParameters.ValidateTokenReplay)
-            {
-                LogHelper.LogVerbose(LogMessages.IDX10246);
-
-                return new ReplayValidationResult(expirationTime);
-            }
 
             // check if token if replay cache is set, then there must be an expiration time.
             if (validationParameters.TokenReplayCache != null)
@@ -126,41 +110,6 @@ namespace Microsoft.IdentityModel.Tokens
             // if it reaches here, that means no token replay is detected.
             LogHelper.LogInformation(LogMessages.IDX10240);
             return new ReplayValidationResult(expirationTime);
-        }
-
-        private static ReplayValidationResult ValidateTokenReplayUsingDelegate(DateTime? expirationTime, string securityToken, TokenValidationParameters validationParameters)
-        {
-            try
-            {
-                if (!validationParameters.TokenReplayValidator(expirationTime, securityToken, validationParameters))
-                    return new ReplayValidationResult(
-                        expirationTime,
-                        ValidationFailureType.TokenReplayValidationFailed,
-                        new ExceptionDetail(
-                            new MessageDetail(
-                                LogMessages.IDX10228,
-                                LogHelper.MarkAsUnsafeSecurityArtifact(securityToken, t => t.ToString())),
-                            typeof(SecurityTokenReplayDetectedException),
-                            new StackFrame(),
-                            null));
-
-                return new ReplayValidationResult(expirationTime);
-            }
-#pragma warning disable CA1031 // Do not catch general exception types
-            catch (Exception exception)
-#pragma warning restore CA1031 // Do not catch general exception types
-            {
-                return new ReplayValidationResult(
-                    expirationTime,
-                    ValidationFailureType.TokenReplayValidationFailed,
-                    new ExceptionDetail(
-                        new MessageDetail(
-                            LogMessages.IDX10228,
-                            LogHelper.MarkAsUnsafeSecurityArtifact(securityToken, t => t.ToString())),
-                        exception.GetType(),
-                        new StackFrame(),
-                        exception));
-            }
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
@@ -10,6 +10,21 @@ using Microsoft.IdentityModel.Logging;
 #nullable enable
 namespace Microsoft.IdentityModel.Tokens
 {
+    /// <summary>
+    /// Definition for delegate that will validate the token type of a token.
+    /// </summary>
+    /// <param name="type">The token type or <c>null</c> if it couldn't be resolved (e.g from the 'typ' header for a JWT).</param>
+    /// <param name="securityToken">The <see cref="SecurityToken"/> that is being validated.</param>
+    /// <param name="validationParameters"><see cref="ValidationParameters"/> required for validation.</param>
+    /// <param name="callContext"></param>
+    /// <returns> A <see cref="TokenTypeValidationResult"/>that contains the results of validating the token type.</returns>
+    /// <remarks>An EXACT match is required. <see cref="StringComparison.Ordinal"/> (case sensitive) is used for comparing <paramref name="type"/> against <see cref="TokenValidationParameters.ValidTypes"/>.</remarks>
+    internal delegate TokenTypeValidationResult TypeValidatorDelegate(
+        string? type,
+        SecurityToken? securityToken,
+        ValidationParameters validationParameters,
+        CallContext callContext);
+
     public static partial class Validators
     {
         /// <summary>
@@ -19,10 +34,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="securityToken">The <see cref="SecurityToken"/> that is being validated.</param>
         /// <param name="validationParameters"><see cref="ValidationParameters"/> required for validation.</param>
         /// <param name="callContext"></param>
-        /// <exception cref="ArgumentNullException">If <paramref name="validationParameters"/> is null.</exception>
-        /// <exception cref="ArgumentNullException">If <paramref name="securityToken"/> is null.</exception>
-        /// <exception cref="SecurityTokenInvalidTypeException">If <paramref name="type"/> is null or whitespace and <see cref="ValidationParameters.ValidTypes"/> is not null.</exception>
-        /// <exception cref="SecurityTokenInvalidTypeException">If <paramref name="type"/> failed to match <see cref="ValidationParameters.ValidTypes"/>.</exception>
+        /// <returns> A <see cref="TokenTypeValidationResult"/>that contains the results of validating the token type.</returns>
         /// <remarks>An EXACT match is required. <see cref="StringComparison.Ordinal"/> (case sensitive) is used for comparing <paramref name="type"/> against <see cref="TokenValidationParameters.ValidTypes"/>.</remarks>
 #pragma warning disable CA1801 // TODO: remove pragma disable once callContext is used for logging
         internal static TokenTypeValidationResult ValidateTokenType(

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
@@ -18,7 +18,7 @@ namespace Microsoft.IdentityModel.Tokens
     /// <param name="validationParameters"><see cref="ValidationParameters"/> required for validation.</param>
     /// <param name="callContext"></param>
     /// <returns> A <see cref="TokenTypeValidationResult"/>that contains the results of validating the token type.</returns>
-    /// <remarks>An EXACT match is required. <see cref="StringComparison.Ordinal"/> (case sensitive) is used for comparing <paramref name="type"/> against <see cref="TokenValidationParameters.ValidTypes"/>.</remarks>
+    /// <remarks>An EXACT match is required. <see cref="StringComparison.Ordinal"/> (case sensitive) is used for comparing <paramref name="type"/> against <see cref="ValidationParameters.ValidTypes"/>.</remarks>
     internal delegate TokenTypeValidationResult TypeValidatorDelegate(
         string? type,
         SecurityToken? securityToken,
@@ -35,7 +35,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="validationParameters"><see cref="ValidationParameters"/> required for validation.</param>
         /// <param name="callContext"></param>
         /// <returns> A <see cref="TokenTypeValidationResult"/>that contains the results of validating the token type.</returns>
-        /// <remarks>An EXACT match is required. <see cref="StringComparison.Ordinal"/> (case sensitive) is used for comparing <paramref name="type"/> against <see cref="TokenValidationParameters.ValidTypes"/>.</remarks>
+        /// <remarks>An EXACT match is required. <see cref="StringComparison.Ordinal"/> (case sensitive) is used for comparing <paramref name="type"/> against <see cref="ValidationParameters.ValidTypes"/>.</remarks>
 #pragma warning disable CA1801 // TODO: remove pragma disable once callContext is used for logging
         internal static TokenTypeValidationResult ValidateTokenType(
             string? type,
@@ -70,7 +70,7 @@ namespace Microsoft.IdentityModel.Tokens
                         new StackFrame(true)));
             }
 
-            if (validationParameters.ValidTypes == null || validationParameters.ValidTypes.Count == 0)
+            if (validationParameters.ValidTypes.Count == 0)
             {
                 LogHelper.LogVerbose(LogMessages.IDX10255);
                 return new TokenTypeValidationResult(type);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/LifetimeValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/LifetimeValidationResultTests.cs
@@ -58,52 +58,28 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         Expires = oneHourFromNow,
                         NotBefore = oneHourAgo,
                         LifetimeValidationResult = new LifetimeValidationResult(oneHourAgo, oneHourFromNow),
-                        ValidationParameters = new TokenValidationParameters()
-                    },
-                    new ValidateLifetimeTheoryData("Valid_ValidateLifetimeIsFalse_DatesAreNotNull")
-                    {
-                        Expires = oneHourFromNow,
-                        NotBefore = oneHourAgo,
-                        LifetimeValidationResult = new LifetimeValidationResult(oneHourAgo, oneHourFromNow),
-                        ValidationParameters = new TokenValidationParameters { ValidateLifetime = false }
-                    },
-                    new ValidateLifetimeTheoryData("Valid_ValidateLifetimeIsFalse_DatesAreNull")
-                    {
-                        Expires = null,
-                        NotBefore = null,
-                        LifetimeValidationResult = new LifetimeValidationResult(null, null),
-                        ValidationParameters = new TokenValidationParameters { ValidateLifetime = false }
+                        ValidationParameters = new ValidationParameters()
                     },
                     new ValidateLifetimeTheoryData("Valid_NotBeforeIsNull")
                     {
                         Expires = oneHourFromNow,
                         NotBefore = null,
                         LifetimeValidationResult = new LifetimeValidationResult(null, oneHourFromNow),
-                        ValidationParameters = new TokenValidationParameters()
+                        ValidationParameters = new ValidationParameters()
                     },
                     new ValidateLifetimeTheoryData("Valid_SkewForward")
                     {
                         Expires = oneHourFromNow,
                         NotBefore = twoMinutesFromNow,
-                        ValidationParameters = new TokenValidationParameters { ClockSkew = TimeSpan.FromMinutes(5) },
+                        ValidationParameters = new ValidationParameters { ClockSkew = TimeSpan.FromMinutes(5) },
                         LifetimeValidationResult = new LifetimeValidationResult(twoMinutesFromNow, oneHourFromNow),
                     },
                     new ValidateLifetimeTheoryData("Valid_SkewBackward")
                     {
                         Expires = oneMinuteAgo,
                         NotBefore = twoMinutesAgo,
-                        ValidationParameters = new TokenValidationParameters { ClockSkew = TimeSpan.FromMinutes(5) },
+                        ValidationParameters = new ValidationParameters { ClockSkew = TimeSpan.FromMinutes(5) },
                         LifetimeValidationResult = new LifetimeValidationResult(twoMinutesAgo, oneMinuteAgo),
-                    },
-                    new ValidateLifetimeTheoryData("Valid_DelegateReturnsTrue")
-                    {
-                        Expires = oneHourFromNow,
-                        NotBefore = oneHourAgo,
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            LifetimeValidator = (DateTime? notBefore, DateTime? expires, SecurityToken securityToken, TokenValidationParameters validationParameters) => true
-                        },
-                        LifetimeValidationResult = new LifetimeValidationResult(oneHourAgo, oneHourFromNow),
                     },
                     new ValidateLifetimeTheoryData("Invalid_ValidationParametersIsNull")
                     {
@@ -126,7 +102,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     new ValidateLifetimeTheoryData("Invalid_ExpiresIsNull")
                     {
                         NotBefore = oneHourAgo,
-                        ValidationParameters = new TokenValidationParameters(),
+                        ValidationParameters = new ValidationParameters(),
                         ExpectedException = ExpectedException.SecurityTokenNoExpirationException("IDX10225:"),
                         LifetimeValidationResult = new LifetimeValidationResult(
                             oneHourAgo,
@@ -144,7 +120,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     {
                         Expires = oneHourAgo,
                         NotBefore = oneHourFromNow,
-                        ValidationParameters = new TokenValidationParameters(),
+                        ValidationParameters = new ValidationParameters(),
                         ExpectedException = ExpectedException.SecurityTokenInvalidLifetimeException("IDX10224:"),
                         LifetimeValidationResult = new LifetimeValidationResult(
                             oneHourFromNow, // notBefore
@@ -163,7 +139,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     {
                         Expires = twoHoursFromNow,
                         NotBefore = oneHourFromNow,
-                        ValidationParameters = new TokenValidationParameters(),
+                        ValidationParameters = new ValidationParameters(),
                         ExpectedException = ExpectedException.SecurityTokenNotYetValidException("IDX10222:"),
                         LifetimeValidationResult = new LifetimeValidationResult(
                             oneHourFromNow,
@@ -182,7 +158,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     {
                         Expires = oneHourAgo,
                         NotBefore = twoHoursAgo,
-                        ValidationParameters = new TokenValidationParameters(),
+                        ValidationParameters = new ValidationParameters(),
                         ExpectedException = ExpectedException.SecurityTokenExpiredException("IDX10223:"),
                         LifetimeValidationResult = new LifetimeValidationResult(
                             twoHoursAgo,
@@ -201,7 +177,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     {
                         Expires = oneHourFromNow,
                         NotBefore = sixMinutesFromNow,
-                        ValidationParameters = new TokenValidationParameters { ClockSkew = TimeSpan.FromMinutes(5) },
+                        ValidationParameters = new ValidationParameters { ClockSkew = TimeSpan.FromMinutes(5) },
                         ExpectedException = ExpectedException.SecurityTokenNotYetValidException("IDX10222:"),
                         LifetimeValidationResult = new LifetimeValidationResult(
                             sixMinutesFromNow,
@@ -220,7 +196,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     {
                         Expires = sixMinutesAgo,
                         NotBefore = twoHoursAgo,
-                        ValidationParameters = new TokenValidationParameters { ClockSkew = TimeSpan.FromMinutes(5) },
+                        ValidationParameters = new ValidationParameters { ClockSkew = TimeSpan.FromMinutes(5) },
                         ExpectedException = ExpectedException.SecurityTokenExpiredException("IDX10223:"),
                         LifetimeValidationResult = new LifetimeValidationResult(
                             twoHoursAgo,
@@ -234,49 +210,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                                 typeof(SecurityTokenExpiredException),
                                 new StackFrame(true),
                                 null)),
-                    },
-                    new ValidateLifetimeTheoryData("Invalid_DelegateReturnsFalse")
-                    {
-                        Expires = oneHourFromNow,
-                        NotBefore = oneHourAgo,
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            LifetimeValidator = (DateTime? notBefore, DateTime? expires, SecurityToken securityToken, TokenValidationParameters validationParameters) => false
-                        },
-                        ExpectedException = ExpectedException.SecurityTokenInvalidLifetimeException("IDX10230:"),
-                        LifetimeValidationResult = new LifetimeValidationResult(
-                            oneHourAgo,
-                            oneHourFromNow,
-                            ValidationFailureType.LifetimeValidationFailed,
-                            new ExceptionDetail(
-                                new MessageDetail(
-                                    LogMessages.IDX10230,
-                                    "null"),
-                                typeof(SecurityTokenInvalidLifetimeException),
-                                new StackFrame(true),
-                                null)),
-                    },
-                    new ValidateLifetimeTheoryData("Invalid_DelegateThrows")
-                    {
-                        Expires = oneHourFromNow,
-                        NotBefore = oneHourAgo,
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            LifetimeValidator = (DateTime? notBefore, DateTime? expires, SecurityToken securityToken, TokenValidationParameters validationParameters) => throw new SecurityTokenInvalidLifetimeException()
-                        },
-                        ExpectedException = ExpectedException.SecurityTokenInvalidLifetimeException("IDX10230:", innerTypeExpected: typeof(SecurityTokenInvalidLifetimeException)),
-                        LifetimeValidationResult = new LifetimeValidationResult(
-                            oneHourAgo,
-                            oneHourFromNow,
-                            ValidationFailureType.LifetimeValidationFailed,
-                            new ExceptionDetail(
-                                new MessageDetail(
-                                    LogMessages.IDX10230,
-                                    "null"),
-                                typeof(SecurityTokenInvalidLifetimeException),
-                                new StackFrame(true),
-                                null)),
-                    },
+                    }
                 };
             }
         }
@@ -294,7 +228,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
 
         public SecurityToken SecurityToken { get; set; }
 
-        public TokenValidationParameters ValidationParameters { get; set; }
+        internal ValidationParameters ValidationParameters { get; set; }
 
         internal LifetimeValidationResult LifetimeValidationResult { get; set; }
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ReplayValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ReplayValidationResultTests.cs
@@ -51,10 +51,9 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         TestId = "Valid_ReplayCache_Null",
                         ExpirationTime = oneHourAgo,
                         SecurityToken = "token",
-                        ValidationParameters = new TokenValidationParameters
+                        ValidationParameters = new ValidationParameters
                         {
-                            TokenReplayCache = null,
-                            ValidateTokenReplay = true
+                            TokenReplayCache = null
                         },
                         ReplayValidationResult = new ReplayValidationResult(oneHourAgo)
                     },
@@ -63,38 +62,9 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         TestId = "Valid_ReplayCache_NotNull",
                         ExpirationTime = oneHourFromNow,
                         SecurityToken = "token",
-                        ValidationParameters = new TokenValidationParameters
+                        ValidationParameters = new ValidationParameters
                         {
                             TokenReplayCache = new TokenReplayCache { OnAddReturnValue = true, OnFindReturnValue = false },
-                            ValidateTokenReplay = true
-                        },
-                        ReplayValidationResult = new ReplayValidationResult(oneHourFromNow)
-                    },
-                    new TokenReplayTheoryData
-                    {
-                        TestId = "Valid_ValidateTokenReplay_False",
-                        ExpirationTime = oneHourFromNow,
-                        SecurityToken = "token",
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            TokenReplayCache = new TokenReplayCache
-                            {
-                                OnAddReturnValue = true, 
-                                OnFindReturnValue = true // token already exists in cache, if ValidateTokenReplay were true, this would fail.
-                            },
-                            ValidateTokenReplay = false
-                        },
-                        ReplayValidationResult = new ReplayValidationResult(oneHourFromNow)
-                    },
-                    new TokenReplayTheoryData
-                    {
-                        TestId = "Valid_DelegateIsSet_ReturnsTrue",
-                        ExpirationTime = oneHourFromNow,
-                        SecurityToken = "token",
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            TokenReplayValidator = (token, expirationTime, validationParameters) => true,
-                            ValidateTokenReplay = true
                         },
                         ReplayValidationResult = new ReplayValidationResult(oneHourFromNow)
                     },
@@ -103,10 +73,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         TestId = "Invalid_SecurityToken_Null",
                         ExpirationTime = now,
                         SecurityToken = null,
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            ValidateTokenReplay = true
-                        },
+                        ValidationParameters = new ValidationParameters(),
                         ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
                         ReplayValidationResult = new ReplayValidationResult(
                             now,
@@ -124,10 +91,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         TestId = "Invalid_SecurityToken_Empty",
                         ExpirationTime = now,
                         SecurityToken = string.Empty,
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            ValidateTokenReplay = true
-                        },
+                        ValidationParameters = new ValidationParameters(),
                         ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
                         ReplayValidationResult = new ReplayValidationResult(
                             now,
@@ -160,61 +124,16 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new TokenReplayTheoryData
                     {
-                        TestId = "Invalid_DelegateIsSet_ReturnsFalse",
-                        ExpirationTime = now,
-                        SecurityToken = "token",
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            TokenReplayValidator = (token, expirationTime, validationParameters) => false,
-                            ValidateTokenReplay = true
-                        },
-                        ExpectedException = ExpectedException.SecurityTokenReplayDetected("IDX10228"),
-                        ReplayValidationResult = new ReplayValidationResult(
-                            now,
-                            ValidationFailureType.TokenReplayValidationFailed,
-                            new ExceptionDetail(
-                                new MessageDetail(
-                                    LogMessages.IDX10228,
-                                    LogHelper.MarkAsUnsafeSecurityArtifact("token", t => t.ToString())),
-                                typeof(SecurityTokenReplayDetectedException),
-                                new StackFrame(),
-                                null))
-                    },
-                    new TokenReplayTheoryData
-                    {
-                        TestId = "Invalid_DelegateIsSet_ThrowsException",
-                        ExpirationTime = now,
-                        SecurityToken = "token",
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            TokenReplayValidator = (token, expirationTime, validationParameters) => throw new SecurityTokenReplayDetectedException(),
-                            ValidateTokenReplay = true
-                        },
-                        ExpectedException = ExpectedException.SecurityTokenReplayDetected("IDX10228:", innerTypeExpected: typeof(SecurityTokenReplayDetectedException)),
-                        ReplayValidationResult = new ReplayValidationResult(
-                            now,
-                            ValidationFailureType.TokenReplayValidationFailed,
-                            new ExceptionDetail(
-                                new MessageDetail(
-                                    LogMessages.IDX10228,
-                                    LogHelper.MarkAsUnsafeSecurityArtifact("token", t => t.ToString())),
-                                typeof(SecurityTokenReplayDetectedException),
-                                new StackFrame(),
-                                new SecurityTokenReplayDetectedException()))
-                    },
-                    new TokenReplayTheoryData
-                    {
                         TestId = "Invalid_ReplayCacheIsPresent_ExpirationTimeIsNull",
                         ExpirationTime = null,
                         SecurityToken = "token",
-                        ValidationParameters = new TokenValidationParameters
+                        ValidationParameters = new ValidationParameters
                         {
                             TokenReplayCache = new TokenReplayCache
                             {
                                 OnAddReturnValue = true,
                                 OnFindReturnValue = false
-                            },
-                            ValidateTokenReplay = true
+                            }
                         },
                         ExpectedException = ExpectedException.SecurityTokenReplayDetected("IDX10227:"),
                         ReplayValidationResult = new ReplayValidationResult(
@@ -233,14 +152,13 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         TestId = "Invalid_ReplayCacheIsPresent_TokenIsAlreadyInCache",
                         ExpirationTime = oneHourFromNow,
                         SecurityToken= "token",
-                        ValidationParameters = new TokenValidationParameters
+                        ValidationParameters = new ValidationParameters
                         {
                             TokenReplayCache = new TokenReplayCache
                             {
                                 OnAddReturnValue = true,
                                 OnFindReturnValue = true
                             },
-                            ValidateTokenReplay = true
                         },
                         ExpectedException = ExpectedException.SecurityTokenReplayDetected("IDX10228:"),
                         ReplayValidationResult = new ReplayValidationResult(
@@ -259,14 +177,13 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         TestId = "Invalid_ReplayCacheIsPresent_AddingTokenToCacheFails",
                         ExpirationTime = oneHourFromNow,
                         SecurityToken= "token",
-                        ValidationParameters = new TokenValidationParameters
+                        ValidationParameters = new ValidationParameters
                         {
                             TokenReplayCache = new TokenReplayCache
                             {
                                 OnAddReturnValue = false,
                                 OnFindReturnValue = false
-                            },
-                            ValidateTokenReplay = true
+                            }
                         },
                         ExpectedException = ExpectedException.SecurityTokenReplayAddFailed("IDX10229:"),
                         ReplayValidationResult = new ReplayValidationResult(
@@ -291,7 +208,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
 
         public string SecurityToken { get; set; }
 
-        public TokenValidationParameters ValidationParameters { get; set; }
+        internal ValidationParameters ValidationParameters { get; set; }
 
         internal ReplayValidationResult ReplayValidationResult { get; set; }
     }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/TokenTypeValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/TokenTypeValidationResultTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         TestId = "Valid_DefaultTokenTypeValidation",
                         Type = "JWT",
                         SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, "JWT"),
-                        ValidationParameters = new TokenValidationParameters
+                        ValidationParameters = new ValidationParameters
                         {
                             ValidTypes = validTypesWithJwt
                         },
@@ -94,45 +94,11 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new TokenTypeTheoryData
                     {
-                        TestId = "Valid_ValidateTokenTypeUsingDelegate",
+                        TestId = "Valid_ValidationParametersTypeValidTypesAreNull",
                         Type = "JWT",
                         SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, "JWT"),
-                        ValidationParameters = new TokenValidationParameters
+                        ValidationParameters = new ValidationParameters
                         {
-                            TypeValidator = (Type, SecurityToken, TokenValidationParameters) => "JWT"
-                        },
-                        TokenTypeValidationResult = new TokenTypeValidationResult("JWT")
-                    },
-                    new TokenTypeTheoryData
-                    {
-                        TestId = "Invalid_ValidateTokenTypeUsingDelegate",
-                        ExpectedException = ExpectedException.SecurityTokenInvalidTypeException(substringExpected: "IDX10259:", innerTypeExpected: typeof(SecurityTokenInvalidTypeException)),
-                        Type = "JWT",
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, "JWT"),
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            TypeValidator = (Type, SecurityToken, TokenValidationParameters) => throw new SecurityTokenInvalidTypeException()
-                        },
-                        TokenTypeValidationResult = new TokenTypeValidationResult(
-                            "JWT",
-                            ValidationFailureType.TokenTypeValidationFailed,
-                            new ExceptionDetail(
-                                new MessageDetail(
-                                    LogMessages.IDX10259,
-                                    LogHelper.MarkAsNonPII("TypeValidator"),
-                                    LogHelper.MarkAsNonPII("Delegate message")),
-                                typeof(SecurityTokenInvalidTypeException),
-                                new StackFrame(true),
-                                new SecurityTokenInvalidTypeException()))
-                    },
-                    new TokenTypeTheoryData
-                    {
-                        TestId = "Valid_TokenValidationParametersTypeValidatorAndValidTypesAreNull",
-                        Type = "JWT",
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, "JWT"),
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            TypeValidator = null,
                             ValidTypes = null
                         },
                         TokenTypeValidationResult = new TokenTypeValidationResult("JWT")
@@ -143,7 +109,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidTypeException("IDX10256:"),
                         Type = String.Empty,
                         SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, String.Empty),
-                        ValidationParameters = new TokenValidationParameters
+                        ValidationParameters = new ValidationParameters
                         {
                             ValidTypes = validTypesNoJwt
                         },
@@ -163,7 +129,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidTypeException("IDX10256:"),
                         Type = null,
                         SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, null),
-                        ValidationParameters = new TokenValidationParameters
+                        ValidationParameters = new ValidationParameters
                         {
                             ValidTypes = validTypesNoJwt
                         },
@@ -179,11 +145,11 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new TokenTypeTheoryData
                     {
-                        TestId = "Invalid_TokenValidationParametersValidTypesDoesNotSupportType",
+                        TestId = "Invalid_ValidationParametersValidTypesDoesNotSupportType",
                         ExpectedException = ExpectedException.SecurityTokenInvalidTypeException("IDX10257:"),
                         Type = "JWT",
                         SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, "JWT"),
-                        ValidationParameters = new TokenValidationParameters
+                        ValidationParameters = new ValidationParameters
                         {
                             ValidTypes = validTypesNoJwt
                         },
@@ -208,7 +174,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
 
             public SecurityToken SecurityToken { get; set; }
 
-            public TokenValidationParameters ValidationParameters { get; set; }
+            internal ValidationParameters ValidationParameters { get; set; }
 
             internal TokenTypeValidationResult TokenTypeValidationResult { get; set; }
         }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/TokenTypeValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/TokenTypeValidationResultTests.cs
@@ -94,17 +94,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new TokenTypeTheoryData
                     {
-                        TestId = "Valid_ValidationParametersTypeValidTypesAreNull",
-                        Type = "JWT",
-                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, "JWT"),
-                        ValidationParameters = new ValidationParameters
-                        {
-                            ValidTypes = null
-                        },
-                        TokenTypeValidationResult = new TokenTypeValidationResult("JWT")
-                    },
-                    new TokenTypeTheoryData
-                    {
                         TestId = "Invalid_TokenTypeIsEmpty",
                         ExpectedException = ExpectedException.SecurityTokenInvalidTypeException("IDX10256:"),
                         Type = String.Empty,

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationParametersTests.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Tokens.Tests.Validation
+{
+    public class ValidationParametersTests
+    {
+        [Fact]
+        public void SetValidators_NullValue_ThrowsArgumentNullException()
+        {
+            var validationParameters = new ValidationParameters();
+            Assert.Throws<ArgumentNullException>(() => validationParameters.IssuerValidatorAsync = null);
+            Assert.Throws<ArgumentNullException>(() => validationParameters.TokenReplayValidator = null);
+            Assert.Throws<ArgumentNullException>(() => validationParameters.LifetimeValidator = null);
+            Assert.Throws<ArgumentNullException>(() => validationParameters.TypeValidator = null);
+            Assert.Throws<ArgumentNullException>(() => validationParameters.AudienceValidator = null);
+        }
+
+        [Fact]
+        public void ValidTypes_Get_ReturnsValidTokenTypes()
+        {
+            var validationParameters = new ValidationParameters();
+            var validTokenTypes = new List<string> { "JWT", "SAML" };
+            validationParameters.ValidTypes = validTokenTypes;
+
+            var result = validationParameters.ValidTypes;
+
+            Assert.Equal(validTokenTypes, result);
+        }
+
+        [Fact]
+        public void ValidTypes_Set_UpdatesValidTokenTypes()
+        {
+            var validationParameters = new ValidationParameters();
+            var validTokenTypes = new List<string> { "JWT", "SAML" };
+
+            validationParameters.ValidTypes = validTokenTypes;
+
+            Assert.Equal(validTokenTypes, validationParameters.ValidTypes);
+        }
+
+        [Fact]
+        public void ValidTypes_Set_Null_ThrowsArgumentNullException()
+        {
+            var validationParameters = new ValidationParameters();
+            Assert.Throws<ArgumentNullException>(() => validationParameters.ValidTypes = null);
+        }
+    }
+}


### PR DESCRIPTION
# Remove Delegate Checks in Multiple Validators and Prevents Null Setting of Delegates.

## Description

- Removed delegate checks from our default token type, lifetime and token replay validation.
- Moved away from using `TokenValidationParameters` in favor of the new `ValidationParameters`.
- Updated unit tests and added new tests for ValidationParameters class.
- Fixed minor inconsistencies on the code.
