### PR TITLE
Use correct runtime in test-aot.ps1

### DIFF
--- a/build/test-aot.ps1
+++ b/build/test-aot.ps1
@@ -27,7 +27,7 @@ if ($LastExitCode -ne 0)
 $runtime = if ($IsWindows) {  "win-x64" } elseif ($IsMacOS) { "macos-x64"} else {"linux-x64"}
 $app = if ($IsWindows ) {"./$projectName.exe" } else {"./projectName" }
 
-Push-Location $rootDirectory/test/$projectName/bin/Release/$targetNetFramework/win-x64
+Push-Location $rootDirectory/test/$projectName/bin/Release/$targetNetFramework/$runtime
 
 Write-Host "Executing test App..."
 $app


### PR DESCRIPTION
Use correct runtime in `test-aot.ps1`.