### PR TITLE
Regression tests: Audience

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/AudienceValidationError.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/AudienceValidationError.cs
@@ -10,7 +10,7 @@ namespace Microsoft.IdentityModel.Tokens
 {
     internal class AudienceValidationError : ValidationError
     {
-        private string? _invalidAudience;
+        private IList<string>? _invalidAudiences;
 
         public AudienceValidationError(
             MessageDetail messageDetail,
@@ -19,13 +19,13 @@ namespace Microsoft.IdentityModel.Tokens
             IList<string>? invalidAudiences)
             : base(messageDetail, ValidationFailureType.AudienceValidationFailed, exceptionType, stackFrame)
         {
-            _invalidAudience = Utility.SerializeAsSingleCommaDelimitedString(invalidAudiences);
+            _invalidAudiences = invalidAudiences;
         }
 
         internal override void AddAdditionalInformation(ISecurityTokenException exception)
         {
             if (exception is SecurityTokenInvalidAudienceException invalidAudienceException)
-                invalidAudienceException.InvalidAudience = _invalidAudience;
+                invalidAudienceException.InvalidAudience = Utility.SerializeAsSingleCommaDelimitedString(_invalidAudiences);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/AudienceValidationError.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/AudienceValidationError.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+#nullable enable
+namespace Microsoft.IdentityModel.Tokens
+{
+    internal class AudienceValidationError : ValidationError
+    {
+        private string? _invalidAudience;
+
+        public AudienceValidationError(
+            MessageDetail messageDetail,
+            Type exceptionType,
+            StackFrame stackFrame,
+            IList<string>? invalidAudiences)
+            : base(messageDetail, ValidationFailureType.AudienceValidationFailed, exceptionType, stackFrame)
+        {
+            _invalidAudience = Utility.SerializeAsSingleCommaDelimitedString(invalidAudiences);
+        }
+
+        internal override void AddAdditionalInformation(ISecurityTokenException exception)
+        {
+            if (exception is SecurityTokenInvalidAudienceException invalidAudienceException)
+                invalidAudienceException.InvalidAudience = _invalidAudience;
+        }
+    }
+}
+#nullable restore

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Audience.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Audience.cs
@@ -52,31 +52,31 @@ namespace Microsoft.IdentityModel.Tokens
                     new StackFrame(true));
 
             if (tokenAudiences == null)
-                return new ValidationError(
+                return new AudienceValidationError(
                     new MessageDetail(LogMessages.IDX10207),
-                    ValidationFailureType.AudienceValidationFailed,
                     typeof(SecurityTokenInvalidAudienceException),
-                    new StackFrame(true));
+                    new StackFrame(true),
+                    tokenAudiences);
 
             if (tokenAudiences.Count == 0)
-                return new ValidationError(
+                return new AudienceValidationError(
                     new MessageDetail(LogMessages.IDX10206),
-                    ValidationFailureType.AudienceValidationFailed,
                     typeof(SecurityTokenInvalidAudienceException),
-                    new StackFrame(true));
+                    new StackFrame(true),
+                    tokenAudiences);
 
             string? validAudience = ValidTokenAudience(tokenAudiences, validationParameters.ValidAudiences, validationParameters.IgnoreTrailingSlashWhenValidatingAudience);
             if (validAudience != null)
                 return validAudience;
 
-            return new ValidationError(
+            return new AudienceValidationError(
                 new MessageDetail(
                     LogMessages.IDX10215,
                     LogHelper.MarkAsNonPII(Utility.SerializeAsSingleCommaDelimitedString(tokenAudiences)),
                     LogHelper.MarkAsNonPII(Utility.SerializeAsSingleCommaDelimitedString(validationParameters.ValidAudiences))),
-                ValidationFailureType.AudienceValidationFailed,
                 typeof(SecurityTokenInvalidAudienceException),
-                new StackFrame(true));
+                new StackFrame(true),
+                tokenAudiences);
         }
 
         private static string? ValidTokenAudience(IList<string> tokenAudiences, IList<string> validAudiences, bool ignoreTrailingSlashWhenValidatingAudience)

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.SkipValidations.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.SkipValidations.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+#nullable enable
+namespace Microsoft.IdentityModel.Tokens
+{
+    public static partial class Validators
+    {
+        internal static AlgorithmValidatorDelegate SkipAlgorithmValidation = delegate (
+            string algorithm,
+            SecurityKey securityKey,
+            SecurityToken securityToken,
+            ValidationParameters
+            validationParameters,
+            CallContext callContext)
+        {
+            return algorithm;
+        };
+
+        internal static AudienceValidatorDelegate SkipAudienceValidation = delegate (
+            IList<string> audiences,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return "skipped"; // The audience that was validated.
+        };
+
+        internal static IssuerValidationDelegateAsync SkipIssuerValidation = delegate (
+            string issuer,
+            SecurityToken securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new ValidationResult<ValidatedIssuer>(
+                new ValidatedIssuer(issuer, IssuerValidationSource.NotValidated)));
+        };
+
+        internal static IssuerSigningKeyValidatorDelegate SkipIssuerSigningKeyValidation = delegate (
+            SecurityKey signingKey,
+            SecurityToken securityToken,
+            ValidationParameters validationParameters,
+            BaseConfiguration? configuration,
+            CallContext? callContext)
+        {
+            return new ValidatedSigningKeyLifetime(
+                null, // ValidFrom
+                null, // ValidTo
+                null);// ValidationTime
+        };
+
+        internal static LifetimeValidatorDelegate SkipLifetimeValidation = delegate (
+            DateTime? notBefore,
+            DateTime? expires,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new ValidatedLifetime(notBefore, expires);
+        };
+
+        internal static SignatureValidatorDelegate SkipSignatureValidation = delegate (
+            SecurityToken securityToken,
+            ValidationParameters validationParameters,
+            BaseConfiguration? configuration,
+            CallContext? callContext)
+        {
+            // This key is not used during the validation process. It is only used to satisfy the delegate signature.
+            // Follow up PR will change this to remove the SecurityKey return value.
+            return new(result: new JsonWebKey());
+        };
+
+        internal static TokenReplayValidatorDelegate SkipTokenReplayValidation = delegate (
+            DateTime? expirationTime,
+            string securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return expirationTime;
+        };
+
+        internal static TypeValidatorDelegate SkipTypeValidation = delegate (
+            string? type,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new ValidatedTokenType("skipped", 0);
+        };
+    }
+}
+#nullable restore

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.SkipValidations.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.SkipValidations.cs
@@ -11,7 +11,7 @@ namespace Microsoft.IdentityModel.Tokens
 {
     public static partial class Validators
     {
-        internal static AlgorithmValidatorDelegate SkipAlgorithmValidation = delegate (
+        internal static AlgorithmValidationDelegate SkipAlgorithmValidation = delegate (
             string algorithm,
             SecurityKey securityKey,
             SecurityToken securityToken,
@@ -22,7 +22,7 @@ namespace Microsoft.IdentityModel.Tokens
             return algorithm;
         };
 
-        internal static AudienceValidatorDelegate SkipAudienceValidation = delegate (
+        internal static AudienceValidationDelegate SkipAudienceValidation = delegate (
             IList<string> audiences,
             SecurityToken? securityToken,
             ValidationParameters validationParameters,
@@ -42,7 +42,7 @@ namespace Microsoft.IdentityModel.Tokens
                 new ValidatedIssuer(issuer, IssuerValidationSource.NotValidated)));
         };
 
-        internal static IssuerSigningKeyValidatorDelegate SkipIssuerSigningKeyValidation = delegate (
+        internal static IssuerSigningKeyValidationDelegate SkipIssuerSigningKeyValidation = delegate (
             SecurityKey signingKey,
             SecurityToken securityToken,
             ValidationParameters validationParameters,
@@ -55,7 +55,7 @@ namespace Microsoft.IdentityModel.Tokens
                 null);// ValidationTime
         };
 
-        internal static LifetimeValidatorDelegate SkipLifetimeValidation = delegate (
+        internal static LifetimeValidationDelegate SkipLifetimeValidation = delegate (
             DateTime? notBefore,
             DateTime? expires,
             SecurityToken? securityToken,
@@ -65,7 +65,7 @@ namespace Microsoft.IdentityModel.Tokens
             return new ValidatedLifetime(notBefore, expires);
         };
 
-        internal static SignatureValidatorDelegate SkipSignatureValidation = delegate (
+        internal static SignatureValidationDelegate SkipSignatureValidation = delegate (
             SecurityToken securityToken,
             ValidationParameters validationParameters,
             BaseConfiguration? configuration,
@@ -76,7 +76,7 @@ namespace Microsoft.IdentityModel.Tokens
             return new(result: new JsonWebKey());
         };
 
-        internal static TokenReplayValidatorDelegate SkipTokenReplayValidation = delegate (
+        internal static TokenReplayValidationDelegate SkipTokenReplayValidation = delegate (
             DateTime? expirationTime,
             string securityToken,
             ValidationParameters validationParameters,
@@ -85,7 +85,7 @@ namespace Microsoft.IdentityModel.Tokens
             return expirationTime;
         };
 
-        internal static TypeValidatorDelegate SkipTypeValidation = delegate (
+        internal static TokenTypeValidationDelegate SkipTokenTypeValidation = delegate (
             string? type,
             SecurityToken? securityToken,
             ValidationParameters validationParameters,

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Audience.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Audience.cs
@@ -16,7 +16,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         [Theory, MemberData(nameof(ValidateTokenAsync_AudienceTestCases))]
         public async Task ValidateTokenAsync_Audience(ValidateTokenAsyncAudienceTheoryData theoryData)
         {
-            var context = TestUtilities.WriteHeader($"{this}.ValidateTokenAsync", theoryData);
+            var context = TestUtilities.WriteHeader($"{this}.ValidateTokenAsync_Audience", theoryData);
 
             string jwtString = CreateToken(theoryData.Audience);
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Audience.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Audience.cs
@@ -12,7 +12,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 {
     public partial class JsonWebTokenHandlerValidateTokenAsyncTests
     {
-        [Theory, MemberData(nameof(ValidateTokenAsync_AudienceTestCases))]
+        [Theory, MemberData(nameof(ValidateTokenAsync_AudienceTestCases), DisableDiscoveryEnumeration = true)]
         public async Task ValidateTokenAsync_Audience(ValidateTokenAsyncAudienceTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateTokenAsync_Audience", theoryData);

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Audience.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Audience.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
-using TokenValidators = Microsoft.IdentityModel.Tokens.Validators;
 using Xunit;
 
 namespace Microsoft.IdentityModel.JsonWebTokens.Tests
@@ -138,11 +137,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     validationParameters.IgnoreTrailingSlashWhenValidatingAudience = ignoreTrailingSlashWhenValidatingAudience;
 
                     // Skip all validations except audience
-                    validationParameters.AlgorithmValidator = TokenValidators.SkipAlgorithmValidation;
-                    validationParameters.IssuerValidatorAsync = TokenValidators.SkipIssuerValidation;
-                    validationParameters.IssuerSigningKeyValidator = TokenValidators.SkipIssuerSigningKeyValidation;
-                    validationParameters.LifetimeValidator = TokenValidators.SkipLifetimeValidation;
-                    validationParameters.SignatureValidator = TokenValidators.SkipSignatureValidation;
+                    validationParameters.AlgorithmValidator = SkipValidationDelegates.SkipAlgorithmValidation;
+                    validationParameters.IssuerValidatorAsync = SkipValidationDelegates.SkipIssuerValidation;
+                    validationParameters.IssuerSigningKeyValidator = SkipValidationDelegates.SkipIssuerSigningKeyValidation;
+                    validationParameters.LifetimeValidator = SkipValidationDelegates.SkipLifetimeValidation;
+                    validationParameters.SignatureValidator = SkipValidationDelegates.SkipSignatureValidation;
 
                     return validationParameters;
                 }

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Audience.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Audience.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #nullable enable
-
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -211,5 +210,4 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
     }
 }
-
 #nullable restore

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Audience.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Audience.cs
@@ -1,0 +1,215 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Microsoft.IdentityModel.JsonWebTokens.Tests
+{
+    public partial class JsonWebTokenHandlerValidateTokenAsyncTests
+    {
+        [Theory, MemberData(nameof(ValidateTokenAsync_AudienceTestCases))]
+        public async Task ValidateTokenAsync_Audience(ValidateTokenAsyncAudienceTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.ValidateTokenAsync", theoryData);
+
+            JsonWebTokenHandler jsonWebTokenHandler = new JsonWebTokenHandler();
+
+            SecurityTokenDescriptor securityTokenDescriptor = new SecurityTokenDescriptor
+            {
+                Subject = Default.ClaimsIdentity,
+                SigningCredentials = Default.AsymmetricSigningCredentials,
+                Audience = theoryData.Audience,
+                Issuer = Default.Issuer,
+            };
+
+            string jwtString = jsonWebTokenHandler.CreateToken(securityTokenDescriptor);
+
+            TokenValidationResult tokenValidationParametersResult =
+                    await jsonWebTokenHandler.ValidateTokenAsync(jwtString, theoryData.TokenValidationParameters);
+            ValidationResult<ValidatedToken> validationParametersResult =
+                await jsonWebTokenHandler.ValidateTokenAsync(
+                    jwtString, theoryData.ValidationParameters!, theoryData.CallContext, CancellationToken.None);
+
+            if (tokenValidationParametersResult.IsValid != theoryData.ExpectedIsValid)
+                context.AddDiff($"tokenValidationParametersResult.IsValid != theoryData.ExpectedIsValid");
+
+            if (validationParametersResult.IsSuccess != theoryData.ExpectedIsValid)
+                context.AddDiff($"validationParametersResult.IsSuccess != theoryData.ExpectedIsValid");
+
+            if (theoryData.ExpectedIsValid &&
+                tokenValidationParametersResult.IsValid &&
+                validationParametersResult.IsSuccess)
+            {
+                IdentityComparer.AreEqual(
+                    tokenValidationParametersResult.ClaimsIdentity,
+                    validationParametersResult.UnwrapResult().ClaimsIdentity,
+                    context);
+                IdentityComparer.AreEqual(
+                    tokenValidationParametersResult.Claims,
+                    validationParametersResult.UnwrapResult().Claims,
+                    context);
+            }
+            else
+            {
+                theoryData.ExpectedException.ProcessException(tokenValidationParametersResult.Exception, context);
+
+                if (!validationParametersResult.IsSuccess)
+                {
+                    // If there is a special case for the ValidationParameters path, use that.
+                    if (theoryData.ExpectedExceptionValidationParameters != null)
+                        theoryData.ExpectedExceptionValidationParameters
+                            .ProcessException(validationParametersResult.UnwrapError().GetException(), context);
+                    else
+                        theoryData.ExpectedException
+                            .ProcessException(validationParametersResult.UnwrapError().GetException(), context);
+                }
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<ValidateTokenAsyncAudienceTheoryData> ValidateTokenAsync_AudienceTestCases
+        {
+            get
+            {
+                return new TheoryData<ValidateTokenAsyncAudienceTheoryData>
+                {
+                    new ValidateTokenAsyncAudienceTheoryData("Valid_AudiencesMatch")
+                    {
+                        Audience = Default.Audience,
+                        TokenValidationParameters = CreateTokenValidationParameters([Default.Audience]),
+                        ValidationParameters = CreateValidationParameters([Default.Audience]),
+                    },
+                    new ValidateTokenAsyncAudienceTheoryData("Invalid_AudiencesDontMatch")
+                    {
+                        // This scenario is the same if the token audience is an empty string or whitespace.
+                        // As long as the token audience and the valid audience are not equal, the validation fails.
+                        TokenValidationParameters = CreateTokenValidationParameters([Default.Audience]),
+                        ValidationParameters = CreateValidationParameters([Default.Audience]),
+                        Audience = "InvalidAudience",
+                        ExpectedIsValid = false,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        // ValidateTokenAsync with ValidationParameters returns a different error message to account for the
+                        // removal of the ValidAudience property from the ValidationParameters class.
+                        ExpectedExceptionValidationParameters = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
+                    },
+                    new ValidateTokenAsyncAudienceTheoryData("Valid_AudienceWithinValidAudiences")
+                    {
+                        Audience = Default.Audience,
+                        TokenValidationParameters = CreateTokenValidationParameters(["ExtraAudience", Default.Audience, "AnotherAudience"]),
+                        ValidationParameters = CreateValidationParameters(["ExtraAudience", Default.Audience, "AnotherAudience"]),
+                    },
+                    new ValidateTokenAsyncAudienceTheoryData("Valid_AudienceWithSlash_IgnoreTrailingSlashTrue")
+                    {
+                        // Audience has a trailing slash, but IgnoreTrailingSlashWhenValidatingAudience is true.
+                        Audience = Default.Audience + "/",
+                        TokenValidationParameters = CreateTokenValidationParameters([Default.Audience], true),
+                        ValidationParameters = CreateValidationParameters([Default.Audience], true),
+                    },
+                    new ValidateTokenAsyncAudienceTheoryData("Invalid_AudienceWithSlash_IgnoreTrailingSlashFalse")
+                    {
+                        // Audience has a trailing slash and IgnoreTrailingSlashWhenValidatingAudience is false.
+                        Audience = Default.Audience + "/",
+                        TokenValidationParameters = CreateTokenValidationParameters([Default.Audience], false),
+                        ValidationParameters = CreateValidationParameters([Default.Audience], false),
+                        ExpectedIsValid = false,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        ExpectedExceptionValidationParameters = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
+                    },
+                    new ValidateTokenAsyncAudienceTheoryData("Valid_ValidAudiencesWithSlash_IgnoreTrailingSlashTrue")
+                    {
+                        // ValidAudiences has a trailing slash, but IgnoreTrailingSlashWhenValidatingAudience is true.
+                        Audience = Default.Audience,
+                        TokenValidationParameters = CreateTokenValidationParameters([Default.Audience + "/"], true),
+                        ValidationParameters = CreateValidationParameters([Default.Audience + "/"], true),
+                    },
+                    new ValidateTokenAsyncAudienceTheoryData("Invalid_ValidAudiencesWithSlash_IgnoreTrailingSlashFalse")
+                    {
+                        // ValidAudiences has a trailing slash and IgnoreTrailingSlashWhenValidatingAudience is false.
+                        Audience = Default.Audience,
+                        TokenValidationParameters = CreateTokenValidationParameters([Default.Audience + "/"], false),
+                        ValidationParameters = CreateValidationParameters([Default.Audience + "/"], false),
+                        ExpectedIsValid = false,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        ExpectedExceptionValidationParameters = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
+                    },
+                    new ValidateTokenAsyncAudienceTheoryData("Invalid_AudienceNullIsTreatedAsEmptyList")
+                    {
+                        // JsonWebToken.Audiences defaults to an empty list if no audiences are provided.
+                        TokenValidationParameters = CreateTokenValidationParameters([Default.Audience]),
+                        ValidationParameters = CreateValidationParameters([Default.Audience]),
+                        Audience = null,
+                        ExpectedIsValid = false,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10206:"),
+                    },
+                    new ValidateTokenAsyncAudienceTheoryData("Invalid_ValidAudiencesIsNull")
+                    {
+                        TokenValidationParameters = CreateTokenValidationParameters(null),
+                        ValidationParameters = CreateValidationParameters(null),
+                        Audience = string.Empty,
+                        ExpectedIsValid = false,
+                        // TVP path has a special case when ValidAudience is null or empty and ValidAudiences is null.
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208:"),
+                        // VP path has a default empty List for ValidAudiences, so it will always return IDX10206 if no audiences are provided.
+                        ExpectedExceptionValidationParameters = ExpectedException.SecurityTokenInvalidAudienceException("IDX10206:"),
+                    },
+                };
+
+                static TokenValidationParameters CreateTokenValidationParameters(
+                    List<string>? audiences,
+                    bool ignoreTrailingSlashWhenValidatingAudience = false) =>
+
+                    new TokenValidationParameters
+                    {
+                        ValidateAudience = true,
+                        ValidateIssuer = true,
+                        ValidateLifetime = true,
+                        ValidateTokenReplay = true,
+                        ValidateIssuerSigningKey = true,
+                        IssuerSigningKey = Default.AsymmetricSigningKey,
+                        ValidAudiences = audiences,
+                        ValidIssuer = Default.Issuer,
+                        IgnoreTrailingSlashWhenValidatingAudience = ignoreTrailingSlashWhenValidatingAudience,
+                    };
+
+                static ValidationParameters CreateValidationParameters(
+                    List<string>? audiences,
+                    bool ignoreTrailingSlashWhenValidatingAudience = false)
+                {
+                    ValidationParameters validationParameters = new ValidationParameters();
+                    validationParameters.ValidIssuers.Add(Default.Issuer);
+                    audiences?.ForEach(audience => validationParameters.ValidAudiences.Add(audience));
+                    validationParameters.IssuerSigningKeys.Add(Default.AsymmetricSigningKey);
+                    validationParameters.IgnoreTrailingSlashWhenValidatingAudience = ignoreTrailingSlashWhenValidatingAudience;
+
+                    return validationParameters;
+                }
+            }
+        }
+
+        public class ValidateTokenAsyncAudienceTheoryData : TheoryDataBase
+        {
+            public ValidateTokenAsyncAudienceTheoryData(string testId) : base(testId) { }
+
+            public string? Audience { get; internal set; } = Default.Audience;
+
+            internal bool ExpectedIsValid { get; set; } = true;
+
+            internal TokenValidationParameters? TokenValidationParameters { get; set; }
+
+            internal ValidationParameters? ValidationParameters { get; set; }
+
+            // only set if we expect a different message on this path
+            internal ExpectedException? ExpectedExceptionValidationParameters { get; set; } = null;
+        }
+    }
+}
+
+#nullable restore

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Common.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Common.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+using System.Threading.Tasks;
+using System.Threading;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.IdentityModel.JsonWebTokens.Tests
+{
+    public partial class JsonWebTokenHandlerValidateTokenAsyncTests
+    {
+        internal static async Task ValidateAndCompareResults(
+            string jwtString,
+            ValidateTokenAsyncBaseTheoryData theoryData,
+            CompareContext context)
+        {
+            JsonWebTokenHandler jsonWebTokenHandler = new JsonWebTokenHandler();
+
+            // Validate the token using TokenValidationParameters
+            TokenValidationResult legacyTokenValidationParametersResult =
+                await jsonWebTokenHandler.ValidateTokenAsync(jwtString, theoryData.TokenValidationParameters);
+
+            // Validate the token using ValidationParameters
+            ValidationResult<ValidatedToken> validationParametersResult =
+                await jsonWebTokenHandler.ValidateTokenAsync(
+                    jwtString, theoryData.ValidationParameters!, theoryData.CallContext, CancellationToken.None);
+
+            // Ensure the validity of the results match the expected result
+            if (legacyTokenValidationParametersResult.IsValid != theoryData.ExpectedIsValid)
+                context.AddDiff($"tokenValidationParametersResult.IsValid != theoryData.ExpectedIsValid");
+
+            if (validationParametersResult.IsSuccess != theoryData.ExpectedIsValid)
+                context.AddDiff($"validationParametersResult.IsSuccess != theoryData.ExpectedIsValid");
+
+            if (theoryData.ExpectedIsValid &&
+                legacyTokenValidationParametersResult.IsValid &&
+                validationParametersResult.IsSuccess)
+            {
+                // Compare the ClaimsPrincipal and ClaimsIdentity from one result against the other
+                IdentityComparer.AreEqual(
+                    legacyTokenValidationParametersResult.ClaimsIdentity,
+                    validationParametersResult.UnwrapResult().ClaimsIdentity,
+                    context);
+                IdentityComparer.AreEqual(
+                    legacyTokenValidationParametersResult.Claims,
+                    validationParametersResult.UnwrapResult().Claims,
+                    context);
+            }
+            else
+            {
+                // Verify the exception provided by the TokenValidationParameters path
+                theoryData.ExpectedException.ProcessException(legacyTokenValidationParametersResult.Exception, context);
+
+                if (!validationParametersResult.IsSuccess)
+                {
+                    // Verify the exception provided by the ValidationParameters path
+                    if (theoryData.ExpectedExceptionValidationParameters is not null)
+                    {
+                        // If there is a special case for the ValidationParameters path, use that.
+                        theoryData.ExpectedExceptionValidationParameters
+                            .ProcessException(validationParametersResult.UnwrapError().GetException(), context);
+                    }
+                    else
+                    {
+                        theoryData.ExpectedException
+                            .ProcessException(validationParametersResult.UnwrapError().GetException(), context);
+
+                        // If the expected exception is the same in both paths, verify the message matches
+                        IdentityComparer.AreStringsEqual(
+                            legacyTokenValidationParametersResult.Exception.Message,
+                            validationParametersResult.UnwrapError().GetException().Message,
+                            context);
+                    }
+                }
+
+                // Verify that the exceptions are of the same type.
+                IdentityComparer.AreEqual(
+                    legacyTokenValidationParametersResult.Exception.GetType(),
+                    validationParametersResult.UnwrapError().GetException().GetType(),
+                    context);
+
+                if (legacyTokenValidationParametersResult.Exception is SecurityTokenException)
+                {
+                    // Verify that the custom properties are the same.
+                    IdentityComparer.AreSecurityTokenExceptionsEqual(
+                        legacyTokenValidationParametersResult.Exception,
+                        validationParametersResult.UnwrapError().GetException(),
+                        context);
+                }
+            }
+        }
+    }
+
+    public class ValidateTokenAsyncBaseTheoryData : TheoryDataBase
+    {
+        public ValidateTokenAsyncBaseTheoryData(string testId) : base(testId) { }
+
+        internal bool ExpectedIsValid { get; set; } = true;
+
+        internal TokenValidationParameters? TokenValidationParameters { get; set; }
+
+        internal ValidationParameters? ValidationParameters { get; set; }
+
+        // only set if we expect a different message on this path
+        internal ExpectedException? ExpectedExceptionValidationParameters { get; set; } = null;
+    }
+}
+#nullable restore

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerValidationParametersTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     SigningCredentials = theoryData.SigningCredentials,
                     EncryptingCredentials = theoryData.EncryptingCredentials,
                     AdditionalHeaderClaims = theoryData.AdditionalHeaderParams,
-                    Audience = theoryData.Audience,
+                    Audience = Default.Audience,
                     Issuer = theoryData.Issuer,
                 };
 
@@ -98,17 +98,17 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     new JsonWebTokenHandlerValidationParametersTheoryData("Valid")
                     {
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
+                            Default.Issuer, Default.AsymmetricSigningKey),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
+                            Default.Issuer, Default.AsymmetricSigningKey),
                     },
                     new JsonWebTokenHandlerValidationParametersTheoryData("Invalid_MalformedToken")
                     {
                         TokenString = "malformedToken",
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
+                            Default.Issuer, Default.AsymmetricSigningKey),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
+                            Default.Issuer, Default.AsymmetricSigningKey),
                         ExpectedIsValid = false,
                         ExpectedException = ExpectedException.SecurityTokenMalformedException("IDX14100:"),
                         ExpectedExceptionValidationParameters = ExpectedException.SecurityTokenMalformedException("IDX14107:", typeof(SecurityTokenMalformedException)),
@@ -116,9 +116,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     new JsonWebTokenHandlerValidationParametersTheoryData("Invalid_Issuer")
                     {
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
+                            Default.Issuer, Default.AsymmetricSigningKey),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
+                            Default.Issuer, Default.AsymmetricSigningKey),
                         Issuer = "InvalidIssuer",
                         ExpectedIsValid = false,
                         ExpectedException = ExpectedException.SecurityTokenInvalidIssuerException("IDX10205:"),
@@ -126,25 +126,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         // removal of the ValidIssuer property from the ValidationParameters class.
                         ExpectedExceptionValidationParameters = ExpectedException.SecurityTokenInvalidIssuerException("IDX10212:"),
                     },
-                    new JsonWebTokenHandlerValidationParametersTheoryData("Invalid_Audience")
-                    {
-                        TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
-                        ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
-                        Audience = "InvalidAudience",
-                        ExpectedIsValid = false,
-                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        // ValidateTokenAsync with ValidationParameters returns a different error message to account for the
-                        // removal of the ValidAudience property from the ValidationParameters class.
-                        ExpectedExceptionValidationParameters = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
-                    },
                     new JsonWebTokenHandlerValidationParametersTheoryData("Invalid_TokenNotSigned")
                     {
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
+                            Default.Issuer, Default.AsymmetricSigningKey),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
+                            Default.Issuer, Default.AsymmetricSigningKey),
                         SigningCredentials = null,
                         ExpectedIsValid = false,
                         ExpectedException = ExpectedException.SecurityTokenInvalidSignatureException("IDX10504:"),
@@ -152,9 +139,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     new JsonWebTokenHandlerValidationParametersTheoryData("Invalid_TokenSignedWithDifferentKey_KeyIdPresent_TryAllKeysFalse")
                     {
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
+                            Default.Issuer, Default.AsymmetricSigningKey),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
+                            Default.Issuer, Default.AsymmetricSigningKey),
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         ExpectedIsValid = false,
                         ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500:"),
@@ -165,9 +152,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     new JsonWebTokenHandlerValidationParametersTheoryData("Invalid_TokenSignedWithDifferentKey_KeyIdPresent_TryAllKeysTrue")
                     {
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey, tryAllKeys: true),
+                            Default.Issuer, Default.AsymmetricSigningKey, tryAllKeys: true),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey, tryAllKeys: true),
+                            Default.Issuer, Default.AsymmetricSigningKey, tryAllKeys: true),
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         ExpectedIsValid = false,
                         ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10503:"),
@@ -175,9 +162,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     new JsonWebTokenHandlerValidationParametersTheoryData("Invalid_TokenSignedWithDifferentKey_KeyIdNotPresent_TryAllKeysFalse")
                     {
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
+                            Default.Issuer, Default.AsymmetricSigningKey),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey),
+                            Default.Issuer, Default.AsymmetricSigningKey),
                         SigningCredentials = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2_NoKeyId,
                         ExpectedIsValid = false,
                         ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10500:"),
@@ -185,9 +172,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     new JsonWebTokenHandlerValidationParametersTheoryData("Invalid_TokenSignedWithDifferentKey_KeyIdNotPresent_TryAllKeysTrue")
                     {
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey, tryAllKeys: true),
+                            Default.Issuer, Default.AsymmetricSigningKey, tryAllKeys: true),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], Default.AsymmetricSigningKey, tryAllKeys: true),
+                            Default.Issuer, Default.AsymmetricSigningKey, tryAllKeys: true),
                         SigningCredentials = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2_NoKeyId,
                         ExpectedIsValid = false,
                         ExpectedException = ExpectedException.SecurityTokenSignatureKeyNotFoundException("IDX10517:"),
@@ -196,10 +183,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     {
                         // Token is signed with HmacSha256 but only sha256 is considered valid for this test's purposes
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            Default.Issuer, KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
                             validAlgorithms: [SecurityAlgorithms.Sha256]),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            Default.Issuer, KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
                             validAlgorithms: [SecurityAlgorithms.Sha256]),
                         SigningCredentials = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2,
                         ExpectedIsValid = false,
@@ -216,10 +203,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             SecurityAlgorithms.Aes128CbcHmacSha256),
                         SigningCredentials = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2,
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            Default.Issuer, KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
                             tokenDecryptionKey: KeyingMaterial.DefaultX509Key_2048),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            Default.Issuer, KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
                             tokenDecryptionKey: KeyingMaterial.DefaultX509Key_2048),
                     },
 #if NET472 || NET6_0_OR_GREATER
@@ -235,10 +222,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         SigningCredentials = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2,
                         AdditionalHeaderParams = AdditionalEcdhEsHeaderParameters(KeyingMaterial.JsonWebKeyP521_Public),
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            Default.Issuer, KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
                             tokenDecryptionKey: new ECDsaSecurityKey(KeyingMaterial.JsonWebKeyP521, true)),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            Default.Issuer, KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
                             tokenDecryptionKey: new ECDsaSecurityKey(KeyingMaterial.JsonWebKeyP521, true)),
                     },
 #endif
@@ -250,9 +237,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             SecurityAlgorithms.Aes128CbcHmacSha256),
                         SigningCredentials = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2,
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key),
+                            Default.Issuer, KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key),
+                            Default.Issuer, KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key),
                         ExpectedIsValid = false,
                         ExpectedException = ExpectedException.SecurityTokenDecryptionFailedException("IDX10609:"),
                     },
@@ -264,10 +251,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             SecurityAlgorithms.Aes128CbcHmacSha256),
                         SigningCredentials = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2,
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            Default.Issuer, KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
                             tokenDecryptionKey: KeyingMaterial.DefaultRsaSecurityKey1),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            Default.Issuer, KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
                             tokenDecryptionKey: KeyingMaterial.DefaultRsaSecurityKey1),
                         ExpectedIsValid = false,
                         ExpectedException = ExpectedException.SecurityTokenKeyWrapException("IDX10618:"),
@@ -280,10 +267,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             SecurityAlgorithms.Aes128CbcHmacSha256),
                         SigningCredentials = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2,
                         TokenValidationParameters = CreateTokenValidationParameters(
-                            Default.Issuer, [Default.Audience], KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            Default.Issuer, KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
                             tokenDecryptionKey: KeyingMaterial.DefaultRsaSecurityKey1),
                         ValidationParameters = CreateValidationParameters(
-                            Default.Issuer, [Default.Audience], KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
+                            Default.Issuer, KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key,
                             tokenDecryptionKey: KeyingMaterial.DefaultRsaSecurityKey1),
                         ExpectedIsValid = false,
                         ExpectedException = ExpectedException.SecurityTokenKeyWrapException("IDX10618:"),
@@ -292,7 +279,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
                 static TokenValidationParameters CreateTokenValidationParameters(
                     string issuer,
-                    List<string> audiences,
                     SecurityKey issuerSigningKey,
                     SecurityKey tokenDecryptionKey = null,
                     List<string> validAlgorithms = null,
@@ -306,22 +292,21 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         ValidateIssuerSigningKey = true,
                         IssuerSigningKey = issuerSigningKey,
                         TokenDecryptionKey = tokenDecryptionKey,
-                        ValidAudiences = audiences,
+                        ValidAudiences = [Default.Audience],
                         ValidIssuer = issuer,
                         TryAllIssuerSigningKeys = tryAllKeys,
                     };
 
                 static ValidationParameters CreateValidationParameters(
                     string issuer,
-                    List<string> audiences,
                     SecurityKey issuerSigningKey,
                     SecurityKey tokenDecryptionKey = null,
                     List<string> validAlgorithms = null,
                     bool tryAllKeys = false)
                 {
                     ValidationParameters validationParameters = new ValidationParameters();
+                    validationParameters.ValidAudiences.Add(Default.Audience);
                     validationParameters.ValidIssuers.Add(issuer);
-                    audiences.ForEach(audience => validationParameters.ValidAudiences.Add(audience));
                     validationParameters.IssuerSigningKeys.Add(issuerSigningKey);
                     validationParameters.TryAllIssuerSigningKeys = tryAllKeys;
                     if (validAlgorithms is not null)
@@ -362,7 +347,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             public EncryptingCredentials EncryptingCredentials { get; internal set; }
             public IDictionary<string, object> AdditionalHeaderParams { get; internal set; }
             public ClaimsIdentity Subject { get; internal set; } = Default.ClaimsIdentity;
-            public string Audience { get; internal set; } = Default.Audience;
             public string Issuer { get; internal set; } = Default.Issuer;
             internal bool ExpectedIsValid { get; set; } = true;
             internal TokenValidationParameters TokenValidationParameters { get; set; }

--- a/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/IdentityComparer.cs
@@ -491,6 +491,12 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static bool AreDateTimesEqual(object object1, object object2, CompareContext context)
         {
+            return AreDateTimesEqual(object1, object2, "dateTime1", "dateTime2", context);
+        }
+
+        public static bool AreDateTimesEqual(
+            object object1, object object2, string name1, string name2, CompareContext context)
+        {
             var localContext = new CompareContext(context);
             if (!ContinueCheckingEquality(object1, object2, localContext))
                 return context.Merge(localContext);
@@ -499,7 +505,7 @@ namespace Microsoft.IdentityModel.TestUtils
             DateTime dateTime2 = (DateTime)object2;
 
             if (dateTime1 != dateTime2)
-                localContext.Diffs.Add($"dateTime1 != dateTime2. '{dateTime1}' != '{dateTime2}'.");
+                localContext.Diffs.Add($"{name1} != {name2}. '{dateTime1}' != '{dateTime2}'.");
 
             return context.Merge(localContext);
         }
@@ -1032,6 +1038,92 @@ namespace Microsoft.IdentityModel.TestUtils
         public static bool AreSecurityKeyEnumsEqual(object object1, object object2, CompareContext context)
         {
             return AreEnumsEqual<SecurityKey>(object1 as IEnumerable<SecurityKey>, object2 as IEnumerable<SecurityKey>, context, AreSecurityKeysEqual);
+        }
+
+        public static bool AreSecurityTokenExceptionsEqual(object object1, object object2, CompareContext context)
+        {
+            var localContext = new CompareContext(context);
+            if (!ContinueCheckingEquality(object1, object2, localContext))
+                return context.Merge(localContext);
+
+            if (object1 is SecurityTokenExpiredException securityTokenExpiredException1 &&
+                object2 is SecurityTokenExpiredException securityTokenExpiredException2)
+            {
+                AreDateTimesEqual(securityTokenExpiredException1.Expires,
+                    securityTokenExpiredException2.Expires,
+                    "SecurityTokenExpiredException1.Expires",
+                    "SecurityTokenExpiredException2.Expires",
+                    localContext);
+            }
+            else if (object1 is SecurityTokenInvalidAlgorithmException securityTokenInvalidAlgorithmException1 &&
+                object2 is SecurityTokenInvalidAlgorithmException securityTokenInvalidAlgorithmException2)
+            {
+                AreStringsEqual(securityTokenInvalidAlgorithmException1.InvalidAlgorithm,
+                    securityTokenInvalidAlgorithmException2.InvalidAlgorithm,
+                    "SecurityTokenInvalidAlgorithmException1.InvalidAlgorithm",
+                    "SecurityTokenInvalidAlgorithmException2.InvalidAlgorithm",
+                    localContext);
+            }
+            else if (object1 is SecurityTokenInvalidAudienceException securityTokenInvalidAudienceException1 &&
+                object2 is SecurityTokenInvalidAudienceException securityTokenInvalidAudienceException2)
+            {
+                AreStringsEqual(securityTokenInvalidAudienceException1.InvalidAudience,
+                    securityTokenInvalidAudienceException2.InvalidAudience,
+                    "SecurityTokenInvalidAudienceException1.InvalidAudience",
+                    "SecurityTokenInvalidAudienceException2.InvalidAudience",
+                    localContext);
+            }
+            else if (object1 is SecurityTokenInvalidIssuerException securityTokenInvalidIssuerException1 &&
+                object2 is SecurityTokenInvalidIssuerException securityTokenInvalidIssuerException2)
+            {
+                AreStringsEqual(securityTokenInvalidIssuerException1.InvalidIssuer,
+                    securityTokenInvalidIssuerException2.InvalidIssuer,
+                    "SecurityTokenInvalidIssuerException1.InvalidIssuer",
+                    "SecurityTokenInvalidIssuerException2.InvalidIssuer",
+                    localContext);
+            }
+            else if (object1 is SecurityTokenInvalidSigningKeyException securityTokenInvalidSigningKeyException1 &&
+                object2 is SecurityTokenInvalidSigningKeyException securityTokenInvalidSigningKeyException2)
+            {
+                AreSecurityKeysEqual(securityTokenInvalidSigningKeyException1.SigningKey,
+                    securityTokenInvalidSigningKeyException2.SigningKey,
+                    localContext);
+            }
+            else if (object1 is SecurityTokenInvalidLifetimeException securityTokenInvalidLifetimeException1 &&
+                object2 is SecurityTokenInvalidLifetimeException securityTokenInvalidLifetimeException2)
+            {
+                AreDateTimesEqual(securityTokenInvalidLifetimeException1.Expires,
+                    securityTokenInvalidLifetimeException2.Expires,
+                    "SecurityTokenInvalidLifetimeException1.Expires",
+                    "SecurityTokenInvalidLifetimeException2.Expires",
+                    localContext);
+
+                AreDateTimesEqual(securityTokenInvalidLifetimeException1.NotBefore,
+                    securityTokenInvalidLifetimeException2.NotBefore,
+                    "SecurityTokenInvalidLifetimeException1.NotBefore",
+                    "SecurityTokenInvalidLifetimeException2.NotBefore",
+                    localContext);
+            }
+            else if (object1 is SecurityTokenInvalidTypeException securityTokenInvalidTypeException1 &&
+                    object2 is SecurityTokenInvalidTypeException securityTokenInvalidTypeException2)
+            {
+                AreStringsEqual(securityTokenInvalidTypeException1.InvalidType,
+                    securityTokenInvalidTypeException2.InvalidType,
+                    "SecurityTokenInvalidTypeException1.InvalidType",
+                    "SecurityTokenInvalidTypeException2.InvalidType",
+                    localContext);
+            }
+            else if (object1 is SecurityTokenNotYetValidException securityTokenNotYetValidException1 &&
+                object2 is SecurityTokenNotYetValidException securityTokenNotYetValidException2)
+            {
+                AreDateTimesEqual(securityTokenNotYetValidException1.NotBefore,
+                    securityTokenNotYetValidException2.NotBefore,
+                    "SecurityTokenNotYetValidException1.NotBefore",
+                    "SecurityTokenNotYetValidException2.NotBefore",
+                    localContext);
+            }
+
+            return context.Merge(localContext);
         }
 
         public static bool AreSignedInfosEqual(SignedInfo signedInfo1, SignedInfo signedInfo2, CompareContext context)

--- a/test/Microsoft.IdentityModel.TestUtils/SkipValidationDelegates.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/SkipValidationDelegates.cs
@@ -5,11 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
 
 #nullable enable
-namespace Microsoft.IdentityModel.Tokens
+namespace Microsoft.IdentityModel.TestUtils
 {
-    public static partial class Validators
+    public static class SkipValidationDelegates
     {
         internal static AlgorithmValidationDelegate SkipAlgorithmValidation = delegate (
             string algorithm,

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
@@ -18,14 +18,14 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
         {
             CompareContext context = TestUtilities.WriteHeader($"{this}.ValidateAudienceParameters", theoryData);
 
-            if (theoryData.AudiencesToAdd != null)
+            if (theoryData.ValidAudiences != null)
             {
-                foreach (string audience in theoryData.AudiencesToAdd)
+                foreach (string audience in theoryData.ValidAudiences)
                     theoryData.ValidationParameters.ValidAudiences.Add(audience);
             }
 
             ValidationResult<string> result = Validators.ValidateAudience(
-                theoryData.Audiences,
+                theoryData.TokenAudiences,
                 theoryData.SecurityToken,
                 theoryData.ValidationParameters,
                 theoryData.CallContext);
@@ -47,6 +47,11 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     theoryData.Result.UnwrapError().FailureType.Name,
                     context);
 
+                IdentityComparer.AreStringsEqual(
+                    validationError.MessageDetail.Message,
+                    theoryData.Result.UnwrapError().MessageDetail.Message,
+                    context);
+
                 Exception exception = validationError.GetException();
                 theoryData.ExpectedException.ProcessException(exception, context);
             }
@@ -62,7 +67,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 {
                     new AudienceValidationTheoryData("ValidationParametersNull")
                     {
-                        Audiences = new List<string> { "audience1" },
+                        TokenAudiences = new List<string> { "audience1" },
                         ExpectedException = ExpectedException.SecurityTokenArgumentNullException("IDX10000:"),
                         ValidationParameters = null,
                         Result = new ValidationError(
@@ -75,7 +80,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("AudiencesNull")
                     {
-                        Audiences = null,
+                        TokenAudiences = null,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10207:"),
                         Result = new ValidationError(
                             new MessageDetail(LogMessages.IDX10207),
@@ -85,7 +90,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("AudiencesEmptyList")
                     {
-                        Audiences = new List<string> { },
+                        TokenAudiences = new List<string> { },
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10206:"),
                         ValidationParameters = new ValidationParameters(),
                         Result = new ValidationError(
@@ -98,30 +103,30 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("AudiencesEmptyString")
                     {
-                        Audiences = new List<string> { "audience1" },
+                        TokenAudiences = new List<string> { string.Empty },
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = [string.Empty],
+                        ValidAudiences = ["audience1"],
                         Result = new ValidationError(
                             new MessageDetail(
                                 LogMessages.IDX10215,
-                                LogHelper.MarkAsNonPII("audience1"),
-                                LogHelper.MarkAsNonPII(string.Empty)),
+                                LogHelper.MarkAsNonPII(string.Empty),
+                                LogHelper.MarkAsNonPII("audience1")),
                             ValidationFailureType.AudienceValidationFailed,
                             typeof(SecurityTokenInvalidAudienceException),
                             null)
                     },
                     new AudienceValidationTheoryData("AudiencesWhiteSpace")
                     {
-                        Audiences = new List<string> { "audience1" },
+                        TokenAudiences = new List<string> { "    " },
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = ["    "],
+                        ValidAudiences = ["audience1"],
                         Result = new ValidationError(
                             new MessageDetail(
                                 LogMessages.IDX10215,
-                                LogHelper.MarkAsNonPII("audience1"),
-                                LogHelper.MarkAsNonPII("    ")),
+                                LogHelper.MarkAsNonPII("    "),
+                                LogHelper.MarkAsNonPII("audience1")),
                             ValidationFailureType.AudienceValidationFailed,
                             typeof(SecurityTokenInvalidAudienceException),
                             null)
@@ -136,14 +141,14 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
         {
             CompareContext context = TestUtilities.WriteHeader($"{this}.ValidateAudienceTests", theoryData);
 
-            if (theoryData.AudiencesToAdd != null)
+            if (theoryData.ValidAudiences != null)
             {
-                foreach (string audience in theoryData.AudiencesToAdd)
+                foreach (string audience in theoryData.ValidAudiences)
                     theoryData.ValidationParameters.ValidAudiences.Add(audience);
             }
 
             ValidationResult<string> result = Validators.ValidateAudience(
-                theoryData.Audiences,
+                theoryData.TokenAudiences,
                 theoryData.SecurityToken,
                 theoryData.ValidationParameters,
                 theoryData.CallContext);
@@ -195,18 +200,18 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 {
                     new AudienceValidationTheoryData("Valid_SameLengthMatched")
                     {
-                        Audiences = audiences1,
+                        TokenAudiences = audiences1,
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = [audience1],
+                        ValidAudiences = [audience1],
                         SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         Result = audience1
                     },
                     new AudienceValidationTheoryData("Invalid_SameLengthNotMatched")
                     {
-                        Audiences = audiences1,
+                        TokenAudiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = [audience2],
+                        ValidAudiences = [audience2],
                         SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         Result = new ValidationError(
                             new MessageDetail(
@@ -219,10 +224,10 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("Invalid_AudiencesValidAudienceWithSlashNotMatched")
                     {
-                        Audiences = audiences1,
+                        TokenAudiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = [audience2 + "/"],
+                        ValidAudiences = [audience2 + "/"],
                         SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
                         Result = new ValidationError(
                             new MessageDetail(
@@ -235,10 +240,10 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("Invalid_AudiencesWithSlashValidAudienceSameLengthNotMatched")
                     {
-                        Audiences = audiences2WithSlash,
+                        TokenAudiences = audiences2WithSlash,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = [audience1],
+                        ValidAudiences = [audience1],
                         Result = new ValidationError(
                             new MessageDetail(
                                 LogMessages.IDX10215,
@@ -250,10 +255,10 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("Invalid_ValidAudienceWithSlash_IgnoreTrailingSlashFalse")
                     {
-                        Audiences = audiences1,
+                        TokenAudiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false },
-                        AudiencesToAdd = [audience1 + "/"],
+                        ValidAudiences = [audience1 + "/"],
                         Result = new ValidationError(
                             new MessageDetail(
                                 LogMessages.IDX10215,
@@ -265,17 +270,17 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("Valid_ValidAudienceWithSlash_IgnoreTrailingSlashTrue")
                     {
-                        Audiences = audiences1,
+                        TokenAudiences = audiences1,
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = [audience1 + "/"],
+                        ValidAudiences = [audience1 + "/"],
                         Result = audience1
                     },
                     new AudienceValidationTheoryData("Invalid_ValidAudiencesWithSlash_IgnoreTrailingSlashFalse")
                     {
-                        Audiences = audiences1,
+                        TokenAudiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false },
-                        AudiencesToAdd = audiences1WithSlash,
+                        ValidAudiences = audiences1WithSlash,
                         Result = new ValidationError(
                             new MessageDetail(
                                 LogMessages.IDX10215,
@@ -287,17 +292,17 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("Valid_ValidAudiencesWithSlash_IgnoreTrailingSlashTrue")
                     {
-                        Audiences = audiences1,
+                        TokenAudiences = audiences1,
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = audiences1WithSlash,
+                        ValidAudiences = audiences1WithSlash,
                         Result = audience1
                     },
                     new AudienceValidationTheoryData("Invalid_ValidAudienceWithExtraChar")
                     {
-                        Audiences = audiences1,
+                        TokenAudiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = [audience1 + "A"],
+                        ValidAudiences = [audience1 + "A"],
                         Result = new ValidationError(
                             new MessageDetail(
                                 LogMessages.IDX10215,
@@ -309,10 +314,10 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("Invalid_ValidAudienceWithDoubleSlash_IgnoreTrailingSlashTrue")
                     {
-                        Audiences = audiences1,
+                        TokenAudiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = [audience1 + "//"],
+                        ValidAudiences = [audience1 + "//"],
                         Result = new ValidationError(
                             new MessageDetail(
                                 LogMessages.IDX10215,
@@ -324,10 +329,10 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("Invalid_ValidAudiencesWithDoubleSlash_IgnoreTrailingSlashTrue")
                     {
-                        Audiences = audiences1,
+                        TokenAudiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = audiences1WithTwoSlashes,
+                        ValidAudiences = audiences1WithTwoSlashes,
                         Result = new ValidationError(
                             new MessageDetail(
                                 LogMessages.IDX10215,
@@ -339,10 +344,10 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("Invalid_TokenAudienceWithSlash_IgnoreTrailingSlashFalse")
                     {
-                        Audiences = audiences1WithSlash,
+                        TokenAudiences = audiences1WithSlash,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false },
-                        AudiencesToAdd = [audience1],
+                        ValidAudiences = [audience1],
                         Result = new ValidationError(
                             new MessageDetail(
                                 LogMessages.IDX10215,
@@ -354,17 +359,17 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("Valid_TokenAudienceWithSlash_IgnoreTrailingSlashTrue")
                     {
-                        Audiences = audiences1WithSlash,
+                        TokenAudiences = audiences1WithSlash,
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = [audience1],
+                        ValidAudiences = [audience1],
                         Result = audience1Slash
                     },
                     new AudienceValidationTheoryData("Invalid_TokenAudienceWithSlashNotEqual")
                     {
-                        Audiences = audiences2WithSlash,
+                        TokenAudiences = audiences2WithSlash,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = [audience1],
+                        ValidAudiences = [audience1],
                         Result = new ValidationError(
                             new MessageDetail(
                                 LogMessages.IDX10215,
@@ -376,10 +381,10 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("Invalid_TokenAudiencesWithSlash_IgnoreTrailingSlashFalse")
                     {
-                        Audiences = audiences1WithSlash,
+                        TokenAudiences = audiences1WithSlash,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false },
-                        AudiencesToAdd = [audience1],
+                        ValidAudiences = [audience1],
                         Result = new ValidationError(
                             new MessageDetail(
                                 LogMessages.IDX10215,
@@ -391,17 +396,17 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("Valid_TokenAudiencesWithSlash_IgnoreTrailingSlashTrue")
                     {
-                        Audiences = audiences1WithSlash,
+                        TokenAudiences = audiences1WithSlash,
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = [audience1],
+                        ValidAudiences = [audience1],
                         Result = audience1Slash
                     },
                     new AudienceValidationTheoryData("Invalid_TokenAudiencesWithSlashValidAudiencesNotMatched_IgnoreTrailingSlashTrue")
                     {
-                        Audiences = audiences1WithSlash,
+                        TokenAudiences = audiences1WithSlash,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = audiences2,
+                        ValidAudiences = audiences2,
                         Result = new ValidationError(
                             new MessageDetail(
                                 LogMessages.IDX10215,
@@ -413,10 +418,10 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                     },
                     new AudienceValidationTheoryData("TokenAudienceWithTwoSlashesVPTrue")
                     {
-                        Audiences = audiences1WithTwoSlashes,
+                        TokenAudiences = audiences1WithTwoSlashes,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
                         ValidationParameters = new ValidationParameters(),
-                        AudiencesToAdd = [audience1],
+                        ValidAudiences = [audience1],
                         Result = new ValidationError(
                             new MessageDetail(
                                 LogMessages.IDX10215,
@@ -434,7 +439,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
         {
             public AudienceValidationTheoryData(string testId) : base(testId) { }
 
-            public List<string> Audiences { get; set; }
+            public List<string> TokenAudiences { get; set; }
 
             public SecurityToken SecurityToken { get; set; }
 
@@ -442,7 +447,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
 
             internal ValidationFailureType ValidationFailureType { get; set; }
 
-            public List<string> AudiencesToAdd { get; set; }
+            public List<string> ValidAudiences { get; set; }
 
             internal ValidationResult<string> Result { get; set; }
         }


### PR DESCRIPTION
# Regression tests: Audience
- Extracted regression tests related to audience to a separate file.
- Added extra scenarios for audience related validations.
- Fixed audience validation unit tests and renamed variables to improve clarity.

Note: Upcoming PRs will continue to extract the different aspects of regression tests into separate files.

Part of #2711
