### PR TITLE
Regression tests: Added inner exception detail and invalid signature failure due to invalid algorithm used

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateSignature.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateSignature.cs
@@ -241,7 +241,14 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 callContext);
 
             if (!result.IsSuccess)
-                return new(result.UnwrapError()); // Because we return an interface type, we need to explicitly create the Result.
+                return new ExceptionDetail(
+                    new MessageDetail(
+                        TokenLogMessages.IDX10518,
+                        result.UnwrapError().MessageDetail.Message),
+                    ValidationFailureType.SignatureValidationFailed,
+                    typeof(SecurityTokenInvalidSignatureException),
+                    new StackFrame(true),
+                    result.UnwrapError());
 
             SignatureProvider signatureProvider = cryptoProviderFactory.CreateForVerifying(key, jsonWebToken.Alg);
             try

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -106,6 +106,7 @@ namespace Microsoft.IdentityModel.Tokens
         //public const string IDX10515 = "IDX10515: Signature validation failed. Unable to match key: \nKeyInfo: '{0}'.\nExceptions caught:\n '{1}'. \ntoken: '{2}'. Valid Lifetime: '{3}'. Valid Issuer: '{4}'";
         //public const string IDX10516 = "IDX10516: Signature validation failed. Unable to match key: \nkid: '{0}'. \nNumber of keys in TokenValidationParameters: '{1}'. \nNumber of keys in Configuration: '{2}'. \nExceptions caught:\n '{3}'. \ntoken: '{4}'. Valid Lifetime: '{5}'. Valid Issuer: '{6}'";
         public const string IDX10517 = "IDX10517: Signature validation failed. The token's kid is missing. Keys tried: '{0}'. Number of keys in TokenValidationParameters: '{1}'. \nNumber of keys in Configuration: '{2}'. \nExceptions caught:\n '{3}'.\ntoken: '{4}'. See https://aka.ms/IDX10503 for details.";
+        public const string IDX10518 = "IDX10518: Signature validation failed. Algorithm validation failed with error: '{0}'.";
 
         // encryption / decryption
         // public const string IDX10600 = "IDX10600:";

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerValidationParametersTests.cs
@@ -186,10 +186,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         ExpectedIsValid = false,
                         ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10517:"),
                     },
-                    new JsonWebTokenHandlerValidationParametersTheoryData
+                    new JsonWebTokenHandlerValidationParametersTheoryData("Invalid_TokenSignedWithInvalidAlgorithm")
                     {
                         // Token is signed with HmacSha256 but only sha256 is considered valid for this test's purposes
-                        TestId = "Invalid_TokenSignedWithInvalidAlgorithm",
                         TokenValidationParameters = CreateTokenValidationParameters(
                             Default.Issuer, [Default.Audience], KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
                             validAlgorithms: [SecurityAlgorithms.Sha256]),


### PR DESCRIPTION
# Regression tests: Added inner exception detail and invalid signature failure due to invalid algorithm used

- Added inner exception detail to provide inner exceptions without allocating them ahead of time
- Wrap invalid algorithm validation error inside an invalid signature validation error to match the existing path
- Added test case comparing the invalid algorithm on the signature validation error

Part of #2711 
