### PR TITLE
Cache UseRfcDefinitionOfEpkAndKid switch.

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
@@ -1065,7 +1065,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     // is treated as opt-in. When the library is at the point where it is able to make breaking changes
                     // (such as the next major version update) we should consider whether or not this app-compat switch
                     // needs to be maintained.
-                    if (AppContext.TryGetSwitch(AppCompatSwitches.UseRfcDefinitionOfEpkAndKid, out bool isEnabled) && isEnabled)
+                    if (AppContextSwitches.UseRfcDefinitionOfEpkAndKid)
                     {
                         if (encryptingCredentials.KeyExchangePublicKey.KeyId != null)
                             writer.WriteString(JwtHeaderUtf8Bytes.Kid, encryptingCredentials.KeyExchangePublicKey.KeyId);
@@ -1396,7 +1396,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                         // is treated as opt-in. When the library is at the point where it is able to make breaking changes
                         // (such as the next major version update) we should consider whether or not this app-compat switch
                         // needs to be maintained.
-                        if (AppContext.TryGetSwitch(AppCompatSwitches.UseRfcDefinitionOfEpkAndKid, out bool isEnabled) && isEnabled)
+                        if (AppContextSwitches.UseRfcDefinitionOfEpkAndKid)
                         {
                             // on decryption we get the public key from the EPK value see: https://datatracker.ietf.org/doc/html/rfc7518#appendix-C
                             jwtToken.TryGetHeaderValue(JwtHeaderParameterNames.Epk, out string epk);

--- a/src/Microsoft.IdentityModel.Tokens/AppCompatSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppCompatSwitches.cs
@@ -7,13 +7,7 @@ namespace Microsoft.IdentityModel.Tokens;
 /// Identifiers used for switching between different app compat behaviors within the Microsoft.IdentityModel libraries.
 /// </summary>
 /// <remarks>
-/// The Microsoft.IdentityModel libraries use <see cref="System.AppContext" /> to turn on or off certain API behavioral
-/// changes that might have an effect on application compatibility. This class defines the set of switches that are
-/// available to modify library behavior. Application compatibility is favored as the default - so if your application
-/// needs to rely on the new behavior, you will need to enable the switch manually. Setting a switch's value can be
-/// done programmatically through the <see cref="System.AppContext.SetSwitch" /> method, or through other means such as
-/// setting it through MSBuild, app configuration, or registry settings. These alternate methods are described in the
-/// <see cref="System.AppContext.SetSwitch" /> documentation.
+/// Use <see cref="AppContextSwitches"/> instead.
 /// </remarks>
 public static class AppCompatSwitches
 {

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -7,8 +7,17 @@ using System.Security.Claims;
 namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
-    /// AppContext switches for Microsoft.IdentityModel.Tokens and referencing packages.
+    /// Identifiers used for switching between different app compatibility behaviors within the Microsoft.IdentityModel packages.
     /// </summary>
+    /// <remarks>
+    /// The Microsoft.IdentityModel libraries use <see cref="System.AppContext" /> to turn on or off certain API behavioral
+    /// changes that might have an effect on application compatibility. This class defines the set of switches that are
+    /// available to modify library behavior. Application compatibility is favored as the default - so if your application
+    /// needs to rely on the new behavior, you will need to enable the switch manually. Setting a switch's value can be
+    /// done programmatically through the <see cref="System.AppContext.SetSwitch" /> method, or through other means such as
+    /// setting it through MSBuild, app configuration, or registry settings. These alternate methods are described in the
+    /// <see cref="System.AppContext.SetSwitch" /> documentation.
+    /// </remarks>
     internal static class AppContextSwitches
     {
         /// <summary>
@@ -38,6 +47,24 @@ namespace Microsoft.IdentityModel.Tokens
         private static bool? _tryAllStringClaimsAsDateTime;
 
         internal static bool TryAllStringClaimsAsDateTime => _tryAllStringClaimsAsDateTime ??= (AppContext.TryGetSwitch(TryAllStringClaimsAsDateTimeSwitch, out bool tryAsDateTime) && tryAsDateTime);
+
+        /// <summary>
+        /// Uses <see cref="EncryptingCredentials.KeyExchangePublicKey"/> for the token's `kid` header parameter. When using
+        /// ECDH-based key wrap algorithms the public key portion of <see cref="EncryptingCredentials.Key" /> is also written
+        /// to the token's `epk` header parameter.
+        /// </summary>
+        /// <remarks>
+        /// Enabling this switch improves the library's conformance to RFC 7518 with regards to how the header values for
+        /// `kid` and `epk` are set in ECDH key wrap scenarios. The previous behavior erroneously used key ID of
+        /// <see cref="EncryptingCredentials.Key"/> as the `kid` parameter, and did not automatically set `epk` as the spec
+        /// defines. This switch enables the intended behavior where <see cref="EncryptingCredentials.KeyExchangePublicKey"/>
+        /// is used for `kid` and the public portion of <see cref="EncryptingCredentials.Key"/> is used for `epk`.
+        /// </remarks>
+        internal const string UseRfcDefinitionOfEpkAndKidSwitch = "Switch.Microsoft.IdentityModel.UseRfcDefinitionOfEpkAndKid";
+
+        private static bool? _useRfcDefinitionOfEpkAndKid;
+
+        internal static bool UseRfcDefinitionOfEpkAndKid => _useRfcDefinitionOfEpkAndKid ??= (AppContext.TryGetSwitch(UseRfcDefinitionOfEpkAndKidSwitch, out bool isEnabled) && isEnabled);
 
         /// <summary>
         /// Used for testing to reset all switches to its default value.

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -25,9 +25,9 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         internal const string UseClaimsIdentityTypeSwitch = "Microsoft.IdentityModel.Tokens.UseClaimsIdentityType";
 
-        private static bool? _useClaimsIdentity;
+        private static bool? _useClaimsIdentityType;
 
-        internal static bool UseClaimsIdentityType => _useClaimsIdentity ??= (AppContext.TryGetSwitch(UseClaimsIdentityTypeSwitch, out bool useClaimsIdentityType) && useClaimsIdentityType);
+        internal static bool UseClaimsIdentityType => _useClaimsIdentityType ??= (AppContext.TryGetSwitch(UseClaimsIdentityTypeSwitch, out bool useClaimsIdentityType) && useClaimsIdentityType);
 
         /// <summary>
         /// When validating the issuer signing key, specifies whether to fail if the 'tid' claim is missing.
@@ -71,7 +71,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         internal static void ResetAllSwitches()
         {
-            _useClaimsIdentity = null;
+            _useClaimsIdentityType = null;
             AppContext.SetSwitch(UseClaimsIdentityTypeSwitch, false);
 
             _doNotFailOnMissingTid = null;
@@ -79,6 +79,9 @@ namespace Microsoft.IdentityModel.Tokens
 
             _tryAllStringClaimsAsDateTime = null;
             AppContext.SetSwitch(TryAllStringClaimsAsDateTimeSwitch, false);
+
+            _useRfcDefinitionOfEpkAndKid = null;
+            AppContext.SetSwitch(UseRfcDefinitionOfEpkAndKidSwitch, false);
         }
     }
 }

--- a/src/System.IdentityModel.Tokens.Jwt/JwtHeader.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtHeader.cs
@@ -219,7 +219,7 @@ namespace System.IdentityModel.Tokens.Jwt
             // is treated as opt-in. When the library is at the point where it is able to make breaking changes
             // (such as the next major version update) we should consider whether or not this app-compat switch
             // needs to be maintained.
-            if (AppContext.TryGetSwitch(AppCompatSwitches.UseRfcDefinitionOfEpkAndKid, out bool isEnabled) && isEnabled)
+            if (AppContextSwitches.UseRfcDefinitionOfEpkAndKid)
             {
                 if (!string.IsNullOrEmpty(encryptingCredentials.KeyExchangePublicKey.KeyId))
                     Kid = encryptingCredentials.KeyExchangePublicKey.KeyId;

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1865,7 +1865,7 @@ namespace System.IdentityModel.Tokens.Jwt
                         // is treated as opt-in. When the library is at the point where it is able to make breaking changes
                         // (such as the next major version update) we should consider whether or not this app-compat switch
                         // needs to be maintained.
-                        if (AppContext.TryGetSwitch(AppCompatSwitches.UseRfcDefinitionOfEpkAndKid, out bool isEnabled) && isEnabled)
+                        if (AppContextSwitches.UseRfcDefinitionOfEpkAndKid)
                         {
                             //// on decryption we get the public key from the EPK value see: https://datatracker.ietf.org/doc/html/rfc7518#appendix-C
                             string epk = jwtToken.Header.GetStandardClaim(JwtHeaderParameterNames.Epk);


### PR DESCRIPTION
Cache UseRfcDefinitionOfEpkAndKid switch.

Also updated the wiki: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/App-Context-Switches-in-IdentityModel