### PR TITLE
Allow Jwt payload to be the empty string.

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonWebToken.PayloadClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonWebToken.PayloadClaimSet.cs
@@ -19,6 +19,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
         internal JsonClaimSet CreatePayloadClaimSet(ReadOnlySpan<byte> byteSpan)
         {
+            if (byteSpan.Length == 0)
+                return new JsonClaimSet([]);
+
             Utf8JsonReader reader = new(byteSpan);
             if (!JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartObject, true))
                 throw LogHelper.LogExceptionMessage(

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -114,7 +114,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// Initializes a new instance of the <see cref="JsonWebToken"/> class where the header contains the crypto algorithms applied to the encoded header and payload.
         /// </summary>
         /// <param name="header">A string containing JSON which represents the cryptographic operations applied to the JWT and optionally any additional properties of the JWT.</param>
-        /// <param name="payload">A string containing JSON which represents the claims contained in the JWT. Each claim is a JSON object of the form { Name, Value }.</param>
+        /// <param name="payload">A string containing JSON which represents the claims contained in the JWT. Each claim is a JSON object of the form { Name, Value }. Can be the empty.</param>
         /// <remarks>
         /// See: <see href="https://datatracker.ietf.org/doc/html/rfc7519"/> (JWT).
         /// See: <see href="https://datatracker.ietf.org/doc/html/rfc7515"/> (JWS).
@@ -124,14 +124,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// </para>
         /// </remarks>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="header"/> is null or empty.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="payload"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="payload"/> is null.</exception>
         public JsonWebToken(string header, string payload)
         {
             if (string.IsNullOrEmpty(header))
                 throw LogHelper.LogArgumentNullException(nameof(header));
 
-            if (string.IsNullOrEmpty(payload))
-                throw LogHelper.LogArgumentNullException(nameof(payload));
+            _ = payload ?? throw LogHelper.LogArgumentNullException(nameof(payload));
 
             var encodedHeader = Base64UrlEncoder.Encode(header);
             var encodedPayload = Base64UrlEncoder.Encode(payload);

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
@@ -13,7 +13,6 @@ using System.Text.Json;
 using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.IdentityModel.Tokens.Json;
 using JsonPrimitives = Microsoft.IdentityModel.Tokens.Json.JsonSerializerPrimitives;
 using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
 
@@ -34,10 +33,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <returns>A JWS in Compact Serialization format.</returns>
         public virtual string CreateToken(string payload)
         {
-            if (string.IsNullOrEmpty(payload))
-                throw LogHelper.LogArgumentNullException(nameof(payload));
+            _ = payload ?? throw LogHelper.LogArgumentNullException(nameof(payload));
 
-                return CreateToken(
+            return CreateToken(
                     payload,
                     null,
                     null,
@@ -59,9 +57,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             string payload,
             IDictionary<string, object> additionalHeaderClaims)
         {
-            if (string.IsNullOrEmpty(payload))
-                throw LogHelper.LogArgumentNullException(nameof(payload));
-
+            _ = payload ?? throw LogHelper.LogArgumentNullException(nameof(payload));
             _ = additionalHeaderClaims ?? throw LogHelper.LogArgumentNullException(nameof(additionalHeaderClaims));
 
             return CreateToken(payload,
@@ -85,9 +81,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             string payload,
             SigningCredentials signingCredentials)
         {
-            if (string.IsNullOrEmpty(payload))
-                throw LogHelper.LogArgumentNullException(nameof(payload));
-
+            _ = payload ?? throw LogHelper.LogArgumentNullException(nameof(payload));
             _ = signingCredentials ?? throw LogHelper.LogArgumentNullException(nameof(signingCredentials));
 
             return CreateToken(
@@ -118,9 +112,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             SigningCredentials signingCredentials,
             IDictionary<string, object> additionalHeaderClaims)
         {
-            if (string.IsNullOrEmpty(payload))
-                throw LogHelper.LogArgumentNullException(nameof(payload));
-
+            _ = payload ?? throw LogHelper.LogArgumentNullException(nameof(payload));
             _ = signingCredentials ?? throw LogHelper.LogArgumentNullException(nameof(signingCredentials));
             _ = additionalHeaderClaims ?? throw LogHelper.LogArgumentNullException(nameof(additionalHeaderClaims));
 
@@ -296,9 +288,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             string payload,
             EncryptingCredentials encryptingCredentials)
         {
-            if (string.IsNullOrEmpty(payload))
-                throw LogHelper.LogArgumentNullException(nameof(payload));
-
+            _ = payload ?? throw LogHelper.LogArgumentNullException(nameof(payload));
             _ = encryptingCredentials ?? throw LogHelper.LogArgumentNullException(nameof(encryptingCredentials));
 
             return CreateToken(
@@ -329,9 +319,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             EncryptingCredentials encryptingCredentials,
             IDictionary<string, object> additionalHeaderClaims)
         {
-            if (string.IsNullOrEmpty(payload))
-                throw LogHelper.LogArgumentNullException(nameof(payload));
-
+            _ = payload ?? throw LogHelper.LogArgumentNullException(nameof(payload));
             _ = encryptingCredentials ?? throw LogHelper.LogArgumentNullException(nameof(encryptingCredentials));
             _ = additionalHeaderClaims ?? throw LogHelper.LogArgumentNullException(nameof(additionalHeaderClaims));
 
@@ -360,9 +348,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             SigningCredentials signingCredentials,
             EncryptingCredentials encryptingCredentials)
         {
-            if (string.IsNullOrEmpty(payload))
-                throw LogHelper.LogArgumentNullException(nameof(payload));
-
+            _ = payload ?? throw LogHelper.LogArgumentNullException(nameof(payload));
             _ = signingCredentials ?? throw LogHelper.LogArgumentNullException(nameof(signingCredentials));
             _ = encryptingCredentials ?? throw LogHelper.LogArgumentNullException(nameof(encryptingCredentials));
 
@@ -397,9 +383,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             EncryptingCredentials encryptingCredentials,
             IDictionary<string, object> additionalHeaderClaims)
         {
-            if (string.IsNullOrEmpty(payload))
-                throw LogHelper.LogArgumentNullException(nameof(payload));
-
+            _ = payload ?? throw LogHelper.LogArgumentNullException(nameof(payload));
             _ = signingCredentials ?? throw LogHelper.LogArgumentNullException(nameof(signingCredentials));
             _ = encryptingCredentials ?? throw LogHelper.LogArgumentNullException(nameof(encryptingCredentials));
             _ = additionalHeaderClaims ?? throw LogHelper.LogArgumentNullException(nameof(additionalHeaderClaims));
@@ -420,14 +404,16 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <param name="payload">A string containing JSON which represents the JWT token payload.</param>
         /// <param name="encryptingCredentials">The security key and algorithm that will be used to encrypt the JWT.</param>
         /// <param name="compressionAlgorithm">The compression algorithm that will be used to compress the JWT token payload.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="payload"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="encryptingCredentials"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="compressionAlgorithm"/> is null or empty.</exception>
         /// <returns>A JWE in Compact Serialization format.</returns>
         public virtual string CreateToken(
             string payload,
             EncryptingCredentials encryptingCredentials,
             string compressionAlgorithm)
         {
-            if (string.IsNullOrEmpty(payload))
-                throw LogHelper.LogArgumentNullException(nameof(payload));
+            _ = payload ?? throw LogHelper.LogArgumentNullException(nameof(payload));
 
             if (string.IsNullOrEmpty(compressionAlgorithm))
                 throw LogHelper.LogArgumentNullException(nameof(compressionAlgorithm));
@@ -462,7 +448,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             EncryptingCredentials encryptingCredentials,
             string compressionAlgorithm)
         {
-            if (string.IsNullOrEmpty(payload))
+            if (payload == null)
                 throw LogHelper.LogArgumentNullException(nameof(payload));
 
             if (string.IsNullOrEmpty(compressionAlgorithm))
@@ -507,7 +493,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             IDictionary<string, object> additionalHeaderClaims,
             IDictionary<string, object> additionalInnerHeaderClaims)
         {
-            if (string.IsNullOrEmpty(payload))
+            if (payload == null)
                 throw LogHelper.LogArgumentNullException(nameof(payload));
 
             if (string.IsNullOrEmpty(compressionAlgorithm))
@@ -552,7 +538,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             string compressionAlgorithm,
             IDictionary<string, object> additionalHeaderClaims)
         {
-            if (string.IsNullOrEmpty(payload))
+            if (payload == null)
                 throw LogHelper.LogArgumentNullException(nameof(payload));
 
             if (string.IsNullOrEmpty(compressionAlgorithm))

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
@@ -1599,12 +1599,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     ExpectedException = new ExpectedException(typeof(ArgumentException), "IDX14102:", typeof(JsonReaderException), true),
                 });
 
-                theoryData.Add(new JwtTheoryData(nameof(EncodedJwts.JWSEmptyPayload))
-                {
-                    Token = EncodedJwts.JWSEmptyPayload,
-                    ExpectedException = new ExpectedException(typeof(ArgumentException), "IDX14101:", typeof(JsonReaderException), true),
-                });
-
                 theoryData.Add(new JwtTheoryData(nameof(EncodedJwts.JWEEmptyHeader))
                 {
                     Token = EncodedJwts.JWEEmptyHeader,


### PR DESCRIPTION
Nothing in the jwt spec requires the payload to have any values.
This PR allows the payload to be empty.

Fixes #2656
