### PR TITLE
Remove Obsolete BinaryFormatter 

### DIFF
--- a/test/Microsoft.IdentityModel.TestUtils/SecurityKeyCustomConverter.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/SecurityKeyCustomConverter.cs
@@ -23,7 +23,6 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 #endregion
 
-#if NET8_0_OR_GREATER
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -100,4 +99,3 @@ namespace Microsoft.IdentityModel.TestUtils
         }
     }
 }
-#endif

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SecurityTokenExceptionTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SecurityTokenExceptionTests.cs
@@ -5,11 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization;
-#if NET8_0_OR_GREATER
 using System.Text.Json;
-#else
-using System.Runtime.Serialization.Formatters.Binary;
-#endif
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -31,27 +27,13 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
                 var memoryStream = new MemoryStream();
 
-#if NET8_0_OR_GREATER
                 var serializerOptions = new JsonSerializerOptions();
                 serializerOptions.Converters.Add(new SecurityKeyConverterWithTypeDiscriminator());
 
                 JsonSerializer.Serialize(memoryStream, exception, theoryData.ExceptionType, serializerOptions);
                 memoryStream.Seek(0, SeekOrigin.Begin);
                 var serializedException = JsonSerializer.Deserialize(memoryStream, theoryData.ExceptionType, serializerOptions);
-#else
-                BinaryFormatter formatter = new BinaryFormatter();
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                formatter.Serialize(memoryStream, exception);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
 
-                memoryStream.Seek(0, SeekOrigin.Begin);
-
-                formatter.Binder = new ExceptionSerializationBinder();
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                var serializedException = formatter.Deserialize(memoryStream);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
-
-#endif
                 theoryData.ExpectedException.ProcessNoException(context);
 
                 IdentityComparer.AreEqual(exception, serializedException, context);


### PR DESCRIPTION
Due to [security vulnerabilities](https://learn.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide#binaryformatter-security-vulnerabilities) in [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter), [BinaryFormatter.Serialize](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter.serialize) was marked as obsolete in .NET 5. Using it in code generates warning or error SYSLIB0011 at compile time.

Noticed when I was working on [PR 2850](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/2850). And it bothered me.