### PR TITLE
Set custom BenchmarkDotNetconfig as default

### DIFF
--- a/benchmark/Microsoft.IdentityModel.Benchmarks/BenchmarkConfig.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/BenchmarkConfig.cs
@@ -16,14 +16,15 @@ namespace Microsoft.IdentityModel.Benchmarks
         {
             AddJob(Job.MediumRun
                 .WithLaunchCount(4)
-                .WithMaxAbsoluteError(TimeInterval.FromMilliseconds(10)).AsDefault())
-                // uncomment to disable validation to enable debugging through benchmarks
-                //.WithOption(ConfigOptions.DisableOptimizationsValidator, true)
-                .AddColumn(StatisticColumn.P90, StatisticColumn.P95, StatisticColumn.P100)
-                .WithOrderer(new DefaultOrderer(SummaryOrderPolicy.Method))
-                .HideColumns(Column.WarmupCount, Column.Type, Column.Job)
-                .AddDiagnoser(MemoryDiagnoser.Default); // https://benchmarkdotnet.org/articles/configs/diagnosers.html
-                                                        //.AddDiagnoser(new EtwProfiler()) // Uncomment to generate traces / flame graphs. Doc: https://adamsitnik.com/ETW-Profiler/
+                .WithMaxAbsoluteError(TimeInterval.FromMilliseconds(10))
+                .AsDefault())
+                    // uncomment to disable validation to enable debugging through benchmarks
+                    //.WithOption(ConfigOptions.DisableOptimizationsValidator, true)
+                    .AddColumn(StatisticColumn.P90, StatisticColumn.P95, StatisticColumn.P100)
+                    .WithOrderer(new DefaultOrderer(SummaryOrderPolicy.Method))
+                    .HideColumns(Column.WarmupCount, Column.Type, Column.Job)
+                    .AddDiagnoser(MemoryDiagnoser.Default); // https://benchmarkdotnet.org/articles/configs/diagnosers.html
+                    //.AddDiagnoser(new EtwProfiler()) // Uncomment to generate traces / flame graphs. Doc: https://adamsitnik.com/ETW-Profiler/
         }
     }
 }

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/BenchmarkConfig.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/BenchmarkConfig.cs
@@ -16,7 +16,7 @@ namespace Microsoft.IdentityModel.Benchmarks
         {
             AddJob(Job.MediumRun
                 .WithLaunchCount(4)
-                .WithMaxAbsoluteError(TimeInterval.FromMilliseconds(10)))
+                .WithMaxAbsoluteError(TimeInterval.FromMilliseconds(10)).AsDefault())
                 // uncomment to disable validation to enable debugging through benchmarks
                 //.WithOption(ConfigOptions.DisableOptimizationsValidator, true)
                 .AddColumn(StatisticColumn.P90, StatisticColumn.P95, StatisticColumn.P100)


### PR DESCRIPTION
Currently, if you run the tests from command line and specify runtimes (`--runtimes net8.0 net9.0`), BDN will use a default config for the runtimes in addition to running tests for the custom config.

This change makes sure our custom BDN config is used as default.

See [BDN doc](https://benchmarkdotnet.org/articles/guides/console-args.html#specifying-custom-default-settings-for-console-argument-parser).