### PR TITLE
Validate IssuerSigningKey: Refactor to use ValidationParameters over TVP

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
@@ -29,6 +29,7 @@ namespace Microsoft.IdentityModel.Tokens
         private LifetimeValidatorDelegate _lifetimeValidator = Validators.ValidateLifetime;
         private TokenReplayValidatorDelegate _tokenReplayValidator = Validators.ValidateTokenReplay;
         private TypeValidatorDelegate _typeValidator = Validators.ValidateTokenType;
+        private IssuerSigningKeyValidatorDelegate _issuerSigningKeyValidator = Validators.ValidateIssuerSigningKey;
 
         /// <summary>
         /// This is the default value of <see cref="ClaimsIdentity.AuthenticationType"/> when creating a <see cref="ClaimsIdentity"/>.
@@ -269,7 +270,11 @@ namespace Microsoft.IdentityModel.Tokens
         /// If both <see cref="IssuerSigningKeyValidatorUsingConfiguration"/> and <see cref="IssuerSigningKeyValidator"/> are set, IssuerSigningKeyResolverUsingConfiguration takes
         /// priority.
         /// </remarks>
-        public IssuerSigningKeyValidator IssuerSigningKeyValidator { get; set; }
+        public IssuerSigningKeyValidatorDelegate IssuerSigningKeyValidator
+        {
+            get => _issuerSigningKeyValidator;
+            set => _issuerSigningKeyValidator = value ?? throw new ArgumentNullException(nameof(value), "IssuerSigningKeyValidator cannot be set as null.");
+        }
 
         /// <summary>
         /// Gets a <see cref="IDictionary{String, Object}"/> that is unique to this instance.

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSecurityKey.cs
@@ -25,7 +25,7 @@ namespace Microsoft.IdentityModel.Tokens
     internal delegate Task<SigningKeyValidationResult> IssuerSecurityKeyValidationDelegate(
         SecurityKey signingKey,
         SecurityToken securityToken,
-        TokenValidationParameters validationParameters,
+        ValidationParameters validationParameters,
         CallContext callContext,
         CancellationToken cancellationToken);
 
@@ -40,28 +40,16 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         /// <param name="securityKey">The <see cref="SecurityKey"/> that signed the <see cref="SecurityToken"/>.</param>
         /// <param name="securityToken">The <see cref="SecurityToken"/> being validated.</param>
-        /// <param name="validationParameters">The <see cref="TokenValidationParameters"/> to be used for validating the token.</param>
+        /// <param name="validationParameters">The <see cref="ValidationParameters"/> to be used for validating the token.</param>
         /// <param name="callContext"></param>
         /// <exception cref="ArgumentNullException"> if 'securityKey' is null and ValidateIssuerSigningKey is true.</exception>
         /// <exception cref="ArgumentNullException"> if 'securityToken' is null and ValidateIssuerSigningKey is true.</exception>
         /// <exception cref="ArgumentNullException"> if 'validationParameters' is null.</exception>
-        internal static SigningKeyValidationResult ValidateIssuerSecurityKey(SecurityKey securityKey, SecurityToken securityToken, TokenValidationParameters validationParameters, CallContext callContext)
-        {
-            return ValidateIssuerSecurityKey(securityKey, securityToken, validationParameters, null, callContext);
-        }
-
-        /// <summary>
-        /// Validates the <see cref="SecurityKey"/> that signed a <see cref="SecurityToken"/>.
-        /// </summary>
-        /// <param name="securityKey">The <see cref="SecurityKey"/> that signed the <see cref="SecurityToken"/>.</param>
-        /// <param name="securityToken">The <see cref="SecurityToken"/> being validated.</param>
-        /// <param name="validationParameters">The <see cref="TokenValidationParameters"/> to be used for validating the token.</param>
-        /// <param name="configuration">The <see cref="BaseConfiguration"/> required for issuer and signing key validation.</param>
-        /// <param name="callContext"></param>
-        /// <exception cref="ArgumentNullException"> if 'securityKey' is null and ValidateIssuerSigningKey is true.</exception>
-        /// <exception cref="ArgumentNullException"> if 'securityToken' is null and ValidateIssuerSigningKey is true.</exception>
-        /// <exception cref="ArgumentNullException"> if 'validationParameters' is null.</exception>
-        internal static SigningKeyValidationResult ValidateIssuerSecurityKey(SecurityKey securityKey, SecurityToken securityToken, TokenValidationParameters validationParameters, BaseConfiguration? configuration, CallContext callContext)
+        internal static SigningKeyValidationResult ValidateIssuerSecurityKey(
+            SecurityKey securityKey,
+            SecurityToken securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
         {
             if (validationParameters == null)
                 return new SigningKeyValidationResult(
@@ -74,28 +62,7 @@ namespace Microsoft.IdentityModel.Tokens
                         typeof(ArgumentNullException),
                         new StackFrame(true)));
 
-            if (validationParameters.IssuerSigningKeyValidatorUsingConfiguration != null)
-            {
-                return ValidateSigningKeyUsingDelegateAndConfiguration(securityKey, securityToken, validationParameters, configuration);
-            }
-
-            if (validationParameters.IssuerSigningKeyValidator != null)
-            {
-                return ValidateSigningKeyUsingDelegateAndConfiguration(securityKey, securityToken, validationParameters, null);
-            }
-
-            if (!validationParameters.ValidateIssuerSigningKey)
-            {
-                LogHelper.LogVerbose(LogMessages.IDX10237);
-                return new SigningKeyValidationResult(securityKey);
-            }
-
-            if (!validationParameters.RequireSignedTokens && securityKey == null)
-            {
-                LogHelper.LogInformation(LogMessages.IDX10252);
-                return new SigningKeyValidationResult(securityKey);
-            }
-            else if (securityKey == null)
+            if (securityKey == null)
             {
                 return new SigningKeyValidationResult(
                     securityKey,
@@ -129,7 +96,10 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="validationParameters">The <see cref="TokenValidationParameters"/> to be used for validating the token.</param>
         /// <param name="callContext"></param>
 #pragma warning disable CA1801 // Review unused parameters
-        internal static SigningKeyValidationResult ValidateIssuerSigningKeyLifeTime(SecurityKey securityKey, TokenValidationParameters validationParameters, CallContext callContext)
+        internal static SigningKeyValidationResult ValidateIssuerSigningKeyLifeTime(
+            SecurityKey securityKey,
+            ValidationParameters validationParameters,
+            CallContext callContext)
 #pragma warning restore CA1801 // Review unused parameters
         {
             X509SecurityKey? x509SecurityKey = securityKey as X509SecurityKey;
@@ -175,45 +145,7 @@ namespace Microsoft.IdentityModel.Tokens
             return new SigningKeyValidationResult(securityKey);
         }
 
-        private static SigningKeyValidationResult ValidateSigningKeyUsingDelegateAndConfiguration(SecurityKey securityKey, SecurityToken securityToken, TokenValidationParameters validationParameters, BaseConfiguration? configuration)
-        {
-            try
-            {
-                bool success;
-                if (configuration != null)
-                    success = validationParameters.IssuerSigningKeyValidatorUsingConfiguration(securityKey, securityToken, validationParameters, configuration);
-                else
-                    success = validationParameters.IssuerSigningKeyValidator(securityKey, securityToken, validationParameters);
-
-                if (!success)
-                    return new SigningKeyValidationResult(
-                        securityKey,
-                        ValidationFailureType.SigningKeyValidationFailed,
-                        new ExceptionDetail(
-                            new MessageDetail(
-                                LogMessages.IDX10232,
-                                securityKey),
-                            typeof(SecurityTokenInvalidSigningKeyException),
-                            new StackFrame(true)));
-
-                return new SigningKeyValidationResult(securityKey);
-            }
-#pragma warning disable CA1031 // Do not catch general exception types
-            catch (Exception exception)
-#pragma warning restore CA1031 // Do not catch general exception types
-            {
-                return new SigningKeyValidationResult(
-                    securityKey,
-                    ValidationFailureType.SigningKeyValidationFailed,
-                    new ExceptionDetail(
-                        new MessageDetail(
-                            LogMessages.IDX10232,
-                            securityKey),
-                        exception.GetType(),
-                        new StackFrame(true),
-                        exception));
-            }
-        }
+        
     }
 }
 #nullable restore

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
@@ -17,7 +17,7 @@ namespace Microsoft.IdentityModel.Tokens
     /// </summary>
     /// <param name="signingKey">The security key to validate.</param>
     /// <param name="securityToken">The <see cref="SecurityToken"/> that is being validated.</param>
-    /// <param name="validationParameters">The <see cref="TokenValidationParameters"/> to be used for validating the token.</param>
+    /// <param name="validationParameters">The <see cref="ValidationParameters"/> to be used for validating the token.</param>
     /// <param name="callContext"></param> The <see cref="CallContext"/> to be used for logging.
     /// <returns>A <see cref="SigningKeyValidationResult"/>that contains the results of validating the issuer.</returns>
     /// <remarks>This delegate is not expected to throw.</remarks>
@@ -91,7 +91,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// Given a signing key, when it's derived from a certificate, validates that the certificate is already active and non-expired
         /// </summary>
         /// <param name="securityKey">The <see cref="SecurityKey"/> that signed the <see cref="SecurityToken"/>.</param>
-        /// <param name="validationParameters">The <see cref="TokenValidationParameters"/> to be used for validating the token.</param>
+        /// <param name="validationParameters">The <see cref="ValidationParameters"/> to be used for validating the token.</param>
         /// <param name="callContext"></param>
 #pragma warning disable CA1801 // Review unused parameters
         internal static SigningKeyValidationResult ValidateIssuerSigningKeyLifeTime(

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
@@ -25,7 +25,7 @@ namespace Microsoft.IdentityModel.Tokens
         SecurityKey signingKey,
         SecurityToken securityToken,
         ValidationParameters validationParameters,
-        CallContext callContext);
+        CallContext? callContext);
 
     /// <summary>
     /// SigningKeyValidation
@@ -47,7 +47,7 @@ namespace Microsoft.IdentityModel.Tokens
             SecurityKey securityKey,
             SecurityToken securityToken,
             ValidationParameters validationParameters,
-            CallContext callContext)
+            CallContext? callContext)
         {
             if (validationParameters == null)
                 return new SigningKeyValidationResult(
@@ -97,7 +97,7 @@ namespace Microsoft.IdentityModel.Tokens
         internal static SigningKeyValidationResult ValidateIssuerSigningKeyLifeTime(
             SecurityKey securityKey,
             ValidationParameters validationParameters,
-            CallContext callContext)
+            CallContext? callContext)
 #pragma warning restore CA1801 // Review unused parameters
         {
             X509SecurityKey? x509SecurityKey = securityKey as X509SecurityKey;

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
@@ -18,7 +18,7 @@ namespace Microsoft.IdentityModel.Tokens
     /// <param name="signingKey">The security key to validate.</param>
     /// <param name="securityToken">The <see cref="SecurityToken"/> that is being validated.</param>
     /// <param name="validationParameters">The <see cref="ValidationParameters"/> to be used for validating the token.</param>
-    /// <param name="callContext"></param> The <see cref="CallContext"/> to be used for logging.
+    /// <param name="callContext">The <see cref="CallContext"/> to be used for logging.</param> 
     /// <returns>A <see cref="SigningKeyValidationResult"/>that contains the results of validating the issuer.</returns>
     /// <remarks>This delegate is not expected to throw.</remarks>
     internal delegate SigningKeyValidationResult IssuerSigningKeyValidatorDelegate(

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
@@ -18,6 +18,7 @@ namespace Microsoft.IdentityModel.Tokens
     /// <param name="signingKey">The security key to validate.</param>
     /// <param name="securityToken">The <see cref="SecurityToken"/> that is being validated.</param>
     /// <param name="validationParameters">The <see cref="ValidationParameters"/> to be used for validating the token.</param>
+    /// <param name="configuration">The <see cref="BaseConfiguration"/> to be used for validation.</param>
     /// <param name="callContext">The <see cref="CallContext"/> to be used for logging.</param> 
     /// <returns>A <see cref="SigningKeyValidationResult"/>that contains the results of validating the issuer.</returns>
     /// <remarks>This delegate is not expected to throw.</remarks>
@@ -25,6 +26,7 @@ namespace Microsoft.IdentityModel.Tokens
         SecurityKey signingKey,
         SecurityToken securityToken,
         ValidationParameters validationParameters,
+        BaseConfiguration? configuration,
         CallContext? callContext);
 
     /// <summary>
@@ -39,7 +41,8 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="securityKey">The <see cref="SecurityKey"/> that signed the <see cref="SecurityToken"/>.</param>
         /// <param name="securityToken">The <see cref="SecurityToken"/> being validated.</param>
         /// <param name="validationParameters">The <see cref="ValidationParameters"/> to be used for validating the token.</param>
-        /// <param name="callContext"></param>
+        /// <param name="configuration">The <see cref="BaseConfiguration"/> to be used for validation.</param>
+        /// <param name="callContext">The <see cref="CallContext"/> to be used for logging.</param>
         /// <exception cref="ArgumentNullException"> if 'securityKey' is null and ValidateIssuerSigningKey is true.</exception>
         /// <exception cref="ArgumentNullException"> if 'securityToken' is null and ValidateIssuerSigningKey is true.</exception>
         /// <exception cref="ArgumentNullException"> if 'validationParameters' is null.</exception>
@@ -47,6 +50,9 @@ namespace Microsoft.IdentityModel.Tokens
             SecurityKey securityKey,
             SecurityToken securityToken,
             ValidationParameters validationParameters,
+#pragma warning disable CA1801 // Review unused parameters
+            BaseConfiguration? configuration,
+#pragma warning restore CA1801 // Review unused parameters
             CallContext? callContext)
         {
             if (validationParameters == null)

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
@@ -18,16 +18,14 @@ namespace Microsoft.IdentityModel.Tokens
     /// <param name="signingKey">The security key to validate.</param>
     /// <param name="securityToken">The <see cref="SecurityToken"/> that is being validated.</param>
     /// <param name="validationParameters">The <see cref="TokenValidationParameters"/> to be used for validating the token.</param>
-    /// <param name="callContext"></param>
-    /// <param name="cancellationToken"></param>
+    /// <param name="callContext"></param> The <see cref="CallContext"/> to be used for logging.
     /// <returns>A <see cref="SigningKeyValidationResult"/>that contains the results of validating the issuer.</returns>
     /// <remarks>This delegate is not expected to throw.</remarks>
-    internal delegate Task<SigningKeyValidationResult> IssuerSecurityKeyValidationDelegate(
+    internal delegate SigningKeyValidationResult IssuerSigningKeyValidatorDelegate(
         SecurityKey signingKey,
         SecurityToken securityToken,
         ValidationParameters validationParameters,
-        CallContext callContext,
-        CancellationToken cancellationToken);
+        CallContext callContext);
 
     /// <summary>
     /// SigningKeyValidation
@@ -45,7 +43,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <exception cref="ArgumentNullException"> if 'securityKey' is null and ValidateIssuerSigningKey is true.</exception>
         /// <exception cref="ArgumentNullException"> if 'securityToken' is null and ValidateIssuerSigningKey is true.</exception>
         /// <exception cref="ArgumentNullException"> if 'validationParameters' is null.</exception>
-        internal static SigningKeyValidationResult ValidateIssuerSecurityKey(
+        internal static SigningKeyValidationResult ValidateIssuerSigningKey(
             SecurityKey securityKey,
             SecurityToken securityToken,
             ValidationParameters validationParameters,

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
@@ -142,8 +142,6 @@ namespace Microsoft.IdentityModel.Tokens
 
             return new SigningKeyValidationResult(securityKey);
         }
-
-        
     }
 }
 #nullable restore

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/SigningKeyValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/SigningKeyValidationResultTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 theoryData.SecurityKey,
                 theoryData.SecurityToken,
                 theoryData.ValidationParameters,
+                theoryData.BaseConfiguration,
                 new CallContext());
 
             if (signingKeyValidationResult.Exception != null)

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/SigningKeyValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/SigningKeyValidationResultTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 theoryData.SecurityKey,
                 theoryData.SecurityToken,
                 theoryData.ValidationParameters,
-                theoryData.BaseConfiguration,
                 new CallContext());
 
             if (signingKeyValidationResult.Exception != null)
@@ -50,83 +49,11 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 {
                     new SigningKeyValidationTheoryData
                     {
-                        TestId = "Valid_SecurityTokenIsPresent_ValidateIssuerSigningKeyIsTrue",
+                        TestId = "Valid_SecurityTokenIsPresent",
                         ExpectedException = ExpectedException.NoExceptionExpected,
                         SecurityKey = KeyingMaterial.SymmetricSecurityKey2_256,
                         SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters { ValidateIssuerSigningKey = true },
-                        SigningKeyValidationResult = new SigningKeyValidationResult(KeyingMaterial.SymmetricSecurityKey2_256)
-                    },
-                    new SigningKeyValidationTheoryData
-                    {
-                        TestId = "Valid_SecurityKeyIsNull_ValidateIssuerSigningKeyIsFalse",
-                        ExpectedException = ExpectedException.NoExceptionExpected,
-                        SecurityKey = null,
-                        SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters { ValidateIssuerSigningKey = false },
-                        SigningKeyValidationResult = new SigningKeyValidationResult(null)
-                    },
-                    new SigningKeyValidationTheoryData
-                    {
-                        TestId = "Valid_SecurityTokenIsNull_ValidateIssuerSigningKeyIsFalse",
-                        ExpectedException = ExpectedException.NoExceptionExpected,
-                        SecurityKey = KeyingMaterial.SymmetricSecurityKey2_256,
-                        SecurityToken = null,
-                        ValidationParameters = new TokenValidationParameters { ValidateIssuerSigningKey = false },
-                        SigningKeyValidationResult = new SigningKeyValidationResult(KeyingMaterial.SymmetricSecurityKey2_256)
-                    },
-                    new SigningKeyValidationTheoryData
-                    {
-                        TestId = "Valid_SecurityKeyIsNull_RequireSignedTokensIsFalse",
-                        ExpectedException = ExpectedException.NoExceptionExpected,
-                        SecurityKey = null,
-                        SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters { ValidateIssuerSigningKey = true, RequireSignedTokens = false },
-                        SigningKeyValidationResult = new SigningKeyValidationResult(null)
-                    },
-                    new SigningKeyValidationTheoryData
-                    {
-                        TestId = "Valid_SecurityKeyIsPresent_RequireSignedTokensIsTrue",
-                        ExpectedException = ExpectedException.NoExceptionExpected,
-                        SecurityKey = KeyingMaterial.SymmetricSecurityKey2_256,
-                        SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters { ValidateIssuerSigningKey = true, RequireSignedTokens = true },
-                        SigningKeyValidationResult = new SigningKeyValidationResult(KeyingMaterial.SymmetricSecurityKey2_256)
-                    },
-                    new SigningKeyValidationTheoryData
-                    {
-                        TestId = "Valid_SecurityKeyIsPresent_RequireSignedTokensIsFalse",
-                        ExpectedException = ExpectedException.NoExceptionExpected,
-                        SecurityKey = KeyingMaterial.SymmetricSecurityKey2_256,
-                        SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters { ValidateIssuerSigningKey = true, RequireSignedTokens = false },
-                        SigningKeyValidationResult = new SigningKeyValidationResult(KeyingMaterial.SymmetricSecurityKey2_256)
-                    },
-                    new SigningKeyValidationTheoryData
-                    {
-                        TestId = "Valid_DelegateSet_ReturnsTrue",
-                        ExpectedException = ExpectedException.NoExceptionExpected,
-                        SecurityKey = KeyingMaterial.SymmetricSecurityKey2_256,
-                        SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            ValidateIssuerSigningKey = true,
-                            IssuerSigningKeyValidator = (SecurityKey securityKey, SecurityToken token, TokenValidationParameters validationParameters) => true
-                        },
-                        SigningKeyValidationResult = new SigningKeyValidationResult(KeyingMaterial.SymmetricSecurityKey2_256)
-                    },
-                    new SigningKeyValidationTheoryData
-                    {
-                        TestId = "Valid_DelegateUsingConfigurationSet_ReturnsTrue",
-                        ExpectedException = ExpectedException.NoExceptionExpected,
-                        SecurityKey = KeyingMaterial.SymmetricSecurityKey2_256,
-                        SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            ValidateIssuerSigningKey = true,
-                            IssuerSigningKeyValidatorUsingConfiguration = (SecurityKey securityKey, SecurityToken token, TokenValidationParameters validationParameters, BaseConfiguration configuration) => true
-                        },
-                        BaseConfiguration = new OpenIdConnectConfiguration(),
+                        ValidationParameters = new ValidationParameters(),
                         SigningKeyValidationResult = new SigningKeyValidationResult(KeyingMaterial.SymmetricSecurityKey2_256)
                     },
                     new SigningKeyValidationTheoryData
@@ -135,7 +62,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.ArgumentNullException(substringExpected: "IDX10253:"),
                         SecurityKey = null,
                         SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters { ValidateIssuerSigningKey = true },
+                        ValidationParameters = new ValidationParameters(),
                         SigningKeyValidationResult = new SigningKeyValidationResult(
                             null, // SecurityKey
                             ValidationFailureType.NullArgument,
@@ -146,11 +73,11 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new SigningKeyValidationTheoryData
                     {
-                        TestId = "Invalid_SecurityTokenIsNullAndValidateIssuerSigningKeyTrue",
+                        TestId = "Invalid_SecurityTokenIsNull",
                         ExpectedException = ExpectedException.ArgumentNullException(),
                         SecurityKey = KeyingMaterial.SymmetricSecurityKey2_256,
                         SecurityToken = null,
-                        ValidationParameters = new TokenValidationParameters { ValidateIssuerSigningKey = true },
+                        ValidationParameters = new ValidationParameters (),
                         SigningKeyValidationResult = new SigningKeyValidationResult(
                             KeyingMaterial.SymmetricSecurityKey2_256,
                             ValidationFailureType.NullArgument,
@@ -184,7 +111,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidSigningKeyException(substringExpected: "IDX10249:"),
                         SecurityKey = KeyingMaterial.ExpiredX509SecurityKey_Public,
                         SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters { ValidateIssuerSigningKey = true },
+                        ValidationParameters = new ValidationParameters (),
                         SigningKeyValidationResult = new SigningKeyValidationResult(
                             KeyingMaterial.ExpiredX509SecurityKey_Public,
                             ValidationFailureType.SigningKeyValidationFailed,
@@ -202,7 +129,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidSigningKeyException(substringExpected: "IDX10248:"),
                         SecurityKey = KeyingMaterial.NotYetValidX509SecurityKey_Public,
                         SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters { ValidateIssuerSigningKey = true },
+                        ValidationParameters = new ValidationParameters (),
                         SigningKeyValidationResult = new SigningKeyValidationResult(
                             KeyingMaterial.NotYetValidX509SecurityKey_Public,
                             ValidationFailureType.SigningKeyValidationFailed,
@@ -216,11 +143,11 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new SigningKeyValidationTheoryData
                     {
-                        TestId = "Invalid_SecurityKeyIsNull_RequireSignedTokensIsTrue",
+                        TestId = "Invalid_SecurityKeyIsNull",
                         ExpectedException = ExpectedException.ArgumentNullException(substringExpected: "IDX10253:"),
                         SecurityKey = null,
                         SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters { ValidateIssuerSigningKey = true, RequireSignedTokens = true },
+                        ValidationParameters = new ValidationParameters (),
                         SigningKeyValidationResult = new SigningKeyValidationResult(
                             null,
                             ValidationFailureType.NullArgument,
@@ -229,105 +156,18 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                                 typeof(ArgumentNullException),
                                 new StackFrame(true)))
                     },
-                    new SigningKeyValidationTheoryData
-                    {
-                        TestId = "Invalid_DelegateIsSet_ReturnsFalse",
-                        ExpectedException = ExpectedException.SecurityTokenInvalidSigningKeyException(substringExpected: "IDX10232:"),
-                        SecurityKey = KeyingMaterial.SymmetricSecurityKey2_256,
-                        SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            ValidateIssuerSigningKey = true,
-                            IssuerSigningKeyValidator = (SecurityKey securityKey, SecurityToken token, TokenValidationParameters validationParameters) => false
-                        },
-                        SigningKeyValidationResult = new SigningKeyValidationResult(
-                            KeyingMaterial.SymmetricSecurityKey2_256,
-                            ValidationFailureType.SigningKeyValidationFailed,
-                            new ExceptionDetail(
-                                new MessageDetail(
-                                    LogMessages.IDX10232,
-                                    KeyingMaterial.SymmetricSecurityKey2_256),
-                                typeof(SecurityTokenInvalidSigningKeyException),
-                                new StackFrame(true)))
-                    },
-                    new SigningKeyValidationTheoryData
-                    {
-                        TestId = "Invalid_DelegateUsingConfigurationSet_ReturnsFalse",
-                        ExpectedException = ExpectedException.SecurityTokenInvalidSigningKeyException(substringExpected: "IDX10232:"),
-                        SecurityKey = KeyingMaterial.SymmetricSecurityKey2_256,
-                        SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            ValidateIssuerSigningKey = true,
-                            IssuerSigningKeyValidatorUsingConfiguration = (SecurityKey securityKey, SecurityToken token, TokenValidationParameters validationParameters, BaseConfiguration configuration) => false
-                        },
-                        BaseConfiguration = new OpenIdConnectConfiguration(),
-                        SigningKeyValidationResult = new SigningKeyValidationResult(
-                            KeyingMaterial.SymmetricSecurityKey2_256,
-                            ValidationFailureType.SigningKeyValidationFailed,
-                            new ExceptionDetail(
-                                new MessageDetail(
-                                    LogMessages.IDX10232,
-                                    KeyingMaterial.SymmetricSecurityKey2_256),
-                                typeof(SecurityTokenInvalidSigningKeyException),
-                                new StackFrame(true)))
-                    },
-                    new SigningKeyValidationTheoryData
-                    {
-                        TestId = "Invalid_DelegateIsSet_Throws",
-                        ExpectedException = ExpectedException.SecurityTokenInvalidSigningKeyException(substringExpected: "IDX10232:", innerTypeExpected: typeof(SecurityTokenInvalidSigningKeyException)),
-                        SecurityKey = KeyingMaterial.SymmetricSecurityKey2_256,
-                        SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            ValidateIssuerSigningKey = true,
-                            IssuerSigningKeyValidator = (SecurityKey securityKey, SecurityToken token, TokenValidationParameters validationParameters) => throw new SecurityTokenInvalidSigningKeyException()
-                        },
-                        SigningKeyValidationResult = new SigningKeyValidationResult(
-                            KeyingMaterial.SymmetricSecurityKey2_256,
-                            ValidationFailureType.SigningKeyValidationFailed,
-                            new ExceptionDetail(
-                                new MessageDetail(
-                                    LogMessages.IDX10232,
-                                    KeyingMaterial.SymmetricSecurityKey2_256),
-                                typeof(SecurityTokenInvalidSigningKeyException),
-                                new StackFrame(true),
-                                new SecurityTokenInvalidSigningKeyException()))
-                    },
-                    new SigningKeyValidationTheoryData
-                    {
-                        TestId = "Invalid_DelegateUsingConfigurationSet_Throws",
-                        ExpectedException = ExpectedException.SecurityTokenInvalidSigningKeyException(substringExpected: "IDX10232:", innerTypeExpected: typeof(SecurityTokenInvalidSigningKeyException)),
-                        SecurityKey = KeyingMaterial.SymmetricSecurityKey2_256,
-                        SecurityToken = new JwtSecurityToken(),
-                        ValidationParameters = new TokenValidationParameters
-                        {
-                            ValidateIssuerSigningKey = true,
-                            IssuerSigningKeyValidatorUsingConfiguration = (SecurityKey securityKey, SecurityToken token, TokenValidationParameters validationParameters, BaseConfiguration configuration) => throw new SecurityTokenInvalidSigningKeyException()
-                        },
-                        BaseConfiguration = new OpenIdConnectConfiguration(),
-                        SigningKeyValidationResult = new SigningKeyValidationResult(
-                            KeyingMaterial.SymmetricSecurityKey2_256,
-                            ValidationFailureType.SigningKeyValidationFailed,
-                            new ExceptionDetail(
-                                new MessageDetail(
-                                    LogMessages.IDX10232,
-                                    KeyingMaterial.SymmetricSecurityKey2_256),
-                                typeof(SecurityTokenInvalidSigningKeyException),
-                                new StackFrame(true),
-                                new SecurityTokenInvalidSigningKeyException()))
-                        },
-                    };
-                }
+
+                };
             }
         }
-
-        public class SigningKeyValidationTheoryData: TheoryDataBase
-        {
-            public SecurityKey SecurityKey { get; set; }
-            public SecurityToken SecurityToken { get; set; }
-            public TokenValidationParameters ValidationParameters { get; set; }
-            public BaseConfiguration BaseConfiguration { get; set; }
-            internal SigningKeyValidationResult SigningKeyValidationResult { get; set; }
-        }
     }
+
+    public class SigningKeyValidationTheoryData : TheoryDataBase
+    {
+        public SecurityKey SecurityKey { get; set; }
+        public SecurityToken SecurityToken { get; set; }
+        internal ValidationParameters ValidationParameters { get; set; }
+        public BaseConfiguration BaseConfiguration { get; set; }
+        internal SigningKeyValidationResult SigningKeyValidationResult { get; set; }
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/SigningKeyValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/SigningKeyValidationResultTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
         {
             CompareContext context = TestUtilities.WriteHeader($"{this}.SigningKeyValidationResultTests", theoryData);
 
-            SigningKeyValidationResult signingKeyValidationResult = Validators.ValidateIssuerSecurityKey(
+            SigningKeyValidationResult signingKeyValidationResult = Validators.ValidateIssuerSigningKey(
                 theoryData.SecurityKey,
                 theoryData.SecurityToken,
                 theoryData.ValidationParameters,

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationParametersTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests.Validation
             Assert.Throws<ArgumentNullException>(() => validationParameters.LifetimeValidator = null);
             Assert.Throws<ArgumentNullException>(() => validationParameters.TypeValidator = null);
             Assert.Throws<ArgumentNullException>(() => validationParameters.AudienceValidator = null);
+            Assert.Throws<ArgumentNullException>(() => validationParameters.IssuerSigningKeyValidator = null);
         }
 
         [Fact]


### PR DESCRIPTION
# Validate IssuerSigningKey: Refactor to use ValidationParameters over TVP
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

## Description
Replaced use of TokenValidationParameters with ValidationParameters inside ValidateIssuerSecurityKey and updated tests accordingly.
Removed version of the method that takes BaseConfiguration as it is not used, and the exposed delegate does not contain it either.

Part of #2711 
