### PR TITLE
Remove TransformBeforeSignatureValidationDelegate from ValidationParameters

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Delegates.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Delegates.cs
@@ -205,13 +205,5 @@ namespace Microsoft.IdentityModel.Tokens
     /// <remarks>This method is not expected to throw.</remarks>
     /// <returns>The validated <see cref="SecurityToken"/>.</returns>
     internal delegate ValidationResult<SecurityKey> SignatureValidationDelegate(SecurityToken token, ValidationParameters validationParameters, BaseConfiguration? configuration, CallContext? callContext);
-
-    /// <summary>
-    /// Transforms the security token before signature validation.
-    /// </summary>
-    /// <param name="token">The <see cref="SecurityToken"/> being validated.</param>
-    /// <param name="validationParameters">The <see cref="ValidationParameters"/> to be used for validating the token.</param>
-    /// <returns>The transformed <see cref="SecurityToken"/>.</returns>
-    internal delegate SecurityToken TransformBeforeSignatureValidationDelegate(SecurityToken token, ValidationParameters validationParameters);
 #nullable restore
 }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
@@ -88,7 +88,6 @@ namespace Microsoft.IdentityModel.Tokens
             TokenDecryptionKeys = other.TokenDecryptionKeys;
             TokenReplayCache = other.TokenReplayCache;
             TokenReplayValidator = other.TokenReplayValidator;
-            TransformBeforeSignatureValidation = other.TransformBeforeSignatureValidation;
             TypeValidator = other.TypeValidator;
             ValidateActor = other.ValidateActor;
             ValidateSignatureLast = other.ValidateSignatureLast;
@@ -318,11 +317,6 @@ namespace Microsoft.IdentityModel.Tokens
             get { return _issuerValidatorAsync; }
             set { _issuerValidatorAsync = value ?? throw new ArgumentNullException(nameof(value), "IssuerValidatorAsync cannot be set as null."); }
         }
-
-        /// <summary>
-        /// Gets or sets a delegate that will be called to transform a token to a supported format before validation.
-        /// </summary>
-        public TransformBeforeSignatureValidationDelegate TransformBeforeSignatureValidation { get; set; }
 
         /// <summary>
         /// Allows overriding the delegate that will be used to validate the lifetime of the token


### PR DESCRIPTION
# Remove TransformBeforeSignatureValidationDelegate from ValidationParameters
- Removed TransformBeforeSignatureValidationDelegate from ValidationParameters since it is not used in the new path

Part of #2711 