### PR TITLE
Update xUnit version and fix test warnings

### DIFF
--- a/build/commonTest.props
+++ b/build/commonTest.props
@@ -35,9 +35,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftVersion)" />
-    <PackageReference Include="xunit.runner.console" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.console" Version="$(XunitRunnerConsoleVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualstudioVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/dependenciesTest.props
+++ b/build/dependenciesTest.props
@@ -8,6 +8,8 @@
     <NewtonsoftVersion>13.0.3</NewtonsoftVersion>
     <SystemSecurityClaimsVersion>4.3.0</SystemSecurityClaimsVersion>
     <SystemTextJson>8.0.4</SystemTextJson>
-    <XunitVersion>2.4.0</XunitVersion>
+    <XunitRunnerConsoleVersion>2.9.0</XunitRunnerConsoleVersion>
+    <XunitRunnerVisualStudioVersion>2.8.2</XunitRunnerVisualStudioVersion>
+    <XunitVersion>2.9.0</XunitVersion>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.IdentityModel.Abstractions.Tests/TelemetryEventDetailsTests.cs
+++ b/test/Microsoft.IdentityModel.Abstractions.Tests/TelemetryEventDetailsTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.IdentityModel.Logging.Tests
             mock.Object.SetProperty("key1", "value");
             mock.Object.SetProperty("key1", false);
 
-            Assert.Equal(1, mock.Object.Properties.Count);
+            Assert.Single(mock.Object.Properties);
             Assert.False((bool)mock.Object.Properties["key1"]);
         }
 
@@ -81,7 +81,7 @@ namespace Microsoft.IdentityModel.Logging.Tests
             CustomTelemetryEventDetails eventDetails = new CustomTelemetryEventDetails();
             eventDetails.SetProperty("foo", new Foo() { Bar = "bar" });
 
-            Assert.Equal(1, eventDetails.Properties.Count);
+            Assert.Single(eventDetails.Properties);
             Assert.Equal("bar", (eventDetails.Properties["foo"] as Foo)?.Bar);
         }
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -91,20 +91,20 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(TokenValidationClaimsTheoryData))]
-        public void ValidateTokenValidationResult(JsonWebTokenTheoryData theoryData)
+        public async Task ValidateTokenValidationResult(JsonWebTokenTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateTokenValidationResult");
-            var tokenValidationResult = theoryData.TokenHandler.ValidateTokenAsync(theoryData.AccessToken, theoryData.ValidationParameters).Result;
+            var tokenValidationResult = await theoryData.TokenHandler.ValidateTokenAsync(theoryData.AccessToken, theoryData.ValidationParameters);
             Assert.Equal(tokenValidationResult.Claims, TokenUtilities.CreateDictionaryFromClaims(tokenValidationResult.ClaimsIdentity.Claims));
         }
 
         [Theory, MemberData(nameof(TokenValidationClaimsTheoryData))]
-        public void ValidateTokenDerivedHandlerValidationResult(JsonWebTokenTheoryData theoryData)
+        public async Task ValidateTokenDerivedHandlerValidationResult(JsonWebTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateTokenDerivedHandlerValidationResult", theoryData);
             var derivedJsonWebTokenHandler = new DerivedJsonWebTokenHandler();
-            var tokenValidationResult = theoryData.TokenHandler.ValidateTokenAsync(theoryData.AccessToken, theoryData.ValidationParameters).Result;
-            var tokenValidationDerivedResult = derivedJsonWebTokenHandler.ValidateTokenAsync(theoryData.AccessToken, theoryData.ValidationParameters).Result;
+            var tokenValidationResult = await theoryData.TokenHandler.ValidateTokenAsync(theoryData.AccessToken, theoryData.ValidationParameters);
+            var tokenValidationDerivedResult = await derivedJsonWebTokenHandler.ValidateTokenAsync(theoryData.AccessToken, theoryData.ValidationParameters);
             IdentityComparer.AreEqual(tokenValidationResult.Claims, TokenUtilities.CreateDictionaryFromClaims(tokenValidationResult.ClaimsIdentity.Claims), context);
             IdentityComparer.AreEqual(tokenValidationDerivedResult.Claims, TokenUtilities.CreateDictionaryFromClaims(tokenValidationDerivedResult.ClaimsIdentity.Claims), context);
             IdentityComparer.AreEqual(tokenValidationResult.Claims, tokenValidationDerivedResult.Claims, context);
@@ -158,7 +158,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(TokenValidationTheoryData))]
-        public void ValidateTokenValidationResultThrowsWarning(JsonWebTokenTheoryData theoryData)
+        public async Task ValidateTokenValidationResultThrowsWarning(JsonWebTokenTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateTokenValidationResultThrowsWarning");
 
@@ -166,7 +166,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             SampleListener listener = SampleListener.CreateLoggerListener(EventLevel.Warning);
 
             //validate token
-            var tokenValidationResult = theoryData.TokenHandler.ValidateTokenAsync(theoryData.AccessToken, theoryData.ValidationParameters).Result;
+            var tokenValidationResult = await theoryData.TokenHandler.ValidateTokenAsync(theoryData.AccessToken, theoryData.ValidationParameters);
 
             //access claims without checking IsValid or Exception
             var claims = tokenValidationResult.Claims;
@@ -177,7 +177,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(TokenValidationTheoryData))]
-        public void ValidateTokenValidationResultDoesNotThrowWarningWithIsValidRead(JsonWebTokenTheoryData theoryData)
+        public async Task ValidateTokenValidationResultDoesNotThrowWarningWithIsValidRead(JsonWebTokenTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateTokenValidationResultDoesNotThrowWarningWithIsValidRead");
 
@@ -185,7 +185,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             SampleListener listener = SampleListener.CreateLoggerListener(EventLevel.Warning);
 
             //validate token
-            var tokenValidationResult = theoryData.TokenHandler.ValidateTokenAsync(theoryData.AccessToken, theoryData.ValidationParameters).Result;
+            var tokenValidationResult = await theoryData.TokenHandler.ValidateTokenAsync(theoryData.AccessToken, theoryData.ValidationParameters);
 
             //checking IsValid first, then access claims
             var isValid = tokenValidationResult.IsValid;
@@ -197,7 +197,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(TokenValidationTheoryData))]
-        public void ValidateTokenValidationResultDoesNotThrowWarningWithExceptionRead(JsonWebTokenTheoryData theoryData)
+        public async Task ValidateTokenValidationResultDoesNotThrowWarningWithExceptionRead(JsonWebTokenTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateTokenValidationResultDoesNotThrowWarningWithExceptionRead");
 
@@ -205,7 +205,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             SampleListener listener = SampleListener.CreateLoggerListener(EventLevel.Warning);
 
             //validate token
-            var tokenValidationResult = theoryData.TokenHandler.ValidateTokenAsync(theoryData.AccessToken, theoryData.ValidationParameters).Result;
+            var tokenValidationResult = await theoryData.TokenHandler.ValidateTokenAsync(theoryData.AccessToken, theoryData.ValidationParameters);
 
             //checking exception first, then access claims
             var exception = tokenValidationResult.Exception;
@@ -282,13 +282,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(CreateTokenWithEmptyPayloadUsingSecurityTokenDescriptorTheoryData))]
-        public void CreateTokenWithEmptyPayloadUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
+        public async Task CreateTokenWithEmptyPayloadUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateEmptyJWSUsingSecurityTokenDescriptor", theoryData);
             try
             {
                 string jwtFromSecurityTokenDescriptor = theoryData.JsonWebTokenHandler.CreateToken(theoryData.TokenDescriptor);
-                var tokenValidationResultFromSecurityTokenDescriptor = theoryData.JsonWebTokenHandler.ValidateTokenAsync(jwtFromSecurityTokenDescriptor, theoryData.ValidationParameters).Result;
+                var tokenValidationResultFromSecurityTokenDescriptor = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(jwtFromSecurityTokenDescriptor, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(tokenValidationResultFromSecurityTokenDescriptor.IsValid, theoryData.IsValid, context);
                 var jwsTokenFromSecurityTokenDescriptor = new JsonWebToken(jwtFromSecurityTokenDescriptor);
 
@@ -406,7 +406,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         /// </summary>
         /// <param name="theoryData">The test data.</param>
         [Theory, MemberData(nameof(CreateJWEWithAesGcmTheoryData))]
-        public void TokenValidationResultsShouldMatch(CreateTokenTheoryData theoryData)
+        public async Task TokenValidationResultsShouldMatch(CreateTokenTheoryData theoryData)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -421,7 +421,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
                     theoryData.ValidationParameters.ValidateLifetime = false;
                     var claimsPrincipal = theoryData.JwtSecurityTokenHandler.ValidateToken(jweFromJwtHandler, theoryData.ValidationParameters, out SecurityToken validatedTokenFromJwtHandler);
-                    var validationResult = theoryData.JwtSecurityTokenHandler.ValidateTokenAsync(jweFromJwtHandler, theoryData.ValidationParameters).Result;
+                    var validationResult = await theoryData.JwtSecurityTokenHandler.ValidateTokenAsync(jweFromJwtHandler, theoryData.ValidationParameters);
 
                     // verify the results from asynchronous and synchronous are the same
                     IdentityComparer.AreClaimsIdentitiesEqual(claimsPrincipal.Identity as ClaimsIdentity, validationResult.ClaimsIdentity, context);
@@ -437,7 +437,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(CreateJWEWithAesGcmTheoryData))]
-        public void CreateJWEWithAesGcm(CreateTokenTheoryData theoryData)
+        public async Task CreateJWEWithAesGcm(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWEWithAesGcm", theoryData);
             try
@@ -447,7 +447,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
                 theoryData.ValidationParameters.ValidateLifetime = false;
                 var claimsPrincipal = theoryData.JwtSecurityTokenHandler.ValidateToken(jweFromJwtHandler, theoryData.ValidationParameters, out SecurityToken validatedTokenFromJwtHandler);
-                var validationResult = theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromJsonHandler, theoryData.ValidationParameters).Result;
+                var validationResult = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromJsonHandler, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(validationResult.IsValid, theoryData.IsValid, context);
                 var validatedTokenFromJsonHandler = validationResult.SecurityToken;
                 IdentityComparer.AreEqual(validationResult.IsValid, theoryData.IsValid, context);
@@ -541,7 +541,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         // Tests checks to make sure that the token string created by the JsonWebTokenHandler is consistent with the 
         // token string created by the JwtSecurityTokenHandler.
         [Theory, MemberData(nameof(CreateJWETheoryData))]
-        public void CreateJWE(CreateTokenTheoryData theoryData)
+        public async Task CreateJWE(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWE", theoryData);
             theoryData.ValidationParameters.ValidateLifetime = false;
@@ -551,11 +551,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 string jweFromJsonHandler = theoryData.JsonWebTokenHandler.CreateToken(theoryData.TokenDescriptor);
 
                 var claimsPrincipalFromJwtHandler = theoryData.JwtSecurityTokenHandler.ValidateToken(jweFromJwtHandler, theoryData.ValidationParameters, out SecurityToken validatedTokenFromJwtHandler);
-                var validationResultFromJsonHandler = theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromJsonHandler, theoryData.ValidationParameters).Result;
+                var validationResultFromJsonHandler = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromJsonHandler, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(validationResultFromJsonHandler.IsValid, theoryData.IsValid, context);
 
                 var validatedTokenFromJsonHandler = validationResultFromJsonHandler.SecurityToken;
-                var validationResultFromJwtJsonHandler = theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromJwtHandler, theoryData.ValidationParameters).Result;
+                var validationResultFromJwtJsonHandler = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromJwtHandler, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(validationResultFromJwtJsonHandler.IsValid, theoryData.IsValid, context);
                 IdentityComparer.AreEqual(claimsPrincipalFromJwtHandler.Identity, validationResultFromJsonHandler.ClaimsIdentity, context);
                 IEnumerable<Claim> jwtHandlerClaims = (validatedTokenFromJwtHandler as JwtSecurityToken).Claims;
@@ -797,7 +797,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         // CreateToken(string payload, SigningCredentials signingCredentials, EncryptingCredentials encryptingCredentials)
         // is equivalent to the token string created by calling CreateToken(SecurityTokenDescriptor tokenDescriptor).
         [Theory, MemberData(nameof(CreateJWEUsingSecurityTokenDescriptorTheoryData))]
-        public void CreateJWEUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
+        public async Task CreateJWEUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWEUsingSecurityTokenDescriptor", theoryData);
             theoryData.ValidationParameters.ValidateLifetime = false;
@@ -818,8 +818,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 else
                     jweFromString = theoryData.JsonWebTokenHandler.CreateToken(theoryData.Payload, theoryData.TokenDescriptor.SigningCredentials, theoryData.TokenDescriptor.EncryptingCredentials);
 
-                var validationResultFromSecurityTokenDescriptor = theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromSecurityTokenDescriptor, theoryData.ValidationParameters).Result;
-                var validationResultFromString = theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromString, theoryData.ValidationParameters).Result;
+                var validationResultFromSecurityTokenDescriptor = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromSecurityTokenDescriptor, theoryData.ValidationParameters);
+                var validationResultFromString = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromString, theoryData.ValidationParameters);
 
                 IdentityComparer.AreEqual(validationResultFromSecurityTokenDescriptor.IsValid, theoryData.IsValid, context);
                 IdentityComparer.AreEqual(validationResultFromString.IsValid, theoryData.IsValid, context);
@@ -1187,7 +1187,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         // Tests checks to make sure that the token string created by the JsonWebTokenHandler is consistent with the 
         // token string created by the JwtSecurityTokenHandler.
         [Theory, MemberData(nameof(CreateJWSTheoryData))]
-        public void CreateJWS(CreateTokenTheoryData theoryData)
+        public async Task CreateJWS(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWS", theoryData);
             theoryData.ValidationParameters.ValidateLifetime = false;
@@ -1197,7 +1197,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 string jwsFromJsonHandler = theoryData.JsonWebTokenHandler.CreateToken(theoryData.TokenDescriptor);
 
                 var claimsPrincipal = theoryData.JwtSecurityTokenHandler.ValidateToken(jwsFromJwtHandler, theoryData.ValidationParameters, out SecurityToken validatedToken);
-                var tokenValidationResult = theoryData.JsonWebTokenHandler.ValidateTokenAsync(jwsFromJsonHandler, theoryData.ValidationParameters).Result;
+                var tokenValidationResult = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(jwsFromJsonHandler, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(tokenValidationResult.IsValid, theoryData.IsValid, context);
                 IdentityComparer.AreEqual(claimsPrincipal.Identity, tokenValidationResult.ClaimsIdentity, context);
 
@@ -1540,7 +1540,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(CreateJWEWithPayloadStringTheoryData))]
-        public void CreateJWEWithPayloadString(CreateTokenTheoryData theoryData)
+        public async Task CreateJWEWithPayloadString(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWEWithPayloadString", theoryData);
             var handler = new JsonWebTokenHandler();
@@ -1587,7 +1587,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 if (theoryData.TokenDescriptor.AdditionalInnerHeaderClaims != null)
                 {
                     theoryData.ValidationParameters.ValidateLifetime = false;
-                    var result = handler.ValidateTokenAsync(jwtTokenWithSigning, theoryData.ValidationParameters).Result;
+                    var result = await handler.ValidateTokenAsync(jwtTokenWithSigning, theoryData.ValidationParameters);
                     var token = result.SecurityToken as JsonWebToken;
                     if (theoryData.TokenDescriptor.AdditionalInnerHeaderClaims.TryGetValue(JwtHeaderParameterNames.Cty, out object innerCtyValue))
                     {
@@ -1721,15 +1721,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
         // This test checks to make sure that additional header claims are added as expected to the outer token header.
         [Theory, MemberData(nameof(CreateJWEWithAdditionalHeaderClaimsTheoryData))]
-        public void CreateJWEWithAdditionalHeaderClaims(CreateTokenTheoryData theoryData)
+        public async Task CreateJWEWithAdditionalHeaderClaims(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWEWithAdditionalHeaderClaims", theoryData);
             var handler = new JsonWebTokenHandler();
             theoryData.ValidationParameters.ValidateLifetime = false;
 
             var jwtTokenFromDescriptor = handler.CreateToken(theoryData.TokenDescriptor);
-            var validatedJwtTokenFromDescriptor = handler.ValidateTokenAsync(jwtTokenFromDescriptor, theoryData.ValidationParameters).Result.SecurityToken as JsonWebToken;
-            var jwtTokenToCompare = handler.ValidateTokenAsync(theoryData.JwtToken, theoryData.ValidationParameters).Result.SecurityToken as JsonWebToken;
+            var validatedJwtTokenFromDescriptor = (await handler.ValidateTokenAsync(jwtTokenFromDescriptor, theoryData.ValidationParameters)).SecurityToken as JsonWebToken;
+            var jwtTokenToCompare = (await handler.ValidateTokenAsync(theoryData.JwtToken, theoryData.ValidationParameters)).SecurityToken as JsonWebToken;
 
             context.PropertiesToIgnoreWhenComparing = new Dictionary<Type, List<string>>
             {
@@ -1904,7 +1904,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         // Tests checks to make sure that the token string (JWS) created by calling CreateToken(string payload, SigningCredentials signingCredentials)
         // is equivalent to the token string created by calling CreateToken(SecurityTokenDescriptor tokenDescriptor).
         [Theory, MemberData(nameof(CreateJWSUsingSecurityTokenDescriptorTheoryData))]
-        public void CreateJWSUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
+        public async Task CreateJWSUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWSUsingSecurityTokenDescriptor", theoryData);
             theoryData.ValidationParameters.ValidateLifetime = false;
@@ -1929,8 +1929,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 var jwsTokenFromSecurityTokenDescriptor = new JsonWebToken(jwtFromSecurityTokenDescriptor);
                 var jwsTokenFromString = new JsonWebToken(jwtPayloadAsString);
 
-                var tokenValidationResultFromSecurityTokenDescriptor = theoryData.JsonWebTokenHandler.ValidateTokenAsync(jwtFromSecurityTokenDescriptor, theoryData.ValidationParameters).Result;
-                var tokenValidationResultFromString = theoryData.JsonWebTokenHandler.ValidateTokenAsync(jwtPayloadAsString, theoryData.ValidationParameters).Result;
+                var tokenValidationResultFromSecurityTokenDescriptor = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(jwtFromSecurityTokenDescriptor, theoryData.ValidationParameters);
+                var tokenValidationResultFromString = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(jwtPayloadAsString, theoryData.ValidationParameters);
 
                 IdentityComparer.AreEqual(tokenValidationResultFromSecurityTokenDescriptor.IsValid, theoryData.IsValid, context);
                 IdentityComparer.AreEqual(tokenValidationResultFromString.IsValid, theoryData.IsValid, context);
@@ -2426,7 +2426,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 IssuerSigningKey = KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key,
             };
 
-            var tokenValidationResult = await tokenHandler.ValidateTokenAsync(jwtString, tokenValidationParameters).ConfigureAwait(false);
+            var tokenValidationResult = await tokenHandler.ValidateTokenAsync(jwtString, tokenValidationParameters);
             JsonWebToken validatedToken = tokenValidationResult.SecurityToken as JsonWebToken;
 
             if (!validatedToken.TryGetHeaderValue(JwtHeaderParameterNames.X5c, out string[] x5cFound))
@@ -2441,7 +2441,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         // Test checks to make sure that the token payload retrieved from ValidateToken is the same as the payload
         // the token was initially created with. 
         [Fact]
-        public void RoundTripJWS()
+        public async Task RoundTripJWS()
         {
             TestUtilities.WriteHeader($"{this}.RoundTripToken");
 
@@ -2456,7 +2456,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             };
 
             string jwtString = tokenHandler.CreateToken(Default.PayloadString, KeyingMaterial.JsonWebKeyRsa256SigningCredentials);
-            var tokenValidationResult = tokenHandler.ValidateTokenAsync(jwtString, tokenValidationParameters).Result;
+            var tokenValidationResult = await tokenHandler.ValidateTokenAsync(jwtString, tokenValidationParameters);
             var validatedToken = tokenValidationResult.SecurityToken as JsonWebToken;
             IdentityComparer.AreEqual(Default.PayloadClaimsIdentity, tokenValidationResult.ClaimsIdentity, context);
             IdentityComparer.AreEqual(Default.PayloadString, Base64UrlEncoder.Decode(validatedToken.EncodedPayload), context);
@@ -2466,7 +2466,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
         // Test ensure paths to creating a token with an empty payload are successful.
         [Theory, MemberData(nameof(RoundTripWithEmptyPayloadTestCases))]
-        public void RoundTripWithEmptyPayload(CreateTokenTheoryData theoryData)
+        public async Task RoundTripWithEmptyPayload(CreateTokenTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.RoundTripWithEmptyPayload");
 
@@ -2480,7 +2480,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                                     theoryData.AdditionalInnerHeaderClaims,
                                     "JWT");
 
-            var tokenValidationResult = theoryData.JsonWebTokenHandler.ValidateTokenAsync(jwtString, theoryData.ValidationParameters).Result;
+            var tokenValidationResult = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(jwtString, theoryData.ValidationParameters);
             var validatedToken = tokenValidationResult.SecurityToken as JsonWebToken;
             var claimsIdentity = tokenValidationResult.ClaimsIdentity;
             IdentityComparer.AreEqual(new CaseSensitiveClaimsIdentity("AuthenticationTypes.Federation"), claimsIdentity, context);
@@ -2611,7 +2611,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(RoundTripJWEDirectTestCases))]
-        public void RoundTripJWEInnerJWSDirect(CreateTokenTheoryData theoryData)
+        public async Task RoundTripJWEInnerJWSDirect(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEInnerJWSDirect", theoryData);
             var jsonWebTokenHandler = new JsonWebTokenHandler();
@@ -2620,7 +2620,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             theoryData.ValidationParameters.ValidateLifetime = false;
             try
             {
-                var tokenValidationResult = jsonWebTokenHandler.ValidateTokenAsync(jweCreatedInMemory, theoryData.ValidationParameters).Result;
+                var tokenValidationResult = await jsonWebTokenHandler.ValidateTokenAsync(jweCreatedInMemory, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(tokenValidationResult.IsValid, theoryData.IsValid, context);
                 if (tokenValidationResult.Exception != null)
                     throw tokenValidationResult.Exception;
@@ -2644,7 +2644,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(RoundTripJWEDirectTestCases))]
-        public void RoundTripJWEDirect(CreateTokenTheoryData theoryData)
+        public async Task RoundTripJWEDirect(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEDirect", theoryData);
             var jsonWebTokenHandler = new JsonWebTokenHandler();
@@ -2654,7 +2654,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             theoryData.ValidationParameters.ValidateLifetime = false;
             try
             {
-                var tokenValidationResult = jsonWebTokenHandler.ValidateTokenAsync(jweCreatedInMemory, theoryData.ValidationParameters).Result;
+                var tokenValidationResult = await jsonWebTokenHandler.ValidateTokenAsync(jweCreatedInMemory, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(tokenValidationResult.IsValid, theoryData.IsValid, context);
                 if (tokenValidationResult.Exception != null)
                     throw tokenValidationResult.Exception;
@@ -2743,7 +2743,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(RoundTripJWEKeyWrapTestCases))]
-        public void RoundTripJWEInnerJWSKeyWrap(CreateTokenTheoryData theoryData)
+        public async Task RoundTripJWEInnerJWSKeyWrap(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEInnerJWSKeyWrap", theoryData);
             var jsonWebTokenHandler = new JsonWebTokenHandler();
@@ -2752,7 +2752,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             try
             {
                 var jweCreatedInMemory = jsonWebTokenHandler.EncryptToken(innerJws, theoryData.EncryptingCredentials);
-                var tokenValidationResult = jsonWebTokenHandler.ValidateTokenAsync(jweCreatedInMemory, theoryData.ValidationParameters).Result;
+                var tokenValidationResult = await jsonWebTokenHandler.ValidateTokenAsync(jweCreatedInMemory, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(tokenValidationResult.IsValid, theoryData.IsValid, context);
                 if (tokenValidationResult.Exception != null)
                     throw tokenValidationResult.Exception;
@@ -2776,7 +2776,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(RoundTripJWEKeyWrapTestCases))]
-        public void RoundTripJWEKeyWrap(CreateTokenTheoryData theoryData)
+        public async Task RoundTripJWEKeyWrap(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEKeyWrap", theoryData);
             var jsonWebTokenHandler = new JsonWebTokenHandler();
@@ -2786,7 +2786,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             try
             {
                 var jweCreatedInMemory = jsonWebTokenHandler.CreateToken(theoryData.Payload, theoryData.SigningCredentials, theoryData.EncryptingCredentials);
-                var tokenValidationResult = jsonWebTokenHandler.ValidateTokenAsync(jweCreatedInMemory, theoryData.ValidationParameters).Result;
+                var tokenValidationResult = await jsonWebTokenHandler.ValidateTokenAsync(jweCreatedInMemory, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(tokenValidationResult.IsValid, theoryData.IsValid, context);
                 if (tokenValidationResult.Exception != null)
                     throw tokenValidationResult.Exception;
@@ -2966,7 +2966,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         // Test checks to make sure that an access token can be successfully validated by the JsonWebTokenHandler.
         // Also ensures that a non-standard claim can be successfully retrieved from the payload and validated.
         [Fact]
-        public void ValidateTokenClaims()
+        public async Task ValidateTokenClaims()
         {
             TestUtilities.WriteHeader($"{this}.ValidateTokenClaims");
 
@@ -2987,7 +2987,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 ValidIssuer = "http://Default.Issuer.com",
                 IssuerSigningKey = KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key,
             };
-            var tokenValidationResult = tokenHandler.ValidateTokenAsync(accessToken, tokenValidationParameters).Result;
+            var tokenValidationResult = await tokenHandler.ValidateTokenAsync(accessToken, tokenValidationParameters);
             var jsonWebToken = tokenValidationResult.SecurityToken as JsonWebToken;
             var email = jsonWebToken.GetPayloadValue<string>(JwtRegisteredClaimNames.Email);
 
@@ -2997,11 +2997,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
 
         [Theory, MemberData(nameof(ValidateTypeTheoryData))]
-        public void ValidateType(JwtTheoryData theoryData)
+        public async Task ValidateType(JwtTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateType", theoryData);
 
-            var tokenValidationResult = new JsonWebTokenHandler().ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
+            var tokenValidationResult = await new JsonWebTokenHandler().ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
             if (tokenValidationResult.Exception != null)
                 theoryData.ExpectedException.ProcessException(tokenValidationResult.Exception);
             else
@@ -3013,14 +3013,14 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         public static TheoryData<JwtTheoryData> ValidateTypeTheoryData = JwtSecurityTokenHandlerTests.ValidateTypeTheoryData;
 
         [Theory, MemberData(nameof(ValidateJweTestCases))]
-        public void ValidateJWE(JwtTheoryData theoryData)
+        public async Task ValidateJWE(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWE", theoryData);
 
             try
             {
                 var handler = new JsonWebTokenHandler();
-                var validationResult = handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
+                var validationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
                 if (validationResult.Exception != null)
                 {
                     if (validationResult.IsValid)
@@ -3156,8 +3156,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             {
                 var handler = new JsonWebTokenHandler();
                 var jwt = handler.ReadJsonWebToken(theoryData.Token);
-                var validationResult = await handler.ValidateTokenAsync(jwt, theoryData.ValidationParameters).ConfigureAwait(false);
-                var rawTokenValidationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).ConfigureAwait(false);
+                var validationResult = await handler.ValidateTokenAsync(jwt, theoryData.ValidationParameters);
+                var rawTokenValidationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(validationResult, rawTokenValidationResult, context);
 
                 if (validationResult.Exception != null)
@@ -3277,15 +3277,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(ValidateJwsTestCases))]
-        public void ValidateJWSAsync(JwtTheoryData theoryData)
+        public async Task ValidateJWSAsync(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWSAsync", theoryData);
 
             try
             {
                 var handler = new JsonWebTokenHandler();
-                var validationResult = handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
-                var rawTokenValidationResult = handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
+                var validationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
+                var rawTokenValidationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(validationResult, rawTokenValidationResult, context);
 
                 if (validationResult.Exception != null)
@@ -3307,14 +3307,14 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(ValidateJwsTestCases))]
-        public void ValidateJWS(JwtTheoryData theoryData)
+        public async Task ValidateJWS(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWS", theoryData);
 
             try
             {
                 var handler = new JsonWebTokenHandler();
-                var validationResult = handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
+                var validationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
                 if (validationResult.Exception != null)
                 {
                     if (validationResult.IsValid)
@@ -3536,14 +3536,14 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(ValidateJwsWithConfigTheoryData))]
-        public void ValidateJWSWithConfig(JwtTheoryData theoryData)
+        public async Task ValidateJWSWithConfig(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWSWithConfig", theoryData);
             try
             {
                 var handler = new JsonWebTokenHandler();
                 AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).ConfigurationManagerV1 = theoryData.ValidationParameters.ConfigurationManager;
-                var validationResult = handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
+                var validationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
                 if (validationResult.IsValid)
                 {
                     if (theoryData.ShouldSetLastKnownConfiguration && theoryData.ValidationParameters.ConfigurationManager.LastKnownGoodConfiguration == null)
@@ -3583,8 +3583,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 var handler = new JsonWebTokenHandler();
                 var jwt = handler.ReadJsonWebToken(theoryData.Token);
                 AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).ConfigurationManagerV1 = theoryData.ValidationParameters.ConfigurationManager;
-                var validationResult = await handler.ValidateTokenAsync(jwt, theoryData.ValidationParameters).ConfigureAwait(false);
-                var rawTokenValidationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).ConfigureAwait(false);
+                var validationResult = await handler.ValidateTokenAsync(jwt, theoryData.ValidationParameters);
+                var rawTokenValidationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
                 IdentityComparer.AreEqual(validationResult, rawTokenValidationResult, context);
 
                 if (validationResult.IsValid)
@@ -3640,7 +3640,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
         [Theory, MemberData(nameof(ValidateJwsWithLastKnownGoodTheoryData))]
-        public void ValidateJWSWithLastKnownGood(JwtTheoryData theoryData)
+        public async Task ValidateJWSWithLastKnownGood(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWSWithLastKnownGood", theoryData);
             try
@@ -3663,7 +3663,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     var previousValidateWithLKG = theoryData.ValidationParameters.ValidateWithLKG;
                     theoryData.ValidationParameters.ValidateWithLKG = false;
 
-                    var setupValidationResult = handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
+                    var setupValidationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
 
                     theoryData.ValidationParameters.ValidateWithLKG = previousValidateWithLKG;
 
@@ -3676,7 +3676,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 }
 
                 AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).ConfigurationManagerV1 = theoryData.ValidationParameters.ConfigurationManager;
-                var validationResult = handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
+                var validationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
                 if (validationResult.Exception != null)
                 {
                     if (validationResult.IsValid)
@@ -3698,7 +3698,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         public static TheoryData<JwtTheoryData> ValidateJwsWithLastKnownGoodTheoryData => JwtTestDatasets.ValidateJwsWithLastKnownGoodTheoryData;
 
         [Theory, MemberData(nameof(ValidateJWEWithLastKnownGoodTheoryData))]
-        public void ValidateJWEWithLastKnownGood(JwtTheoryData theoryData)
+        public async Task ValidateJWEWithLastKnownGood(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWEWithLastKnownGood", theoryData);
             try
@@ -3720,7 +3720,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     var previousValidateWithLKG = theoryData.ValidationParameters.ValidateWithLKG;
                     theoryData.ValidationParameters.ValidateWithLKG = false;
 
-                    var setupValidationResult = handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
+                    var setupValidationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
 
                     theoryData.ValidationParameters.ValidateWithLKG = previousValidateWithLKG;
 
@@ -3733,7 +3733,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 }
 
                 AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).ConfigurationManagerV1 = theoryData.ValidationParameters.ConfigurationManager;
-                var validationResult = handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
+                var validationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
                 if (validationResult.Exception != null)
                 {
                     if (validationResult.IsValid)
@@ -3755,7 +3755,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         public static TheoryData<JwtTheoryData> ValidateJWEWithLastKnownGoodTheoryData => JwtTestDatasets.ValidateJWEWithLastKnownGoodTheoryData;
 
         [Theory, MemberData(nameof(JWECompressionTheoryData))]
-        public void EncryptExistingJWSWithCompressionTest(CreateTokenTheoryData theoryData)
+        public async Task EncryptExistingJWSWithCompressionTest(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.EncryptExistingJWSWithCompressionTest", theoryData);
 
@@ -3770,7 +3770,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     innerJwt = handler.CreateToken(theoryData.Payload);
 
                 var jwtToken = handler.EncryptToken(innerJwt, theoryData.EncryptingCredentials, theoryData.CompressionAlgorithm);
-                var validationResult = handler.ValidateTokenAsync(jwtToken, theoryData.ValidationParameters).Result;
+                var validationResult = await handler.ValidateTokenAsync(jwtToken, theoryData.ValidationParameters);
                 if (validationResult.Exception != null)
                     throw validationResult.Exception;
 
@@ -3787,7 +3787,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(JWECompressionTheoryData))]
-        public void JWECompressionTest(CreateTokenTheoryData theoryData)
+        public async Task JWECompressionTest(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.JWECompressionTest", theoryData);
 
@@ -3805,7 +3805,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 else
                     jwtToken = handler.CreateToken(theoryData.Payload, theoryData.SigningCredentials, theoryData.EncryptingCredentials, theoryData.CompressionAlgorithm);
 
-                var validationResult = handler.ValidateTokenAsync(jwtToken, theoryData.ValidationParameters).Result;
+                var validationResult = await handler.ValidateTokenAsync(jwtToken, theoryData.ValidationParameters);
                 if (validationResult.Exception != null)
                     throw validationResult.Exception;
 
@@ -3936,7 +3936,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(JweDecompressSizeTheoryData))]
-        public void JWEDecompressionSizeTest(JWEDecompressionTheoryData theoryData)
+        public async Task JWEDecompressionSizeTest(JWEDecompressionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.JWEDecompressionTest", theoryData);
 
@@ -3944,7 +3944,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             {
                 var handler = new JsonWebTokenHandler();
                 CompressionProviderFactory.Default = theoryData.CompressionProviderFactory;
-                var validationResult = handler.ValidateTokenAsync(theoryData.JWECompressionString, theoryData.ValidationParameters).Result;
+                var validationResult = await handler.ValidateTokenAsync(theoryData.JWECompressionString, theoryData.ValidationParameters);
                 theoryData.ExpectedException.ProcessException(validationResult.Exception, context);
             }
             catch (Exception ex)
@@ -4000,7 +4000,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(JWEDecompressionTheoryData))]
-        public void JWEDecompressionTest(JWEDecompressionTheoryData theoryData)
+        public async Task JWEDecompressionTest(JWEDecompressionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.JWEDecompressionTest", theoryData);
 
@@ -4008,7 +4008,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             {
                 var handler = new JsonWebTokenHandler();
                 CompressionProviderFactory.Default = theoryData.CompressionProviderFactory;
-                var validationResult = handler.ValidateTokenAsync(theoryData.JWECompressionString, theoryData.ValidationParameters).Result;
+                var validationResult = await handler.ValidateTokenAsync(theoryData.JWECompressionString, theoryData.ValidationParameters);
                 var validatedToken = validationResult.SecurityToken as JsonWebToken;
                 if (validationResult.Exception != null)
                 {
@@ -4119,7 +4119,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(SecurityKeyNotFoundExceptionTestTheoryData))]
-        public void SecurityKeyNotFoundExceptionTest(CreateTokenTheoryData theoryData)
+        public async Task SecurityKeyNotFoundExceptionTest(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SecurityKeyNotFoundExceptionTest", theoryData);
 
@@ -4127,7 +4127,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             {
                 var handler = new JsonWebTokenHandler();
                 var token = handler.CreateToken(theoryData.TokenDescriptor);
-                var validationResult = handler.ValidateTokenAsync(token, theoryData.ValidationParameters).Result;
+                var validationResult = await handler.ValidateTokenAsync(token, theoryData.ValidationParameters);
                 if (validationResult.Exception != null)
                 {
                     if (validationResult.IsValid)
@@ -4218,7 +4218,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Theory, MemberData(nameof(IncludeSecurityTokenOnFailureTestTheoryData))]
-        public void IncludeSecurityTokenOnFailedValidationTest(CreateTokenTheoryData theoryData)
+        public async Task IncludeSecurityTokenOnFailedValidationTest(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.IncludeSecurityTokenOnFailedValidationTest", theoryData);
 
@@ -4226,7 +4226,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             {
                 var handler = new JsonWebTokenHandler();
                 var token = handler.CreateToken(theoryData.TokenDescriptor);
-                var validationResult = handler.ValidateTokenAsync(token, theoryData.ValidationParameters).Result;
+                var validationResult = await handler.ValidateTokenAsync(token, theoryData.ValidationParameters);
                 if (theoryData.ValidationParameters.IncludeTokenOnFailedValidation)
                 {
                     Assert.NotNull(validationResult.TokenOnFailedValidation);
@@ -4315,7 +4315,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             var jweWithExtraCharacters = jwe + "_cannoli_hunts_truffles_";
 
             // act
-            var tokenValidationResult = await jsonWebTokenHandler.ValidateTokenAsync(jweWithExtraCharacters, theoryData.ValidationParameters).ConfigureAwait(false);
+            var tokenValidationResult = await jsonWebTokenHandler.ValidateTokenAsync(jweWithExtraCharacters, theoryData.ValidationParameters);
 
             // assert
             Assert.Equal(theoryData.IsValid, tokenValidationResult.IsValid);

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -340,16 +340,16 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 // AutomaticRefreshInterval interval should return same config.
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AutomaticRefreshIntervalNotHit")
-               {
-                   ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                {
+                    ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                        "AADCommonV1Json",
                        new OpenIdConnectConfigurationRetriever(),
                        InMemoryDocumentRetriever),
-                   ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
-                   ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV1Config,
-                   SyncAfter = DateTime.UtcNow + TimeSpan.FromDays(2),
-                   UpdatedMetadataAddress = "AADCommonV2Json"
-               });
+                    ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
+                    ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV1Config,
+                    SyncAfter = DateTime.UtcNow + TimeSpan.FromDays(2),
+                    UpdatedMetadataAddress = "AADCommonV2Json"
+                });
 
                 // AutomaticRefreshInterval should pick up new bits.
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AutomaticRefreshIntervalHit")
@@ -637,16 +637,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.ExpectedException.ProcessNoException(context);
             }
-            catch (AggregateException ex)
+            catch (Exception ex)
             {
                 // this should throw, because last configuration retrieved was null
-                Assert.Throws<AggregateException>(() => configuration = configurationManager.GetConfigurationAsync().Result);
+                await Assert.ThrowsAsync<InvalidOperationException>(async () => configuration = await configurationManager.GetConfigurationAsync());
 
-                ex.Handle((x) =>
-                {
-                    theoryData.ExpectedException.ProcessException(x, context);
-                    return true;
-                });
+                theoryData.ExpectedException.ProcessException(ex, context);
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -771,9 +767,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         {
             public ConfigurationManager<T> ConfigurationManager { get; set; }
 
-            public ConfigurationManagerTheoryData() {}
+            public ConfigurationManagerTheoryData() { }
 
-            public ConfigurationManagerTheoryData(string testId) : base(testId) {}
+            public ConfigurationManagerTheoryData(string testId) : base(testId) { }
 
             public TimeSpan AutomaticRefreshInterval { get; set; }
 
@@ -810,7 +806,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 return $"{TestId}, {MetadataAddress}, {ExpectedException}";
             }
 
-             public string UpdatedMetadataAddress { get; set; }
+            public string UpdatedMetadataAddress { get; set; }
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/End2EndTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/End2EndTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
 using Xunit;
@@ -16,12 +17,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
     public class End2EndTests
     {
         [Theory, MemberData(nameof(OpenIdConnectTheoryData))]
-        public void OpenIdConnect(OpenIdConnectTheoryData theoryData)
+        public async Task OpenIdConnect(OpenIdConnectTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.OpenIdConnect", theoryData);
             try
             {
-                OpenIdConnectConfiguration configuration = OpenIdConnectConfigurationRetriever.GetAsync(theoryData.OpenIdConnectMetadataFileName, new FileDocumentRetriever(), CancellationToken.None).Result;
+                OpenIdConnectConfiguration configuration = await OpenIdConnectConfigurationRetriever.GetAsync(theoryData.OpenIdConnectMetadataFileName, new FileDocumentRetriever(), CancellationToken.None);
 
                 theoryData.AdditionalValidation?.Invoke(configuration);
 

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectConfigurationTests.cs
@@ -150,7 +150,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             Type type = typeof(OpenIdConnectConfiguration);
             PropertyInfo[] properties = type.GetProperties();
             if (properties.Length != 68)
-                Assert.True(false, "Number of properties has changed from 68 to: " + properties.Length + ", adjust tests");
+                Assert.Fail("Number of properties has changed from 68 to: " + properties.Length + ", adjust tests");
 
             TestUtilities.CallAllPublicInstanceAndStaticPropertyGets(configuration, "OpenIdConnectConfiguration_GetSets");
 

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                 if (theoryData.Json != null)
                     cnf = new Cnf(theoryData.Json);
 
-                _ = await handler.ResolvePopKeyFromCnfClaimAsync(cnf, theoryData.SignedHttpRequestToken, theoryData.ValidatedAccessToken, signedHttpRequestValidationContext, CancellationToken.None).ConfigureAwait(false);
+                _ = await handler.ResolvePopKeyFromCnfClaimAsync(cnf, theoryData.SignedHttpRequestToken, theoryData.ValidatedAccessToken, signedHttpRequestValidationContext, CancellationToken.None);
 
                 if ((bool)signedHttpRequestValidationContext.CallContext.PropertyBag[theoryData.MethodToCall] == false)
                     context.AddDiff($"{theoryData.MethodToCall} was not called.");
@@ -150,7 +150,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             {
                 var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
                 var handler = new SignedHttpRequestHandler();
-                _ = await handler.ResolvePopKeyAsync(theoryData.SignedHttpRequestToken, theoryData.ValidatedAccessToken, signedHttpRequestValidationContext, CancellationToken.None).ConfigureAwait(false);
+                _ = await handler.ResolvePopKeyAsync(theoryData.SignedHttpRequestToken, theoryData.ValidatedAccessToken, signedHttpRequestValidationContext, CancellationToken.None);
 
                 if ((bool)signedHttpRequestValidationContext.CallContext.PropertyBag[theoryData.MethodToCall] == false)
                     context.AddDiff($"{theoryData.MethodToCall} was not called.");
@@ -277,7 +277,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             {
                 var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
                 var handler = new SignedHttpRequestHandler();
-                _ = await handler.ResolvePopKeyFromJweAsync(theoryData.PopKeyString, signedHttpRequestValidationContext, CancellationToken.None).ConfigureAwait(false);
+                _ = await handler.ResolvePopKeyFromJweAsync(theoryData.PopKeyString, signedHttpRequestValidationContext, CancellationToken.None);
 
                 theoryData.ExpectedException.ProcessNoException(context);
             }
@@ -401,7 +401,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             {
                 var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
                 var handler = new SignedHttpRequestHandlerPublic();
-                var popKey = await handler.ResolvePopKeyFromJkuAsync(theoryData.JkuSetUrl, null, signedHttpRequestValidationContext, CancellationToken.None).ConfigureAwait(false);
+                var popKey = await handler.ResolvePopKeyFromJkuAsync(theoryData.JkuSetUrl, null, signedHttpRequestValidationContext, CancellationToken.None);
 
                 if (popKey == null)
                     context.AddDiff("Resolved Pop key is null.");
@@ -634,7 +634,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                 var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
                 var handler = new SignedHttpRequestHandlerPublic();
                 Cnf cnf = new Cnf { Kid = theoryData.Kid };
-                var popKey = await handler.ResolvePopKeyFromJkuAsync(theoryData.JkuSetUrl, cnf, signedHttpRequestValidationContext, CancellationToken.None).ConfigureAwait(false);
+                var popKey = await handler.ResolvePopKeyFromJkuAsync(theoryData.JkuSetUrl, cnf, signedHttpRequestValidationContext, CancellationToken.None);
 
                 if (popKey == null)
                     context.AddDiff("Resolved Pop key is null.");
@@ -750,7 +750,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             {
                 var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
                 var handler = new SignedHttpRequestHandler();
-                var popKeys = await handler.GetPopKeysFromJkuAsync(theoryData.JkuSetUrl, signedHttpRequestValidationContext, CancellationToken.None).ConfigureAwait(false);
+                var popKeys = await handler.GetPopKeysFromJkuAsync(theoryData.JkuSetUrl, signedHttpRequestValidationContext, CancellationToken.None);
 
                 if (popKeys.Count != theoryData.ExpectedNumberOfPopKeysReturned)
                     context.AddDiff($"Number of returned pop keys {popKeys.Count} is not the same as the expected: {theoryData.ExpectedNumberOfPopKeysReturned}.");
@@ -864,7 +864,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             {
                 var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
                 var handler = new SignedHttpRequestHandlerPublic();
-                var popKeys = await handler.ResolvePopKeyFromKeyIdentifierAsync(theoryData.Kid, theoryData.SignedHttpRequestToken, theoryData.ValidatedAccessToken, signedHttpRequestValidationContext, CancellationToken.None).ConfigureAwait(false);
+                var popKeys = await handler.ResolvePopKeyFromKeyIdentifierAsync(theoryData.Kid, theoryData.SignedHttpRequestToken, theoryData.ValidatedAccessToken, signedHttpRequestValidationContext, CancellationToken.None);
                 theoryData.ExpectedException.ProcessNoException(context);
             }
             catch (Exception ex)

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestCreationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestCreationTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
@@ -18,7 +19,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
     public class SignedHttpRequestCreationTests
     {
         [Fact]
-        public void CreateSignedHttpRequest()
+        public async Task CreateSignedHttpRequest()
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateSignedHttpRequest", "", true);
 
@@ -45,7 +46,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                 IssuerSigningKey = SignedHttpRequestTestUtils.DefaultSigningCredentials.Key
             };
 
-            var result = new JsonWebTokenHandler().ValidateTokenAsync(signedHttpRequestString, tvp).Result;
+            var result = await new JsonWebTokenHandler().ValidateTokenAsync(signedHttpRequestString, tvp);
             if (result.IsValid == false)
                 context.AddDiff($"Not able to create and validate signed http request token");
 
@@ -53,7 +54,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         }
 
         [Fact]
-        public void CreateSignedHttpRequestWithAdditionalHeaderClaims()
+        public async Task CreateSignedHttpRequestWithAdditionalHeaderClaims()
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateSignedHttpRequestWithAdditionalHeaderClaims", "", true);
 
@@ -83,7 +84,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                 IssuerSigningKey = SignedHttpRequestTestUtils.DefaultSigningCredentials.Key
             };
 
-            var result = new JsonWebTokenHandler().ValidateTokenAsync(signedHttpRequestString, tvp).Result;
+            var result = await new JsonWebTokenHandler().ValidateTokenAsync(signedHttpRequestString, tvp);
 
             if (result.IsValid == false)
                 context.AddDiff($"Not able to create and validate signed http request token");
@@ -185,7 +186,8 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             {
                 writer = theoryData.GetWriter();
                 theoryData.Handler.AddAtClaim(ref writer, theoryData.BuildSignedHttpRequestDescriptor());
-                CheckClaimValue(ref writer, theoryData, context); theoryData.ExpectedException.ProcessNoException(context);
+                CheckClaimValue(ref writer, theoryData, context);
+                theoryData.ExpectedException.ProcessNoException(context);
                 theoryData.ExpectedException.ProcessNoException(context);
             }
             catch (Exception ex)

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestE2ETests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestE2ETests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
 
 
                 var signedHttpRequestValidationContext = new SignedHttpRequestValidationContext(signedHttpRequest, theoryData.HttpRequestData, theoryData.TokenValidationParameters, theoryData.SignedHttpRequestValidationParameters);
-                var result = await handler.ValidateSignedHttpRequestAsync(signedHttpRequestValidationContext, CancellationToken.None).ConfigureAwait(false);
+                var result = await handler.ValidateSignedHttpRequestAsync(signedHttpRequestValidationContext, CancellationToken.None);
                 if (cryptoProviderFactory.CryptoProviderCache.TryGetSignatureProvider(
                     signedHttpRequestDescriptor.SigningCredentials.Key,
                     signedHttpRequestDescriptor.SigningCredentials.Algorithm,

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestUtilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestUtilityTests.cs
@@ -263,7 +263,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             var context = TestUtilities.WriteHeader($"{this}.ToHttpRequestDataAsync", theoryData);
             try
             {
-                var httpRequestData = await SignedHttpRequestUtilities.ToHttpRequestDataAsync(theoryData.HttpRequestMessage).ConfigureAwait(false);
+                var httpRequestData = await SignedHttpRequestUtilities.ToHttpRequestDataAsync(theoryData.HttpRequestMessage);
                 IdentityComparer.AreStringsEqual(httpRequestData.Method, theoryData.ExpectedHttpRequestData.Method, context);
                 IdentityComparer.AreUrisEqual(httpRequestData.Uri, theoryData.ExpectedHttpRequestData.Uri, context);
                 IdentityComparer.AreBytesEqual(httpRequestData.Body, theoryData.ExpectedHttpRequestData.Body, context);

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
     public class SignedHttpRequestValidationTests
     {
         [Fact]
-        public async void SignedHttpRequestReplayValidation()
+        public async Task SignedHttpRequestReplayValidation()
         {
             HashSet<string> nonceCache = new HashSet<string>();
 
@@ -53,15 +53,15 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             };
 
             var signedHttpRequestValidationContext1 = new SignedHttpRequestValidationContext(signedHttpRequest1, new HttpRequestData(), SignedHttpRequestTestUtils.DefaultTokenValidationParameters, signedHttpRequestValidationParameters);
-            var result1 = await handler.ValidateSignedHttpRequestAsync(signedHttpRequestValidationContext1, CancellationToken.None).ConfigureAwait(false);
+            var result1 = await handler.ValidateSignedHttpRequestAsync(signedHttpRequestValidationContext1, CancellationToken.None);
             Assert.True(result1.IsValid);
 
             var signedHttpRequestValidationContext2 = new SignedHttpRequestValidationContext(signedHttpRequest2, new HttpRequestData(), SignedHttpRequestTestUtils.DefaultTokenValidationParameters, signedHttpRequestValidationParameters);
-            var result2 = await handler.ValidateSignedHttpRequestAsync(signedHttpRequestValidationContext2, CancellationToken.None).ConfigureAwait(false);
+            var result2 = await handler.ValidateSignedHttpRequestAsync(signedHttpRequestValidationContext2, CancellationToken.None);
             Assert.True(result2.IsValid);
 
             var signedHttpRequestValidationContext3 = new SignedHttpRequestValidationContext(signedHttpRequest3, new HttpRequestData(), SignedHttpRequestTestUtils.DefaultTokenValidationParameters, signedHttpRequestValidationParameters);
-            var result3 = await handler.ValidateSignedHttpRequestAsync(signedHttpRequestValidationContext3, CancellationToken.None).ConfigureAwait(false);
+            var result3 = await handler.ValidateSignedHttpRequestAsync(signedHttpRequestValidationContext3, CancellationToken.None);
             Assert.False(result3.IsValid);
             Assert.IsType<InvalidOperationException>(result3.Exception);
             Assert.Equal("Replay detected", result3.Exception.Message);
@@ -925,7 +925,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
 
             var handler = new SignedHttpRequestHandlerPublic();
-            var signedHttpRequest = await handler.ValidateSignedHttpRequestPayloadAsync(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext, CancellationToken.None).ConfigureAwait(false);
+            var signedHttpRequest = await handler.ValidateSignedHttpRequestPayloadAsync(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext, CancellationToken.None);
 
             var methodCalledStatus = (bool)signedHttpRequestValidationContext.CallContext.PropertyBag["onlyTrack_ValidateTsClaimCall"];
             if (methodCalledStatus != signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.ValidateTs &&
@@ -1267,7 +1267,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             {
                 var handler = new SignedHttpRequestHandler();
                 var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
-                var signingKey = await handler.ValidateSignatureAsync(theoryData.SignedHttpRequestToken, theoryData.PopKey, signedHttpRequestValidationContext, CancellationToken.None).ConfigureAwait(false);
+                var signingKey = await handler.ValidateSignatureAsync(theoryData.SignedHttpRequestToken, theoryData.PopKey, signedHttpRequestValidationContext, CancellationToken.None);
                 IdentityComparer.AreSecurityKeysEqual(signingKey, theoryData.ExpectedPopKey, context);
                 theoryData.ExpectedException.ProcessNoException(context);
             }
@@ -1375,7 +1375,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                 if (signedHttpRequestValidationContext.CallContext.PropertyBag != null && signedHttpRequestValidationContext.CallContext.PropertyBag.ContainsKey("makeSignedHttpRequestValidationContextNull"))
                     signedHttpRequestValidationContext = null;
 
-                var result = await handler.ValidateSignedHttpRequestAsync(signedHttpRequestValidationContext, CancellationToken.None).ConfigureAwait(false);
+                var result = await handler.ValidateSignedHttpRequestAsync(signedHttpRequestValidationContext, CancellationToken.None);
 
                 if (result.Exception != null)
                 {

--- a/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             configManager.RequestRefresh();
 
             // Wait for the refresh to complete.
-            await Task.Delay(250);
+            await Task.Delay(500);
             configuration2 = await configManager.GetConfigurationAsync();
 
             if (IdentityComparer.AreEqual(configuration.Issuer, configuration2.Issuer))

--- a/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
@@ -49,12 +49,12 @@ namespace Microsoft.IdentityModel.Protocols.Tests
     public class ExtensibilityTests
     {
         [Theory, MemberData(nameof(GetMetadataTheoryData))]
-        public void GetMetadataTest(DocumentRetrieverTheoryData theoryData)
+        public async Task GetMetadataTest(DocumentRetrieverTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.GetMetadataTest", theoryData);
             try
             {
-                string doc = theoryData.DocumentRetriever.GetDocumentAsync(theoryData.Address, CancellationToken.None).Result;
+                string doc = await theoryData.DocumentRetriever.GetDocumentAsync(theoryData.Address, CancellationToken.None);
                 Assert.NotNull(doc);
                 theoryData.ExpectedException.ProcessNoException();
             }
@@ -75,25 +75,25 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             var configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever);
             var context = new CompareContext($"{this}.ConfigurationManagerUsingCustomClass");
 
-            var configuration = configManager.GetConfigurationAsync().Result;
+            var configuration = await configManager.GetConfigurationAsync();
             configManager.MetadataAddress = "IssuerMetadata.json";
-            var configuration2 = configManager.GetConfigurationAsync().Result;
+            var configuration2 = await configManager.GetConfigurationAsync();
             if (!IdentityComparer.AreEqual(configuration.Issuer, configuration2.Issuer, context))
                 context.Diffs.Add("!IdentityComparer.AreEqual(configuration, configuration2)");
 
             // AutomaticRefreshInterval should pick up new bits.
             configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever);
             configManager.RequestRefresh();
-            configuration = configManager.GetConfigurationAsync().Result;
+            configuration = await configManager.GetConfigurationAsync();
             TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTimeOffset.UtcNow - TimeSpan.FromHours(1));
             configManager.MetadataAddress = "IssuerMetadata2.json";
             configManager.RequestRefresh();
 
             // Wait for the refresh to complete.
-            await Task.Delay(250).ContinueWith(_ =>
+            await Task.Delay(250).ContinueWith(async _ =>
             {
 
-                configuration2 = configManager.GetConfigurationAsync().GetAwaiter().GetResult();
+                configuration2 = await configManager.GetConfigurationAsync();
                 if (IdentityComparer.AreEqual(configuration.Issuer, configuration2.Issuer))
                     context.Diffs.Add("IdentityComparer.AreEqual(configuration.Issuer, configuration2.Issuer)");
             });

--- a/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
@@ -58,13 +58,9 @@ namespace Microsoft.IdentityModel.Protocols.Tests
                 Assert.NotNull(doc);
                 theoryData.ExpectedException.ProcessNoException();
             }
-            catch (AggregateException aex)
+            catch (Exception ex)
             {
-                aex.Handle((x) =>
-                {
-                    theoryData.ExpectedException.ProcessException(x);
-                    return true;
-                });
+                theoryData.ExpectedException.ProcessException(ex);
             }
         }
 

--- a/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
@@ -86,8 +86,10 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             configManager.RequestRefresh();
 
             // Wait for the refresh to complete.
-            await Task.Delay(500);
-            configuration2 = await configManager.GetConfigurationAsync();
+            await Task.Delay(250).ContinueWith(_ =>
+            {
+                configuration2 = configManager.GetConfigurationAsync().GetAwaiter().GetResult();
+            });
 
             if (IdentityComparer.AreEqual(configuration.Issuer, configuration2.Issuer))
                 context.Diffs.Add("IdentityComparer.AreEqual(configuration.Issuer, configuration2.Issuer)");

--- a/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
@@ -86,10 +86,8 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             configManager.RequestRefresh();
 
             // Wait for the refresh to complete.
-            await Task.Delay(250).ContinueWith(async _ =>
-            {
-                configuration2 = await configManager.GetConfigurationAsync();
-            });
+            await Task.Delay(250);
+            configuration2 = await configManager.GetConfigurationAsync();
 
             if (IdentityComparer.AreEqual(configuration.Issuer, configuration2.Issuer))
                 context.Diffs.Add("IdentityComparer.AreEqual(configuration.Issuer, configuration2.Issuer)");

--- a/test/Microsoft.IdentityModel.Protocols.Tests/FileDocumentRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/FileDocumentRetrieverTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -15,12 +16,12 @@ namespace Microsoft.IdentityModel.Protocols.Tests
     {
 
         [Theory, MemberData(nameof(GetMetadataTheoryData))]
-        public void GetMetadataTest(DocumentRetrieverTheoryData theoryData)
+        public async Task GetMetadataTest(DocumentRetrieverTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.GetMetadataTest", theoryData);
             try
             {
-                string doc = theoryData.DocumentRetriever.GetDocumentAsync(theoryData.Address, CancellationToken.None).Result;
+                string doc = await theoryData.DocumentRetriever.GetDocumentAsync(theoryData.Address, CancellationToken.None);
                 Assert.NotNull(doc);
                 theoryData.ExpectedException.ProcessNoException();
             }

--- a/test/Microsoft.IdentityModel.Protocols.Tests/FileDocumentRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/FileDocumentRetrieverTests.cs
@@ -25,13 +25,9 @@ namespace Microsoft.IdentityModel.Protocols.Tests
                 Assert.NotNull(doc);
                 theoryData.ExpectedException.ProcessNoException();
             }
-            catch (AggregateException aex)
+            catch (Exception ex)
             {
-                aex.Handle((x) =>
-                {
-                    theoryData.ExpectedException.ProcessException(x);
-                    return true;
-                });
+                theoryData.ExpectedException.ProcessException(ex);
             }
         }
 

--- a/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
@@ -65,21 +65,17 @@ namespace Microsoft.IdentityModel.Protocols.Tests
                 Assert.NotNull(doc);
                 theoryData.ExpectedException.ProcessNoException();
             }
-            catch (AggregateException aex)
+            catch (Exception ex)
             {
-                aex.Handle((x) =>
+                if (ex.Data.Count > 0)
                 {
-                    if (x.Data.Count > 0)
-                    {
-                        if (!x.Data.Contains(HttpDocumentRetriever.StatusCode))
-                            context.AddDiff("!x.Data.Contains(HttpResponseConstants.StatusCode)");
-                        if (!x.Data.Contains(HttpDocumentRetriever.ResponseContent))
-                            context.AddDiff("!x.Data.Contains(HttpResponseConstants.ResponseContent)");
-                        IdentityComparer.AreEqual(x.Data[HttpDocumentRetriever.StatusCode], theoryData.ExpectedStatusCode, context);
-                    }
-                    theoryData.ExpectedException.ProcessException(x);
-                    return true;
-                });
+                    if (!ex.Data.Contains(HttpDocumentRetriever.StatusCode))
+                        context.AddDiff("!x.Data.Contains(HttpResponseConstants.StatusCode)");
+                    if (!ex.Data.Contains(HttpDocumentRetriever.ResponseContent))
+                        context.AddDiff("!x.Data.Contains(HttpResponseConstants.ResponseContent)");
+                    IdentityComparer.AreEqual(ex.Data[HttpDocumentRetriever.StatusCode], theoryData.ExpectedStatusCode, context);
+                }
+                theoryData.ExpectedException.ProcessException(ex);
             }
 
             TestUtilities.AssertFailIfErrors(context);

--- a/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Net;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -55,12 +56,12 @@ namespace Microsoft.IdentityModel.Protocols.Tests
         }
 
         [Theory, MemberData(nameof(GetMetadataTheoryData))]
-        public void GetMetadataTest(DocumentRetrieverTheoryData theoryData)
+        public async Task GetMetadataTest(DocumentRetrieverTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetMetadataTest", theoryData);
             try
             {
-                string doc = theoryData.DocumentRetriever.GetDocumentAsync(theoryData.Address, CancellationToken.None).Result;
+                string doc = await theoryData.DocumentRetriever.GetDocumentAsync(theoryData.Address, CancellationToken.None);
                 Assert.NotNull(doc);
                 theoryData.ExpectedException.ProcessNoException();
             }

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             {
                 // TODO - need to pass actual Saml2Token
                 if (theoryData.CanRead != theoryData.Handler.CanReadToken(theoryData.Token))
-                    Assert.False(true, $"Expected CanRead != CanRead, token: {theoryData.Token}");
+                    Assert.Fail($"Expected CanRead != CanRead, token: {theoryData.Token}");
 
                 theoryData.ExpectedException.ProcessNoException(context);
             }

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             try
             {
                 if (theoryData.CanRead != theoryData.Handler.CanReadToken(theoryData.Token))
-                    Assert.False(true, $"Expected CanRead != CanRead, token: {theoryData.Token}");
+                    Assert.Fail($"Expected CanRead != CanRead, token: {theoryData.Token}");
 
                 theoryData.ExpectedException.ProcessNoException(context);
             }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AbstractVirtualsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AbstractVirtualsTests.cs
@@ -15,13 +15,13 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     {
         #region BaseConfigurationManager
         [Fact]
-        public void BaseConfigurationManager_GetBaseConfigurationAsync()
+        public async Task BaseConfigurationManager_GetBaseConfigurationAsync()
         {
             TestUtilities.WriteHeader($"{this}.BaseConfigurationManager_GetBaseConfigurationAsync");
 
             try
             {
-                new DerivedBaseConfigurationManager().GetBaseConfigurationAsync(default).GetAwaiter().GetResult();
+                await new DerivedBaseConfigurationManager().GetBaseConfigurationAsync(default);
             }
             catch (Exception ex)
             {
@@ -116,7 +116,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
             try
             {
-                await new DerivedTokenHandler().ValidateTokenAsync("token", new TokenValidationParameters()).ConfigureAwait(false);
+                await new DerivedTokenHandler().ValidateTokenAsync("token", new TokenValidationParameters());
             }
             catch (Exception ex)
             {
@@ -131,7 +131,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
             try
             {
-                await new DerivedTokenHandler().ValidateTokenAsync(new DerivedSecurityToken(), new TokenValidationParameters()).ConfigureAwait(false);
+                await new DerivedTokenHandler().ValidateTokenAsync(new DerivedSecurityToken(), new TokenValidationParameters());
             }
             catch (Exception ex)
             {

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AuthenticatedEncryptionProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AuthenticatedEncryptionProviderTests.cs
@@ -109,7 +109,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 #endif
 
         [Theory, MemberData(nameof(AEPConstructorTheoryData))]
-        public void Constructors(string testId, SymmetricSecurityKey key, string algorithm, ExpectedException ee)
+        public void Constructors(string testId, SecurityKey key, string algorithm, ExpectedException ee)
         {
             TestUtilities.WriteHeader("Constructors - " + testId, true);
             try

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CallContextTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CallContextTests.cs
@@ -1,8 +1,7 @@
-﻿// Copyright (c) Microsoft Corporation.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
-using System.CodeDom;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
@@ -26,11 +25,11 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Assert.Null(context.PropertyBag);
         }
 
-        public static TheoryData<TheoryDataBase> CallContextTestTheoryData
+        public static TheoryData<CallContextTheoryData> CallContextTestTheoryData
         {
             get
             {
-                var theoryData = new TheoryData<TheoryDataBase>();
+                var theoryData = new TheoryData<CallContextTheoryData>();
 
                 theoryData.Add(new CallContextTheoryData
                 {

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ClaimsIdentityFactoryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ClaimsIdentityFactoryTests.cs
@@ -12,6 +12,11 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     [Collection(nameof(ClaimsIdentityFactoryTests))]
     public class ClaimsIdentityFactoryTests
     {
+        public ClaimsIdentityFactoryTests()
+        {
+            AppContextSwitches.ResetAllSwitches();
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderFactoryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderFactoryTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Type type = typeof(CryptoProviderFactory);
             PropertyInfo[] properties = type.GetProperties();
             if (properties.Length != 7)
-                Assert.True(false, "Number of public fields has changed from 7 to: " + properties.Length + ", adjust tests");
+                Assert.Fail("Number of public fields has changed from 7 to: " + properties.Length + ", adjust tests");
 
             CustomCryptoProvider customCryptoProvider = new CustomCryptoProvider();
             GetSetContext getSetContext =
@@ -924,7 +924,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         }
 
         [Fact(Skip = "too long")]
-        public void ReferenceCountingTest_MultiThreaded()
+        public async Task ReferenceCountingTest_MultiThreaded()
         {
             var context = new CompareContext($"{this}.ReferenceCountingTest_MultiThreaded");
             var cryptoProviderFactory = new CryptoProviderFactory(CryptoProviderCacheTests.CreateCacheForTesting());
@@ -957,7 +957,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 });
             }
 
-            Task.WaitAll(tasks);
+            await Task.WhenAll(tasks);
 
             cryptoProviderFactory.CacheSignatureProviders = false;
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/EventBasedLRUCacheTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/EventBasedLRUCacheTests.cs
@@ -360,7 +360,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         }
 
         [Fact(Skip = "Large test meant to be run manually.")]
-        public void CacheOverflowTestMultithreaded()
+        public async Task CacheOverflowTestMultithreaded()
         {
             TestUtilities.WriteHeader($"{this}.CacheOverflowTestMultithreaded");
             var context = new CompareContext($"{this}.CacheOverflowTestMultithreaded");
@@ -376,7 +376,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 }));
             }
 
-            Task.WaitAll(taskList.ToArray());
+            await Task.WhenAll(taskList.ToArray());
             cache.WaitForProcessing();
 
             // Cache size should be less than the capacity (somewhere between 800 - 1000 items).

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -159,7 +160,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
         }
 
         [Fact]
-        public void SigningKeysExtensibility()
+        public async Task SigningKeysExtensibility()
         {
             var context = new CompareContext($"{this}.SigningKeysExtensibility");
             TestUtilities.WriteHeader($"{this}.SigningKeysExtensibility");
@@ -180,7 +181,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
                     ValidateLifetime = false,
                 };
 
-                var tokenValidationResult = new JsonWebTokens.JsonWebTokenHandler().ValidateTokenAsync(Default.AsymmetricJwt, tokenValidationParameters).Result;
+                var tokenValidationResult = await new JsonWebTokens.JsonWebTokenHandler().ValidateTokenAsync(Default.AsymmetricJwt, tokenValidationParameters);
 
                 if (tokenValidationResult.IsValid != true)
                     context.Diffs.Add("tokenValidationResult.IsValid != true");

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JweUsingEchdTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JweUsingEchdTests.cs
@@ -4,22 +4,20 @@
 #if NET472 || NET6_0_OR_GREATER
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
+using System.Threading.Tasks;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.TestUtils;
-using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json.Linq;
 using Xunit;
-using KEY = Microsoft.IdentityModel.TestUtils.KeyingMaterial;
 
 namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class JweUsingEcdhEsTests
     {
         [Theory, MemberData(nameof(CreateEcdhEsTestcases))]
-        public void CreateJweEcdhEsTests(CreateEcdhEsTheoryData theoryData)
+        public async Task CreateJweEcdhEsTests(CreateEcdhEsTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJweEcdhEsTests", theoryData);
             context.AddClaimTypesToIgnoreWhenComparing("exp", "iat", "nbf");
@@ -44,10 +42,10 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 string jsonJwe = jsonWebTokenHandler.CreateToken(securityTokenDescriptor);
                 string jwtJwe = jwtSecurityTokenHandler.CreateEncodedJwt(securityTokenDescriptor);
 
-                TokenValidationResult tokenValidationResult1 = jsonWebTokenHandler.ValidateTokenAsync(jsonJwe, theoryData.TokenValidationParameters).Result;
-                TokenValidationResult tokenValidationResult2 = jsonWebTokenHandler.ValidateTokenAsync(jwtJwe, theoryData.TokenValidationParameters).Result;
-                TokenValidationResult tokenValidationResult3 = jwtSecurityTokenHandler.ValidateTokenAsync(jsonJwe, theoryData.TokenValidationParameters).GetAwaiter().GetResult();
-                TokenValidationResult tokenValidationResult4 = jwtSecurityTokenHandler.ValidateTokenAsync(jwtJwe, theoryData.TokenValidationParameters).GetAwaiter().GetResult();
+                TokenValidationResult tokenValidationResult1 = await jsonWebTokenHandler.ValidateTokenAsync(jsonJwe, theoryData.TokenValidationParameters);
+                TokenValidationResult tokenValidationResult2 = await jsonWebTokenHandler.ValidateTokenAsync(jwtJwe, theoryData.TokenValidationParameters);
+                TokenValidationResult tokenValidationResult3 = await jwtSecurityTokenHandler.ValidateTokenAsync(jsonJwe, theoryData.TokenValidationParameters);
+                TokenValidationResult tokenValidationResult4 = await jwtSecurityTokenHandler.ValidateTokenAsync(jwtJwe, theoryData.TokenValidationParameters);
 
                 if (tokenValidationResult1.IsValid != theoryData.ExpectedIsValid)
                     context.AddDiff($"tokenValidationResult1.IsValid != theoryData.ExpectedIsValid");

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaSecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaSecurityKeyTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         }
 
         [Theory, MemberData(nameof(HasPrivateKeyTheoryData))]
-        public void HasPrivateKey(string testId, AsymmetricSecurityKey key, bool expected)
+        public void HasPrivateKey(string testId, RsaSecurityKey key, bool expected)
         {
             if (expected)
                 Assert.True(key.PrivateKeyStatus == PrivateKeyStatus.Exists, testId);
@@ -63,9 +63,9 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 Assert.True(key.PrivateKeyStatus != PrivateKeyStatus.Exists, testId);
         }
 
-        public static TheoryData<string, SecurityKey, bool> HasPrivateKeyTheoryData()
+        public static TheoryData<string, RsaSecurityKey, bool> HasPrivateKeyTheoryData()
         {
-            var theoryData = new TheoryData<string, SecurityKey, bool>();
+            var theoryData = new TheoryData<string, RsaSecurityKey, bool>();
 #if NET462
             theoryData.Add(
                 "KeyingMaterial.RsaSecurityKeyWithCspProvider_2048",

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -337,7 +337,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 else if (testCase.StartsWith("Dispose"))
                     provider.Dispose();
                 else
-                    Assert.True(false, "Test case does not match any scenario");
+                    Assert.Fail("Test case does not match any scenario");
 
                 expectedException.ProcessNoException();
             }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Type type = typeof(TokenValidationParameters);
             PropertyInfo[] properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
             if (properties.Length != ExpectedPropertyCount)
-                Assert.True(false, $"Number of properties has changed from {ExpectedPropertyCount} to: " + properties.Length + ", adjust tests");
+                Assert.Fail($"Number of properties has changed from {ExpectedPropertyCount} to: " + properties.Length + ", adjust tests");
 
             TokenValidationParameters actorValidationParameters = new TokenValidationParameters();
             SecurityKey issuerSigningKey = KeyingMaterial.DefaultX509Key_2048_Public;

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationResultTests.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Security.Claims;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
@@ -22,7 +21,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Type type = typeof(TokenValidationResult);
             PropertyInfo[] properties = type.GetProperties();
             if (properties.Length != 10)
-                Assert.True(false, "Number of public fields has changed from 10 to: " + properties.Length + ", adjust tests");
+                Assert.Fail("Number of public fields has changed from 10 to: " + properties.Length + ", adjust tests");
 
             GetSetContext context =
                 new GetSetContext

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AsyncValidatorsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AsyncValidatorsTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         theoryData.SecurityToken,
                         theoryData.ValidationParameters,
                         null,
-                        CancellationToken.None).ConfigureAwait(false);
+                        CancellationToken.None);
                 Exception exception = result.Exception;
                 context.Diffs.Add("Exception: " + exception.ToString());
             }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/IssuerValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/IssuerValidationResultTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 theoryData.SecurityToken,
                 theoryData.ValidationParameters,
                 new CallContext(),
-                CancellationToken.None).ConfigureAwait(false);
+                CancellationToken.None);
 
             if (issuerValidationResult.Exception != null)
                 theoryData.ExpectedException.ProcessException(issuerValidationResult.Exception, context);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationParametersTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests.Validation
         {
             var validationParameters = new ValidationParameters();
 
-            Assert.Equal(0, validationParameters.ValidIssuers.Count);
+            Assert.Empty(validationParameters.ValidIssuers);
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests.Validation
         {
             var validationParameters = new ValidationParameters();
 
-            Assert.Equal(0, validationParameters.ValidAudiences.Count);
+            Assert.Empty(validationParameters.ValidAudiences);
             Assert.True(validationParameters.ValidAudiences is IList<string>);
         }
 
@@ -42,8 +42,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests.Validation
         public void ValidTypes_Get_ReturnsEmptyList()
         {
             var validationParameters = new ValidationParameters();
-          
-            Assert.Equal(0, validationParameters.ValidTypes.Count);
+
+            Assert.Empty(validationParameters.ValidTypes);
             Assert.True(validationParameters.ValidTypes is IList<string>);
         }
     }

--- a/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/AadSigningKeyIssuerValidatorTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
                 AadIssuerValidator.GetAadIssuerValidator(Default.AadV1Authority).ConfigurationManagerV1 = theoryData.TokenValidationParameters.ConfigurationManager;
                 theoryData.TokenValidationParameters.EnableAadSigningKeyIssuerValidation();
 
-                var validationResult = await handler.ValidateTokenAsync(jwt, theoryData.TokenValidationParameters).ConfigureAwait(false);
+                var validationResult = await handler.ValidateTokenAsync(jwt, theoryData.TokenValidationParameters);
                 theoryData.ExpectedException.ProcessNoException(context);
                 Assert.NotNull(theoryData.TokenValidationParameters.IssuerSigningKeyValidatorUsingConfiguration);
                 Assert.True(validationResult.IsValid);

--- a/test/Microsoft.IdentityModel.Xml.Tests/EnvelopedSignatureReaderTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/EnvelopedSignatureReaderTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
                 if (theoryData.ExpectSignature)
                 {
                     if (envelopedReader.Signature == null)
-                        Assert.False(true, "theoryData.ExpectSignature == true && envelopedReader.ExpectSignature == null");
+                        Assert.Fail("theoryData.ExpectSignature == true && envelopedReader.ExpectSignature == null");
 
                     envelopedReader.Signature.Verify(theoryData.SecurityKey, theoryData.SecurityKey.CryptoProviderFactory);
                 }
@@ -97,7 +97,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
                 if (theoryData.ExpectSignature)
                 {
                     if (envelopedReader.Signature == null)
-                        Assert.False(true, "theoryData.ExpectSignature == true && envelopedReader.Signature == null");
+                        Assert.Fail("theoryData.ExpectSignature == true && envelopedReader.Signature == null");
 
                     envelopedReader.Signature.Verify(theoryData.SecurityKey, theoryData.CryptoProviderFactory);
                 }

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
@@ -60,7 +60,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             PropertyInfo[] properties = type.GetProperties();
 #if NET9_0_OR_GREATER
             if (properties.Length != 26) //Additional inherited "Capacity" property from Dictionary is added in .NET 9 
-                Assert.True(false, "Number of properties has changed from 26 to: " + properties.Length + ", adjust tests");
+                Assert.Fail("Number of properties has changed from 26 to: " + properties.Length + ", adjust tests");
 #else
             if (properties.Length != 25)
                 Assert.Fail("Number of properties has changed from 25 to: " + properties.Length + ", adjust tests");

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
@@ -30,19 +30,19 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
             foreach (Claim c in jwtPayload.Claims)
             {
-                Assert.True(false, "jwtPayload.Claims should be empty");
+                Assert.Fail("jwtPayload.Claims should be empty");
             }
 
             Assert.True(jwtPayload.Aud != null, "jwtPayload.Aud should not be null");
             foreach (string audience in jwtPayload.Aud)
             {
-                Assert.True(false, "jwtPayload.Aud should be empty");
+                Assert.Fail("jwtPayload.Aud should be empty");
             }
 
             Assert.True(jwtPayload.Amr != null, "jwtPayload.Amr should not be null");
             foreach (string audience in jwtPayload.Amr)
             {
-                Assert.True(false, "jwtPayload.Amr should be empty");
+                Assert.Fail("jwtPayload.Amr should be empty");
             }
 
             Assert.True(jwtPayload.ValidFrom == DateTime.MinValue, "jwtPayload.ValidFrom != DateTime.MinValue");
@@ -63,7 +63,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 Assert.True(false, "Number of properties has changed from 26 to: " + properties.Length + ", adjust tests");
 #else
             if (properties.Length != 25)
-                Assert.True(false, "Number of properties has changed from 25 to: " + properties.Length + ", adjust tests");
+                Assert.Fail("Number of properties has changed from 25 to: " + properties.Length + ", adjust tests");
 #endif
             GetSetContext context =
                 new GetSetContext
@@ -165,7 +165,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
 
             if (!claimFound)
-                Assert.True(false, "Claim with expected type: nullClaim is not found");
+                Assert.Fail("Claim with expected type: nullClaim is not found");
 
             Assert.Equal(payload.SerializeToJson(), compareTo);
         }

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -259,7 +259,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
         // Tests for expected differences between the JwtSecurityTokenHandler and the JsonWebTokenHandler.
         [Theory, MemberData(nameof(CreateJWEUsingSecurityTokenDescriptorTheoryData))]
-        public void CheckExpectedDifferenceInAudClaimUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
+        public async Task CheckExpectedDifferenceInAudClaimUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
         {
             if (theoryData.TokenDescriptor == null)
                 return;
@@ -295,7 +295,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 string jweFromJsonHandler = theoryData.JsonWebTokenHandler.CreateToken(theoryData.TokenDescriptor);
 
                 ClaimsPrincipal claimsPrincipalJwtHandler = theoryData.JwtSecurityTokenHandler.ValidateToken(tokenFromJwtHandler, theoryData.ValidationParameters, out SecurityToken validatedTokenFromJwtHandler);
-                TokenValidationResult validationResultJsonHandler = theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromJsonHandler, theoryData.ValidationParameters).Result;
+                TokenValidationResult validationResultJsonHandler = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromJsonHandler, theoryData.ValidationParameters);
 
                 int expectedAudClaimCount = 0;
                 int additionalAudClaimsForJwtHandler = 0;
@@ -340,7 +340,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                                 Assert.True(expectedAudClaimCount == enumerable.Count());
                                 break;
                             default:
-                                Assert.True(false, "Unexpected type for 'aud' claim.");
+                                Assert.Fail("Unexpected type for 'aud' claim.");
                                 break;
                         }
                     }
@@ -384,7 +384,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         // Tests checks to make sure that the token string created by the JwtSecurityTokenHandler is consistent with the 
         // token string created by the JsonWebTokenHandler.
         [Theory, MemberData(nameof(CreateJWEUsingSecurityTokenDescriptorTheoryData))]
-        public void CreateJWEUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
+        public async Task CreateJWEUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
         {
             CompareContext context = TestUtilities.WriteHeader($"{this}.CreateJWEUsingSecurityTokenDescriptor", theoryData);
             theoryData.ValidationParameters.ValidateLifetime = false;
@@ -403,7 +403,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 string jweFromJsonHandler = theoryData.JsonWebTokenHandler.CreateToken(theoryData.TokenDescriptor);
 
                 var claimsPrincipalJwt = theoryData.JwtSecurityTokenHandler.ValidateToken(tokenFromTokenDescriptor, theoryData.ValidationParameters, out SecurityToken validatedTokenFromJwtHandler);
-                var validationResultJson = theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromJsonHandler, theoryData.ValidationParameters).Result;
+                var validationResultJson = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(jweFromJsonHandler, theoryData.ValidationParameters);
 
                 if (validationResultJson.Exception != null && validationResultJson.IsValid)
                     context.Diffs.Add("validationResultJsonHandler.IsValid, validationResultJsonHandler.Exception != null");
@@ -411,7 +411,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 IdentityComparer.AreEqual(validationResultJson.IsValid, theoryData.IsValid, context);
 
                 var validatedTokenFromJsonHandler = validationResultJson.SecurityToken;
-                var validationResult2 = theoryData.JsonWebTokenHandler.ValidateTokenAsync(tokenFromTokenDescriptor, theoryData.ValidationParameters).Result;
+                var validationResult2 = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(tokenFromTokenDescriptor, theoryData.ValidationParameters);
 
                 if (validationResult2.Exception != null && validationResult2.IsValid)
                 {
@@ -1136,7 +1136,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             handler = new JwtSecurityTokenHandler();
 
             // Make sure that we don't populate the InboundClaimTypeMap if DefaultMapInboundClaims was previously set to false.
-            Assert.Equal(0, handler.InboundClaimTypeMap.Count);
+            Assert.Empty(handler.InboundClaimTypeMap);
 
             var claims = new List<Claim>
             {
@@ -1331,7 +1331,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             {
                 var handler = new JwtSecurityTokenHandler();
                 CompressionProviderFactory.Default = theoryData.CompressionProviderFactory;
-                var validationResult = await handler.ValidateTokenAsync(theoryData.JWECompressionString, theoryData.ValidationParameters).ConfigureAwait(false);
+                var validationResult = await handler.ValidateTokenAsync(theoryData.JWECompressionString, theoryData.ValidationParameters);
                 theoryData.ExpectedException.ProcessException(validationResult.Exception, context);
             }
             catch (Exception ex)
@@ -2433,7 +2433,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         [Theory, MemberData(nameof(ValidateJwsWithLastKnownGoodTheoryData))]
-        public void ValidateJWSWithLastKnownGood(JwtTheoryData theoryData)
+        public async Task ValidateJWSWithLastKnownGood(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWSWithLastKnownGood", theoryData);
 
@@ -2457,7 +2457,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     var previousValidateWithLKG = theoryData.ValidationParameters.ValidateWithLKG;
                     theoryData.ValidationParameters.ValidateWithLKG = false;
 
-                    var setupValidationResult = handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
+                    var setupValidationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
 
                     theoryData.ValidationParameters.ValidateWithLKG = previousValidateWithLKG;
 
@@ -2484,7 +2484,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         public static TheoryData<JwtTheoryData> ValidateJwsWithLastKnownGoodTheoryData => JwtTestDatasets.ValidateJwsWithLastKnownGoodTheoryData;
 
         [Theory, MemberData(nameof(ValidateJWEWithLastKnownGoodTheoryData))]
-        public void ValidateJWEWithLastKnownGood(JwtTheoryData theoryData)
+        public async Task ValidateJWEWithLastKnownGood(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWEWithLastKnownGood", theoryData);
 
@@ -2508,7 +2508,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                     var previousValidateWithLKG = theoryData.ValidationParameters.ValidateWithLKG;
                     theoryData.ValidationParameters.ValidateWithLKG = false;
 
-                    var setupValidationResult = handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters).Result;
+                    var setupValidationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
 
                     theoryData.ValidationParameters.ValidateWithLKG = previousValidateWithLKG;
 

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
@@ -88,7 +88,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
             foreach (Claim c in jwt.Claims)
             {
-                Assert.True(false, "claims.Count != 0");
+                Assert.Fail("claims.Count != 0");
                 break;
             }
 
@@ -96,7 +96,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             Assert.NotNull(jwt.Audiences);
             foreach (string aud in jwt.Audiences)
             {
-                Assert.True(false, "jwt.Audiences should be empty");
+                Assert.Fail("jwt.Audiences should be empty");
             }
             Assert.Null(jwt.Id);
             Assert.Null(jwt.Issuer);
@@ -234,7 +234,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
             catch (Exception ex)
             {
-                Assert.True(false, string.Format("Testcase: {0}. UnExpected when getting a properties: '{1}'", outerTokenVariation.Name, ex.ToString()));
+                Assert.Fail(string.Format("Testcase: {0}. UnExpected when getting a properties: '{1}'", outerTokenVariation.Name, ex.ToString()));
             }
 
             try
@@ -252,7 +252,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
             catch (Exception ex)
             {
-                Assert.True(false, string.Format("Testcase: {0}. UnExpected when getting a properties: '{1}'", testId, ex.ToString()));
+                Assert.Fail(string.Format("Testcase: {0}. UnExpected when getting a properties: '{1}'", testId, ex.ToString()));
             }
 
             try
@@ -267,7 +267,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
             catch (Exception ex)
             {
-                Assert.True(false, string.Format("Testcase: {0}. Unexpected inequality between outer and inner token properties: '{1}'", testId, ex.ToString()));
+                Assert.Fail(string.Format("Testcase: {0}. Unexpected inequality between outer and inner token properties: '{1}'", testId, ex.ToString()));
             }
 
         }
@@ -419,7 +419,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
             catch (Exception ex)
             {
-                Assert.True(false, string.Format("Testcase: {0}. UnExpected when getting a properties: '{1}'", variation.Name, ex.ToString()));
+                Assert.Fail(string.Format("Testcase: {0}. UnExpected when getting a properties: '{1}'", variation.Name, ex.ToString()));
             }
         }
 


### PR DESCRIPTION
Updates xUnit version and fixes test warnings which are due to the new xUnit analyzers.

Related to removing `ConfigureAwait` from tests: https://xunit.net/xunit.analyzers/rules/xUnit1030