### PR TITLE
Added ArgumentNullException type with ValidationError

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenArgumentNullException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenArgumentNullException.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+#if !NET8_0_OR_GREATER
+using System.Text;
+#endif
+
+#nullable enable
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    internal class SecurityTokenArgumentNullException : ArgumentNullException, ISecurityTokenException
+    {
+        private string? _stackTrace;
+        private ValidationError? _validationError;
+
+        public SecurityTokenArgumentNullException()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenArgumentNullException"/> class with a specified null parameter.
+        /// </summary>
+        /// <param name="paramName">The name of the null parameter that triggered the exception.</param>
+        public SecurityTokenArgumentNullException(string? paramName)
+            : base(paramName)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenArgumentNullException"/> class with a specified error message
+        /// and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The <see cref="Exception"/> that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        public SecurityTokenArgumentNullException(string? message, Exception? innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public SecurityTokenArgumentNullException(string? paramName, string? message)
+            : base(paramName, message)
+        {
+        }
+
+        public void SetValidationError(ValidationError validationError)
+        {
+            _validationError = validationError;
+        }
+
+
+        /// <summary>
+        /// Gets the stack trace that is captured when the exception is created.
+        /// </summary>
+        public override string? StackTrace
+        {
+            get
+            {
+                if (_stackTrace == null)
+                {
+                    if (_validationError == null)
+                        return base.StackTrace;
+#if NET8_0_OR_GREATER
+                    _stackTrace = new StackTrace(_validationError.StackFrames).ToString();
+#else
+                    StringBuilder sb = new();
+                    foreach (StackFrame frame in _validationError.StackFrames)
+                    {
+                        sb.Append(frame.ToString());
+                        sb.Append(Environment.NewLine);
+                    }
+
+                    _stackTrace = sb.ToString();
+#endif
+                }
+
+                return _stackTrace;
+            }
+        }
+    }
+}
+#nullable restore

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenArgumentNullException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenArgumentNullException.cs
@@ -16,6 +16,9 @@ namespace Microsoft.IdentityModel.Tokens
         private string? _stackTrace;
         private ValidationError? _validationError;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenArgumentNullException"/> class.
+        /// </summary>
         public SecurityTokenArgumentNullException()
             : base()
         {
@@ -41,11 +44,20 @@ namespace Microsoft.IdentityModel.Tokens
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityTokenArgumentNullException"/> class with a specified null parameter and an error message.
+        /// </summary>
+        /// <param name="paramName">The name of the null parameter that triggered the exception.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
         public SecurityTokenArgumentNullException(string? paramName, string? message)
             : base(paramName, message)
         {
         }
 
+        /// <summary>
+        /// Sets the <see cref="ValidationError"/> that is associated with the exception.
+        /// </summary>
+        /// <param name="validationError">The validation error to associate with the exception.</param>
         public void SetValidationError(ValidationError validationError)
         {
             _validationError = validationError;

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.cs
@@ -53,9 +53,6 @@ namespace Microsoft.IdentityModel.Tokens
         public SecurityTokenException(string message, Exception innerException)
             : base(message, innerException)
         {
-            Nullable<string> something;
-            something.HasValue();
-            something.Value;
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.cs
@@ -20,10 +20,12 @@ namespace Microsoft.IdentityModel.Tokens
     /// Represents a security token exception.
     /// </summary>
     [Serializable]
-    public class SecurityTokenException : Exception
+    public class SecurityTokenException : Exception, ISecurityTokenException
     {
         [NonSerialized]
         private string _stackTrace;
+
+        private ValidationError _validationError;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SecurityTokenException"/> class.
@@ -51,6 +53,9 @@ namespace Microsoft.IdentityModel.Tokens
         public SecurityTokenException(string message, Exception innerException)
             : base(message, innerException)
         {
+            Nullable<string> something;
+            something.HasValue();
+            something.Value;
         }
 
         /// <summary>
@@ -67,6 +72,15 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="validationError"></param>
+        public void SetValidationError(ValidationError validationError)
+        {
+            _validationError = validationError;
+        }
+
+        /// <summary>
         /// Gets the stack trace that is captured when the exception is created.
         /// </summary>
         public override string StackTrace
@@ -75,13 +89,13 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 if (_stackTrace == null)
                 {
-                    if (ValidationError == null)
+                    if (_validationError == null)
                         return base.StackTrace;
 #if NET8_0_OR_GREATER
-                    _stackTrace = new StackTrace(ValidationError.StackFrames).ToString();
+                    _stackTrace = new StackTrace(_validationError.StackFrames).ToString();
 #else
                     StringBuilder sb = new();
-                    foreach (StackFrame frame in ValidationError.StackFrames)
+                    foreach (StackFrame frame in _validationError.StackFrames)
                     {
                         sb.Append(frame.ToString());
                         sb.Append(Environment.NewLine);
@@ -102,11 +116,6 @@ namespace Microsoft.IdentityModel.Tokens
         {
             get => base.Source;
             set => base.Source = value;
-        }
-
-        internal ValidationError ValidationError
-        {
-            get; set;
         }
 
 #if NET472 || NETSTANDARD2_0 || NET6_0_OR_GREATER

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.cs
@@ -69,7 +69,7 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
         /// <summary>
-        /// 
+        /// Sets the <see cref="ValidationError"/> that caused the exception.
         /// </summary>
         /// <param name="validationError"></param>
         public void SetValidationError(ValidationError validationError)

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/LifetimeValidationError.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/LifetimeValidationError.cs
@@ -47,7 +47,7 @@ namespace Microsoft.IdentityModel.Tokens
                 _additionalInformation = additionalInformation.Value;
         }
 
-        protected override void AddAdditionalInformation(Exception exception)
+        internal override void AddAdditionalInformation(ISecurityTokenException exception)
         {
             if (exception is SecurityTokenExpiredException expiredException &&
                 _additionalInformation.ExpirationDate.HasValue)

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/ValidatedToken.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/ValidatedToken.cs
@@ -49,12 +49,19 @@ namespace Microsoft.IdentityModel.Tokens
 
         #region Validated Properties
         public ValidatedToken? ActorValidationResult { get; internal set; }
+
         public string? ValidatedAudience { get; internal set; }
+
         public ValidatedIssuer? ValidatedIssuer { get; internal set; }
+
         public ValidatedLifetime? ValidatedLifetime { get; internal set; }
+
         public DateTime? ValidatedTokenReplayExpirationTime { get; internal set; }
+
         public ValidatedTokenType? ValidatedTokenType { get; internal set; }
+
         public SecurityKey? ValidatedSigningKey { get; internal set; }
+
         public ValidatedSigningKeyLifetime? ValidatedSigningKeyLifetime { get; internal set; }
         #endregion
 

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
@@ -42,9 +42,9 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="validationParameters">The <see cref="ValidationParameters"/> to be used for validating the token.</param>
         /// <param name="configuration">The <see cref="BaseConfiguration"/> to be used for validation.</param>
         /// <param name="callContext">The <see cref="CallContext"/> to be used for logging.</param>
-        /// <exception cref="ArgumentNullException"> if 'securityKey' is null and ValidateIssuerSigningKey is true.</exception>
-        /// <exception cref="ArgumentNullException"> if 'securityToken' is null and ValidateIssuerSigningKey is true.</exception>
-        /// <exception cref="ArgumentNullException"> if 'validationParameters' is null.</exception>
+        /// <exception cref="SecurityTokenArgumentNullException"> if 'securityKey' is null and ValidateIssuerSigningKey is true.</exception>
+        /// <exception cref="SecurityTokenArgumentNullException"> if 'securityToken' is null and ValidateIssuerSigningKey is true.</exception>
+        /// <exception cref="SecurityTokenArgumentNullException"> if 'validationParameters' is null.</exception>
         internal static ValidationResult<ValidatedSigningKeyLifetime> ValidateIssuerSigningKey(
             SecurityKey securityKey,
             SecurityToken securityToken,
@@ -63,7 +63,7 @@ namespace Microsoft.IdentityModel.Tokens
                 return new ValidationError(
                     new MessageDetail(LogMessages.IDX10253, nameof(securityKey)),
                     ValidationFailureType.SigningKeyValidationFailed,
-                    typeof(ArgumentNullException),
+                    typeof(SecurityTokenArgumentNullException),
                     new StackFrame(true));
 
             if (securityToken == null)

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.DecryptTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.DecryptTokenTests.cs
@@ -120,11 +120,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         TestId = "Invalid_SecurityTokenIsNull",
                         Token = null,
                         ValidationParameters = new ValidationParameters(),
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         Result = new ValidationError(
                             new MessageDetail(TokenLogMessages.IDX10000, "jwtToken"),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null),
                     },
                     new TokenDecryptingTheoryData
@@ -132,11 +132,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         TestId = "Invalid_ValidationParametersIsNull",
                         Token = token,
                         ValidationParameters = null,
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         Result = new ValidationError(
                             new MessageDetail(TokenLogMessages.IDX10000, "validationParameters"),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null),
                     },
                     new TokenDecryptingTheoryData

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.DecryptTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.DecryptTokenTests.cs
@@ -223,7 +223,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         {
                             TokenDecryptionKeys = new List<SecurityKey>(){ KeyingMaterial.DefaultSymmetricSecurityKey_256 },
                         },
-                        Result = new ExceptionDetail(
+                        Result = new ValidationError(
                             new MessageDetail(
                                 TokenLogMessages.IDX10609,
                                 LogHelper.MarkAsSecurityArtifact(

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ReadTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ReadTokenTests.cs
@@ -71,26 +71,26 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     {
                         TestId = "Invalid_NullToken",
                         Token = null,
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         Result = new ValidationError(
                             new MessageDetail(
                                 TokenLogMessages.IDX10000,
                                 LogHelper.MarkAsNonPII("token")),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null)
                     },
                     new TokenReadingTheoryData
                     {
                         TestId = "Invalid_EmptyToken",
                         Token = string.Empty,
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         Result = new ValidationError(
                             new MessageDetail(
                                 TokenLogMessages.IDX10000,
                                 LogHelper.MarkAsNonPII("token")),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null)
                     },
                     new TokenReadingTheoryData

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateSignatureTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateSignatureTests.cs
@@ -81,26 +81,26 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     new JsonWebTokenHandlerValidateSignatureTheoryData {
                         TestId = "Invalid_Null_JWT",
                         JWT = null,
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         Result = new ValidationError(
                             new MessageDetail(
                                 TokenLogMessages.IDX10000,
                                 "jwtToken"),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null)
                     },
                     new JsonWebTokenHandlerValidateSignatureTheoryData {
                         TestId = "Invalid_Null_ValidationParameters",
                         JWT = new JsonWebToken(EncodedJwts.LiveJwt),
                         ValidationParameters = null,
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         Result = new ValidationError(
                             new MessageDetail(
                                 TokenLogMessages.IDX10000,
                                 "validationParameters"),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null)
                     },
                     new JsonWebTokenHandlerValidateSignatureTheoryData {
@@ -110,13 +110,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         {
                             SignatureValidator = (token, parameters, configuration, callContext) => ValidationError.NullParameter("fakeParameter", null)
                         },
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         Result = new ValidationError(
                             new MessageDetail(
                                 TokenLogMessages.IDX10000,
                                 "fakeParameter"),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null)
                     },
                     new JsonWebTokenHandlerValidateSignatureTheoryData

--- a/test/Microsoft.IdentityModel.TestUtils/ExpectedException.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ExpectedException.cs
@@ -213,6 +213,11 @@ namespace Microsoft.IdentityModel.TestUtils
                 throw new TestException($"List<string> errors == null, error in test: {error}.");
         }
 
+        public static ExpectedException SecurityTokenArgumentNullException(string substringExpected = null, Type inner = null)
+        {
+            return new ExpectedException(typeof(SecurityTokenArgumentNullException), substringExpected, inner);
+        }
+
         public static ExpectedException SecurityTokenEncryptionKeyNotFoundException(string substringExpected = null, Type innerTypeExpected = null)
         {
             return new ExpectedException(typeof(SecurityTokenEncryptionKeyNotFoundException), substringExpected, innerTypeExpected);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AlgorithmValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AlgorithmValidationResultTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     {
                         TestId = "Invalid_ValidationParametersAreNull",
                         Algorithm = null,
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         SecurityKey = null,
                         SecurityToken = null,
                         ValidationParameters = null,
@@ -67,7 +67,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                                 LogMessages.IDX10000,
                                 LogHelper.MarkAsNonPII("validationParameters")),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null) // StackFrame
                     },
                     new AlgorithmTheoryData

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     new AudienceValidationTheoryData
                     {
                         Audiences = new List<string> { "audience1" },
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         TestId = "Invalid_ValidationParametersIsNull",
                         ValidationParameters = null,
                         Result = new ValidationError(
@@ -86,7 +86,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                                 LogMessages.IDX10000,
                                 LogHelper.MarkAsNonPII("validationParameters")),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null)
                     },
                     new AudienceValidationTheoryData

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/IssuerValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/IssuerValidationResultTests.cs
@@ -84,14 +84,14 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
 
                 theoryData.Add(new IssuerValidationResultsTheoryData("NULL_ValidationParameters")
                 {
-                    ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                    ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                     Issuer = issClaim,
                     Result = new ValidationError(
                         new MessageDetail(
                             LogMessages.IDX10000,
                             LogHelper.MarkAsNonPII("validationParameters")),
                         ValidationFailureType.NullArgument,
-                        typeof(ArgumentNullException),
+                        typeof(SecurityTokenArgumentNullException),
                         null),
                     SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, issClaim),
                     ValidationParameters = null
@@ -99,14 +99,14 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
 
                 theoryData.Add(new IssuerValidationResultsTheoryData("NULL_SecurityToken")
                 {
-                    ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                    ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                     Issuer = issClaim,
                     Result = new ValidationError(
                         new MessageDetail(
                             LogMessages.IDX10000,
                             LogHelper.MarkAsNonPII("securityToken")),
                         ValidationFailureType.NullArgument,
-                        typeof(ArgumentNullException),
+                        typeof(SecurityTokenArgumentNullException),
                         null),
                     SecurityToken = null,
                     ValidationParameters = new ValidationParameters()

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/LifetimeValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/LifetimeValidationResultTests.cs
@@ -93,14 +93,14 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new ValidateLifetimeTheoryData("Invalid_ValidationParametersIsNull")
                     {
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         Expires = oneHourFromNow,
                         NotBefore = oneHourAgo,
                         ValidationParameters = null,
                         Result = new ValidationError(
                             new MessageDetail(LogMessages.IDX10000, "validationParameters"),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null),
                     },
                     new ValidateLifetimeTheoryData("Invalid_ExpiresIsNull")

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ReplayValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ReplayValidationResultTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     new TokenReplayTheoryData
                     {
                         TestId = "Invalid_SecurityToken_Null",
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         ExpirationTime = now,
                         SecurityToken = null,
                         ValidationParameters = new ValidationParameters(),
@@ -90,13 +90,13 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                                 LogMessages.IDX10000,
                                 LogHelper.MarkAsNonPII("securityToken")),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null),
                     },
                     new TokenReplayTheoryData
                     {
                         TestId = "Invalid_SecurityToken_Empty",
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         ExpirationTime = now,
                         SecurityToken = string.Empty,
                         ValidationParameters = new ValidationParameters(),
@@ -105,13 +105,13 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                                 LogMessages.IDX10000,
                                 LogHelper.MarkAsNonPII("securityToken")),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null),
                     },
                     new TokenReplayTheoryData
                     {
                         TestId = "Invalid_ValidationParameters_Null",
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         ExpirationTime = now,
                         SecurityToken = "token",
                         ValidationParameters = null,
@@ -120,7 +120,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                                 LogMessages.IDX10000,
                                 LogHelper.MarkAsNonPII("validationParameters")),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null),
                     },
                     new TokenReplayTheoryData

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/SigningKeyValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/SigningKeyValidationResultTests.cs
@@ -68,20 +68,20 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     new SigningKeyValidationTheoryData
                     {
                         TestId = "Invalid_SecurityKeyIsNull",
-                        ExpectedException = ExpectedException.ArgumentNullException(substringExpected: "IDX10253:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException(substringExpected: "IDX10253:"),
                         SecurityKey = null,
                         SecurityToken = new JwtSecurityToken(),
                         ValidationParameters = new ValidationParameters(),
                         Result = new ValidationError(
                             new MessageDetail(LogMessages.IDX10253),
                             ValidationFailureType.SigningKeyValidationFailed,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null),
                     },
                     new SigningKeyValidationTheoryData
                     {
                         TestId = "Invalid_SecurityTokenIsNull",
-                        ExpectedException = ExpectedException.ArgumentNullException(substringExpected: "IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException(substringExpected: "IDX10000:"),
                         SecurityKey = KeyingMaterial.SymmetricSecurityKey2_256,
                         SecurityToken = null,
                         ValidationParameters = new ValidationParameters (),
@@ -90,13 +90,13 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                                 LogMessages.IDX10000,
                                 LogHelper.MarkAsNonPII("securityToken")),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null),
                     },
                     new SigningKeyValidationTheoryData
                     {
                         TestId = "Invalid_ValidationParametersIsNull",
-                        ExpectedException = ExpectedException.ArgumentNullException(substringExpected: "IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException(substringExpected: "IDX10000:"),
                         SecurityKey = KeyingMaterial.SymmetricSecurityKey2_256,
                         SecurityToken = new JwtSecurityToken(),
                         ValidationParameters = null,
@@ -105,7 +105,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                                 LogMessages.IDX10000,
                                 LogHelper.MarkAsNonPII("validationParameters")),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null),
                     },
                     new SigningKeyValidationTheoryData
@@ -143,14 +143,14 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     new SigningKeyValidationTheoryData
                     {
                         TestId = "Invalid_SecurityKeyIsNull",
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10253:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10253:"),
                         SecurityKey = null,
                         SecurityToken = new JwtSecurityToken(),
                         ValidationParameters = new ValidationParameters (),
                         Result = new ValidationError(
                             new MessageDetail(LogMessages.IDX10253),
                             ValidationFailureType.SigningKeyValidationFailed,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null),
                     },
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/TokenTypeValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/TokenTypeValidationResultTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     new TokenTypeTheoryData
                     {
                         TestId = "Invalid_SecurityTokenIsNull",
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         Type = "JWT",
                         SecurityToken = null,
                         ValidationParameters = null,
@@ -85,13 +85,13 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                                 LogMessages.IDX10000,
                                 LogHelper.MarkAsNonPII("securityToken")),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null)
                     },
                     new TokenTypeTheoryData
                     {
                         TestId = "Invalid_ValidationParametersAreNull",
-                        ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
+                        ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         Type = "JWT",
                         SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Typ, "JWT"),
                         ValidationParameters = null,
@@ -100,7 +100,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                                 LogMessages.IDX10000,
                                 LogHelper.MarkAsNonPII("validationParameters")),
                             ValidationFailureType.NullArgument,
-                            typeof(ArgumentNullException),
+                            typeof(SecurityTokenArgumentNullException),
                             null)
                     },
                     new TokenTypeTheoryData


### PR DESCRIPTION
# Added ArgumentNullException type with ValidationError

- Added ISecurityTokenException interface to align system exceptions and custom exceptions under a single entry point to inject the validation error used to return the stack traces.
- Added SecurityTokenArgumentNullException implementing the interface.
- Updated usage of ArgumentNullException in code and tests to consume the new type.

Part of #2711 