### PR TITLE
remove prefix for release builds

### DIFF
--- a/buildConfiguration.xml
+++ b/buildConfiguration.xml
@@ -3,7 +3,7 @@
   <nugetVersion>3.5.0-rc-1285</nugetVersion>
   <runtimes>net45,net461,netstandard2.0</runtimes>
   <assemblyVersion>6.36.0</assemblyVersion>
-  <nugetSuffix>preview</nugetSuffix>
+  <nugetSuffix></nugetSuffix>
   <projects>
     <src>
       <project name="Microsoft.IdentityModel.Logging" />


### PR DESCRIPTION
Set nugetSuffix in buildConfiguration.xml to empty so preview will not show up in release build.