### PR TITLE
Remove lock when creating a SignatureProvider

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -1,6 +1,6 @@
 <!-- This file may be overwritten by automation. Only values allowed here are VersionPrefix and VersionSuffix.  -->
 <Project>
-<!-- Wilson version  -->
+<!-- MicrosoftIdentityModelVersion  -->
   <PropertyGroup>
     <MicrosoftIdentityModelCurrentVersion>8.0.1</MicrosoftIdentityModelCurrentVersion>
 


### PR DESCRIPTION
Remove the lock on creating a SignatureProvider an allow a rare case where a SignatureProvider is created and not cached.
