### PR TITLE
Fix OIDC Test

### DIFF
--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -327,7 +327,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
 
             // get configuration from https address, should throw
-            configManager = new ConfigurationManager<OpenIdConnectConfiguration>("https://someaddress.com", new OpenIdConnectConfigurationRetriever());
+            configManager = new ConfigurationManager<OpenIdConnectConfiguration>("https://someadress.com", new OpenIdConnectConfigurationRetriever());
             ee = new ExpectedException(typeof(InvalidOperationException), "IDX20803:", typeof(IOException));
             try
             {

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -307,7 +307,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 context.Diffs.Add("!object.ReferenceEquals(configuration, configuration2)");
 
             // get configuration from http address, should throw
-            configManager = new ConfigurationManager<OpenIdConnectConfiguration>("http://someaddress.com", new OpenIdConnectConfigurationRetriever());
+            configManager = new ConfigurationManager<OpenIdConnectConfiguration>("http://127.0.0.1", new OpenIdConnectConfigurationRetriever());
             var ee = new ExpectedException(typeof(InvalidOperationException), "IDX20803:", typeof(ArgumentException));
             try
             {
@@ -327,7 +327,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
 
             // get configuration from https address, should throw
-            configManager = new ConfigurationManager<OpenIdConnectConfiguration>("https://someadress.com", new OpenIdConnectConfigurationRetriever());
+            configManager = new ConfigurationManager<OpenIdConnectConfiguration>("https://127.0.0.1", new OpenIdConnectConfigurationRetriever());
             ee = new ExpectedException(typeof(InvalidOperationException), "IDX20803:", typeof(IOException));
             try
             {


### PR DESCRIPTION
Change the URL in the config manager test to prevent an html response from coming back, which causes the test to fail