### PR TITLE
Removed attribute that causes issues with internal builds.

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Microsoft.IdentityModel.Tokens.csproj
+++ b/src/Microsoft.IdentityModel.Tokens/Microsoft.IdentityModel.Tokens.csproj
@@ -57,8 +57,4 @@
     <PackageReference Include="System.Text.Json" Version="$(SystemTextJson)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="..\Common\TrimmingAttributes.cs" LinkBase="Common" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/LifetimeValidationError.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/LifetimeValidationError.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 
 #nullable enable
 namespace Microsoft.IdentityModel.Tokens
@@ -18,7 +17,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         public LifetimeValidationError(
             MessageDetail messageDetail,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type exceptionType,
+            Type exceptionType,
             StackFrame stackFrame)
             : base(messageDetail, ValidationFailureType.LifetimeValidationFailed, exceptionType, stackFrame)
         {
@@ -26,7 +25,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         public LifetimeValidationError(
             MessageDetail messageDetail,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type exceptionType,
+            Type exceptionType,
             StackFrame stackFrame,
             AdditionalInformation? additionalInformation)
             : base(messageDetail, ValidationFailureType.LifetimeValidationFailed, exceptionType, stackFrame)
@@ -37,7 +36,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         public LifetimeValidationError(
             MessageDetail messageDetail,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type exceptionType,
+            Type exceptionType,
             StackFrame stackFrame,
             Exception innerException,
             AdditionalInformation? additionalInformation)

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/ValidationError.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/ValidationError.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.IdentityModel.Tokens
 {
@@ -13,7 +12,6 @@ namespace Microsoft.IdentityModel.Tokens
     /// </summary>
     internal class ValidationError
     {
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         private Type _exceptionType;
 
         /// <summary>
@@ -26,7 +24,7 @@ namespace Microsoft.IdentityModel.Tokens
         public ValidationError(
             MessageDetail MessageDetail,
             ValidationFailureType failureType,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type exceptionType,
+            Type exceptionType,
             StackFrame stackFrame)
             : this(MessageDetail, failureType, exceptionType, stackFrame, innerException: null)
         {
@@ -43,7 +41,7 @@ namespace Microsoft.IdentityModel.Tokens
         public ValidationError(
             MessageDetail messageDetail,
             ValidationFailureType failureType,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type exceptionType,
+            Type exceptionType,
             StackFrame stackFrame,
             Exception innerException)
         {
@@ -60,7 +58,7 @@ namespace Microsoft.IdentityModel.Tokens
         public ValidationError(
             MessageDetail messageDetail,
             ValidationFailureType failureType,
-            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type exceptionType,
+            Type exceptionType,
             StackFrame stackFrame,
             ValidationError innerValidationError)
         {
@@ -77,22 +75,114 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Creates an instance of an <see cref="Exception"/> using <see cref="ValidationError"/>
         /// </summary>
-        /// <returns>An instantance of an Exception.</returns>
+        /// <returns>An instance of an Exception.</returns>
         public Exception GetException()
         {
-            Exception exception;
-            if (InnerException == null && InnerValidationError == null)
-                exception = Activator.CreateInstance(_exceptionType, MessageDetail.Message) as Exception;
-            else
-                exception = Activator.CreateInstance(
-                    _exceptionType,
-                    MessageDetail.Message,
-                    InnerException ?? InnerValidationError.GetException()) as Exception;
-
+            Exception exception = GetException(ExceptionType, InnerException);
             if (exception is SecurityTokenException securityTokenException)
                 securityTokenException.ValidationError = this;
 
             AddAdditionalInformation(exception);
+
+            return exception;
+        }
+
+        private Exception GetException(Type exceptionType, Exception innerException)
+        {
+            Exception exception = null;
+
+            if (innerException == null && InnerValidationError == null)
+            {
+                if (exceptionType == typeof(SecurityTokenInvalidAudienceException))
+                    exception = new SecurityTokenInvalidAudienceException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenInvalidIssuerException))
+                    exception = new SecurityTokenInvalidIssuerException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenInvalidLifetimeException))
+                    exception = new SecurityTokenInvalidLifetimeException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenReplayDetectedException))
+                    exception = new SecurityTokenReplayDetectedException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenReplayAddFailedException))
+                    exception = new SecurityTokenReplayAddFailedException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenInvalidSigningKeyException))
+                    exception = new SecurityTokenInvalidSigningKeyException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenInvalidTypeException))
+                    exception = new SecurityTokenInvalidTypeException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenReplayDetectedException))
+                    exception = new SecurityTokenReplayDetectedException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenExpiredException))
+                    exception = new SecurityTokenExpiredException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenNotYetValidException))
+                    exception = new SecurityTokenNotYetValidException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenInvalidLifetimeException))
+                    exception = new SecurityTokenInvalidLifetimeException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenNoExpirationException))
+                    exception = new SecurityTokenNoExpirationException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenInvalidIssuerException))
+                    exception = new SecurityTokenInvalidIssuerException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenSignatureKeyNotFoundException))
+                    exception = new SecurityTokenSignatureKeyNotFoundException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenDecryptionFailedException))
+                    exception = new SecurityTokenDecryptionFailedException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenMalformedException))
+                    exception = new SecurityTokenMalformedException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenInvalidSignatureException))
+                    exception = new SecurityTokenInvalidSignatureException(MessageDetail.Message);
+                else if (exceptionType == typeof(ArgumentNullException))
+                    exception = new ArgumentNullException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenInvalidAlgorithmException))
+                    exception = new SecurityTokenInvalidAlgorithmException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenInvalidAlgorithmException))
+                    exception = new SecurityTokenInvalidAlgorithmException(MessageDetail.Message);
+                else if (exceptionType == typeof(SecurityTokenException))
+                    exception = new SecurityTokenException(MessageDetail.Message);
+            }
+            else
+            {
+                Exception actualException = innerException ?? InnerValidationError.GetException();
+
+                if (exceptionType == typeof(SecurityTokenInvalidAudienceException))
+                    exception = new SecurityTokenInvalidAudienceException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenInvalidIssuerException))
+                    exception = new SecurityTokenInvalidIssuerException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenInvalidLifetimeException))
+                    exception = new SecurityTokenInvalidLifetimeException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenReplayDetectedException))
+                    exception = new SecurityTokenReplayDetectedException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenReplayAddFailedException))
+                    exception = new SecurityTokenReplayAddFailedException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenInvalidSigningKeyException))
+                    exception = new SecurityTokenInvalidSigningKeyException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenInvalidTypeException))
+                    exception = new SecurityTokenInvalidTypeException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenReplayDetectedException))
+                    exception = new SecurityTokenReplayDetectedException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenExpiredException))
+                    exception = new SecurityTokenExpiredException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenNotYetValidException))
+                    exception = new SecurityTokenNotYetValidException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenInvalidLifetimeException))
+                    exception = new SecurityTokenInvalidLifetimeException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenNoExpirationException))
+                    exception = new SecurityTokenNoExpirationException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenInvalidIssuerException))
+                    exception = new SecurityTokenInvalidIssuerException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenSignatureKeyNotFoundException))
+                    exception = new SecurityTokenSignatureKeyNotFoundException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenDecryptionFailedException))
+                    exception = new SecurityTokenDecryptionFailedException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenMalformedException))
+                    exception = new SecurityTokenMalformedException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenInvalidSignatureException))
+                    exception = new SecurityTokenInvalidSignatureException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(ArgumentNullException))
+                    exception = new ArgumentNullException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenInvalidAlgorithmException))
+                    exception = new SecurityTokenInvalidAlgorithmException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenInvalidAlgorithmException))
+                    exception = new SecurityTokenInvalidAlgorithmException(MessageDetail.Message, actualException);
+                else if (exceptionType == typeof(SecurityTokenException))
+                    exception = new SecurityTokenException(MessageDetail.Message, actualException);
+            }
 
             return exception;
         }

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerValidationParametersTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 await jsonWebTokenHandler.ValidateTokenAsync(jwtString, theoryData.TokenValidationParameters);
             ValidationResult<ValidatedToken> validationParametersResult =
                 await jsonWebTokenHandler.ValidateTokenAsync(
-                    jwtString, theoryData.ValidationParameters, new CallContext(), CancellationToken.None);
+                    jwtString, theoryData.ValidationParameters, theoryData.CallContext, CancellationToken.None);
 
             if (tokenValidationParametersResult.IsValid != theoryData.ExpectedIsValid)
                 context.AddDiff($"tokenValidationParametersResult.IsValid != theoryData.ExpectedIsValid");


### PR DESCRIPTION
Defining the following attribute in multiple assemblies (.Tokens, .Logging) causes an internal error.
[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]

This may not be the best or optimal solution, but fixes the internal build error.
Since this code is currently internal and in preview, we can address the model in a future PR.