### PR TITLE
Add disable discovery enumeration = true to all theory tests

### DIFF
--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             new Claim("dateTimeIso8061", _dateTime.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture), ClaimValueTypes.DateTime, "LOCAL AUTHORITY", "LOCAL AUTHORITY"),
         };
 
-        [Theory, MemberData(nameof(DirectClaimSetTestCases))]
+        [Theory, MemberData(nameof(DirectClaimSetTestCases), DisableDiscoveryEnumeration = true)]
         public void DirectClaimSetTests(JsonClaimSetTheoryData theoryData)
         {
             CompareContext context = TestUtilities.WriteHeader($"{this}.ClaimSetTests", theoryData);
@@ -78,7 +78,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(GetClaimAsTypeTheoryData))]
+        [Theory, MemberData(nameof(GetClaimAsTypeTheoryData), DisableDiscoveryEnumeration = true)]
         public void GetClaimAsType(JsonClaimSetTheoryData theoryData)
         {
             CompareContext context = TestUtilities.WriteHeader($"{this}.GetClaimAsType", theoryData);

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             Assert.Throws<ArgumentNullException>(() => handler.CreateToken("Payload", Default.SymmetricEncryptingCredentials, (Dictionary<string, object>)null));
         }
 
-        [Theory, MemberData(nameof(TokenValidationClaimsTheoryData))]
+        [Theory, MemberData(nameof(TokenValidationClaimsTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateTokenValidationResult(JsonWebTokenTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateTokenValidationResult");
@@ -98,7 +98,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             Assert.Equal(tokenValidationResult.Claims, TokenUtilities.CreateDictionaryFromClaims(tokenValidationResult.ClaimsIdentity.Claims));
         }
 
-        [Theory, MemberData(nameof(TokenValidationClaimsTheoryData))]
+        [Theory, MemberData(nameof(TokenValidationClaimsTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateTokenDerivedHandlerValidationResult(JsonWebTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateTokenDerivedHandlerValidationResult", theoryData);
@@ -157,7 +157,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(TokenValidationTheoryData))]
+        [Theory, MemberData(nameof(TokenValidationTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateTokenValidationResultThrowsWarning(JsonWebTokenTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateTokenValidationResultThrowsWarning");
@@ -176,7 +176,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             Assert.Contains(warningId, listener.TraceBuffer);
         }
 
-        [Theory, MemberData(nameof(TokenValidationTheoryData))]
+        [Theory, MemberData(nameof(TokenValidationTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateTokenValidationResultDoesNotThrowWarningWithIsValidRead(JsonWebTokenTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateTokenValidationResultDoesNotThrowWarningWithIsValidRead");
@@ -196,7 +196,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             Assert.DoesNotContain(warningId, listener.TraceBuffer);
         }
 
-        [Theory, MemberData(nameof(TokenValidationTheoryData))]
+        [Theory, MemberData(nameof(TokenValidationTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateTokenValidationResultDoesNotThrowWarningWithExceptionRead(JsonWebTokenTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateTokenValidationResultDoesNotThrowWarningWithExceptionRead");
@@ -245,7 +245,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(SegmentTheoryData))]
+        [Theory, MemberData(nameof(SegmentTheoryData), DisableDiscoveryEnumeration = true)]
         public void SegmentCanRead(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SegmentCanRead", theoryData);
@@ -281,7 +281,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(CreateTokenWithEmptyPayloadUsingSecurityTokenDescriptorTheoryData))]
+        [Theory, MemberData(nameof(CreateTokenWithEmptyPayloadUsingSecurityTokenDescriptorTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task CreateTokenWithEmptyPayloadUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateEmptyJWSUsingSecurityTokenDescriptor", theoryData);
@@ -405,7 +405,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         /// Verify the results from ValidateToken() and ValidateTokenAsync() should match.
         /// </summary>
         /// <param name="theoryData">The test data.</param>
-        [Theory, MemberData(nameof(CreateJWEWithAesGcmTheoryData))]
+        [Theory, MemberData(nameof(CreateJWEWithAesGcmTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task TokenValidationResultsShouldMatch(CreateTokenTheoryData theoryData)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -436,7 +436,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateJWEWithAesGcmTheoryData))]
+        [Theory, MemberData(nameof(CreateJWEWithAesGcmTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task CreateJWEWithAesGcm(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWEWithAesGcm", theoryData);
@@ -540,7 +540,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
         // Tests checks to make sure that the token string created by the JsonWebTokenHandler is consistent with the 
         // token string created by the JwtSecurityTokenHandler.
-        [Theory, MemberData(nameof(CreateJWETheoryData))]
+        [Theory, MemberData(nameof(CreateJWETheoryData), DisableDiscoveryEnumeration = true)]
         public async Task CreateJWE(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWE", theoryData);
@@ -662,7 +662,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(SecurityTokenDecryptionTheoryData))]
+        [Theory, MemberData(nameof(SecurityTokenDecryptionTheoryData), DisableDiscoveryEnumeration = true)]
         public void GetEncryptionKeys(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.EncryptionKeysCheck", theoryData);
@@ -827,7 +827,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         // Tests checks to make sure that the token string (JWE) created by calling 
         // CreateToken(string payload, SigningCredentials signingCredentials, EncryptingCredentials encryptingCredentials)
         // is equivalent to the token string created by calling CreateToken(SecurityTokenDescriptor tokenDescriptor).
-        [Theory, MemberData(nameof(CreateJWEUsingSecurityTokenDescriptorTheoryData))]
+        [Theory, MemberData(nameof(CreateJWEUsingSecurityTokenDescriptorTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task CreateJWEUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWEUsingSecurityTokenDescriptor", theoryData);
@@ -1217,7 +1217,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
         // Tests checks to make sure that the token string created by the JsonWebTokenHandler is consistent with the 
         // token string created by the JwtSecurityTokenHandler.
-        [Theory, MemberData(nameof(CreateJWSTheoryData))]
+        [Theory, MemberData(nameof(CreateJWSTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task CreateJWS(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWS", theoryData);
@@ -1348,7 +1348,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         // This test checks to make sure that SecurityTokenDescriptor.Audience, Expires, IssuedAt, NotBefore, Issuer have priority over SecurityTokenDescriptor.Claims.
-        [Theory, MemberData(nameof(CreateJWSWithSecurityTokenDescriptorClaimsTheoryData))]
+        [Theory, MemberData(nameof(CreateJWSWithSecurityTokenDescriptorClaimsTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateJWSWithSecurityTokenDescriptorClaims(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWSWithSecurityTokenDescriptorClaims", theoryData);
@@ -1496,7 +1496,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
 
         // This test checks to make sure that additional header claims are added as expected to the JWT token header.
-        [Theory, MemberData(nameof(CreateJWSWithAdditionalHeaderClaimsTheoryData))]
+        [Theory, MemberData(nameof(CreateJWSWithAdditionalHeaderClaimsTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateJWSWithAdditionalHeaderClaims(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWSWithAdditionalHeaderClaims", theoryData);
@@ -1570,7 +1570,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateJWEWithPayloadStringTheoryData))]
+        [Theory, MemberData(nameof(CreateJWEWithPayloadStringTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task CreateJWEWithPayloadString(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWEWithPayloadString", theoryData);
@@ -1751,7 +1751,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         // This test checks to make sure that additional header claims are added as expected to the outer token header.
-        [Theory, MemberData(nameof(CreateJWEWithAdditionalHeaderClaimsTheoryData))]
+        [Theory, MemberData(nameof(CreateJWEWithAdditionalHeaderClaimsTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task CreateJWEWithAdditionalHeaderClaims(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWEWithAdditionalHeaderClaims", theoryData);
@@ -1934,7 +1934,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
         // Tests checks to make sure that the token string (JWS) created by calling CreateToken(string payload, SigningCredentials signingCredentials)
         // is equivalent to the token string created by calling CreateToken(SecurityTokenDescriptor tokenDescriptor).
-        [Theory, MemberData(nameof(CreateJWSUsingSecurityTokenDescriptorTheoryData))]
+        [Theory, MemberData(nameof(CreateJWSUsingSecurityTokenDescriptorTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task CreateJWSUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWSUsingSecurityTokenDescriptor", theoryData);
@@ -2496,7 +2496,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         // Test ensure paths to creating a token with an empty payload are successful.
-        [Theory, MemberData(nameof(RoundTripWithEmptyPayloadTestCases))]
+        [Theory, MemberData(nameof(RoundTripWithEmptyPayloadTestCases), DisableDiscoveryEnumeration = true)]
         public async Task RoundTripWithEmptyPayload(CreateTokenTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.RoundTripWithEmptyPayload");
@@ -2641,7 +2641,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(RoundTripJWEDirectTestCases))]
+        [Theory, MemberData(nameof(RoundTripJWEDirectTestCases), DisableDiscoveryEnumeration = true)]
         public async Task RoundTripJWEInnerJWSDirect(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEInnerJWSDirect", theoryData);
@@ -2674,7 +2674,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(RoundTripJWEDirectTestCases))]
+        [Theory, MemberData(nameof(RoundTripJWEDirectTestCases), DisableDiscoveryEnumeration = true)]
         public async Task RoundTripJWEDirect(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEDirect", theoryData);
@@ -2773,7 +2773,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(RoundTripJWEKeyWrapTestCases))]
+        [Theory, MemberData(nameof(RoundTripJWEKeyWrapTestCases), DisableDiscoveryEnumeration = true)]
         public async Task RoundTripJWEInnerJWSKeyWrap(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEInnerJWSKeyWrap", theoryData);
@@ -2806,7 +2806,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(RoundTripJWEKeyWrapTestCases))]
+        [Theory, MemberData(nameof(RoundTripJWEKeyWrapTestCases), DisableDiscoveryEnumeration = true)]
         public async Task RoundTripJWEKeyWrap(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RoundTripJWEKeyWrap", theoryData);
@@ -3027,7 +3027,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
 
-        [Theory, MemberData(nameof(ValidateTypeTheoryData))]
+        [Theory, MemberData(nameof(ValidateTypeTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateType(JwtTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateType", theoryData);
@@ -3043,7 +3043,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
         public static TheoryData<JwtTheoryData> ValidateTypeTheoryData = JwtSecurityTokenHandlerTests.ValidateTypeTheoryData;
 
-        [Theory, MemberData(nameof(ValidateJweTestCases))]
+        [Theory, MemberData(nameof(ValidateJweTestCases), DisableDiscoveryEnumeration = true)]
         public async Task ValidateJWE(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWE", theoryData);
@@ -3178,7 +3178,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(ValidateJweTestCases))]
+        [Theory, MemberData(nameof(ValidateJweTestCases), DisableDiscoveryEnumeration = true)]
         public async Task ValidateJWEAsync(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWEAsync", theoryData);
@@ -3307,7 +3307,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateJwsTestCases))]
+        [Theory, MemberData(nameof(ValidateJwsTestCases), DisableDiscoveryEnumeration = true)]
         public async Task ValidateJWSAsync(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWSAsync", theoryData);
@@ -3337,7 +3337,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(ValidateJwsTestCases))]
+        [Theory, MemberData(nameof(ValidateJwsTestCases), DisableDiscoveryEnumeration = true)]
         public async Task ValidateJWS(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWS", theoryData);
@@ -3566,7 +3566,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateJwsWithConfigTheoryData))]
+        [Theory, MemberData(nameof(ValidateJwsWithConfigTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateJWSWithConfig(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWSWithConfig", theoryData);
@@ -3598,7 +3598,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(ValidateJwsWithConfigTheoryData))]
+        [Theory, MemberData(nameof(ValidateJwsWithConfigTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateJWSWithConfigAsync(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWSWithConfigAsync", theoryData);
@@ -3670,7 +3670,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 return theoryData;
             }
         }
-        [Theory, MemberData(nameof(ValidateJwsWithLastKnownGoodTheoryData))]
+        [Theory, MemberData(nameof(ValidateJwsWithLastKnownGoodTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateJWSWithLastKnownGood(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWSWithLastKnownGood", theoryData);
@@ -3728,7 +3728,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
         public static TheoryData<JwtTheoryData> ValidateJwsWithLastKnownGoodTheoryData => JwtTestDatasets.ValidateJwsWithLastKnownGoodTheoryData;
 
-        [Theory, MemberData(nameof(ValidateJWEWithLastKnownGoodTheoryData))]
+        [Theory, MemberData(nameof(ValidateJWEWithLastKnownGoodTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateJWEWithLastKnownGood(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWEWithLastKnownGood", theoryData);
@@ -3785,7 +3785,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
         public static TheoryData<JwtTheoryData> ValidateJWEWithLastKnownGoodTheoryData => JwtTestDatasets.ValidateJWEWithLastKnownGoodTheoryData;
 
-        [Theory, MemberData(nameof(JWECompressionTheoryData))]
+        [Theory, MemberData(nameof(JWECompressionTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task EncryptExistingJWSWithCompressionTest(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.EncryptExistingJWSWithCompressionTest", theoryData);
@@ -3817,7 +3817,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(JWECompressionTheoryData))]
+        [Theory, MemberData(nameof(JWECompressionTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task JWECompressionTest(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.JWECompressionTest", theoryData);
@@ -3966,7 +3966,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(JweDecompressSizeTheoryData))]
+        [Theory, MemberData(nameof(JweDecompressSizeTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task JWEDecompressionSizeTest(JWEDecompressionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.JWEDecompressionTest", theoryData);
@@ -4030,7 +4030,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(JWEDecompressionTheoryData))]
+        [Theory, MemberData(nameof(JWEDecompressionTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task JWEDecompressionTest(JWEDecompressionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.JWEDecompressionTest", theoryData);
@@ -4149,7 +4149,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             };
         }
 
-        [Theory, MemberData(nameof(SecurityKeyNotFoundExceptionTestTheoryData))]
+        [Theory, MemberData(nameof(SecurityKeyNotFoundExceptionTestTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task SecurityKeyNotFoundExceptionTest(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SecurityKeyNotFoundExceptionTest", theoryData);
@@ -4248,7 +4248,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             };
         }
 
-        [Theory, MemberData(nameof(IncludeSecurityTokenOnFailureTestTheoryData))]
+        [Theory, MemberData(nameof(IncludeSecurityTokenOnFailureTestTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task IncludeSecurityTokenOnFailedValidationTest(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.IncludeSecurityTokenOnFailedValidationTest", theoryData);
@@ -4319,7 +4319,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             };
         }
 
-        [Theory, MemberData(nameof(ValidateAuthenticationTagLengthTheoryData))]
+        [Theory, MemberData(nameof(ValidateAuthenticationTagLengthTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateTokenAsync_ModifiedAuthNTag(CreateTokenTheoryData theoryData)
         {
             // arrange

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerValidationParametersTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 {
     public class JsonWebTokenHandlerValidationParametersTests
     {
-        [Theory, MemberData(nameof(JsonWebTokenHandlerValidationParametersTestCases))]
+        [Theory, MemberData(nameof(JsonWebTokenHandlerValidationParametersTestCases), DisableDiscoveryEnumeration = true)]
         public async Task ValidateTokenAsync(JsonWebTokenHandlerValidationParametersTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateTokenAsync", theoryData);

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
@@ -1466,7 +1466,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
         // Time values can be floats, ints, or strings.
         // This test checks to make sure that parsing does not fault in any of the above cases.
-        [Theory, MemberData(nameof(ParseTimeValuesTheoryData))]
+        [Theory, MemberData(nameof(ParseTimeValuesTheoryData), DisableDiscoveryEnumeration = true)]
         public void ParseTimeValues(ParseTimeValuesTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ParseTimeValues", theoryData);
@@ -1544,7 +1544,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         // Test ensures that we only try to populate a JsonWebToken from a string if it is a properly formatted JWT.
         // More specifically, we only want to try and decode
         // a JWT token if it has the correct number of (JWE or JWS) token parts.
-        [Theory, MemberData(nameof(ParseTokenTheoryData))]
+        [Theory, MemberData(nameof(ParseTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void ParseToken(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ParseToken", theoryData);
@@ -1721,7 +1721,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         // Test to verify equality between JsonWebTokens created from a string and an equivalent span
-        [Theory, MemberData(nameof(ParseTokenTheoryData))]
+        [Theory, MemberData(nameof(ParseTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void StringAndMemoryConstructors_CreateEquivalentTokens(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CompareJsonWebToken", theoryData);

--- a/test/Microsoft.IdentityModel.Logging.Tests/LoggerTests.cs
+++ b/test/Microsoft.IdentityModel.Logging.Tests/LoggerTests.cs
@@ -247,7 +247,7 @@ namespace Microsoft.IdentityModel.Logging.Tests
             var exception = LogHelper.LogExceptionMessage(new ArgumentException("This is the first parameter '{0}'. This is the second parameter '{1}'."));
         }
 
-        [Theory, MemberData(nameof(LoggerTestTheoryData))]
+        [Theory, MemberData(nameof(LoggerTestTheoryData), DisableDiscoveryEnumeration = true)]
         public void LoggerInstanceTests(LoggerTheoryData theoryData)
         {
             LogHelper.Logger = theoryData.Logger;

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/End2EndTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/End2EndTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
     /// </summary>
     public class End2EndTests
     {
-        [Theory, MemberData(nameof(OpenIdConnectTheoryData))]
+        [Theory, MemberData(nameof(OpenIdConnectTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task OpenIdConnect(OpenIdConnectTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.OpenIdConnect", theoryData);

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectMessageTests.cs
@@ -268,7 +268,7 @@ new OpenIdConnectMessageTheoryData("EmptyJsonStringEmptyJobj")
             TestUtilities.AssertFailIfErrors("OpenIdConnectMessage_GetSets*** Test Failures:\n", context.Errors);
         }
 
-        [Theory, MemberData(nameof(CreateAuthenticationRequestUrlTheoryData))]
+        [Theory, MemberData(nameof(CreateAuthenticationRequestUrlTheoryData), DisableDiscoveryEnumeration = true)]
         public void OidcCreateAuthenticationRequestUrl(string testId, OpenIdConnectMessage message, string expectedMessage)
         {
             TestUtilities.WriteHeader(testId, "OidcCreateAuthenticationRequestUrl", true);
@@ -542,7 +542,7 @@ new OpenIdConnectMessageTheoryData("EmptyJsonStringEmptyJobj")
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(CreateLogoutRequestUrlTheoryData))]
+        [Theory, MemberData(nameof(CreateLogoutRequestUrlTheoryData), DisableDiscoveryEnumeration = true)]
         public void OidcCreateLogoutRequestUrl(string testId, OpenIdConnectMessage message, string expectedMessage)
         {
             TestUtilities.WriteHeader("OidcCreateLogoutRequestUrl - " + testId, true);

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/OpenIdConnectProtocolValidatorTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         }
 
 
-        [Theory, MemberData(nameof(ValidateAuthenticationResponseTheoryData))]
+        [Theory, MemberData(nameof(ValidateAuthenticationResponseTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateAuthenticationResponse(OidcProtocolValidatorTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateAuthenticationResponse", theoryData);
@@ -277,7 +277,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateTokenResponseTheoryData))]
+        [Theory, MemberData(nameof(ValidateTokenResponseTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateTokenResponse(OidcProtocolValidatorTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateTokenResponse", theoryData);
@@ -376,7 +376,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateUserInfoResponseTheoryData))]
+        [Theory, MemberData(nameof(ValidateUserInfoResponseTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateUserInfoResponse(OidcProtocolValidatorTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateUserInfoResponse", theoryData);
@@ -498,7 +498,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateIdTokenTheoryData))]
+        [Theory, MemberData(nameof(ValidateIdTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateIdToken(OidcProtocolValidatorTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateIdToken", theoryData);
@@ -726,7 +726,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateCHashTheoryData))]
+        [Theory, MemberData(nameof(ValidateCHashTheoryData), DisableDiscoveryEnumeration = true)]
         private void ValidateCHash(OidcProtocolValidatorTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateCHash", theoryData);
@@ -960,7 +960,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateJWEPayloadCHashTheoryData))]
+        [Theory, MemberData(nameof(ValidateJWEPayloadCHashTheoryData), DisableDiscoveryEnumeration = true)]
         private void ValidateJWEPayloadCHash(OidcProtocolValidatorTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWEPayloadCHash", theoryData);
@@ -1091,7 +1091,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateNonceTheoryData))]
+        [Theory, MemberData(nameof(ValidateNonceTheoryData), DisableDiscoveryEnumeration = true)]
         private void ValidateNonce(OidcProtocolValidatorTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateNonce", theoryData);
@@ -1317,7 +1317,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateAtHashTheoryData))]
+        [Theory, MemberData(nameof(ValidateAtHashTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateAtHash(OidcProtocolValidatorTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateAtHash", theoryData);
@@ -1429,7 +1429,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateJWEPayloadAtHashTheoryData))]
+        [Theory, MemberData(nameof(ValidateJWEPayloadAtHashTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateJWEPayloadAtHash(OidcProtocolValidatorTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWEPayloadAtHash", theoryData);
@@ -1470,7 +1470,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateStateTheoryData))]
+        [Theory, MemberData(nameof(ValidateStateTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateState(OidcProtocolValidatorTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateState", theoryData);
@@ -1629,7 +1629,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 Assert.Equal(hashFound, expectedHash);
         }
 
-        [Theory, MemberData(nameof(HashAlgorithmExtensibilityTheoryData))]
+        [Theory, MemberData(nameof(HashAlgorithmExtensibilityTheoryData), DisableDiscoveryEnumeration = true)]
         public void HashAlgorithmExtensibility(OpenIdConnectProtocolValidator protocolValidator, string alg, Type algorithmType, ExpectedException ee)
         {
             ee.Verbose = false;
@@ -1702,7 +1702,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
         }
 
-        [Theory, MemberData(nameof(GetHashAlgorithmTheoryData))]
+        [Theory, MemberData(nameof(GetHashAlgorithmTheoryData), DisableDiscoveryEnumeration = true)]
         public void GetHashAlgorithm(OpenIdConnectProtocolValidator protocolValidator, string alg, Type algorithmType, ExpectedException ee)
         {
             ee.Verbose = false;

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
     {
         internal const string _defaultJkuDomain = "contoso.com";
 
-        [Theory, MemberData(nameof(ResolvePopKeyFromCnfClaimAsyncTheoryData))]
+        [Theory, MemberData(nameof(ResolvePopKeyFromCnfClaimAsyncTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ResolvePopKeyFromCnfClaimAsync(ResolvePopKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ResolvePopKeyFromCnfClaimAsync", theoryData);
@@ -142,7 +142,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ResolvePopKeyAsyncTheoryData))]
+        [Theory, MemberData(nameof(ResolvePopKeyAsyncTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ResolvePopKeyAsync(ResolvePopKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ResolvePopKeyTheoryData", theoryData);
@@ -198,7 +198,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ResolvePopKeyFromJwkTheoryData))]
+        [Theory, MemberData(nameof(ResolvePopKeyFromJwkTheoryData), DisableDiscoveryEnumeration = true)]
         public void ResolvePopKeyFromJwk(ResolvePopKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ResolvePopKeyTheoryData", theoryData);
@@ -269,7 +269,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ResolvePopKeyFromJweTheoryData))]
+        [Theory, MemberData(nameof(ResolvePopKeyFromJweTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ResolvePopKeyFromJweAsync(ResolvePopKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ResolvePopKeyFromJwe", theoryData);
@@ -393,7 +393,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ResolvePopKeyFromJkuTheoryData))]
+        [Theory, MemberData(nameof(ResolvePopKeyFromJkuTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ResolvePopKeyFromJkuAsync(ResolvePopKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ResolvePopKeyFromJkuAsync", theoryData);
@@ -562,7 +562,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(GetCnfClaimValueTheoryData))]
+        [Theory, MemberData(nameof(GetCnfClaimValueTheoryData), DisableDiscoveryEnumeration = true)]
         public void GetCnfClaimValue(ResolvePopKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetCnfClaimValue", theoryData);
@@ -625,7 +625,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ResolvePopKeyFromJkuKidTheoryData))]
+        [Theory, MemberData(nameof(ResolvePopKeyFromJkuKidTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ResolvePopKeyFromJkuKidAsync(ResolvePopKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ResolvePopKeyFromJkuKidAsync", theoryData);
@@ -742,7 +742,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory(Skip = "flaky"), MemberData(nameof(GetPopKeysFromJkuAsyncTheoryData))]
+        [Theory(Skip = "flaky"), MemberData(nameof(GetPopKeysFromJkuAsyncTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task GetPopKeysFromJkuAsync(ResolvePopKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetPopKeysFromJkuAsync", theoryData);
@@ -856,7 +856,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ResolvePopKeyFromKeyIdentifierAsyncTheoryData))]
+        [Theory, MemberData(nameof(ResolvePopKeyFromKeyIdentifierAsyncTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ResolvePopKeyFromKeyIdentifierAsync(ResolvePopKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ResolvePopKeyFromKeyIdentifierAsync", theoryData);

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestCreationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestCreationTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         }
 
 
-        [Theory, MemberData(nameof(CreateClaimCallsTheoryData))]
+        [Theory, MemberData(nameof(CreateClaimCallsTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateClaimCalls(CreateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateClaimCalls", theoryData);
@@ -177,7 +177,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateAtClaimTheoryData))]
+        [Theory, MemberData(nameof(CreateAtClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateAtClaim(CreateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateAtClaimTheoryData", theoryData);
@@ -217,7 +217,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory(Skip = "This test failed on build server due to some EpochTime changes, should be fixed later"), MemberData(nameof(CreateTsClaimTheoryData))]
+        [Theory(Skip = "This test failed on build server due to some EpochTime changes, should be fixed later"), MemberData(nameof(CreateTsClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateTsClaim(CreateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateTsClaim", theoryData);
@@ -269,7 +269,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateMClaimTheoryData))]
+        [Theory, MemberData(nameof(CreateMClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateMClaim(CreateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateMClaim", theoryData);
@@ -320,7 +320,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateUClaimTheoryData))]
+        [Theory, MemberData(nameof(CreateUClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateUClaim(CreateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateUClaim", theoryData);
@@ -389,7 +389,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreatePClaimTheoryData))]
+        [Theory, MemberData(nameof(CreatePClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreatePClaim(CreateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreatePClaim", theoryData);
@@ -470,7 +470,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateQClaimTheoryData))]
+        [Theory, MemberData(nameof(CreateQClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateQClaim(CreateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateQClaim", theoryData);
@@ -607,7 +607,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateHClaimTheoryData))]
+        [Theory, MemberData(nameof(CreateHClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateHClaim(CreateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateHClaim", theoryData);
@@ -784,7 +784,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateBClaimTheoryData))]
+        [Theory, MemberData(nameof(CreateBClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateBClaim(CreateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateBClaim", theoryData);
@@ -836,7 +836,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateCnfClaimTheoryData))]
+        [Theory, MemberData(nameof(CreateCnfClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateCnfClaim(CreateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateCnfClaim", theoryData);
@@ -929,7 +929,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateNonceClaimTheoryData))]
+        [Theory, MemberData(nameof(CreateNonceClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateNonceClaim(CreateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateNonceClaim", theoryData);
@@ -974,7 +974,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateAdditionalClaimTheoryData))]
+        [Theory, MemberData(nameof(CreateAdditionalClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateAdditionalClaim(CreateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateAdditionalClaim", theoryData);

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestE2ETests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestE2ETests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         });
 
 
-        [Theory, MemberData(nameof(RoundtripTheoryData))]
+        [Theory, MemberData(nameof(RoundtripTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task Roundtrips(RoundtripSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.Roundtrips", theoryData);

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestExceptionTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestExceptionTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
 {
     public class SignedHttpRequestExceptionTests
     {
-        [Theory, MemberData(nameof(ExceptionTypes))]
+        [Theory, MemberData(nameof(ExceptionTypes), DisableDiscoveryEnumeration = true)]
         public void SerializeAndDeserialzeExceptions(SignedHttpExceptionTypeTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.{nameof(SerializeAndDeserialzeExceptions)}", theoryData);

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestUtilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestUtilityTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             Assert.Equal("PoP abcd", SignedHttpRequestUtilities.CreateSignedHttpRequestHeader("abcd"));
         }
 
-        [Theory, MemberData(nameof(AppendHeadersTheoryData))]
+        [Theory, MemberData(nameof(AppendHeadersTheoryData), DisableDiscoveryEnumeration = true)]
         public void AppendHeaders(SignedHttpRequestUtilityTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.AppendHeaders", theoryData);
@@ -58,7 +58,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(CreateJwkClaimTheoryData))]
+        [Theory, MemberData(nameof(CreateJwkClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateJwkClaim(SignedHttpRequestUtilityTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJwkClaim", theoryData);
@@ -257,7 +257,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ToHttpRequestDataAsyncTheoryData))]
+        [Theory, MemberData(nameof(ToHttpRequestDataAsyncTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ToHttpRequestDataAsync(SignedHttpRequestUtilityTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ToHttpRequestDataAsync", theoryData);

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             return handler.CreateSignedHttpRequest(descriptor);
         }
 
-        [Theory, MemberData(nameof(ValidateTsClaimTheoryData))]
+        [Theory, MemberData(nameof(ValidateTsClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateTsClaim(ValidateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateTsClaim", theoryData);
@@ -142,7 +142,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateMClaimTheoryData))]
+        [Theory, MemberData(nameof(ValidateMClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateMClaim(ValidateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateMClaim", theoryData);
@@ -224,7 +224,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateUClaimTheoryData))]
+        [Theory, MemberData(nameof(ValidateUClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateUClaim(ValidateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateUClaim", theoryData);
@@ -318,7 +318,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidatePClaimTheoryData))]
+        [Theory, MemberData(nameof(ValidatePClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidatePClaim(ValidateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidatePClaim", theoryData);
@@ -429,7 +429,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateHClaimTheoryData))]
+        [Theory, MemberData(nameof(ValidateHClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateHClaim(ValidateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateHClaim", theoryData);
@@ -680,7 +680,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateQClaimTheoryData))]
+        [Theory, MemberData(nameof(ValidateQClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateQClaim(ValidateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateQClaim", theoryData);
@@ -855,7 +855,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateBClaimTheoryData))]
+        [Theory, MemberData(nameof(ValidateBClaimTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateBClaim(ValidateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateBClaim", theoryData);
@@ -913,7 +913,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateSignedHttpRequestCallsTheoryData))]
+        [Theory, MemberData(nameof(ValidateSignedHttpRequestCallsTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateSignedHttpRequestCalls(ValidateSignedHttpRequestTheoryData theoryData)
         {
             var containsClaim = new Func<SignedHttpRequestValidationParameters, string, bool>((validationParams, claim) =>
@@ -1259,7 +1259,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateSignedHttpRequestSignatureTheoryData))]
+        [Theory, MemberData(nameof(ValidateSignedHttpRequestSignatureTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateSignedHttpRequestSignature(ValidateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateSignedHttpRequestSignature", theoryData);
@@ -1363,7 +1363,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateSignedHttpRequestTheoryData))]
+        [Theory, MemberData(nameof(ValidateSignedHttpRequestTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateSignedHttpRequest(ValidateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateSignedHttpRequest", theoryData);

--- a/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.IdentityModel.Protocols.Tests
 
     public class ExtensibilityTests
     {
-        [Theory, MemberData(nameof(GetMetadataTheoryData))]
+        [Theory, MemberData(nameof(GetMetadataTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task GetMetadataTest(DocumentRetrieverTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.GetMetadataTest", theoryData);

--- a/test/Microsoft.IdentityModel.Protocols.Tests/FileDocumentRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/FileDocumentRetrieverTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.IdentityModel.Protocols.Tests
     public class FileDocumentRetrieverTests
     {
 
-        [Theory, MemberData(nameof(GetMetadataTheoryData))]
+        [Theory, MemberData(nameof(GetMetadataTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task GetMetadataTest(DocumentRetrieverTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.GetMetadataTest", theoryData);

--- a/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             TestUtilities.AssertFailIfErrors("HttpDocumentRetrieverTests_GetSets", context.Errors);
         }
 
-        [Theory, MemberData(nameof(GetMetadataTheoryData))]
+        [Theory, MemberData(nameof(GetMetadataTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task GetMetadataTest(DocumentRetrieverTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetMetadataTest", theoryData);

--- a/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/WsFederationConfigurationRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/WsFederationConfigurationRetrieverTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
     /// </summary>
     public class WsFederationConfigurationRetrieverTests
     {
-        [Theory, MemberData(nameof(ReadMetadataTheoryData))]
+        [Theory, MemberData(nameof(ReadMetadataTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadMetadata(WsFederationMetadataTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadMetadata", theoryData);
@@ -326,7 +326,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ReadEntityDescriptorTheoryData))]
+        [Theory, MemberData(nameof(ReadEntityDescriptorTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadEntityDescriptor(WsFederationMetadataTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadEntityDescriptor", theoryData);
@@ -366,7 +366,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ReadKeyDescriptorForSigningTheoryData))]
+        [Theory, MemberData(nameof(ReadKeyDescriptorForSigningTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadKeyDescriptorForSigning(WsFederationMetadataTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadKeyDescriptorForSigning", theoryData);
@@ -401,7 +401,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ReadKeyDescriptorForSigningKeyUseTheoryData))]
+        [Theory, MemberData(nameof(ReadKeyDescriptorForSigningKeyUseTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadKeyDescriptorForSigningKeyUse(WsFederationMetadataTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadKeyDescriptorForSigningKeyUse", theoryData);
@@ -446,7 +446,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ReadSecurityTokenServiceTypeRoleDescriptorTheoryData))]
+        [Theory, MemberData(nameof(ReadSecurityTokenServiceTypeRoleDescriptorTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadSecurityTokenServiceTypeRoleDescriptor(WsFederationMetadataTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadSecurityTokenServiceTypeRoleDescriptor", theoryData);
@@ -486,7 +486,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ReadSecurityTokenEndpointTheoryData))]
+        [Theory, MemberData(nameof(ReadSecurityTokenEndpointTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadSecurityTokenEndpoint(WsFederationMetadataTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadSecurityTokenEndpoint", theoryData);
@@ -539,7 +539,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
             }
         }
 
-        [Theory, MemberData(nameof(WriteMetadataTheoryData))]
+        [Theory, MemberData(nameof(WriteMetadataTheoryData), DisableDiscoveryEnumeration = true)]
         public void WriteMetadata(WsFederationMetadataTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.WriteMetadata", theoryData);

--- a/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/WsFederationConfigurationValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/WsFederationConfigurationValidatorTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
     /// </summary>
     public class WsFederationConfigurationValidatorTests
     {
-        [Theory, MemberData(nameof(ValidateConfigurationTheoryData))]
+        [Theory, MemberData(nameof(ValidateConfigurationTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateConfiguration(WsFederationConfigurationTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateConfiguration", theoryData);

--- a/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/WsFederationMessageTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/WsFederationMessageTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
             TestUtilities.AssertFailIfErrors($"{this}.GetSets", context.Errors);
         }
 
-        [Theory, MemberData(nameof(MessageTheoryData))]
+        [Theory, MemberData(nameof(MessageTheoryData), DisableDiscoveryEnumeration = true)]
         public void ConstructorTest(WsFederationMessageTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ConstructorTest", theoryData);
@@ -89,7 +89,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
             }
         }
 
-        [Theory, MemberData(nameof(WaSignInTheoryData))]
+        [Theory, MemberData(nameof(WaSignInTheoryData), DisableDiscoveryEnumeration = true)]
         public void WaSignIn(WsFederationSigninMessageTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.WaSignIn", theoryData);
@@ -275,7 +275,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
 
         }
 
-        [Theory, MemberData(nameof(GetTokenTheoryData))]
+        [Theory, MemberData(nameof(GetTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void GetTokenTest(WsFederationMessageTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetTokenTest", theoryData);
@@ -381,7 +381,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
             }
         }
 
-        [Theory, MemberData(nameof(GetTokenParsingStringData))]
+        [Theory, MemberData(nameof(GetTokenParsingStringData), DisableDiscoveryEnumeration = true)]
         public void GetTokenParsingString(WsFederationMessageTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetTokenParsingString", theoryData);
@@ -507,7 +507,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
             }
         }
 
-        [Theory, MemberData(nameof(GetTokenAspWsFedHandlerTestTheoryData))]
+        [Theory, MemberData(nameof(GetTokenAspWsFedHandlerTestTheoryData), DisableDiscoveryEnumeration = true)]
         public void GetTokenAspWsFedHandlerTest(WsFederationMessageTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetTokenAspWsFedHandlerTest", theoryData);
@@ -546,7 +546,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
             }
         }
 
-        [Theory, MemberData(nameof(GetTokenNegativeTestTheoryData))]
+        [Theory, MemberData(nameof(GetTokenNegativeTestTheoryData), DisableDiscoveryEnumeration = true)]
         public void GetTokenNegativeTest(WsFederationMessageTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetTokenNegativeTest", theoryData);
@@ -634,7 +634,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
             }
         }
 
-        [Theory, MemberData(nameof(MessageTheoryData))]
+        [Theory, MemberData(nameof(MessageTheoryData), DisableDiscoveryEnumeration = true)]
         public void ParametersTest(WsFederationMessageTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ParametersTest", theoryData);
@@ -713,7 +713,7 @@ namespace Microsoft.IdentityModel.Protocols.WsFederation.Tests
             }
         }
 
-        [Theory, MemberData(nameof(QueryStringTheoryData))]
+        [Theory, MemberData(nameof(QueryStringTheoryData), DisableDiscoveryEnumeration = true)]
         public void QueryStringTest(WsFederationMessageTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.QueryStringTest", theoryData);

--- a/test/Microsoft.IdentityModel.TestUtils/TestStub.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/TestStub.cs
@@ -13,7 +13,7 @@ namespace Microsoft.IdentityModel.TestUtils
     /// </summary>
     public class TestStubTests
     {
-        [Theory, MemberData(nameof(TestStubTheoryData))]
+        [Theory, MemberData(nameof(TestStubTheoryData), DisableDiscoveryEnumeration = true)]
         public void TestStubTest1(TestStubTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.TestStubTest1", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/RoundTripSamlTokenTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/RoundTripSamlTokenTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
     public class RoundTripSamlTokenTests
     {
 
-        [Theory, MemberData(nameof(RoundTripTokenTheoryData))]
+        [Theory, MemberData(nameof(RoundTripTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void RoundTripTokens(SamlRoundTripTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RoundTripTokens", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             TestUtilities.AssertFailIfErrors("Saml2SecurityTokenHandlerTests_GetSets", context.Errors);
         }
 
-        [Theory, MemberData(nameof(CanReadTokenTheoryData))]
+        [Theory, MemberData(nameof(CanReadTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void CanReadToken(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.CanReadToken", theoryData);
@@ -111,7 +111,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             };
         }
 
-        [Theory, MemberData(nameof(ConsolidateAttributesTheoryData))]
+        [Theory, MemberData(nameof(ConsolidateAttributesTheoryData), DisableDiscoveryEnumeration = true)]
         public void ConsolidateAttributes(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ConsolidateAttributes", theoryData);
@@ -233,7 +233,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             return context.Merge(localContext);
         }
 
-        [Theory, MemberData(nameof(ReadTokenTheoryData))]
+        [Theory, MemberData(nameof(ReadTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadToken(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadToken", theoryData);
@@ -287,7 +287,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             }
         }
 
-        [Theory, MemberData(nameof(RoundTripActorTheoryData))]
+        [Theory, MemberData(nameof(RoundTripActorTheoryData), DisableDiscoveryEnumeration = true)]
         public void RoundTripActor(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.RoundTripActor", theoryData);
@@ -297,7 +297,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             var actor = handler.CreateActorStringPublic(theoryData.TokenDescriptor.Subject);
         }
 
-        [Theory, MemberData(nameof(WriteTokenTheoryData))]
+        [Theory, MemberData(nameof(WriteTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void WriteToken(Saml2TheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.WriteToken", theoryData);
@@ -497,7 +497,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             Assert.NotEqual(DateTime.MinValue, saml2SecurityToken.ValidTo);
         }
 
-        [Theory, MemberData(nameof(ValidateAudienceTheoryData))]
+        [Theory, MemberData(nameof(ValidateAudienceTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateAudience(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateAudience", theoryData);
@@ -533,7 +533,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateIssuerTheoryData))]
+        [Theory, MemberData(nameof(ValidateIssuerTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateIssuer(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateIssuer", theoryData);
@@ -569,7 +569,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateTokenTheoryData))]
+        [Theory, MemberData(nameof(ValidateTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateToken(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateToken", theoryData);
@@ -1083,7 +1083,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateSaml2TokenUsingTokenDescriptorTheoryData))]
+        [Theory, MemberData(nameof(CreateSaml2TokenUsingTokenDescriptorTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateSaml2TokenUsingTokenDescriptor(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateSaml2TokenUsingTokenDescriptor", theoryData);
@@ -1344,7 +1344,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateValidateActorClaimProcessing))]
+        [Theory, MemberData(nameof(CreateValidateActorClaimProcessing), DisableDiscoveryEnumeration = true)]
         public void ValidateActorClaimProcessing(Saml2TheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateActorClaimProcessing", theoryData);
@@ -1388,7 +1388,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             }
         }
 
-        [Theory, MemberData(nameof(SecurityKeyNotFoundExceptionTestTheoryData))]
+        [Theory, MemberData(nameof(SecurityKeyNotFoundExceptionTestTheoryData), DisableDiscoveryEnumeration = true)]
         public void Saml2SecurityKeyNotFoundExceptionTest(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SecurityKeyNotFoundExceptionTest", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SerializerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SerializerTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
     public class Saml2SerializerTests
     {
         #region Saml2Action
-        [Theory, MemberData(nameof(ReadActionTheoryData))]
+        [Theory, MemberData(nameof(ReadActionTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAction(Saml2TheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadAction", theoryData);
@@ -58,7 +58,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
         #endregion
 
         #region Saml2Advice
-        [Theory, MemberData(nameof(ReadAdviceTheoryData))]
+        [Theory, MemberData(nameof(ReadAdviceTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAdvice(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadAdvice", theoryData);
@@ -99,7 +99,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
         #endregion
 
         #region Saml2Assertion
-        [Theory, MemberData(nameof(ReadAssertionTheoryData))]
+        [Theory, MemberData(nameof(ReadAssertionTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAssertion(Saml2TheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadAssertion", theoryData);
@@ -119,7 +119,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(ReadAssertionTheoryData))]
+        [Theory, MemberData(nameof(ReadAssertionTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAssertionUsingDictionaryReader(Saml2TheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadAssertionUsingDictionaryReader", theoryData);
@@ -139,7 +139,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(ReadAssertionTheoryData))]
+        [Theory, MemberData(nameof(ReadAssertionTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAssertionUsingXDocumentReader(Saml2TheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadAssertionUsingXDocumentReader", theoryData);
@@ -180,7 +180,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
         #endregion
 
         #region Saml2Attribute
-        [Theory, MemberData(nameof(ReadAttributeTheoryData))]
+        [Theory, MemberData(nameof(ReadAttributeTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAttribute(Saml2TheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadAttribute", theoryData);
@@ -220,7 +220,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
         #endregion
 
         #region Saml2AttributeStatement
-        [Theory, MemberData(nameof(ReadAttributeStatementTheoryData))]
+        [Theory, MemberData(nameof(ReadAttributeStatementTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAttributeStatement(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadAttributeStatement", theoryData);
@@ -262,7 +262,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
         #endregion
 
         #region Saml2AudienceRestrictionCondition
-        [Theory, MemberData(nameof(ReadAudienceRestrictionConditionTheoryData))]
+        [Theory, MemberData(nameof(ReadAudienceRestrictionConditionTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAudienceRestriction(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadAudienceRestriction", theoryData);
@@ -304,7 +304,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
         #endregion
 
         #region Saml2AuthenticationStatement
-        [Theory, MemberData(nameof(ReadAuthenticationStatementTheoryData))]
+        [Theory, MemberData(nameof(ReadAuthenticationStatementTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAuthenticationStatement(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadAuthenticationStatement", theoryData);
@@ -345,7 +345,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
         #endregion
 
         #region Saml2AuthorizationDecisionStatement
-        [Theory, MemberData(nameof(ReadAuthorizationDecisionStatementTheoryData))]
+        [Theory, MemberData(nameof(ReadAuthorizationDecisionStatementTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAuthorizationDecisionStatement(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadAuthorizationDecisionStatement", theoryData);
@@ -387,7 +387,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
         #endregion
 
         #region Saml2Conditions
-        [Theory, MemberData(nameof(ReadConditionsTheoryData))]
+        [Theory, MemberData(nameof(ReadConditionsTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadConditions(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadConditions", theoryData);
@@ -432,7 +432,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
         #endregion
 
         #region SamlEvidence
-        [Theory, MemberData(nameof(ReadEvidenceTheoryData))]
+        [Theory, MemberData(nameof(ReadEvidenceTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadEvidence(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadEvidence", theoryData);
@@ -473,7 +473,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
 
         #region Saml2ProxyRestriction
 
-        [Theory, MemberData(nameof(WriteSaml2ProxyRestrictionTheoryData))]
+        [Theory, MemberData(nameof(WriteSaml2ProxyRestrictionTheoryData), DisableDiscoveryEnumeration = true)]
         public void WriteSaml2ProxyRestriction(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.WriteSaml2ProxyRestriction", theoryData);
@@ -521,7 +521,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2.Tests
         #endregion
 
         #region Saml2Subject
-        [Theory, MemberData(nameof(ReadSubjectTheoryData))]
+        [Theory, MemberData(nameof(ReadSubjectTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadSubject(Saml2TheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadSubject", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandlerTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
 
         }
 
-        [Theory, MemberData(nameof(CanReadTokenTheoryData))]
+        [Theory, MemberData(nameof(CanReadTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void CanReadToken(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CanReadToken", theoryData);
@@ -116,7 +116,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateClaimsIdentitiesTheoryData))]
+        [Theory, MemberData(nameof(CreateClaimsIdentitiesTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateClaimsIdentities(SamlTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.CreateClaimsIdentities", theoryData);
@@ -173,7 +173,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ReadTokenTheoryData))]
+        [Theory, MemberData(nameof(ReadTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadToken(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadToken", theoryData);
@@ -236,7 +236,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             Assert.NotEqual(DateTime.MinValue, samlSecurityToken.ValidTo);
         }
 
-        [Theory, MemberData(nameof(ValidateAudienceTheoryData))]
+        [Theory, MemberData(nameof(ValidateAudienceTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateAudience(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateAudience", theoryData);
@@ -271,7 +271,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateIssuerTheoryData))]
+        [Theory, MemberData(nameof(ValidateIssuerTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateIssuer(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateIssuer", theoryData);
@@ -306,7 +306,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateTokenTheoryData))]
+        [Theory, MemberData(nameof(ValidateTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateToken(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateToken", theoryData);
@@ -323,7 +323,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(ValidateTokenTheoryData))]
+        [Theory, MemberData(nameof(ValidateTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateTokenAsync(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateToken", theoryData);
@@ -836,7 +836,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(WriteTokenTheoryData))]
+        [Theory, MemberData(nameof(WriteTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void WriteToken(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.WriteToken", theoryData);
@@ -1012,7 +1012,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(WriteTokenXmlTheoryData))]
+        [Theory, MemberData(nameof(WriteTokenXmlTheoryData), DisableDiscoveryEnumeration = true)]
         public void WriteTokenXml(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.WriteTokenXml", theoryData);
@@ -1068,7 +1068,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateSamlTokenUsingTokenDescriptorTheoryData))]
+        [Theory, MemberData(nameof(CreateSamlTokenUsingTokenDescriptorTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateSamlTokenUsingTokenDescriptor(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateSamlTokenUsingTokenDescriptor", theoryData);
@@ -1345,7 +1345,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(SecurityKeyNotFoundExceptionTestTheoryData))]
+        [Theory, MemberData(nameof(SecurityKeyNotFoundExceptionTestTheoryData), DisableDiscoveryEnumeration = true)]
         public void SamlSecurityKeyNotFoundExceptionTest(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SecurityKeyNotFoundExceptionTest", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenReadTest.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenReadTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
 {
     public class SamlSecurityTokenReadTest
     {
-        [Theory, MemberData(nameof(SamlReadFromTheoryData))]
+        [Theory, MemberData(nameof(SamlReadFromTheoryData), DisableDiscoveryEnumeration = true)]
         public void SamlSecurityTokenReadFrom(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SamlSecurityTokenReadFrom", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSerializerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSerializerTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
     public class SamlSerializerTests
     {
         #region SamlAction
-        [Theory, MemberData(nameof(ReadActionTheoryData))]
+        [Theory, MemberData(nameof(ReadActionTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAction(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadAction", theoryData);
@@ -96,7 +96,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
         #endregion
 
         #region SamlAdvice
-        [Theory, MemberData(nameof(ReadAdviceTheoryData))]
+        [Theory, MemberData(nameof(ReadAdviceTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAdvice(SamlTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadAdvice", theoryData);
@@ -161,7 +161,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
         #endregion
 
         #region SamlAssertion
-        [Theory, MemberData(nameof(ReadAssertionTheoryData))]
+        [Theory, MemberData(nameof(ReadAssertionTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAssertion(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadAssertion", theoryData);
@@ -182,7 +182,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(ReadAssertionTheoryData))]
+        [Theory, MemberData(nameof(ReadAssertionTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAssertionUsingDictionaryReader(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadAssertionUsingDictionaryReader", theoryData);
@@ -203,7 +203,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(ReadAssertionTheoryData))]
+        [Theory, MemberData(nameof(ReadAssertionTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAssertionUsingXDocumentReader(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadAssertionUsingXDocumentReader", theoryData);
@@ -348,7 +348,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(WriteAssertionTheoryData))]
+        [Theory, MemberData(nameof(WriteAssertionTheoryData), DisableDiscoveryEnumeration = true)]
         public void WriteAssertion(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.WriteToken", theoryData);
@@ -413,7 +413,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
         #endregion
 
         #region SamlAttribute
-        [Theory, MemberData(nameof(ReadAttributeTheoryData))]
+        [Theory, MemberData(nameof(ReadAttributeTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAttribute(SamlTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadAttribute", theoryData);
@@ -498,7 +498,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
         #endregion
 
         #region SamlAttributeStatement
-        [Theory, MemberData(nameof(ReadAttributeStatementTheoryData))]
+        [Theory, MemberData(nameof(ReadAttributeStatementTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAttributeStatement(SamlTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadAttributeStatement", theoryData);
@@ -558,7 +558,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
         #endregion
 
         #region SamlAudienceRestrictionCondition
-        [Theory, MemberData(nameof(ReadAudienceRestrictionConditionTheoryData))]
+        [Theory, MemberData(nameof(ReadAudienceRestrictionConditionTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAudienceRestrictionCondition(SamlTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadAudienceRestrictionCondition", theoryData);
@@ -625,7 +625,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
         #endregion
 
         #region SamlAuthenticationStatement
-        [Theory, MemberData(nameof(ReadAuthenticationStatementTheoryData))]
+        [Theory, MemberData(nameof(ReadAuthenticationStatementTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAuthenticationStatement(SamlTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadAuthenticationStatement", theoryData);
@@ -744,7 +744,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
         #endregion
 
         #region SamlAuthorizationDecisionStatement
-        [Theory, MemberData(nameof(ReadAuthorizationDecisionStatementTheoryData))]
+        [Theory, MemberData(nameof(ReadAuthorizationDecisionStatementTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadAuthorizationDecisionStatement(SamlTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadAuthorizationDecisionStatement", theoryData);
@@ -844,7 +844,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
         #endregion
 
         #region SamlConditions
-        [Theory, MemberData(nameof(ReadConditionsTheoryData))]
+        [Theory, MemberData(nameof(ReadConditionsTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadConditions(SamlTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadConditions", theoryData);
@@ -914,7 +914,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
         #endregion
 
         #region SamlEvidence
-        [Theory, MemberData(nameof(ReadEvidenceTheoryData))]
+        [Theory, MemberData(nameof(ReadEvidenceTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadEvidence(SamlTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadEvidence", theoryData);
@@ -987,7 +987,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
         #endregion
 
         #region SamlSubject
-        [Theory, MemberData(nameof(ReadSubjectTheoryData))]
+        [Theory, MemberData(nameof(ReadSubjectTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadSubject(SamlTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadSubject", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricAdapterTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricAdapterTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class AsymmetricAdapterTests
     {
-        [Theory, MemberData(nameof(AsymmetricAdapterUsageTestCases))]
+        [Theory, MemberData(nameof(AsymmetricAdapterUsageTestCases), DisableDiscoveryEnumeration = true)]
         public void AsymmetricAdapterUsageTests(AsymmetricAdapterTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.AsymmetricAdapterUsageTests", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AsymmetricSignatureTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(SignVerifyTheoryData))]
+        [Theory, MemberData(nameof(SignVerifyTheoryData), DisableDiscoveryEnumeration = true)]
         public void SignVerify(SignatureProviderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SignVerify", theoryData);
@@ -273,7 +273,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateAsymmetricKeySizeTheoryData))]
+        [Theory, MemberData(nameof(ValidateAsymmetricKeySizeTheoryData), DisableDiscoveryEnumeration = true)]
         public void VerifyAsymmetricKeySize(AsymmetricSignatureProviderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.VerifyAsymmetricKeySize", theoryData);
@@ -376,7 +376,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         /// This test ensures that if every algorithm in SupportedAlgorithms has a value in our maps that validate key sizes
         /// </summary>
         /// <param name="theoryData"></param>
-        [Theory, MemberData(nameof(VerifyAlgorithmsInDefaultMinimumAsymmetricKeySizeTests))]
+        [Theory, MemberData(nameof(VerifyAlgorithmsInDefaultMinimumAsymmetricKeySizeTests), DisableDiscoveryEnumeration = true)]
         public void VerifyAlgorithmsInDefaultMinimumAsymmetricKeySize(AsymmetricSignatureProviderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.VerifyAlgorithmsInDefaultMinimumAsymmetricKeySize", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AuthenticatedEncryptionProviderExtensibilityTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AuthenticatedEncryptionProviderExtensibilityTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Assert.True(provider.EncryptCalled);
         }
 
-        [Theory, MemberData(nameof(GetKeyBytesTheoryData))]
+        [Theory, MemberData(nameof(GetKeyBytesTheoryData), DisableDiscoveryEnumeration = true)]
         public void GetKeyBytes(AuthenticatedEncryptionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetKeyBytes", theoryData);
@@ -97,7 +97,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             };
         }
 
-        [Theory, MemberData(nameof(IsSupportedAlgorithmTheoryData))]
+        [Theory, MemberData(nameof(IsSupportedAlgorithmTheoryData), DisableDiscoveryEnumeration = true)]
         public void IsSupportedAlgorithm(AuthenticatedEncryptionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.IsSupportedAlgorithm", theoryData);
@@ -156,7 +156,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             };
         }
 
-        [Theory, MemberData(nameof(ValidateKeySizeTheoryData))]
+        [Theory, MemberData(nameof(ValidateKeySizeTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateKeySize(AuthenticatedEncryptionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateKeySize", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/AuthenticatedEncryptionProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/AuthenticatedEncryptionProviderTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         }
 #endif
 
-        [Theory, MemberData(nameof(AEPConstructorTheoryData))]
+        [Theory, MemberData(nameof(AEPConstructorTheoryData), DisableDiscoveryEnumeration = true)]
         public void Constructors(string testId, SecurityKey key, string algorithm, ExpectedException ee)
         {
             TestUtilities.WriteHeader("Constructors - " + testId, true);
@@ -161,7 +161,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(DecryptTheoryData))]
+        [Theory, MemberData(nameof(DecryptTheoryData), DisableDiscoveryEnumeration = true)]
         public void Decrypt(AuthenticatedEncryptionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.Decrypt", theoryData);
@@ -284,7 +284,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             });
         }
 
-        [Theory, MemberData(nameof(DecryptMismatchTheoryData))]
+        [Theory, MemberData(nameof(DecryptMismatchTheoryData), DisableDiscoveryEnumeration = true)]
         public void DecryptMismatch(AuthenticatedEncryptionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.DecryptMismatch", theoryData);
@@ -391,7 +391,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             });
         }
 
-        [Theory, MemberData(nameof(DisposeTheoryData))]
+        [Theory, MemberData(nameof(DisposeTheoryData), DisableDiscoveryEnumeration = true)]
         public void Dispose(AuthenticatedEncryptionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.Dispose", theoryData);
@@ -639,7 +639,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         }
         #endregion
 
-        [Theory, MemberData(nameof(EncryptDecryptTheoryData))]
+        [Theory, MemberData(nameof(EncryptDecryptTheoryData), DisableDiscoveryEnumeration = true)]
         public void EncryptDecrypt(AuthenticatedEncryptionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.EncryptDecrypt", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/BaseConfigurationComparerTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/BaseConfigurationComparerTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class BaseConfigurationComparerTests
     {
-        [Theory, MemberData(nameof(ComparerTheoryData))]
+        [Theory, MemberData(nameof(ComparerTheoryData), DisableDiscoveryEnumeration = true)]
         public void Compare(BaseConfigurationComparerTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.Compare", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CallContextTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CallContextTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class CallContextTests
     {
-        [Theory, MemberData(nameof(CallContextTestTheoryData))]
+        [Theory, MemberData(nameof(CallContextTestTheoryData), DisableDiscoveryEnumeration = true)]
         public void LoggerInstanceTests(CallContextTheoryData theoryData)
         {
             var context = new CallContext(theoryData.ActivityId) { DebugId = theoryData.TestId };

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CaseSensitiveClaimsIdentityTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CaseSensitiveClaimsIdentityTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             [JwtRegisteredClaimNames.Aud] = Default.Audience,
         };
 
-        [Theory, MemberData(nameof(GetCaseSensitiveClaimsIdentityTheoryData))]
+        [Theory, MemberData(nameof(GetCaseSensitiveClaimsIdentityTheoryData), DisableDiscoveryEnumeration = true)]
         public void FindAll_DoesCaseSensitiveSearch(CaseSensitiveClaimsIdentityTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.FindAll_DoesCaseSensitiveSearch", theoryData);
@@ -45,7 +45,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(GetCaseSensitiveClaimsIdentityTheoryData))]
+        [Theory, MemberData(nameof(GetCaseSensitiveClaimsIdentityTheoryData), DisableDiscoveryEnumeration = true)]
         public void FindFirst_DoesCaseSensitiveSearch(CaseSensitiveClaimsIdentityTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.FindFirst_DoesCaseSensitiveSearch", theoryData);
@@ -65,7 +65,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(GetCaseSensitiveClaimsIdentityTheoryData))]
+        [Theory, MemberData(nameof(GetCaseSensitiveClaimsIdentityTheoryData), DisableDiscoveryEnumeration = true)]
         public void HasClaim_DoesCaseSensitiveSearch(CaseSensitiveClaimsIdentityTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.HasClaim_DoesCaseSensitiveSearch", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CrossTokenTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CrossTokenTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     /// </summary>
     public class CrossTokenTests
     {
-        [Theory, MemberData(nameof(CrossTokenValidateTokenTheoryData))]
+        [Theory, MemberData(nameof(CrossTokenValidateTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void CrossTokenValidateToken(CrossTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CrossTokenValidateToken", theoryData);
@@ -81,7 +81,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CanReadTokenTheoryData))]
+        [Theory, MemberData(nameof(CanReadTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void CanReadToken(TokenHandlerTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CanReadToken", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CryptoExtensibilityTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CryptoExtensibilityTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         /// <summary>
         /// SecurityTokenDescriptor.CryptoProviderFactory has priority over SecurityKey.CryptoProviderFactory
         /// </summary>
-        [Theory, MemberData(nameof(SecurityTokenDescriptorDataSet))]
+        [Theory, MemberData(nameof(SecurityTokenDescriptorDataSet), DisableDiscoveryEnumeration = true)]
         public void CryptoProviderOrderingWhenSigning(SecurityTokenDescriptor tokenDescriptor)
         {
             var tokenHandler = new JwtSecurityTokenHandler();
@@ -80,7 +80,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         /// <summary>
         /// TokenValidationParameters.CryptoProviderFactory has priority over SecurityKey.CryptoProviderFactory
         /// </summary>
-        [Theory, MemberData(nameof(SigningCredentialsDataSet))]
+        [Theory, MemberData(nameof(SigningCredentialsDataSet), DisableDiscoveryEnumeration = true)]
         public void CryptoProviderOrderingWhenVerifying(string testId, TokenValidationParameters validationParameters, string jwt)
         {
             TestUtilities.WriteHeader("CryptoProviderOrderingWhenVerifying - " + testId, true);
@@ -212,7 +212,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Assert.False(customHashAlgorithm.DisposeCalled, "customHashAlgorithm.DisposeCalled");
         }
 
-        [Theory, MemberData(nameof(CreateSignatureProviderExtensibilityTheoryData))]
+        [Theory, MemberData(nameof(CreateSignatureProviderExtensibilityTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateSignatureProviderExtensibility(CryptoProviderFactoryTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateSignatureProviderExtensibility", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderCacheTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderCacheTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         /// Tests that a cache key generated from a <see cref="SignatureProvider"/> or a set of components are equal.
         /// </summary>
         /// <param name="theoryData"></param>
-        [Theory, MemberData(nameof(GetCacheKeyTheoryData))]
+        [Theory, MemberData(nameof(GetCacheKeyTheoryData), DisableDiscoveryEnumeration = true)]
         public void GetCacheKey(CryptoProviderCacheTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetCacheKey", theoryData);
@@ -165,7 +165,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(TryAddTheoryData))]
+        [Theory, MemberData(nameof(TryAddTheoryData), DisableDiscoveryEnumeration = true)]
         public void TryAdd(CryptoProviderCacheTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.TryAdd", theoryData);
@@ -296,7 +296,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         /// Tests that a cache key generated from a <see cref="SignatureProvider"/> or a set of components are equal.
         /// </summary>
         /// <param name="theoryData"></param>
-        [Theory, MemberData(nameof(TryGetSignatureProviderTheoryData))]
+        [Theory, MemberData(nameof(TryGetSignatureProviderTheoryData), DisableDiscoveryEnumeration = true)]
         public void TryGetSignatureProvider(CryptoProviderCacheTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.TryGetSignatureProvider", theoryData);
@@ -447,7 +447,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(TryRemoveTheoryData))]
+        [Theory, MemberData(nameof(TryRemoveTheoryData), DisableDiscoveryEnumeration = true)]
         public void TryRemove(CryptoProviderCacheTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.TryRemove", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderFactoryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderFactoryTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         /// <summary>
         /// This test checks that SignatureProviders are properly created and released when CryptoProviderFactory.CacheSignatureProviders = false.
         /// </summary>
-        [Theory, MemberData(nameof(CreateAndReleaseSignatureProvidersTheoryData))]
+        [Theory, MemberData(nameof(CreateAndReleaseSignatureProvidersTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateAndReleaseSignatureProviders(SignatureProviderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateAndReleaseSignatureProvidersTheoryData", theoryData);
@@ -185,7 +185,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         /// Tests that SymmetricSignatureProviders that fault will be removed from cache
         /// </summary>
         /// <param name="theoryData"></param>
-        [Theory, MemberData(nameof(FaultingAsymmetricSignatureProvidersTheoryData))]
+        [Theory, MemberData(nameof(FaultingAsymmetricSignatureProvidersTheoryData), DisableDiscoveryEnumeration = true)]
         public void FaultingAsymmetricSignatureProviders(SignatureProviderTheoryData theoryData)
         {
             IdentityModelEventSource.ShowPII = true;
@@ -303,7 +303,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         /// Tests that SymmetricSignatureProviders that fault will be removed from cache
         /// </summary>
         /// <param name="theoryData"></param>
-        [Theory, MemberData(nameof(FaultingSymmetricSignatureProvidersTheoryData))]
+        [Theory, MemberData(nameof(FaultingSymmetricSignatureProvidersTheoryData), DisableDiscoveryEnumeration = true)]
         public void FaultingSymmetricSignatureProviders(SignatureProviderTheoryData theoryData)
         {
             IdentityModelEventSource.ShowPII = true;
@@ -547,7 +547,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ReleaseSignatureProvidersTheoryData))]
+        [Theory, MemberData(nameof(ReleaseSignatureProvidersTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReleaseSignatureProviders(SignatureProviderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReleaseSignatureProviders", theoryData);
@@ -636,7 +636,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ReleaseHashAlgorithmsTheoryData))]
+        [Theory, MemberData(nameof(ReleaseHashAlgorithmsTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReleaseHashAlgorithms(CryptoProviderFactoryTheoryData theoryData)
         {
             IdentityModelEventSource.ShowPII = true;
@@ -691,7 +691,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ReleaseKeyWrapProvidersTheoryData))]
+        [Theory, MemberData(nameof(ReleaseKeyWrapProvidersTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReleaseKeyWrapProviders(CryptoProviderFactoryTheoryData theoryData)
         {
             IdentityModelEventSource.ShowPII = true;
@@ -748,7 +748,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ReleaseRsaKeyWrapProvidersTheoryData))]
+        [Theory, MemberData(nameof(ReleaseRsaKeyWrapProvidersTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReleaseRsaKeyWrapProviders(CryptoProviderFactoryTheoryData theoryData)
         {
             IdentityModelEventSource.ShowPII = true;

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ECDsaAdapterTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ECDsaAdapterTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class ECDsaAdapterTests
     {
-        [Theory, MemberData(nameof(CreateECDsaFromJsonWebKeyTheoryData))]
+        [Theory, MemberData(nameof(CreateECDsaFromJsonWebKeyTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateECDsa(JsonWebKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateECDsa", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/EcdhEsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/EcdhEsTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class EcdhEsTests
     {
-        [Theory, MemberData(nameof(CreateEcdhEsTestCases))]
+        [Theory, MemberData(nameof(CreateEcdhEsTestCases), DisableDiscoveryEnumeration = true)]
         public void EcdhEsKeyExchangeProviderTests(EcdhEsTheoryData theoryData)
         {
             var context = new CompareContext();
@@ -43,7 +43,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         }
 
 
-        [Theory, MemberData(nameof(CreateEcdhEsTestCases))]
+        [Theory, MemberData(nameof(CreateEcdhEsTestCases), DisableDiscoveryEnumeration = true)]
         public void CreateEcdhEsTests(EcdhEsTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateEcdhEsTests", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/EncryptingCredentialsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/EncryptingCredentialsTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     public class EncryptingCredentialsTests
     {
         //public EncryptingCredentials(SecurityKey key, string alg, string enc)
-        [Theory, MemberData(nameof(ConstructorATheoryData))]
+        [Theory, MemberData(nameof(ConstructorATheoryData), DisableDiscoveryEnumeration = true)]
         public void ConstructorA(EncryptingCredentialsTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ConstructorA", theoryData);
@@ -31,7 +31,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
         //Used in scenarios when a key represents a 'shared' symmetric key
         //public EncryptingCredentials(SecurityKey key, string enc)
-        [Theory, MemberData(nameof(ConstructorBTheoryData))]
+        [Theory, MemberData(nameof(ConstructorBTheoryData), DisableDiscoveryEnumeration = true)]
         public void ConstructorB(EncryptingCredentialsTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ConstructorB", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySerializationTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySerializationTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
         /// This test is designed to ensure that JsonDeserialize and Utf8Reader are consistent w.r.t. exceptions.
         /// </summary>
         /// <param name="theoryData"></param>
-        [Theory, MemberData(nameof(DeserializeTheoryData))]
+        [Theory, MemberData(nameof(DeserializeTheoryData), DisableDiscoveryEnumeration = true)]
         public void DeserializeExceptions(JsonSerializerTheoryData theoryData)
         {
             var context = new CompareContext(theoryData);
@@ -184,7 +184,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
         /// comparing the results JsonSerializer.Deserialize and Utf8JsonReader.
         /// </summary>
         /// <param name="theoryData"></param>
-        [Theory, MemberData(nameof(DeserializeDataSet))]
+        [Theory, MemberData(nameof(DeserializeDataSet), DisableDiscoveryEnumeration = true)]
         public void Deserialize(JsonWebKeyTheoryData theoryData)
         {
             CompareContext context = new CompareContext(theoryData);
@@ -283,7 +283,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
         /// This test is to ensure that a JsonWebKey serializes roundtripping objects in AdditionalData.
         /// </summary>
         /// <param name="theoryData"></param>
-        [Theory, MemberData(nameof(RoundTripDataSet))]
+        [Theory, MemberData(nameof(RoundTripDataSet), DisableDiscoveryEnumeration = true)]
         public void RoundTrip(JsonWebKeyTheoryData theoryData)
         {
             var context = new CompareContext(theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySetSerializationTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Json/JsonWebKeySetSerializationTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
         /// This test is to ensure that JsonWebKeySet serialization with fully populated with each property checked.
         /// </summary>
         /// <param name="theoryData"></param>
-        [Theory, MemberData(nameof(SerializeDataSet))]
+        [Theory, MemberData(nameof(SerializeDataSet), DisableDiscoveryEnumeration = true)]
         public void Serialize(JsonWebKeySetTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.Serialize", theoryData);
@@ -63,7 +63,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
             }
         }
 
-        [Theory, MemberData(nameof(JsonWebKeySetTheoryData))]
+        [Theory, MemberData(nameof(JsonWebKeySetTheoryData), DisableDiscoveryEnumeration = true)]
         public void Deserialize(JsonWebKeySetTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.Deserialize", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyConverterTest.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyConverterTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class JsonWebKeyConverterTest
     {
-        [Theory, MemberData(nameof(ConvertSecurityKeyToJsonWebKeyTheoryData))]
+        [Theory, MemberData(nameof(ConvertSecurityKeyToJsonWebKeyTheoryData), DisableDiscoveryEnumeration = true)]
         public void ConvertSecurityKeyToJsonWebKey(JsonWebKeyConverterTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ConvertSecurityKeyToJsonWebKey", theoryData);
@@ -32,7 +32,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(ConvertToJsonWebKeyToSecurityKeyTheoryData))]
+        [Theory, MemberData(nameof(ConvertToJsonWebKeyToSecurityKeyTheoryData), DisableDiscoveryEnumeration = true)]
         public void ConvertJsonWebKeyToSecurityKey(JsonWebKeyConverterTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ConvertJsonWebKeyToSecurityKey", theoryData);
@@ -52,7 +52,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(ConvertX509SecurityKeyToJsonWebKeyTheoryData))]
+        [Theory, MemberData(nameof(ConvertX509SecurityKeyToJsonWebKeyTheoryData), DisableDiscoveryEnumeration = true)]
         public void ConvertX509SecurityKeyAsRsaSecurityKeyToJsonWebKey(JsonWebKeyConverterTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ConvertX509SecurityKeyToJsonWebKeyTheoryData", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeySetTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
 {
     public class JsonWebKeySetTests
     {
-        [Theory, MemberData(nameof(ConstructorDataSet))]
+        [Theory, MemberData(nameof(ConstructorDataSet), DisableDiscoveryEnumeration = true)]
         public void Constructors(JsonWebKeySetTheoryData theoryData)
         {
             var context = new CompareContext(theoryData);
@@ -219,7 +219,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
             return null;
         }
 
-        [Theory, MemberData(nameof(GetSigningKeysTheoryData))]
+        [Theory, MemberData(nameof(GetSigningKeysTheoryData), DisableDiscoveryEnumeration = true)]
         public void GetSigningKeys(JsonWebKeySetTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetSigningKeys", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
 {
     public class JsonWebKeyTests
     {
-        [Theory, MemberData(nameof(ConstructorDataSet))]
+        [Theory, MemberData(nameof(ConstructorDataSet), DisableDiscoveryEnumeration = true)]
         public void Constructors(JsonWebKeyTheoryData theoryData)
         {
             var context = new CompareContext();
@@ -198,7 +198,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(ComputeJwkThumbprintTheoryData))]
+        [Theory, MemberData(nameof(ComputeJwkThumbprintTheoryData), DisableDiscoveryEnumeration = true)]
         public void ComputeJwkThumbprint(JwkThumbprintTheoryData theoryData)
         {
             Logging.IdentityModelEventSource.ShowPII = true;
@@ -217,7 +217,7 @@ namespace Microsoft.IdentityModel.Tokens.Json.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(ComputeJwkThumbprintTheoryData))]
+        [Theory, MemberData(nameof(ComputeJwkThumbprintTheoryData), DisableDiscoveryEnumeration = true)]
         public void CanComputeJwkThumbprint(JwkThumbprintTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CanComputeJwkThumbprint", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JweUsingEchdTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JweUsingEchdTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class JweUsingEcdhEsTests
     {
-        [Theory, MemberData(nameof(CreateEcdhEsTestCases), DisableDiscoveryEnumeration = true)]
+        [Theory, MemberData(nameof(CreateEcdhEsTestcases), DisableDiscoveryEnumeration = true)]
         public async Task CreateJweEcdhEsTests(CreateEcdhEsTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJweEcdhEsTests", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JweUsingEchdTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JweUsingEchdTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class JweUsingEcdhEsTests
     {
-        [Theory, MemberData(nameof(CreateEcdhEsTestcases))]
+        [Theory, MemberData(nameof(CreateEcdhEsTestCases), DisableDiscoveryEnumeration = true)]
         public async Task CreateJweEcdhEsTests(CreateEcdhEsTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJweEcdhEsTests", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/KeyVaultVerify.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/KeyVaultVerify.cs
@@ -13,7 +13,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class KeyVaultVerify
     {
-        [Theory, MemberData(nameof(KeyWrapTheoryData))]
+        [Theory, MemberData(nameof(KeyWrapTheoryData), DisableDiscoveryEnumeration = true)]
         public void DecryptValidate(KeyWrapTestParams testParams)
         {
             if (testParams.Algorithm.Equals(SecurityAlgorithms.Aes128KW, StringComparison.OrdinalIgnoreCase)
@@ -40,7 +40,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(KeyWrapTheoryData))]
+        [Theory, MemberData(nameof(KeyWrapTheoryData), DisableDiscoveryEnumeration = true)]
         public void EncryptValidate(KeyWrapTestParams testParams)
         {
             if (testParams.Algorithm.Equals(SecurityAlgorithms.Aes128KW, StringComparison.OrdinalIgnoreCase)

--- a/test/Microsoft.IdentityModel.Tokens.Tests/KeyWrapProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/KeyWrapProviderTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     /// </summary>
     public class KeyWrapProviderTests
     {
-        [Theory, MemberData(nameof(KeyWrapConstructorTestCases))]
+        [Theory, MemberData(nameof(KeyWrapConstructorTestCases), DisableDiscoveryEnumeration = true)]
         public void Constructors(SupportedAlgorithmTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.Constructors", theoryData);
@@ -109,7 +109,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Assert.True(provider.GetSymmetricAlgorithmCalled);
         }
 
-        [Theory, MemberData(nameof(WrapUnwrapTheoryData))]
+        [Theory, MemberData(nameof(WrapUnwrapTheoryData), DisableDiscoveryEnumeration = true)]
         public void WrapUnwrapKey(KeyWrapTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.WrapUnwrapKey", theoryData);
@@ -171,7 +171,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             });
         }
 
-        [Theory, MemberData(nameof(UnwrapTamperedTheoryData))]
+        [Theory, MemberData(nameof(UnwrapTamperedTheoryData), DisableDiscoveryEnumeration = true)]
         public void UnwrapTamperedData(KeyWrapTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.UnwrapTamperedData", theoryData);
@@ -217,7 +217,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             });
         }
 
-        [Theory, MemberData(nameof(UnwrapMismatchTheoryData))]
+        [Theory, MemberData(nameof(UnwrapMismatchTheoryData), DisableDiscoveryEnumeration = true)]
         public void UnwrapMismatch(KeyWrapTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.UnwrapMismatch", theoryData);
@@ -262,7 +262,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             });
         }
 
-        [Theory, MemberData(nameof(UnwrapTheoryData))]
+        [Theory, MemberData(nameof(UnwrapTheoryData), DisableDiscoveryEnumeration = true)]
         public void UnwrapParameterCheck(KeyWrapTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.UnwrapParameterCheck", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/MultiThreadingTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/MultiThreadingTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class MultiThreadingTokenTests
     {
-        [Theory, MemberData(nameof(MultiThreadingCreateAndVerifyTestCases))]
+        [Theory, MemberData(nameof(MultiThreadingCreateAndVerifyTestCases), DisableDiscoveryEnumeration = true)]
         public void MultiThreadingCreateAndVerify(MultiThreadingTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.MultiThreadingCreateAndVerify", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/ReferenceTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/ReferenceTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(AuthenticatedEncryptionTheoryData))]
+        [Theory, MemberData(nameof(AuthenticatedEncryptionTheoryData), DisableDiscoveryEnumeration = true)]
         public void AuthenticatedEncryptionReferenceTest(AuthenticationEncryptionTestParams testParams)
         {
             var context = TestUtilities.WriteHeader("AuthenticatedEncryptionReferenceTest", testParams);
@@ -167,7 +167,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(KeyWrapTheoryData))]
+        [Theory, MemberData(nameof(KeyWrapTheoryData), DisableDiscoveryEnumeration = true)]
         public void KeyWrapReferenceTest(KeyWrapTestParams testParams)
         {
             if (testParams.Algorithm.Equals(SecurityAlgorithms.Aes128KW, StringComparison.OrdinalIgnoreCase)

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaCryptoServiceProviderProxyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaCryptoServiceProviderProxyTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class RsaCryptoServiceProviderProxyTests
     {
-        [Theory, MemberData(nameof(RSADecryptTheoryData))]
+        [Theory, MemberData(nameof(RSADecryptTheoryData), DisableDiscoveryEnumeration = true)]
         public void RSADecrypt(RSACryptoServiceProviderProxyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RSADecrypt", theoryData);
@@ -36,7 +36,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(RSADecryptTheoryData))]
+        [Theory, MemberData(nameof(RSADecryptTheoryData), DisableDiscoveryEnumeration = true)]
         public void RSADecryptValue(RSACryptoServiceProviderProxyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RSADecryptValue", theoryData);
@@ -84,7 +84,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(RSAEncryptDecryptTheoryData))]
+        [Theory, MemberData(nameof(RSAEncryptDecryptTheoryData), DisableDiscoveryEnumeration = true)]
         public void RSAEncryptDecrypt(RSACryptoServiceProviderProxyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RSAEncryptDecrypt", theoryData);
@@ -158,7 +158,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(RSAEncryptDecryptValueTheoryData))]
+        [Theory, MemberData(nameof(RSAEncryptDecryptValueTheoryData), DisableDiscoveryEnumeration = true)]
         public void RSAEncryptDecryptValue(RSACryptoServiceProviderProxyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RSAEncryptDecryptValue", theoryData);
@@ -224,7 +224,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(RSASignVerifyDataTheoryData))]
+        [Theory, MemberData(nameof(RSASignVerifyDataTheoryData), DisableDiscoveryEnumeration = true)]
         public void RSASignVerifyData(RSACryptoServiceProviderProxyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RSASignVerifyData", theoryData);
@@ -304,7 +304,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(RSAVerifyDataTheoryData))]
+        [Theory, MemberData(nameof(RSAVerifyDataTheoryData), DisableDiscoveryEnumeration = true)]
         public void RSAVerifyData(RSACryptoServiceProviderProxyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RSAVerifyData", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaKeyWrapProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaKeyWrapProviderTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     /// </summary>
     public class RsaKeyWrapProviderTests
     {
-        [Theory, MemberData(nameof(RsaKeyWrapConstructorTheoryData))]
+        [Theory, MemberData(nameof(RsaKeyWrapConstructorTheoryData), DisableDiscoveryEnumeration = true)]
         public void Constructors(KeyWrapTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.Constructors", theoryData);
@@ -159,7 +159,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Assert.True(provider.WrapKeyCalled);
         }
 
-        [Theory, MemberData(nameof(RsaUnwrapMismatchTheoryData))]
+        [Theory, MemberData(nameof(RsaUnwrapMismatchTheoryData), DisableDiscoveryEnumeration = true)]
         public void RsaUnwrapMismatch(KeyWrapTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RsaUnwrapParameterCheck", theoryData);
@@ -214,7 +214,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             };
         }
 
-        [Theory, MemberData(nameof(RsaUnwrapTamperedTheoryData))]
+        [Theory, MemberData(nameof(RsaUnwrapTamperedTheoryData), DisableDiscoveryEnumeration = true)]
         public void RsaUnwrapTamperedData(KeyWrapTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RsaUnwrapParameterCheck", theoryData);
@@ -273,7 +273,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             });
         }
 
-        [Theory, MemberData(nameof(RsaUnwrapTheoryData))]
+        [Theory, MemberData(nameof(RsaUnwrapTheoryData), DisableDiscoveryEnumeration = true)]
         public void RsaUnwrapParameterCheck(KeyWrapTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RsaUnwrapParameterCheck", theoryData);
@@ -315,7 +315,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             };
         }
 
-        [Theory, MemberData(nameof(RsaWrapUnwrapTheoryData))]
+        [Theory, MemberData(nameof(RsaWrapUnwrapTheoryData), DisableDiscoveryEnumeration = true)]
         public void RsaWrapUnwrapKey(KeyWrapTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RsaWrapUnwrapKey", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/RsaSecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/RsaSecurityKeyTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(HasPrivateKeyTheoryData))]
+        [Theory, MemberData(nameof(HasPrivateKeyTheoryData), DisableDiscoveryEnumeration = true)]
         public void HasPrivateKey(string testId, RsaSecurityKey key, bool expected)
         {
             if (expected)

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 #endif
         }
 
-        [Theory, MemberData(nameof(CompareJwkThumbprintsTestCases))]
+        [Theory, MemberData(nameof(CompareJwkThumbprintsTestCases), DisableDiscoveryEnumeration = true)]
         public void CompareJwkThumbprints(JsonWebKeyConverterTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CompareJwkThumbprints", theoryData);
@@ -107,7 +107,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateInternalIdsTestCases))]
+        [Theory, MemberData(nameof(CreateInternalIdsTestCases), DisableDiscoveryEnumeration = true)]
         public void CreateInternalIds(SecurityKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateInternalIds", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SecurityTokenExceptionTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SecurityTokenExceptionTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class SecurityTokenExceptionTests
     {
-        [Theory, MemberData(nameof(ExceptionTestData))]
+        [Theory, MemberData(nameof(ExceptionTestData), DisableDiscoveryEnumeration = true)]
         public void SecurityTokenExceptionSerializationTests(SecurityTokenExceptionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.{nameof(SecurityTokenExceptionSerializationTests)}", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     /// </summary>
     public class SignatureProviderTests
     {
-        [Theory, MemberData(nameof(SignatureProviderConstructorParamsTheoryData))]
+        [Theory, MemberData(nameof(SignatureProviderConstructorParamsTheoryData), DisableDiscoveryEnumeration = true)]
         public void CryptoProviderFactoryConstructorParams(CryptoProviderFactoryTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CryptoProviderFactoryConstructorParams", theoryData);
@@ -47,7 +47,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(SignatureProviderConstructorParamsTheoryData))]
+        [Theory, MemberData(nameof(SignatureProviderConstructorParamsTheoryData), DisableDiscoveryEnumeration = true)]
         public void AsymmetricSignatureProviderConstructorParams(SignatureProviderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.AsymmetricSignatureProviderConstructorParams", theoryData);
@@ -65,7 +65,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(SignatureProviderConstructorParamsTheoryData))]
+        [Theory, MemberData(nameof(SignatureProviderConstructorParamsTheoryData), DisableDiscoveryEnumeration = true)]
         public void SymmetricSignatureProviderConstructorParams(SignatureProviderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SymmetricSignatureProviderConstructorParams", theoryData);
@@ -117,7 +117,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         /// Tests Asymmetric SecurityKeys
         /// </summary>
         /// <param name="theoryData"></param>
-        [Theory, MemberData(nameof(AsymmetricSignAndVerifyTheoryData))]
+        [Theory, MemberData(nameof(AsymmetricSignAndVerifyTheoryData), DisableDiscoveryEnumeration = true)]
         public void AsymmetricSignAndVerify(SignatureProviderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.AsymmetricSignAndVerify", theoryData);
@@ -209,7 +209,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             };
         }
 
-        [Theory, MemberData(nameof(SymmetricSignAndVerifyTheoryData))]
+        [Theory, MemberData(nameof(SymmetricSignAndVerifyTheoryData), DisableDiscoveryEnumeration = true)]
         public void SymmetricSignAndVerify(SignatureProviderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SignAndVerify", theoryData);
@@ -406,7 +406,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
         }
 
-        [Theory, MemberData(nameof(AsymmetricSignatureProviderVerifyParameterChecksTheoryData))]
+        [Theory, MemberData(nameof(AsymmetricSignatureProviderVerifyParameterChecksTheoryData), DisableDiscoveryEnumeration = true)]
         public void AsymmetricSignatureProviderVerifyParameterChecks(SignatureProviderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.AsymmetricSignatureProviderVerifyParameterChecks", theoryData);
@@ -466,7 +466,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(SymmetricSignatureProviderVerifyParameterChecksTheoryData))]
+        [Theory, MemberData(nameof(SymmetricSignatureProviderVerifyParameterChecksTheoryData), DisableDiscoveryEnumeration = true)]
         public void SymmetricSignatureProviderVerifyParameterChecks(SignatureProviderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SymmetricSignatureProviderVerifyParameterChecks", theoryData);
@@ -526,7 +526,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(SymmetricVerifySignatureSizeTheoryData))]
+        [Theory, MemberData(nameof(SymmetricVerifySignatureSizeTheoryData), DisableDiscoveryEnumeration = true)]
         public void SymmetricVerify1Tests(SignatureProviderTheoryData theoryData)
         {
             // verifies: public bool Verify(byte[] input, byte[] signature)
@@ -544,7 +544,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(SymmetricVerifySignatureSizeTheoryData))]
+        [Theory, MemberData(nameof(SymmetricVerifySignatureSizeTheoryData), DisableDiscoveryEnumeration = true)]
         public void SymmetricVerify2Tests(SignatureProviderTheoryData theoryData)
         {
             // verifies: public bool Verify(byte[] input, byte[] signature, int length)
@@ -562,7 +562,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(SymmetricVerifySignatureSizeTheoryData))]
+        [Theory, MemberData(nameof(SymmetricVerifySignatureSizeTheoryData), DisableDiscoveryEnumeration = true)]
         public void SymmetricVerify3Tests(SignatureProviderTheoryData theoryData)
         {
             // verifies: public override bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength)
@@ -611,7 +611,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(SymmetricVerifySignatureSizeInternalTheoryData))]
+        [Theory, MemberData(nameof(SymmetricVerifySignatureSizeInternalTheoryData), DisableDiscoveryEnumeration = true)]
         public void SymmetricVerify4Tests(SignatureProviderTheoryData theoryData)
         {
             // verifies: internal bool Verify(byte[] input, int inputOffset, int inputLength, byte[] signature, int signatureOffset, int signatureLength, string algorithm)
@@ -698,7 +698,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(SymmetricSecurityKeySizesTheoryData))]
+        [Theory, MemberData(nameof(SymmetricSecurityKeySizesTheoryData), DisableDiscoveryEnumeration = true)]
         public void SymmetricSecurityKeySizesSign(SymmetricSignatureProviderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SymmetricSecurityKeySizes", theoryData);
@@ -717,7 +717,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(SymmetricSecurityKeySizesTheoryData))]
+        [Theory, MemberData(nameof(SymmetricSecurityKeySizesTheoryData), DisableDiscoveryEnumeration = true)]
         public void SymmetricSecurityKeySizesVerify(SymmetricSignatureProviderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SymmetricSecurityKeySizes", theoryData);
@@ -819,7 +819,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(KeyDisposeData))]
+        [Theory, MemberData(nameof(KeyDisposeData), DisableDiscoveryEnumeration = true)]
         public void SignatureProviderDispose_Test(string testId, SecurityKey securityKey, string algorithm, ExpectedException ee)
         {
             try
@@ -938,7 +938,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(SignatureTheoryData))]
+        [Theory, MemberData(nameof(SignatureTheoryData), DisableDiscoveryEnumeration = true)]
         public void SignatureTampering(SignatureProviderTheoryData theoryData)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -970,7 +970,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(SignatureTheoryData))]
+        [Theory, MemberData(nameof(SignatureTheoryData), DisableDiscoveryEnumeration = true)]
         public void SignatureTruncation(SignatureProviderTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.SignatureTruncation", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/StaticCryptoProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/StaticCryptoProviderTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests.Static
         /// Tests that we can set the default <see cref="CompressionProviderFactory"/>.
         /// </summary>
         /// <param name="theoryData"></param>
-        [Theory, MemberData(nameof(CompressionFactoryTestsTheoryData))]
+        [Theory, MemberData(nameof(CompressionFactoryTestsTheoryData), DisableDiscoveryEnumeration = true)]
         public void CompressionFactoryTests(CompressionProviderFactoryTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CompressionFactoryTests", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SupportedAlgorithmTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SupportedAlgorithmTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         /// 2. Our default algorithms are supported.
         /// </summary>
         /// <param name="theoryData"></param>
-        [Theory, MemberData(nameof(IsSupportedAlgorithmAndKeyTestCases))]
+        [Theory, MemberData(nameof(IsSupportedAlgorithmAndKeyTestCases), DisableDiscoveryEnumeration = true)]
         public void IsSupportedAlgorithmAndKey(SupportedAlgorithmTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.IsSupportedAlgorithm", theoryData);
@@ -174,7 +174,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(IsSymmetricKeyWrapSupportedTests))]
+        [Theory, MemberData(nameof(IsSymmetricKeyWrapSupportedTests), DisableDiscoveryEnumeration = true)]
         public void IsSymmetricKeyWrapSupported(SupportedAlgorithmTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.IsSymmetricKeyWrapSupported", theoryData);
@@ -215,7 +215,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(GetDigestFromSignatureAlgorithmTests))]
+        [Theory, MemberData(nameof(GetDigestFromSignatureAlgorithmTests), DisableDiscoveryEnumeration = true)]
         public void GetDigestFromSignatureAlgorithm(SupportedAlgorithmTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetDigestFromSignatureAlgorithm", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SymmetricSecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SymmetricSecurityKeyTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
     public class SymmetricSecurityKeyTests
     {
 
-        [Theory, MemberData(nameof(ConstructorDataSet))]
+        [Theory, MemberData(nameof(ConstructorDataSet), DisableDiscoveryEnumeration = true)]
         public void Constructor(byte[] key, EE ee)
         {
             try

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TamperedTokenTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TamperedTokenTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class TamperedTokenTests
     {
-        [Theory, MemberData(nameof(JwtSignatureTruncationTheoryData))]
+        [Theory, MemberData(nameof(JwtSignatureTruncationTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task JwtSignatureTruncation(ValidateTokenTheoryData theoryData)
         {
             CompareContext compareContext = TestUtilities.WriteHeader($"{this}.JwtSignatureTruncation", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidatorsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidatorsTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class ValidatorsTests
     {
-        [Theory, MemberData(nameof(ValidateAudienceParametersTheoryData))]
+        [Theory, MemberData(nameof(ValidateAudienceParametersTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateAudienceParameters(AudienceValidationTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateAudienceParameters", theoryData);
@@ -118,7 +118,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateAudienceTheoryData))]
+        [Theory, MemberData(nameof(ValidateAudienceTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateAudience(AudienceValidationTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateAudience", theoryData);
@@ -280,7 +280,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(IssuerDataSet))]
+        [Theory, MemberData(nameof(IssuerDataSet), DisableDiscoveryEnumeration = true)]
         public void Issuer(string issuer, SecurityToken securityToken, TokenValidationParameters validationParameters, BaseConfiguration configuration, ExpectedException ee)
         {
             try
@@ -319,7 +319,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(LifeTimeDataSet))]
+        [Theory, MemberData(nameof(LifeTimeDataSet), DisableDiscoveryEnumeration = true)]
         public void Lifetime(DateTime? notBefore, DateTime? expires, SecurityToken securityToken, TokenValidationParameters validationParameters, ExpectedException ee)
         {
             try
@@ -374,7 +374,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(SecurityKeyDataSet))]
+        [Theory, MemberData(nameof(SecurityKeyDataSet), DisableDiscoveryEnumeration = true)]
         public void SecurityKey(SecurityKey securityKey, SecurityToken securityToken, TokenValidationParameters validationParameters, ExpectedException ee)
         {
             try
@@ -410,7 +410,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
         }
 
-        [Theory, MemberData(nameof(TokenReplayDataSet))]
+        [Theory, MemberData(nameof(TokenReplayDataSet), DisableDiscoveryEnumeration = true)]
         public void TokenReplay(string securityToken, DateTime? expirationTime, TokenValidationParameters validationParameters, ExpectedException ee)
         {
             try
@@ -444,7 +444,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
         // Each TokenReplayValidator in this test checks that the expiration parameter passed into it is equal to the expiration time of the token.
         // If they're not equal, the test will fail.
-        [Theory, MemberData(nameof(CheckParametersForTokenReplayTheoryData))]
+        [Theory, MemberData(nameof(CheckParametersForTokenReplayTheoryData), DisableDiscoveryEnumeration = true)]
         public void CheckParametersForTokenReplay(TokenReplayTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.CheckParametersForTokenReplay", theoryData);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/X509EncryptingCredentialsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/X509EncryptingCredentialsTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class X509EncryptingCredentialsTests
     {
-        [Theory, MemberData(nameof(ConstructorsTheoryData))]
+        [Theory, MemberData(nameof(ConstructorsTheoryData), DisableDiscoveryEnumeration = true)]
         public void Constructors(X509EncryptingCredentialsTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.Constructors", theoryData);

--- a/test/Microsoft.IdentityModel.Validators.Tests/AadIssuerValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/AadIssuerValidatorTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
 {
     public class AadIssuerValidatorTests
     {
-        [Theory, MemberData(nameof(AadIssuerValidationTestCases))]
+        [Theory, MemberData(nameof(AadIssuerValidationTestCases), DisableDiscoveryEnumeration = true)]
         public static void IsValidIssuer_ValidatesIssuersCorrectly(AadIssuerValidatorTheoryData theoryData)
         {
             // Act

--- a/test/Microsoft.IdentityModel.Validators.Tests/AadTokenValidationParametersExtensionTests.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/AadTokenValidationParametersExtensionTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
     [Collection(nameof(AadTokenValidationParametersExtensionTests))]
     public class AadTokenValidationParametersExtensionTests
     {
-        [Theory, MemberData(nameof(EnableEntraIdSigningKeyCloudInstanceValidationTestCases))]
+        [Theory, MemberData(nameof(EnableEntraIdSigningKeyCloudInstanceValidationTestCases), DisableDiscoveryEnumeration = true)]
         public async Task EnableEntraIdSigningKeyCloudInstanceValidationTests(EnableEntraIdSigningKeyValidationTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.EnableAadSigningKeyValidationTests", theoryData);
@@ -159,7 +159,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(EnableAadSigningKeyIssuerValidationTestCases))]
+        [Theory, MemberData(nameof(EnableAadSigningKeyIssuerValidationTestCases), DisableDiscoveryEnumeration = true)]
         public async Task EnableAadSigningKeyIssuerValidationTests(EnableEntraIdSigningKeyValidationTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.EnableAadSigningKeyIssuerValidationTests", theoryData);
@@ -228,7 +228,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(ValidateSigningKeyCloudInstanceNameTestCases))]
+        [Theory, MemberData(nameof(ValidateSigningKeyCloudInstanceNameTestCases), DisableDiscoveryEnumeration = true)]
         public void ValidateSigningKeyCloudInstanceNameTests(AadSigningKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateSigningKeyCloudInstanceNameTests", theoryData);
@@ -327,7 +327,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateIssuerSigningKeyCertificateTestCases))]
+        [Theory, MemberData(nameof(ValidateIssuerSigningKeyCertificateTestCases), DisableDiscoveryEnumeration = true)]
         public void ValidateIssuerSigningKeyCertificateTests(AadSigningKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateIssuerSigningKeyCertificateTests", theoryData);
@@ -392,7 +392,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(ValidateIssuerSigningKeyTestCases))]
+        [Theory, MemberData(nameof(ValidateIssuerSigningKeyTestCases), DisableDiscoveryEnumeration = true)]
         public void ValidateIssuerSigningKeyTests(AadSigningKeyTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateIssuerSigningKeyTests", theoryData);

--- a/test/Microsoft.IdentityModel.Xml.Tests/DSigSerializerTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/DSigSerializerTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             TestUtilities.AssertFailIfErrors("DSigSerializerTests_GetSets", context.Errors);
         }
 
-        [Theory, MemberData(nameof(ReadKeyInfoTheoryData))]
+        [Theory, MemberData(nameof(ReadKeyInfoTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadKeyInfo(DSigSerializerTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadKeyInfo", theoryData);
@@ -100,7 +100,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(WriteKeyInfoTheoryData))]
+        [Theory, MemberData(nameof(WriteKeyInfoTheoryData), DisableDiscoveryEnumeration = true)]
         public void WriteKeyInfo(DSigSerializerTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.WriteKeyInfo", theoryData);
@@ -148,7 +148,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             };
         }
 
-        [Theory, MemberData(nameof(ReadSignatureTheoryData))]
+        [Theory, MemberData(nameof(ReadSignatureTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadSignature(DSigSerializerTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadSignature", theoryData);
@@ -236,7 +236,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(WriteSignatureTheoryData))]
+        [Theory, MemberData(nameof(WriteSignatureTheoryData), DisableDiscoveryEnumeration = true)]
         public void WriteSignature(DSigSerializerTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.WriteSignature", theoryData);
@@ -287,7 +287,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             };
         }
 
-        [Theory, MemberData(nameof(ReadSignedInfoTheoryData))]
+        [Theory, MemberData(nameof(ReadSignedInfoTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadSignedInfo(DSigSerializerTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadSignedInfo", theoryData);
@@ -337,7 +337,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(WriteSignedInfoTheoryData))]
+        [Theory, MemberData(nameof(WriteSignedInfoTheoryData), DisableDiscoveryEnumeration = true)]
         public void WriteSignedInfo(DSigSerializerTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.WriteSignedInfo", theoryData);
@@ -387,7 +387,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             };
         }
 
-        [Theory, MemberData(nameof(ReadReferenceTheoryData))]
+        [Theory, MemberData(nameof(ReadReferenceTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadReference(DSigSerializerTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadReference", theoryData);
@@ -433,7 +433,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             };
         }
 
-        [Theory, MemberData(nameof(ReadTransformsTheoryData))]
+        [Theory, MemberData(nameof(ReadTransformsTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadTransforms(DSigSerializerTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadTransform", theoryData);
@@ -506,7 +506,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             };
         }
 
-        [Theory, MemberData(nameof(ReadTransformTheoryData))]
+        [Theory, MemberData(nameof(ReadTransformTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadTransform(DSigSerializerTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadTransforms", theoryData);
@@ -553,7 +553,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             };
         }
 
-        [Theory, MemberData(nameof(WriteReferenceTheoryData))]
+        [Theory, MemberData(nameof(WriteReferenceTheoryData), DisableDiscoveryEnumeration = true)]
         public void WriteReference(DSigSerializerTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.WriteReference", theoryData);

--- a/test/Microsoft.IdentityModel.Xml.Tests/DelegatingXmlDictionaryReaderTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/DelegatingXmlDictionaryReaderTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
 {
     public class DelegatingXmlDictionaryReaderTests
     {
-        [Theory, MemberData(nameof(ReadXmlTheoryData))]
+        [Theory, MemberData(nameof(ReadXmlTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadXml(DelegatingXmlDictionaryReaderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadXml", theoryData);
@@ -40,7 +40,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(ReadPartialXmlWithUniqueIdTheoryData))]
+        [Theory, MemberData(nameof(ReadPartialXmlWithUniqueIdTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadPartialXml(DelegatingXmlDictionaryReaderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadXml", theoryData);

--- a/test/Microsoft.IdentityModel.Xml.Tests/DelegatingXmlDictionaryWriterTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/DelegatingXmlDictionaryWriterTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
 {
     public class DelegatingXmlDictionaryWriterTests
     {
-        [Theory, MemberData(nameof(WriteXmlTheoryData))]
+        [Theory, MemberData(nameof(WriteXmlTheoryData), DisableDiscoveryEnumeration = true)]
         public void WriteXml(DelegatingXmlDictionaryWriterTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.WriteXml", theoryData);

--- a/test/Microsoft.IdentityModel.Xml.Tests/EnvelopedSignatureReaderTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/EnvelopedSignatureReaderTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
             TestUtilities.AssertFailIfErrors($"{this}.GetSets", context.Errors);
         }
 
-        [Theory, MemberData(nameof(ConstructorTheoryData))]
+        [Theory, MemberData(nameof(ConstructorTheoryData), DisableDiscoveryEnumeration = true)]
         public void Constructor(EnvelopedSignatureTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.Constructor", theoryData);
@@ -83,7 +83,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ReadSignedXmlTheoryData))]
+        [Theory, MemberData(nameof(ReadSignedXmlTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadSignedXml(EnvelopedSignatureTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadSignedXml", theoryData);
@@ -163,7 +163,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ReadXmlElementsTheoryData))]
+        [Theory, MemberData(nameof(ReadXmlElementsTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadXmlElements(EnvelopedSignatureTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ReadXmlElements", theoryData);

--- a/test/Microsoft.IdentityModel.Xml.Tests/EnvelopedSignatureWriterTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/EnvelopedSignatureWriterTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
 {
     public class EnvelopedSignatureWriterTests
     {
-        [Theory, MemberData(nameof(ConstructorTestCases))]
+        [Theory, MemberData(nameof(ConstructorTestCases), DisableDiscoveryEnumeration = true)]
         public void Constructor(EnvelopedSignatureTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.Constructor", theoryData);
@@ -60,7 +60,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(CreateSignatureWithoutSpecifyingDigestTestCases))]
+        [Theory, MemberData(nameof(CreateSignatureWithoutSpecifyingDigestTestCases), DisableDiscoveryEnumeration = true)]
         public void CreateSignatureWithoutSpecifyingDigest(EnvelopedSignatureTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateSignatureWithoutSpecifyingDigest", theoryData);
@@ -149,7 +149,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
             };
         }
 
-        [Theory, MemberData(nameof(RoundTripSaml2TestCases))]
+        [Theory, MemberData(nameof(RoundTripSaml2TestCases), DisableDiscoveryEnumeration = true)]
         public void RoundTripSaml2(EnvelopedSignatureTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RoundTripSaml2", theoryData);
@@ -202,7 +202,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(RoundTripWsMetadataTestCases))]
+        [Theory, MemberData(nameof(RoundTripWsMetadataTestCases), DisableDiscoveryEnumeration = true)]
         public void RoundTripWsMetadata(EnvelopedSignatureTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.RoundTripWsMetadata", theoryData);

--- a/test/Microsoft.IdentityModel.Xml.Tests/ExclusiveCanonicalizationTransformTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/ExclusiveCanonicalizationTransformTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
             TestUtilities.AssertFailIfErrors($"{this}.GetSets", context.Errors);
         }
 
-        [Theory, MemberData(nameof(ConstructorTheoryData))]
+        [Theory, MemberData(nameof(ConstructorTheoryData), DisableDiscoveryEnumeration = true)]
         public void Constructor(ExclusiveCanonicalizationTransformTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.Constructor", theoryData);
@@ -83,7 +83,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ProcessAndDigestTheoryData))]
+        [Theory, MemberData(nameof(ProcessAndDigestTheoryData), DisableDiscoveryEnumeration = true)]
         public void ProcessAndDigest(ExclusiveCanonicalizationTransformTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}", "ProcessAndDigest", true);

--- a/test/Microsoft.IdentityModel.Xml.Tests/IssuerSerialTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/IssuerSerialTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             Assert.True(Enumerable.SequenceEqual(list, secondList));
         }
 
-        [Theory, MemberData(nameof(IssuerSerialComparisonData))]
+        [Theory, MemberData(nameof(IssuerSerialComparisonData), DisableDiscoveryEnumeration = true)]
         public void IssuerSerial_HashCodeTests(IssuerSerialComparisonTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.{nameof(IssuerSerial_HashCodeTests)}", theoryData);
@@ -62,7 +62,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(IssuerSerialComparisonData))]
+        [Theory, MemberData(nameof(IssuerSerialComparisonData), DisableDiscoveryEnumeration = true)]
         public void IssuerSerial_EqualsTests(IssuerSerialComparisonTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.{nameof(IssuerSerial_EqualsTests)}", theoryData);

--- a/test/Microsoft.IdentityModel.Xml.Tests/KeyInfoTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/KeyInfoTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
 
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
 
-        [Theory, MemberData(nameof(KeyInfoDataComparisonData))]
+        [Theory, MemberData(nameof(KeyInfoDataComparisonData), DisableDiscoveryEnumeration = true)]
         public void KeyInfo_HashCodeTests(KeyInfoComparisonTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.${nameof(KeyInfo_HashCodeTests)}", theoryData);
@@ -98,7 +98,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
         }
 
 
-        [Theory, MemberData(nameof(KeyInfoDataComparisonData))]
+        [Theory, MemberData(nameof(KeyInfoDataComparisonData), DisableDiscoveryEnumeration = true)]
         public void KeyInfo_EqualsTests(KeyInfoComparisonTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.{nameof(KeyInfo_EqualsTests)}", theoryData);

--- a/test/Microsoft.IdentityModel.Xml.Tests/ReferenceTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/ReferenceTests.cs
@@ -80,7 +80,7 @@ return</saml:AttributeValue></saml:Attribute></saml:AttributeStatement><saml:Aut
             //MIIDCDCCAfCgAwIBAgIQNz4YVbYAIJVFCc47HFD3RzANBgkqhkiG9w0BAQsFADBAMT4wPAYDVQQDEzVBREZTIFNpZ25pbmcgLSBzdHMuc3ViMi5mcmFjYXMzNjUubXNmdG9ubGluZXJlcHJvLmNvbTAeFw0xNTAzMzExMDQyMTNaFw0zNDA1MzAxMDQyMTNaMEAxPjA8BgNVBAMTNUFERlMgU2lnbmluZyAtIHN0cy5zdWIyLmZyYWNhczM2NS5tc2Z0b25saW5lcmVwcm8uY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxdjzB+wGV6hYekOvWwKoL/DFNBiLQsLx6w02FzcFnpGwR38gVTn/glg9CNSsOT0riRM3/MwU8o2fwseQyVtv9Kee/yvia8cB6GD0CARlYizb6GkJJzMvWkPSas1zpn10Bs3SBBgn0pvAKZCWWir5WJ7DRY32X2yo2do8mQftsoLGYsEU8+jj9AMYQWaR3A86AEWjXoQY3AodfMMzdVFX+O/kjsvKcBfPqGRT6jUSGBOOaqzMOJBT39SueD8zePDW7SejBl7fRi4TLx5H6xuMldOAAH6oD70yIrobqosGG9X/LdijHajMSoaYzZIlG7fl4PCVvAjh1Dytw/y8K70flQIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBy08dAsSTKd2YlNE8bM4O5C2bFKR1YakR8L/zLEy8g+RNsKN5V/cIll0b/tf9iQ5464nc+nM///U+UVxqT8ipeR7ThIPwuWX98cFZFQNNGkha4PaYap/osquEpRAJOcTqZf2K95ipeQ+5Hhw00mK0hcV1QT/7maTUqCHDfBCaD+uYAFvaNBXOYpdoIGM9cMk7Qjc/yowLDm+DpmJek54MWmN+iZ0YtDEhMSh//QPFMLPT5Ucat+qRTen1HZNGdxfZ7NIIDL3dNKVDN+vDUbW7rjvPyxA8Rtj4JplI9ENqpzRq4m1sDWUTk2hJYw9Ec1kGo7AFKRmOS6DRbwUn5Ptdc
         }
 
-        [Theory, MemberData(nameof(VerifyTheoryData))]
+        [Theory, MemberData(nameof(VerifyTheoryData), DisableDiscoveryEnumeration = true)]
         public void Verify(ReferenceTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.Verify", theoryData);

--- a/test/Microsoft.IdentityModel.Xml.Tests/RsaKeyValueTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/RsaKeyValueTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             Assert.True(inCollection);
         }
 
-        [Theory, MemberData(nameof(IssuerSerialComparisonData))]
+        [Theory, MemberData(nameof(IssuerSerialComparisonData), DisableDiscoveryEnumeration = true)]
         public void RsaKeyValue_HashCodeTests(RsaKeyValueComparisonTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.{nameof(RsaKeyValue_HashCodeTests)}", theoryData);
@@ -61,7 +61,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(IssuerSerialComparisonData))]
+        [Theory, MemberData(nameof(IssuerSerialComparisonData), DisableDiscoveryEnumeration = true)]
         public void RsaKeyValue_EqualsTests(RsaKeyValueComparisonTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.{nameof(RsaKeyValue_EqualsTests)}", theoryData);

--- a/test/Microsoft.IdentityModel.Xml.Tests/SignatureTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/SignatureTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             TestUtilities.AssertFailIfErrors($"{this}.Publics", context.Errors);
         }
 
-        [Theory, MemberData(nameof(ConstructorTheoryData))]
+        [Theory, MemberData(nameof(ConstructorTheoryData), DisableDiscoveryEnumeration = true)]
         public void Constructor(SignatureTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.Constructor", theoryData);
@@ -97,7 +97,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             }
         }
 
-        [Theory, MemberData(nameof(VerifyTheoryData))]
+        [Theory, MemberData(nameof(VerifyTheoryData), DisableDiscoveryEnumeration = true)]
         public void Verify(SignatureTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.Verify", theoryData);

--- a/test/Microsoft.IdentityModel.Xml.Tests/SignedInfoTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/SignedInfoTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             TestUtilities.AssertFailIfErrors($"{this}.GetSets", context.Errors);
         }
 
-        [Theory, MemberData(nameof(SignedInfoConstructorTheoryData))]
+        [Theory, MemberData(nameof(SignedInfoConstructorTheoryData), DisableDiscoveryEnumeration = true)]
         public void SignedInfoConstructor(SignedInfoTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.SignedInfoConstructor", theoryData);

--- a/test/Microsoft.IdentityModel.Xml.Tests/TransformFactoryTest.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/TransformFactoryTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
 {
     public class TransformFactoryTest
     {
-        [Theory, MemberData(nameof(GetTransformTestTheoryData))]
+        [Theory, MemberData(nameof(GetTransformTestTheoryData), DisableDiscoveryEnumeration = true)]
         public void GetTransformTest(TransformTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetTransformTest", theoryData);
@@ -48,7 +48,7 @@ namespace Microsoft.IdentityModel.Tokens.Xml.Tests
             };
         }
 
-        [Theory, MemberData(nameof(GetCanonicalizingTransformTestTheoryData))]
+        [Theory, MemberData(nameof(GetCanonicalizingTransformTestTheoryData), DisableDiscoveryEnumeration = true)]
         public void GetCanonicalizingTransformTest(TransformTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.GetCanonicalizingTransformTest", theoryData);

--- a/test/Microsoft.IdentityModel.Xml.Tests/X509DataTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/X509DataTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
             Assert.True(inCollection);
         }
 
-        [Theory, MemberData(nameof(X509DataComparisonData))]
+        [Theory, MemberData(nameof(X509DataComparisonData), DisableDiscoveryEnumeration = true)]
         public void X509Data_HashCodeTests(X509DataComparisonTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.{nameof(X509Data_HashCodeTests)}", theoryData);
@@ -72,7 +72,7 @@ namespace Microsoft.IdentityModel.Xml.Tests
         }
 
 
-        [Theory, MemberData(nameof(X509DataComparisonData))]
+        [Theory, MemberData(nameof(X509DataComparisonData), DisableDiscoveryEnumeration = true)]
         public void X509Data_EqualsTests(X509DataComparisonTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.{nameof(X509Data_EqualsTests)}", theoryData);

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/CreateAndValidateTokens.cs
@@ -165,7 +165,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             TestUtilities.AssertFailIfErrors(context.Diffs);
         }
 
-        [Theory, MemberData(nameof(RoundTripTokensUsingCacheTheoryData))]
+        [Theory, MemberData(nameof(RoundTripTokensUsingCacheTheoryData), DisableDiscoveryEnumeration = true)]
         public void RoundTripTokensUsingCache(JwtTheoryData theoryData)
         {
             var handler = new JwtSecurityTokenHandler();
@@ -390,7 +390,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
 
-        [Theory, MemberData(nameof(RoundTripTokensTheoryData))]
+        [Theory, MemberData(nameof(RoundTripTokensTheoryData), DisableDiscoveryEnumeration = true)]
         public void RoundTripTokens(JwtTheoryData theoryData)
         {
             var handler = new JwtSecurityTokenHandler();
@@ -636,7 +636,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(SerializeDeserializeJwtTokensTheoryData))]
+        [Theory, MemberData(nameof(SerializeDeserializeJwtTokensTheoryData), DisableDiscoveryEnumeration = true)]
         public void SerializeDeserializeJwtTokens(JwtTheoryData theoryData)
         {
             var handler = new JwtSecurityTokenHandler();
@@ -679,7 +679,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
         }
 
-        [Theory, MemberData(nameof(RoundTripJWEParams))]
+        [Theory, MemberData(nameof(RoundTripJWEParams), DisableDiscoveryEnumeration = true)]
         public void RoundTripJWETokens(string testId, SecurityTokenDescriptor tokenDescriptor, TokenValidationParameters validationParameters, ExpectedException ee)
         {
             var handler = new JwtSecurityTokenHandler();
@@ -875,7 +875,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(CreationJWEParams))]
+        [Theory, MemberData(nameof(CreationJWEParams), DisableDiscoveryEnumeration = true)]
         public void CreateJWETokens(string testId, string jweToken, TokenValidationParameters validationParameters, JwtPayload expectedPayload, ExpectedException ee)
         {
             var handler = new JwtSecurityTokenHandler();

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtHeaderTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtHeaderTests.cs
@@ -41,7 +41,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             Assert.True(jwtHeader.Comparer.GetType() == StringComparer.Ordinal.GetType(), "jwtHeader.Comparer.GetType() != StringComparer.Ordinal.GetType()");
         }
 
-        [Theory, MemberData(nameof(ConstructorTheoryData))]
+        [Theory, MemberData(nameof(ConstructorTheoryData), DisableDiscoveryEnumeration = true)]
         public void Constructors(JwtHeaderTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.Constructors", theoryData);

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
@@ -191,7 +191,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             Assert.True(DateTime.MaxValue == expirationTime, "EpochTime.DateTime( time ) != jwtPayload.ValidTo");
         }
 
-        [Theory, MemberData(nameof(PayloadDataSet))]
+        [Theory, MemberData(nameof(PayloadDataSet), DisableDiscoveryEnumeration = true)]
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters
         public void RoundTrip(string name, List<Claim> claims, JwtPayload payloadDirect, JwtPayload payloadUsingNewtonsoft)
 #pragma warning restore xUnit1026 // Theory methods should use all of their parameters

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtReferenceTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtReferenceTests.cs
@@ -12,7 +12,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 {
     public class JwtReferenceTests
     {
-        [Theory, MemberData(nameof(Base64UrlEncodingTheoryData))]
+        [Theory, MemberData(nameof(Base64UrlEncodingTheoryData), DisableDiscoveryEnumeration = true)]
         public void Base64UrlEncoding(string testId, string dataToEncode, string encodedData)
         {
             TestUtilities.WriteHeader($"Base64UrlEncoding - {testId}", true);
@@ -35,7 +35,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
         }
 
-        [Theory, MemberData(nameof(JwtEncodingTheoryData))]
+        [Theory, MemberData(nameof(JwtEncodingTheoryData), DisableDiscoveryEnumeration = true)]
         public void JwtEncoding(string testId, JwtHeader header, string encodedData)
         {
             TestUtilities.WriteHeader($"JwtEncoding - {testId}", true);
@@ -56,7 +56,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
         }
 
-        [Theory, MemberData(nameof(JwtSigningTheoryData))]
+        [Theory, MemberData(nameof(JwtSigningTheoryData), DisableDiscoveryEnumeration = true)]
         public void JwtSigning(JwtSigningTestParams testParams)
         {
             var providerForSigning = CryptoProviderFactory.Default.CreateForSigning(testParams.PrivateKey, testParams.Algorithm);

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenConverterTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenConverterTests.cs
@@ -20,7 +20,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             Assert.Throws<ArgumentNullException>(() => JwtSecurityTokenConverter.Convert(null));
         }
 
-        [Theory, MemberData(nameof(ConverterTheoryData))]
+        [Theory, MemberData(nameof(ConverterTheoryData), DisableDiscoveryEnumeration = true)]
         public void JsonWebTokenToJwtSecurityTokenConversions(JwtSecurityTokenConverterTheoryData theoryData)
         {
             var output = JwtSecurityTokenConverter.Convert(theoryData.InputToken);

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerExtensibilityTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerExtensibilityTests.cs
@@ -11,7 +11,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 {
     public class JwtSecurityTokenHandlerExtensibilityTests
     {
-        [Theory, MemberData(nameof(DecryptTokenTheoryData))]
+        [Theory, MemberData(nameof(DecryptTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void DecryptToken(TheoryParams theoryParams)
         {
             try

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -56,7 +56,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 Assert.NotNull(aTypeClaims.SingleOrDefault(c => c.Value == value));
         }
 
-        [Theory, MemberData(nameof(CreateJWEWithPayloadStringTheoryData))]
+        [Theory, MemberData(nameof(CreateJWEWithPayloadStringTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateJWEWithAdditionalHeaderClaims(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.CreateJWEWithAdditionalHeaderClaims", theoryData);
@@ -258,7 +258,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
         // Tests for expected differences between the JwtSecurityTokenHandler and the JsonWebTokenHandler.
-        [Theory, MemberData(nameof(CreateJWEUsingSecurityTokenDescriptorTheoryData))]
+        [Theory, MemberData(nameof(CreateJWEUsingSecurityTokenDescriptorTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task CheckExpectedDifferenceInAudClaimUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
         {
             if (theoryData.TokenDescriptor == null)
@@ -383,7 +383,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
         // Tests checks to make sure that the token string created by the JwtSecurityTokenHandler is consistent with the 
         // token string created by the JsonWebTokenHandler.
-        [Theory, MemberData(nameof(CreateJWEUsingSecurityTokenDescriptorTheoryData))]
+        [Theory, MemberData(nameof(CreateJWEUsingSecurityTokenDescriptorTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task CreateJWEUsingSecurityTokenDescriptor(CreateTokenTheoryData theoryData)
         {
             CompareContext context = TestUtilities.WriteHeader($"{this}.CreateJWEUsingSecurityTokenDescriptor", theoryData);
@@ -639,7 +639,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ActorTheoryData))]
+        [Theory, MemberData(nameof(ActorTheoryData), DisableDiscoveryEnumeration = true)]
         public void Actor(JwtTheoryData theoryData)
         {
             var context = new CompareContext();
@@ -798,7 +798,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
         }
 
-        [Theory, MemberData(nameof(BootstrapContextTheoryData))]
+        [Theory, MemberData(nameof(BootstrapContextTheoryData), DisableDiscoveryEnumeration = true)]
         public void BootstrapContext(JwtTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.BootstrapContext", theoryData);
@@ -1158,7 +1158,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             Assert.True(JwtSecurityTokenHandler.DefaultMapInboundClaims == false);
         }
 
-        [Theory, MemberData(nameof(ReadTimesExpressedAsDoublesTheoryData))]
+        [Theory, MemberData(nameof(ReadTimesExpressedAsDoublesTheoryData), DisableDiscoveryEnumeration = true)]
         public void ReadTimesExpressedAsDoubles(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ReadTimesExpressedAsDoubles", theoryData);
@@ -1322,7 +1322,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             Assert.True(identity.HasClaim("internalClaim", "claimValue"));
         }
 
-        [Theory, MemberData(nameof(JweDecompressSizeTheoryData))]
+        [Theory, MemberData(nameof(JweDecompressSizeTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task JWEDecompressionSizeTest(JWEDecompressionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.JWEDecompressionTest", theoryData);
@@ -1387,7 +1387,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(JWEDecompressionTheoryData))]
+        [Theory, MemberData(nameof(JWEDecompressionTheoryData), DisableDiscoveryEnumeration = true)]
         public void JWEDecompressionTest(JWEDecompressionTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.JWEDecompressionTest", theoryData);
@@ -1535,7 +1535,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             TestUtilities.ValidateTokenReplay(Default.AsymmetricJwt, new JwtSecurityTokenHandler(), Default.AsymmetricSignTokenValidationParameters);
         }
 
-        [Theory, MemberData(nameof(SegmentTheoryData))]
+        [Theory, MemberData(nameof(SegmentTheoryData), DisableDiscoveryEnumeration = true)]
         public void SegmentRead(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SegmentRead", theoryData);
@@ -1552,7 +1552,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Theory, MemberData(nameof(SegmentTheoryData))]
+        [Theory, MemberData(nameof(SegmentTheoryData), DisableDiscoveryEnumeration = true)]
         public void SegmentCanRead(JwtTheoryData theoryData)
         {
             Assert.Equal(theoryData.CanRead, theoryData.TokenHandler.CanReadToken(theoryData.Token));
@@ -1581,7 +1581,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(ValidateAlgorithmTheoryData))]
+        [Theory, MemberData(nameof(ValidateAlgorithmTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateAlgorithm(JwtTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateAlgorithm", theoryData);
@@ -1789,7 +1789,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateAudienceTheoryData))]
+        [Theory, MemberData(nameof(ValidateAudienceTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateAudience(JwtTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateAudience", theoryData);
@@ -1949,7 +1949,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             };
         }
 
-        [Theory, MemberData(nameof(ValidateIssuerTheoryData))]
+        [Theory, MemberData(nameof(ValidateIssuerTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateIssuer(JwtTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateIssuer", theoryData);
@@ -2052,7 +2052,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
         }
 
-        [Theory, MemberData(nameof(TokenReplayValidationTheoryData))]
+        [Theory, MemberData(nameof(TokenReplayValidationTheoryData), DisableDiscoveryEnumeration = true)]
         public void TokenReplayValidation(TokenReplayTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.TokenReplayValidation", theoryData);
@@ -2109,7 +2109,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             };
         }
 
-        [Theory, MemberData(nameof(ValidateLifetimeTheoryData))]
+        [Theory, MemberData(nameof(ValidateLifetimeTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateLifetime(JwtTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateLifetime", theoryData);
@@ -2167,7 +2167,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             };
         }
 
-        [Theory, MemberData(nameof(ValidateSignatureTheoryData))]
+        [Theory, MemberData(nameof(ValidateSignatureTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateSignature(JwtTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateSignature", theoryData);
@@ -2381,7 +2381,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             };
         }
 
-        [Theory, MemberData(nameof(ValidateJwsWithConfigTheoryData))]
+        [Theory, MemberData(nameof(ValidateJwsWithConfigTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateJWSWithConfig(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWSWithConfig", theoryData);
@@ -2432,7 +2432,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
         }
 
-        [Theory, MemberData(nameof(ValidateJwsWithLastKnownGoodTheoryData))]
+        [Theory, MemberData(nameof(ValidateJwsWithLastKnownGoodTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateJWSWithLastKnownGood(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWSWithLastKnownGood", theoryData);
@@ -2483,7 +2483,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
         public static TheoryData<JwtTheoryData> ValidateJwsWithLastKnownGoodTheoryData => JwtTestDatasets.ValidateJwsWithLastKnownGoodTheoryData;
 
-        [Theory, MemberData(nameof(ValidateJWEWithLastKnownGoodTheoryData))]
+        [Theory, MemberData(nameof(ValidateJWEWithLastKnownGoodTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task ValidateJWEWithLastKnownGood(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidateJWEWithLastKnownGood", theoryData);
@@ -2534,7 +2534,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
         public static TheoryData<JwtTheoryData> ValidateJWEWithLastKnownGoodTheoryData => JwtTestDatasets.ValidateJWEWithLastKnownGoodTheoryData;
 
-        [Theory, MemberData(nameof(ValidateTokenTheoryData))]
+        [Theory, MemberData(nameof(ValidateTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateToken(JwtTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateToken", theoryData);
@@ -2673,7 +2673,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         }
 
 
-        [Theory, MemberData(nameof(ValidateTypeTheoryData))]
+        [Theory, MemberData(nameof(ValidateTypeTheoryData), DisableDiscoveryEnumeration = true)]
         public void ValidateType(JwtTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateType", theoryData);
@@ -2832,7 +2832,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
         }
 
-        [Theory, MemberData(nameof(WriteTokenTheoryData))]
+        [Theory, MemberData(nameof(WriteTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void WriteToken(JwtTheoryData theoryData)
         {
             try
@@ -2957,7 +2957,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(KeyWrapTokenTheoryData))]
+        [Theory, MemberData(nameof(KeyWrapTokenTheoryData), DisableDiscoveryEnumeration = true)]
         public void KeyWrapTokenTest(KeyWrapTokenTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.KeyWrapTokenTest", theoryData);
@@ -3023,7 +3023,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             return theoryData;
         }
 
-        [Theory, MemberData(nameof(ParametersCheckTheoryData))]
+        [Theory, MemberData(nameof(ParametersCheckTheoryData), DisableDiscoveryEnumeration = true)]
         public void ParametersCheckTest(ParametersCheckTheoryData theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ParametersCheckTest", theoryData);
@@ -3059,7 +3059,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             };
         }
 
-        [Theory, MemberData(nameof(SecurityTokenDecryptionTheoryData))]
+        [Theory, MemberData(nameof(SecurityTokenDecryptionTheoryData), DisableDiscoveryEnumeration = true)]
         public void GetEncryptionKeys(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.EncryptionKeysCheck", theoryData);
@@ -3153,7 +3153,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             }
         }
 
-        [Theory, MemberData(nameof(SecurityKeyNotFoundExceptionTestTheoryData))]
+        [Theory, MemberData(nameof(SecurityKeyNotFoundExceptionTestTheoryData), DisableDiscoveryEnumeration = true)]
         public void SecurityKeyNotFoundExceptionTest(CreateTokenTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.SecurityKeyNotFoundExceptionTest", theoryData);

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenTests.cs
@@ -180,7 +180,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 });
         }
 
-        [Theory, MemberData(nameof(EmbeddedTokenConstructorData))]
+        [Theory, MemberData(nameof(EmbeddedTokenConstructorData), DisableDiscoveryEnumeration = true)]
         public void EmbeddedTokenConstructor1(string testId, JwtSecurityTokenTestVariation outerTokenVariation, JwtSecurityTokenTestVariation innerTokenVariation, string jwt, ExpectedException ee)
         {
             JwtSecurityToken outerJwt = null;
@@ -434,7 +434,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 expires: variation.Expires);
         }
 
-        [Theory, MemberData(nameof(JwtSegmentTheoryData))]
+        [Theory, MemberData(nameof(JwtSegmentTheoryData), DisableDiscoveryEnumeration = true)]
         public void JwtSegment(JwtTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.JwtSegment", theoryData);


### PR DESCRIPTION
Getting us to a point where all the theory tests have this attribute and hopefully test will run faster.

Thanks for mentioning this @brentschmaltz!