### PR TITLE
Re-factor Issuer Validator to Follow New Validation Model

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -36,6 +36,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10208 = "IDX10208: Unable to validate audience. validationParameters.ValidAudience is null or whitespace and validationParameters.ValidAudiences is null.";
         public const string IDX10209 = "IDX10209: Token has length: '{0}' which is larger than the MaximumTokenSizeInBytes: '{1}'.";
         public const string IDX10211 = "IDX10211: Unable to validate issuer. The 'issuer' parameter is null or whitespace.";
+        public const string IDX10212 = "IDX10212: Issuer validation failed. Issuer: '{0}'. Did not match any: validationParameters.ValidIssuers: '{1}' or validationParameters.ConfigurationManager.CurrentConfiguration.Issuer: '{2}'. For more details, see https://aka.ms/IdentityModel/issuer-validation. ";
         public const string IDX10214 = "IDX10214: Audience validation failed. Audiences: '{0}'. Did not match: validationParameters.ValidAudience: '{1}' or validationParameters.ValidAudiences: '{2}'.";
         public const string IDX10222 = "IDX10222: Lifetime validation failed. The token is not yet valid. ValidFrom (UTC): '{0}', Current time (UTC): '{1}'.";
         public const string IDX10223 = "IDX10223: Lifetime validation failed. The token is expired. ValidTo (UTC): '{0}', Current time (UTC): '{1}'.";

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Security.Claims;
+using System.Threading;
 using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.Logging;
 
@@ -20,7 +21,7 @@ namespace Microsoft.IdentityModel.Tokens
         private string _nameClaimType = ClaimsIdentity.DefaultNameClaimType;
         private string _roleClaimType = ClaimsIdentity.DefaultRoleClaimType;
         private Dictionary<string, object> _instancePropertyBag;
-        private IList<string> _validIssuers = [];
+        private IList<string> _validIssuers;
         private IList<string> _validTokenTypes = [];
 
         private AlgorithmValidatorDelegate _algorithmValidator = Validators.ValidateAlgorithm;
@@ -90,7 +91,7 @@ namespace Microsoft.IdentityModel.Tokens
             ValidateWithLKG = other.ValidateWithLKG;
             ValidAlgorithms = other.ValidAlgorithms;
             ValidAudiences = other.ValidAudiences;
-            ValidIssuers = other.ValidIssuers;
+            _validIssuers = other.ValidIssuers;
             ValidTypes = other.ValidTypes;
         }
 
@@ -518,16 +519,14 @@ namespace Microsoft.IdentityModel.Tokens
         public IList<string> ValidAudiences { get; }
 
         /// <summary>
-        /// Gets or sets the <see cref="IList{String}"/> that contains valid issuers that will be used to check against the token's issuer.
+        /// Gets the <see cref="IList{String}"/> that contains valid issuers that will be used to check against the token's issuer.
         /// The default is an empty collection.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when the value is set as null.</exception>
         /// <returns>The <see cref="IList{String}"/> that contains valid issuers that will be used to check against the token's 'iss' claim.</returns>
-        public IList<string> ValidIssuers
-        {
-            get { return _validIssuers; }
-            set { _validIssuers = value ?? throw new ArgumentNullException(nameof(value), "ValidIssuers cannot be set as null."); }
-        }
+        public IList<string> ValidIssuers =>
+            _validIssuers ??
+            Interlocked.CompareExchange(ref _validIssuers, [], null) ??
+            _validIssuers;
 
         /// <summary>
         /// Gets the <see cref="IList{String}"/> that contains valid types that will be used to check against the JWT header's 'typ' claim.

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Security.Claims;
-using System.Threading;
 using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.Logging;
 
@@ -21,6 +20,7 @@ namespace Microsoft.IdentityModel.Tokens
         private string _nameClaimType = ClaimsIdentity.DefaultNameClaimType;
         private string _roleClaimType = ClaimsIdentity.DefaultRoleClaimType;
         private Dictionary<string, object> _instancePropertyBag;
+        private IList<string> _validIssuers = [];
         private IList<string> _validTokenTypes = [];
 
         private AlgorithmValidatorDelegate _algorithmValidator = Validators.ValidateAlgorithm;
@@ -518,10 +518,16 @@ namespace Microsoft.IdentityModel.Tokens
         public IList<string> ValidAudiences { get; }
 
         /// <summary>
-        /// Gets the <see cref="IList{String}"/> that contains valid issuers that will be used to check against the token's issuer.
-        /// The default is <c>null</c>.
+        /// Gets or sets the <see cref="IList{String}"/> that contains valid issuers that will be used to check against the token's issuer.
+        /// The default is an empty collection.
         /// </summary>
-        public IList<string> ValidIssuers { get; }
+        /// <exception cref="ArgumentNullException">Thrown when the value is set as null.</exception>
+        /// <returns>The <see cref="IList{String}"/> that contains valid issuers that will be used to check against the token's 'iss' claim.</returns>
+        public IList<string> ValidIssuers
+        {
+            get { return _validIssuers; }
+            set { _validIssuers = value ?? throw new ArgumentNullException(nameof(value), "ValidIssuers cannot be set as null."); }
+        }
 
         /// <summary>
         /// Gets the <see cref="IList{String}"/> that contains valid types that will be used to check against the JWT header's 'typ' claim.

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Issuer.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Issuer.cs
@@ -92,7 +92,7 @@ namespace Microsoft.IdentityModel.Tokens
                 configuration = await validationParameters.ConfigurationManager.GetBaseConfigurationAsync(cancellationToken).ConfigureAwait(false);
 
             // Return failed IssuerValidationResult if all possible places to validate against are null or empty.
-            if (validationParameters.ValidIssuers.IsNullOrEmpty() && string.IsNullOrWhiteSpace(configuration?.Issuer))
+            if (validationParameters.ValidIssuers.Count == 0 && string.IsNullOrWhiteSpace(configuration?.Issuer))
             {
                 return new IssuerValidationResult(
                     issuer,

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AsyncValidatorsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AsyncValidatorsTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 theoryData.Add(new IssuerValidatorTheoryData
                 {
                     Issuer = null,
-                    ValidationParameters = new TokenValidationParameters(),
+                    ValidationParameters = new ValidationParameters(),
                 });
 
                 return theoryData;
@@ -52,7 +52,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
     public class IssuerValidatorTheoryData : TheoryDataBase
     {
         public string Issuer { get; set; }
-        public TokenValidationParameters ValidationParameters { get; set; }
+        internal ValidationParameters ValidationParameters { get; set; }
         public SecurityToken SecurityToken { get; set; }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/IssuerValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/IssuerValidationResultTests.cs
@@ -56,26 +56,8 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
 
                 string validIssuer = Guid.NewGuid().ToString();
                 string issClaim = Guid.NewGuid().ToString();
-                theoryData.Add(new IssuerValidationResultsTheoryData("Invalid_Issuer")
-                {
-                    ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX10205:"),
-                    Issuer = issClaim,
-                    IssuerValidationResult = new IssuerValidationResult(
-                        issClaim,
-                        ValidationFailureType.IssuerValidationFailed,
-                        new ExceptionDetail(
-                            new MessageDetail(
-                                LogMessages.IDX10205,
-                                LogHelper.MarkAsNonPII(issClaim),
-                                LogHelper.MarkAsNonPII(validIssuer),
-                                LogHelper.MarkAsNonPII(Utility.SerializeAsSingleCommaDelimitedString(null)),
-                                LogHelper.MarkAsNonPII(null)),
-                            typeof(SecurityTokenInvalidIssuerException),
-                            new StackFrame(true))),
-                    IsValid = false,
-                    SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, issClaim),
-                    ValidationParameters = new TokenValidationParameters { ValidIssuer = validIssuer }
-                });
+                var validConfig = new OpenIdConnectConfiguration() { Issuer = issClaim };
+                string[] validIssuers = new string[] { validIssuer };
 
                 theoryData.Add(new IssuerValidationResultsTheoryData("NULL_Issuer")
                 {
@@ -94,7 +76,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                             new StackFrame(true))),
                     IsValid = false,
                     SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, issClaim),
-                    ValidationParameters = new TokenValidationParameters(),
+                    ValidationParameters = new ValidationParameters()
                 });
 
                 theoryData.Add(new IssuerValidationResultsTheoryData("NULL_ValidationParameters")
@@ -132,10 +114,9 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         null)),
                     IsValid = false,
                     SecurityToken = null,
-                    ValidationParameters = new TokenValidationParameters()
+                    ValidationParameters = new ValidationParameters()
                 });
 
-                var validConfig = new OpenIdConnectConfiguration() { Issuer = issClaim };
                 theoryData.Add(new IssuerValidationResultsTheoryData("Valid_FromConfig")
                 {
                     ExpectedException = ExpectedException.NoExceptionExpected,
@@ -145,24 +126,9 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         IssuerValidationResult.ValidationSource.IssuerIsConfigurationIssuer),
                     IsValid = true,
                     SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, issClaim),
-                    ValidationParameters = new TokenValidationParameters()
+                    ValidationParameters = new ValidationParameters()
                     {
                         ConfigurationManager = new MockConfigurationManager<OpenIdConnectConfiguration>(validConfig)
-                    }
-                });
-
-                theoryData.Add(new IssuerValidationResultsTheoryData("Valid_FromValidationParametersValidIssuer")
-                {
-                    ExpectedException = ExpectedException.NoExceptionExpected,
-                    Issuer = issClaim,
-                    IssuerValidationResult = new IssuerValidationResult(
-                        issClaim,
-                        IssuerValidationResult.ValidationSource.IssuerIsValidIssuer),
-                    IsValid = true,
-                    SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, issClaim),
-                    ValidationParameters = new TokenValidationParameters()
-                    {
-                        ValidIssuer = issClaim
                     }
                 });
 
@@ -175,10 +141,30 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         IssuerValidationResult.ValidationSource.IssuerIsAmongValidIssuers),
                     IsValid = true,
                     SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, issClaim),
-                    ValidationParameters = new TokenValidationParameters()
+                    ValidationParameters = new ValidationParameters()
                     {
                         ValidIssuers = [issClaim]
                     }
+                });
+
+                theoryData.Add(new IssuerValidationResultsTheoryData("Invalid_Issuer")
+                {
+                    ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX10212:"),
+                    Issuer = issClaim,
+                    IssuerValidationResult = new IssuerValidationResult(
+                        issClaim,
+                        ValidationFailureType.IssuerValidationFailed,
+                        new ExceptionDetail(
+                            new MessageDetail(
+                                LogMessages.IDX10212,
+                                LogHelper.MarkAsNonPII(issClaim),
+                                LogHelper.MarkAsNonPII(Utility.SerializeAsSingleCommaDelimitedString(validIssuers)),
+                                LogHelper.MarkAsNonPII(null)),
+                            typeof(SecurityTokenInvalidIssuerException),
+                            new StackFrame(true))),
+                    IsValid = false,
+                    SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, issClaim),
+                    ValidationParameters = new ValidationParameters { ValidIssuers = [validIssuer] }
                 });
 
                 return theoryData;
@@ -202,7 +188,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
 
         public SecurityToken SecurityToken { get; set; }
 
-        public TokenValidationParameters ValidationParameters { get; set; }
+        internal ValidationParameters ValidationParameters { get; set; }
 
         internal ValidationFailureType ValidationFailureType { get; set; }
     }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationParametersTests.cs
@@ -21,6 +21,25 @@ namespace Microsoft.IdentityModel.Tokens.Tests.Validation
         }
 
         [Fact]
+        public void ValidIssuers_GetSet_ValidIssuersList()
+        {
+            var validationParameters = new ValidationParameters();
+            var validIssuers = new List<string> { "issuer1", "issuer2" };
+
+            validationParameters.ValidIssuers = validIssuers;
+
+            Assert.Equal(validIssuers, validationParameters.ValidIssuers);
+        }
+
+        [Fact]
+        public void ValidIssuers_SetNull_ThrowsArgumentNullException()
+        {
+            var validationParameters = new ValidationParameters();
+
+            Assert.Throws<ArgumentNullException>(() => validationParameters.ValidIssuers = null);
+        }
+
+        [Fact]
         public void ValidTypes_Get_ReturnsValidTokenTypes()
         {
             var validationParameters = new ValidationParameters();

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationParametersTests.cs
@@ -21,22 +21,11 @@ namespace Microsoft.IdentityModel.Tokens.Tests.Validation
         }
 
         [Fact]
-        public void ValidIssuers_GetSet_ValidIssuersList()
-        {
-            var validationParameters = new ValidationParameters();
-            var validIssuers = new List<string> { "issuer1", "issuer2" };
-
-            validationParameters.ValidIssuers = validIssuers;
-
-            Assert.Equal(validIssuers, validationParameters.ValidIssuers);
-        }
-
-        [Fact]
-        public void ValidIssuers_SetNull_ThrowsArgumentNullException()
+        public void ValidIssuers_GetReturnsEmptyList()
         {
             var validationParameters = new ValidationParameters();
 
-            Assert.Throws<ArgumentNullException>(() => validationParameters.ValidIssuers = null);
+            Assert.Equal(0, validationParameters.ValidIssuers.Count);
         }
 
         [Fact]


### PR DESCRIPTION
# Re-factor Issuer Validator to Follow New Validation Model

## Description

- Removed checks for `ValidIssuer` from Issuer validation.
- Moved away from using `TokenValidationParameters` in favor of the new `ValidationParameters`.
- Added new tests in ValidationParameters class.
- Fixed minor inconsistencies on the code.
