### PR TITLE
Rename TokenReadingResult to TokenReadResult

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ClaimsIdentity.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ClaimsIdentity.cs
@@ -6,9 +6,9 @@ using System.Security.Claims;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.IdentityModel.Logging;
 
+#nullable enable
 namespace Microsoft.IdentityModel.JsonWebTokens
 {
-#nullable enable
     public partial class JsonWebTokenHandler
     {
         /// <summary>
@@ -141,5 +141,5 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             return identity;
         }
     }
-#nullable restore
 }
+#nullable restore

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.DecryptToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.DecryptToken.cs
@@ -10,9 +10,9 @@ using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
 using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
 
+#nullable enable
 namespace Microsoft.IdentityModel.JsonWebTokens
 {
-#nullable enable
     public partial class JsonWebTokenHandler : TokenHandler
     {
         /// <summary>
@@ -249,6 +249,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
             return null;
         }
-#nullable restore
     }
 }
+#nullable restore

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ReadToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ReadToken.cs
@@ -6,22 +6,22 @@ using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
 using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
 
+#nullable enable
 namespace Microsoft.IdentityModel.JsonWebTokens
 {
     /// <remarks>This partial class contains methods and logic related to the validation of tokens.</remarks>
     public partial class JsonWebTokenHandler : TokenHandler
     {
-#nullable enable
         /// <summary>
-        /// Converts a string into an instance of <see cref="JsonWebToken"/>, returned inside of a <see cref="TokenReadingResult"/>.
+        /// Converts a string into an instance of <see cref="JsonWebToken"/>, returned inside of a <see cref="TokenReadResult"/>.
         /// </summary>
         /// <param name="token">A JSON Web Token (JWT) in JWS or JWE Compact Serialization format.</param>
         /// <param name="callContext"></param>
-        /// <returns>A <see cref="TokenReadingResult"/> with the <see cref="JsonWebToken"/> if valid, or an Exception.</returns>
+        /// <returns>A <see cref="TokenReadResult"/> with the <see cref="JsonWebToken"/> if valid, or an Exception.</returns>
         /// <exception cref="ArgumentNullException">returned if <paramref name="token"/> is null or empty.</exception>
         /// <exception cref="SecurityTokenMalformedException">returned if the validationParameters.TokenReader delegate is not able to parse/read the token as a valid <see cref="JsonWebToken"/>.</exception>
         /// <exception cref="SecurityTokenMalformedException">returned if <paramref name="token"/> is not a valid JWT, <see cref="JsonWebToken"/>.</exception>
-        internal static TokenReadingResult ReadToken(
+        internal static TokenReadResult ReadToken(
             string token,
 #pragma warning disable CA1801 // TODO: remove pragma disable once callContext is used for logging
             CallContext? callContext)
@@ -29,7 +29,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         {
             if (String.IsNullOrEmpty(token))
             {
-                return new TokenReadingResult(
+                return new TokenReadResult(
                     token,
                     ValidationFailureType.NullArgument,
                     new ExceptionDetail(
@@ -43,15 +43,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             try
             {
                 JsonWebToken jsonWebToken = new JsonWebToken(token);
-                return new TokenReadingResult(jsonWebToken, token);
+                return new TokenReadResult(token, jsonWebToken);
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
 #pragma warning restore CA1031 // Do not catch general exception types
             {
-                return new TokenReadingResult(
+                return new TokenReadResult(
                     token,
-                    ValidationFailureType.TokenReadingFailed,
+                    ValidationFailureType.TokenReadFailed,
                     new ExceptionDetail(
                         new MessageDetail(LogMessages.IDX14107),
                         ExceptionDetail.ExceptionType.SecurityTokenMalformed,

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -83,6 +83,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10265 = "IDX10265: Reading issuer signing keys from configuration.";
         //public const string IDX10266 = "IDX10266: Unable to validate issuer. validationParameters.ValidIssuer is null or whitespace, validationParameters.ValidIssuers is null or empty and ConfigurationManager is null.";
         public const string IDX10267 = "IDX10267: '{0}' has been called by a derived class '{1}' which has not implemented this method. For this call graph to succeed, '{1}' will need to implement '{0}'.";
+        public const string IDX10268 = "IDX10268: Algorithm Validated: '{0}'";
 
 
         // 10500 - SignatureValidation

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/SignatureValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/SignatureValidationResult.cs
@@ -4,9 +4,9 @@
 using System;
 using Microsoft.IdentityModel.Tokens;
 
+#nullable enable
 namespace Microsoft.IdentityModel.JsonWebTokens.Results
 {
-#nullable enable
     /// <summary>
     /// Contains the result of validating a signature.
     /// The <see cref="TokenValidationResult"/> contains a collection of <see cref="ValidationResult"/> for each step in the token validation.
@@ -72,5 +72,5 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Results
             }
         }
     }
-#nullable restore
 }
+#nullable restore

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/SigningKeyValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/SigningKeyValidationResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+
 #nullable enable
 namespace Microsoft.IdentityModel.Tokens
 {

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/TokenReadResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/TokenReadResult.cs
@@ -10,34 +10,42 @@ namespace Microsoft.IdentityModel.Tokens
     /// Contains the result of reading a <see cref="SecurityToken"/>.
     /// The <see cref="TokenValidationResult"/> contains a collection of <see cref="ValidationResult"/> for each step in the token validation.
     /// </summary>
-    internal class TokenReadingResult : ValidationResult
+    internal class TokenReadResult : ValidationResult
     {
         private Exception? _exception;
-        private SecurityToken? _securityToken;
 
         /// <summary>
-        /// Creates an instance of <see cref="TokenReadingResult"/>.
+        /// Creates an instance of <see cref="TokenReadResult"/>.
         /// </summary>
-        /// <paramref name="tokenInput"/> is the string from which the <see cref="SecurityToken"/> was created.
+        /// <paramref name="token"/> is the string from which the <see cref="SecurityToken"/> was created.
         /// <paramref name="securityToken"/> is the <see cref="SecurityToken"/> that was created.
-        public TokenReadingResult(SecurityToken securityToken, string tokenInput)
+        public TokenReadResult(string token, SecurityToken securityToken)
             : base(ValidationFailureType.ValidationSucceeded)
         {
-            IsValid = true;
-            TokenInput = tokenInput;
-            _securityToken = securityToken;
+            if (token == null || securityToken == null)
+            {
+                IsValid = false;
+                ValidationFailureType = ValidationFailureType.TokenReadFailed;
+            }
+            else
+            {
+                IsValid = true;
+            }
+
+            Token = token;
+            SecurityToken = securityToken;
         }
 
         /// <summary>
-        /// Creates an instance of <see cref="TokenReadingResult"/>
+        /// Creates an instance of <see cref="TokenReadResult"/>
         /// </summary>
-        /// <paramref name="tokenInput"/> is the string that failed to create a <see cref="SecurityToken"/>.
+        /// <paramref name="token"/> is the string that failed to create a <see cref="SecurityToken"/>.
         /// <paramref name="validationFailure"/> is the <see cref="ValidationFailureType"/> that occurred during reading.
         /// <paramref name="exceptionDetail"/> is the <see cref="ExceptionDetail"/> that occurred during reading.
-        public TokenReadingResult(string? tokenInput, ValidationFailureType validationFailure, ExceptionDetail exceptionDetail)
+        public TokenReadResult(string? token, ValidationFailureType validationFailure, ExceptionDetail exceptionDetail)
             : base(validationFailure, exceptionDetail)
         {
-            TokenInput = tokenInput;
+            Token = token;
             IsValid = false;
         }
 
@@ -46,13 +54,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         /// <exception cref="InvalidOperationException"/> if the <see cref="SecurityToken"/> is null.
         /// <remarks>It is expected that the caller would check <see cref="ValidationResult.IsValid"/> returns true before accessing this.</remarks>
-        public SecurityToken SecurityToken()
-        {
-            if (_securityToken is null)
-                throw new InvalidOperationException("Attempted to retrieve the SecurityToken from a failed TokenReading result.");
-
-            return _securityToken;
-        }
+        public SecurityToken? SecurityToken { get; }
 
         /// <summary>
         /// Gets the <see cref="Exception"/> that occurred during reading.
@@ -80,7 +82,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Gets the string from which the <see cref="SecurityToken"/> was read.
         /// </summary>
-        public string? TokenInput { get; }
+        public string? Token { get; }
     }
 }
 #nullable restore

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/TokenTypeValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/TokenTypeValidationResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+
 #nullable enable
 namespace Microsoft.IdentityModel.Tokens
 {

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/ValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/ValidationResult.cs
@@ -106,6 +106,7 @@ namespace Microsoft.IdentityModel.Tokens
         public ValidationFailureType ValidationFailureType
         {
             get;
+            protected set;
         } = ValidationFailureType.ValidationNotEvaluated;
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
@@ -78,8 +78,8 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Defines a type that represents that a token could not be read.
         /// </summary>
-        public static readonly ValidationFailureType TokenReadingFailed = new TokenReadingFailure("TokenReadingFailed");
-        private class TokenReadingFailure : ValidationFailureType { internal TokenReadingFailure(string name) : base(name) { } }
+        public static readonly ValidationFailureType TokenReadFailed = new TokenReadFailure("TokenReadFailed");
+        private class TokenReadFailure : ValidationFailureType { internal TokenReadFailure(string name) : base(name) { } }
 
         /// <summary>
         /// Defines a type that represents that a JWE could not be decrypted.

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Algorithm.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Algorithm.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.Logging;
 
 #nullable enable
@@ -70,6 +71,10 @@ namespace Microsoft.IdentityModel.Tokens
                         ExceptionDetail.ExceptionType.SecurityTokenInvalidAlgorithm,
                         new StackFrame(true)));
             }
+
+            // if we get here the algorithm is valid.
+            if (LogHelper.IsEnabled(EventLogLevel.Informational))
+                LogHelper.LogInformation(LogMessages.IDX10268, algorithm);
 
             return new AlgorithmValidationResult(algorithm);
         }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Audience.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Audience.cs
@@ -43,7 +43,11 @@ namespace Microsoft.IdentityModel.Tokens
         /// <exception cref="SecurityTokenInvalidAudienceException">If none of the 'audiences' matched either <see cref="TokenValidationParameters.ValidAudience"/> or one of <see cref="TokenValidationParameters.ValidAudiences"/>.</exception>
         /// <remarks>An EXACT match is required.</remarks>
 #pragma warning disable CA1801 // TODO: remove pragma disable once callContext is used for logging
-        internal static AudienceValidationResult ValidateAudience(IList<string> tokenAudiences, SecurityToken? securityToken, ValidationParameters validationParameters, CallContext callContext)
+        internal static AudienceValidationResult ValidateAudience(
+            IList<string> tokenAudiences,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
 #pragma warning restore CA1801
         {
             if (validationParameters == null)

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Lifetime.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Lifetime.cs
@@ -48,7 +48,12 @@ namespace Microsoft.IdentityModel.Tokens
         /// <remarks>All time comparisons apply <see cref="ValidationParameters.ClockSkew"/>.</remarks>
         /// <remarks>Exceptions are not thrown, but embedded in <see cref="LifetimeValidationResult.Exception"/>.</remarks>
 #pragma warning disable CA1801 // TODO: remove pragma disable once callContext is used for logging
-        internal static LifetimeValidationResult ValidateLifetime(DateTime? notBefore, DateTime? expires, SecurityToken? securityToken, ValidationParameters validationParameters, CallContext callContext)
+        internal static LifetimeValidationResult ValidateLifetime(
+            DateTime? notBefore,
+            DateTime? expires,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
 #pragma warning restore CA1801
         {
             if (validationParameters == null)

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenReplay.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenReplay.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.Logging;
 
 namespace Microsoft.IdentityModel.Tokens
@@ -40,7 +41,11 @@ namespace Microsoft.IdentityModel.Tokens
         /// <exception cref="SecurityTokenReplayDetectedException">If the 'securityToken' is found in the cache.</exception>
         /// <exception cref="SecurityTokenReplayAddFailedException">If the 'securityToken' could not be added to the <see cref="ValidationParameters.TokenReplayCache"/>.</exception>
 #pragma warning disable CA1801 // Review unused parameters
-        internal static ReplayValidationResult ValidateTokenReplay(DateTime? expirationTime, string securityToken, ValidationParameters validationParameters, CallContext callContext)
+        internal static ReplayValidationResult ValidateTokenReplay(
+            DateTime? expirationTime,
+            string securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
 #pragma warning restore CA1801 // Review unused parameters
         {
             if (string.IsNullOrWhiteSpace(securityToken))
@@ -107,8 +112,10 @@ namespace Microsoft.IdentityModel.Tokens
                             null));
             }
 
-            // if it reaches here, that means no token replay is detected.
-            LogHelper.LogInformation(LogMessages.IDX10240);
+            // if we get here no token replay is detected.
+            if (LogHelper.IsEnabled(EventLogLevel.Informational))
+                LogHelper.LogInformation(LogMessages.IDX10240);
+
             return new ReplayValidationResult(expirationTime);
         }
     }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
@@ -104,9 +104,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
 
             if (LogHelper.IsEnabled(EventLogLevel.Informational))
-            {
                 LogHelper.LogInformation(LogMessages.IDX10258, LogHelper.MarkAsNonPII(type));
-            }
 
             return new TokenTypeValidationResult(type);
         }

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ReadTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ReadTokenTests.cs
@@ -14,57 +14,47 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
     public class JsonWebTokenHandlerReadTokenTests
     {
         [Theory, MemberData(nameof(JsonWebTokenHandlerReadTokenTestCases), DisableDiscoveryEnumeration = true)]
-        public void ReadToken(TokenReadingTheoryData theoryData)
+        public void ReadToken(TokenReadTheoryData theoryData)
         {
             CompareContext context = TestUtilities.WriteHeader($"{this}.JsonWebTokenHandlerReadTokenTests", theoryData);
-            TokenReadingResult tokenReadingResult = JsonWebTokenHandler.ReadToken(
+            TokenReadResult tokenReadResult = JsonWebTokenHandler.ReadToken(
                 theoryData.Token,
                 new CallContext());
 
-            if (tokenReadingResult.Exception != null)
-                theoryData.ExpectedException.ProcessException(tokenReadingResult.Exception);
+            if (tokenReadResult.Exception != null)
+                theoryData.ExpectedException.ProcessException(tokenReadResult.Exception);
             else
                 theoryData.ExpectedException.ProcessNoException();
 
-            IdentityComparer.AreTokenReadingResultsEqual(
-                tokenReadingResult,
-                theoryData.TokenReadingResult,
+            IdentityComparer.AreTokenReadResultsEqual(
+                tokenReadResult,
+                theoryData.TokenReadResult,
                 context);
 
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Fact]
-        public void ReadToken_ThrowsIfAccessingSecurityTokenOnFailedRead()
-        {
-            TokenReadingResult tokenReadingResult = JsonWebTokenHandler.ReadToken(
-                null,
-                new CallContext());
-
-            Assert.Throws<InvalidOperationException>(() => tokenReadingResult.SecurityToken());
-        }
-
-        public static TheoryData<TokenReadingTheoryData> JsonWebTokenHandlerReadTokenTestCases
+        public static TheoryData<TokenReadTheoryData> JsonWebTokenHandlerReadTokenTestCases
         {
             get
             {
                 var validToken = EncodedJwts.LiveJwt;
-                return new TheoryData<TokenReadingTheoryData>
+                return new TheoryData<TokenReadTheoryData>
                 {
-                    new TokenReadingTheoryData
+                    new TokenReadTheoryData
                     {
                         TestId = "Valid_Jwt",
                         Token = validToken,
-                        TokenReadingResult = new TokenReadingResult(
-                            new JsonWebToken(validToken),
-                            validToken)
+                        TokenReadResult = new TokenReadResult(
+                            validToken,
+                            new JsonWebToken(validToken))
                     },
-                    new TokenReadingTheoryData
+                    new TokenReadTheoryData
                     {
                         TestId = "Invalid_NullToken",
                         Token = null,
                         ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
-                        TokenReadingResult = new TokenReadingResult(
+                        TokenReadResult = new TokenReadResult(
                             null,
                             ValidationFailureType.NullArgument,
                             new ExceptionDetail(
@@ -74,12 +64,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                                 ExceptionDetail.ExceptionType.ArgumentNull,
                                 new System.Diagnostics.StackFrame()))
                     },
-                    new TokenReadingTheoryData
+                    new TokenReadTheoryData
                     {
                         TestId = "Invalid_EmptyToken",
                         Token = string.Empty,
                         ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
-                        TokenReadingResult = new TokenReadingResult(
+                        TokenReadResult = new TokenReadResult(
                             string.Empty,
                             ValidationFailureType.NullArgument,
                             new ExceptionDetail(
@@ -89,16 +79,16 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                                 ExceptionDetail.ExceptionType.ArgumentNull,
                                 new System.Diagnostics.StackFrame()))
                     },
-                    new TokenReadingTheoryData
+                    new TokenReadTheoryData
                     {
                         TestId = "Invalid_MalformedToken",
                         Token = "malformed-token",
                         ExpectedException = ExpectedException.SecurityTokenMalformedTokenException(
                             "IDX14107:",
                             typeof(SecurityTokenMalformedException)),
-                        TokenReadingResult = new TokenReadingResult(
+                        TokenReadResult = new TokenReadResult(
                             "malformed-token",
-                            ValidationFailureType.TokenReadingFailed,
+                            ValidationFailureType.TokenReadFailed,
                             new ExceptionDetail(
                                 new MessageDetail(
                                     LogMessages.IDX14107,
@@ -111,9 +101,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
     }
 
-    public class TokenReadingTheoryData : TheoryDataBase
+    public class TokenReadTheoryData : TheoryDataBase
     {
         public string Token { get; set; }
-        public object TokenReadingResult { get; set; }
+
+        public object TokenReadResult { get; set; }
     }
 }

--- a/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
@@ -1009,67 +1009,67 @@ namespace Microsoft.IdentityModel.TestUtils
             return context.Merge(localContext);
         }
 
-        public static bool AreTokenReadingResultsEqual(object object1, object object2, CompareContext context)
+        public static bool AreTokenReadResultsEqual(object object1, object object2, CompareContext context)
         {
             var localContext = new CompareContext(context);
             if (!ContinueCheckingEquality(object1, object2, context))
                 return context.Merge(localContext);
 
-            return AreTokenReadingResultsEqual(
-                object1 as TokenReadingResult,
-                object2 as TokenReadingResult,
-                "TokenReadingResult1",
-                "TokenReadingResult2",
+            return AreTokenReadResultsEqual(
+                object1 as TokenReadResult,
+                object2 as TokenReadResult,
+                "TokenReadResult1",
+                "TokenReadResult2",
                 null,
                 context);
         }
 
-        internal static bool AreTokenReadingResultsEqual(
-            TokenReadingResult tokenReadingResult1,
-            TokenReadingResult tokenReadingResult2,
+        internal static bool AreTokenReadResultsEqual(
+            TokenReadResult tokenReadResult1,
+            TokenReadResult tokenReadResult2,
             string name1,
             string name2,
             string stackPrefix,
             CompareContext context)
         {
             var localContext = new CompareContext(context);
-            if (!ContinueCheckingEquality(tokenReadingResult1, tokenReadingResult2, localContext))
+            if (!ContinueCheckingEquality(tokenReadResult1, tokenReadResult2, localContext))
                 return context.Merge(localContext);
 
-            if (tokenReadingResult1.IsValid != tokenReadingResult2.IsValid)
-                localContext.Diffs.Add($"TokenReadingResult1.IsValid: {tokenReadingResult1.IsValid} != TokenReadingResult2.IsValid: {tokenReadingResult2.IsValid}");
+            if (tokenReadResult1.IsValid != tokenReadResult2.IsValid)
+                localContext.Diffs.Add($"{nameof(tokenReadResult1)}.IsValid: {tokenReadResult1.IsValid} != {nameof(tokenReadResult2)}.IsValid: {tokenReadResult2.IsValid}");
 
-            if (tokenReadingResult1.TokenInput != tokenReadingResult2.TokenInput)
-                localContext.Diffs.Add($"TokenReadingResult1.TokenInput: '{tokenReadingResult1.TokenInput}' != TokenReadingResult2.TokenInput: '{tokenReadingResult2.TokenInput}'");
+            if (tokenReadResult1.Token != tokenReadResult2.Token)
+                localContext.Diffs.Add($"{nameof(tokenReadResult1)}.TokenInput: '{tokenReadResult1.Token}' != {nameof(tokenReadResult2)}.TokenInput: '{tokenReadResult2.Token}'");
 
             // Only compare the security token if both are valid.
-            if (tokenReadingResult1.IsValid && (tokenReadingResult1.SecurityToken().ToString() != tokenReadingResult2.SecurityToken().ToString()))
-                localContext.Diffs.Add($"TokenReadingResult1.SecurityToken: '{tokenReadingResult1.SecurityToken()}' != TokenReadingResult2.SecurityToken: '{tokenReadingResult2.SecurityToken()}'");
+            if (tokenReadResult1.IsValid && (tokenReadResult1.SecurityToken.ToString() != tokenReadResult2.SecurityToken.ToString()))
+                localContext.Diffs.Add($"{nameof(tokenReadResult1)}.SecurityToken: '{tokenReadResult1.SecurityToken}' != {nameof(tokenReadResult2)}.SecurityToken: '{tokenReadResult2.SecurityToken}'");
 
-            if (tokenReadingResult1.ValidationFailureType != tokenReadingResult2.ValidationFailureType)
-                localContext.Diffs.Add($"TokenReadingResult1.ValidationFailureType: {tokenReadingResult1.ValidationFailureType} != TokenReadingResult2.ValidationFailureType: {tokenReadingResult2.ValidationFailureType}");
+            if (tokenReadResult1.ValidationFailureType != tokenReadResult2.ValidationFailureType)
+                localContext.Diffs.Add($"{nameof(tokenReadResult1)}.ValidationFailureType: {tokenReadResult1.ValidationFailureType} != {nameof(tokenReadResult2)}.ValidationFailureType: {tokenReadResult2.ValidationFailureType}");
 
             // true => both are not null.
-            if (ContinueCheckingEquality(tokenReadingResult1.Exception, tokenReadingResult2.Exception, localContext))
+            if (ContinueCheckingEquality(tokenReadResult1.Exception, tokenReadResult2.Exception, localContext))
             {
                 AreStringsEqual(
-                    tokenReadingResult1.Exception.Message,
-                    tokenReadingResult2.Exception.Message,
+                    tokenReadResult1.Exception.Message,
+                    tokenReadResult2.Exception.Message,
                     $"({name1}).Exception.Message",
                     $"({name2}).Exception.Message",
                     localContext);
 
                 AreStringsEqual(
-                    tokenReadingResult1.Exception.Source,
-                    tokenReadingResult2.Exception.Source,
+                    tokenReadResult1.Exception.Source,
+                    tokenReadResult2.Exception.Source,
                     $"({name1}).Exception.Source",
                     $"({name2}).Exception.Source",
                     localContext);
 
                 if (!string.IsNullOrEmpty(stackPrefix))
                     AreStringPrefixesEqual(
-                        tokenReadingResult1.Exception.StackTrace.Trim(),
-                        tokenReadingResult2.Exception.StackTrace.Trim(),
+                        tokenReadResult1.Exception.StackTrace.Trim(),
+                        tokenReadResult2.Exception.StackTrace.Trim(),
                         $"({name1}).Exception.StackTrace",
                         $"({name2}).Exception.StackTrace",
                         stackPrefix.Trim(),


### PR DESCRIPTION
Some name changes, name consistency, parameter names, parameter ordering

TokenReadResult.SecurityToken is a Property
Placement of nullable pragmas are consistent in files
Spacing and naming cleanup
When passing a token as a string use name 'token', as SecurityToken use 'securityToken'
