### PR TITLE
Rename ResolveTokenDecryptionKeyDelegate to DecryptionKeyResolverDelegate

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Delegates.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Delegates.cs
@@ -193,7 +193,7 @@ namespace Microsoft.IdentityModel.Tokens
     /// <param name="validationParameters">The <see cref="ValidationParameters"/> to be used for validating the token.</param>
     /// <param name="callContext">The <see cref="CallContext"/> to be used for logging.</param>
     /// <returns>The <see cref="SecurityKey"/> used to decrypt the token.</returns>
-    internal delegate IList<SecurityKey> ResolveTokenDecryptionKeyDelegate(string token, SecurityToken securityToken, string kid, ValidationParameters validationParameters, CallContext? callContext);
+    internal delegate IList<SecurityKey> DecryptionKeyResolverDelegate(string token, SecurityToken securityToken, string kid, ValidationParameters validationParameters, CallContext? callContext);
 
     /// <summary>
     /// Validates the signature of the security token.

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
@@ -452,7 +452,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <remarks>
         /// This <see cref="SecurityKey"/> will be used to decrypt the token. This can be helpful when the <see cref="SecurityToken"/> does not contain a key identifier.
         /// </remarks>
-        public ResolveTokenDecryptionKeyDelegate TokenDecryptionKeyResolver { get; set; }
+        public DecryptionKeyResolverDelegate TokenDecryptionKeyResolver { get; set; }
 
         /// <summary>
         /// Gets the <see cref="IList{T}"/> that is to be used for decrypting inbound tokens.


### PR DESCRIPTION
# Rename ResolveTokenDecryptionKeyDelegate to DecryptionKeyResolverDelegate

- Renamed delegate to match naming convention

Part of #2711
