### PR TITLE
Removed multiple public apis

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.cs
@@ -20,7 +20,7 @@ namespace Microsoft.IdentityModel.Tokens
     /// Represents a security token exception.
     /// </summary>
     [Serializable]
-    public class SecurityTokenException : Exception, ISecurityTokenException
+    public class SecurityTokenException : Exception
     {
         [NonSerialized]
         private string _stackTrace;
@@ -72,7 +72,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// Sets the <see cref="ValidationError"/> that caused the exception.
         /// </summary>
         /// <param name="validationError"></param>
-        public void SetValidationError(ValidationError validationError)
+        internal void SetValidationError(ValidationError validationError)
         {
             _validationError = validationError;
         }

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -7,6 +7,7 @@ Microsoft.IdentityModel.Tokens.AudienceValidationError
 Microsoft.IdentityModel.Tokens.AudienceValidationError.AudienceValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, System.Collections.Generic.IList<string> invalidAudiences) -> void
 Microsoft.IdentityModel.Tokens.CertificateHelper
 Microsoft.IdentityModel.Tokens.CertificateHelper.CertificateHelper() -> void
+Microsoft.IdentityModel.Tokens.DecryptionKeyResolverDelegate
 Microsoft.IdentityModel.Tokens.ISecurityTokenException
 Microsoft.IdentityModel.Tokens.ISecurityTokenException.SetValidationError(Microsoft.IdentityModel.Tokens.ValidationError validationError) -> void
 Microsoft.IdentityModel.Tokens.IssuerSigningKeyValidationDelegate
@@ -16,16 +17,9 @@ Microsoft.IdentityModel.Tokens.IssuerValidationSource.IssuerIsConfigurationIssue
 Microsoft.IdentityModel.Tokens.IssuerValidationSource.NotValidated = 0 -> Microsoft.IdentityModel.Tokens.IssuerValidationSource
 Microsoft.IdentityModel.Tokens.LifetimeValidationDelegate
 Microsoft.IdentityModel.Tokens.LifetimeValidationError
-Microsoft.IdentityModel.Tokens.LifetimeValidationError.AdditionalInformation
-Microsoft.IdentityModel.Tokens.LifetimeValidationError.AdditionalInformation.AdditionalInformation() -> void
-Microsoft.IdentityModel.Tokens.LifetimeValidationError.AdditionalInformation.AdditionalInformation(System.DateTime? NotBeforeDate, System.DateTime? ExpirationDate) -> void
-Microsoft.IdentityModel.Tokens.LifetimeValidationError.AdditionalInformation.ExpirationDate.get -> System.DateTime?
-Microsoft.IdentityModel.Tokens.LifetimeValidationError.AdditionalInformation.ExpirationDate.set -> void
-Microsoft.IdentityModel.Tokens.LifetimeValidationError.AdditionalInformation.NotBeforeDate.get -> System.DateTime?
-Microsoft.IdentityModel.Tokens.LifetimeValidationError.AdditionalInformation.NotBeforeDate.set -> void
 Microsoft.IdentityModel.Tokens.LifetimeValidationError.LifetimeValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame) -> void
-Microsoft.IdentityModel.Tokens.LifetimeValidationError.LifetimeValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, Microsoft.IdentityModel.Tokens.LifetimeValidationError.AdditionalInformation? additionalInformation) -> void
-Microsoft.IdentityModel.Tokens.LifetimeValidationError.LifetimeValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, System.Exception innerException, Microsoft.IdentityModel.Tokens.LifetimeValidationError.AdditionalInformation? additionalInformation) -> void
+Microsoft.IdentityModel.Tokens.LifetimeValidationError.LifetimeValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, System.DateTime expires) -> void
+Microsoft.IdentityModel.Tokens.LifetimeValidationError.LifetimeValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, System.DateTime notBefore, System.DateTime expires) -> void
 Microsoft.IdentityModel.Tokens.RSACryptoServiceProviderProxy.SignData(byte[] input, int offset, int length, object hash) -> byte[]
 Microsoft.IdentityModel.Tokens.SecurityTokenArgumentNullException
 Microsoft.IdentityModel.Tokens.SecurityTokenArgumentNullException.SecurityTokenArgumentNullException() -> void
@@ -98,8 +92,14 @@ Microsoft.IdentityModel.Tokens.ValidatedTokenType.ValidatedTokenType() -> void
 Microsoft.IdentityModel.Tokens.ValidatedTokenType.ValidatedTokenType(string Type, int ValidTypeCount) -> void
 Microsoft.IdentityModel.Tokens.ValidatedTokenType.ValidTypeCount.get -> int
 Microsoft.IdentityModel.Tokens.ValidatedTokenType.ValidTypeCount.set -> void
+Microsoft.IdentityModel.Tokens.ValidationError
+Microsoft.IdentityModel.Tokens.ValidationError.AddStackFrame(System.Diagnostics.StackFrame stackFrame) -> Microsoft.IdentityModel.Tokens.ValidationError
+Microsoft.IdentityModel.Tokens.ValidationError.ExceptionType.get -> System.Type
 Microsoft.IdentityModel.Tokens.ValidationError.FailureType.get -> Microsoft.IdentityModel.Tokens.ValidationFailureType
+Microsoft.IdentityModel.Tokens.ValidationError.InnerException.get -> System.Exception
+Microsoft.IdentityModel.Tokens.ValidationError.InnerValidationError.get -> Microsoft.IdentityModel.Tokens.ValidationError
 Microsoft.IdentityModel.Tokens.ValidationError.MessageDetail.get -> Microsoft.IdentityModel.Tokens.MessageDetail
+Microsoft.IdentityModel.Tokens.ValidationError.StackFrames.get -> System.Collections.Generic.IList<System.Diagnostics.StackFrame>
 Microsoft.IdentityModel.Tokens.ValidationError.ValidationError(Microsoft.IdentityModel.Tokens.MessageDetail MessageDetail, Microsoft.IdentityModel.Tokens.ValidationFailureType failureType, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame) -> void
 Microsoft.IdentityModel.Tokens.ValidationError.ValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, Microsoft.IdentityModel.Tokens.ValidationFailureType failureType, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, Microsoft.IdentityModel.Tokens.ValidationError innerValidationError) -> void
 Microsoft.IdentityModel.Tokens.ValidationError.ValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, Microsoft.IdentityModel.Tokens.ValidationFailureType failureType, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, System.Exception innerException) -> void
@@ -110,6 +110,7 @@ Microsoft.IdentityModel.Tokens.ValidationParameters.LifetimeValidator.get -> Mic
 Microsoft.IdentityModel.Tokens.ValidationParameters.SignatureValidator.get -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegate
 Microsoft.IdentityModel.Tokens.ValidationParameters.TimeProvider.get -> System.TimeProvider
 Microsoft.IdentityModel.Tokens.ValidationParameters.TimeProvider.set -> void
+Microsoft.IdentityModel.Tokens.ValidationParameters.TokenDecryptionKeyResolver.get -> Microsoft.IdentityModel.Tokens.DecryptionKeyResolverDelegate
 Microsoft.IdentityModel.Tokens.ValidationParameters.TokenReplayValidator.get -> Microsoft.IdentityModel.Tokens.TokenReplayValidationDelegate
 Microsoft.IdentityModel.Tokens.ValidationParameters.TypeValidator.get -> Microsoft.IdentityModel.Tokens.TokenTypeValidationDelegate
 Microsoft.IdentityModel.Tokens.ValidationParameters.TypeValidator.set -> void
@@ -123,13 +124,12 @@ Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.ValidationResult() -> v
 Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.ValidationResult(Microsoft.IdentityModel.Tokens.ValidationError error) -> void
 Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.ValidationResult(TResult result) -> void
 override Microsoft.IdentityModel.Tokens.AudienceValidationError.AddAdditionalInformation(Microsoft.IdentityModel.Tokens.ISecurityTokenException exception) -> void
-override Microsoft.IdentityModel.Tokens.LifetimeValidationError.AddAdditionalInformation(Microsoft.IdentityModel.Tokens.ISecurityTokenException exception) -> void
+override Microsoft.IdentityModel.Tokens.AudienceValidationError.GetException() -> System.Exception
+override Microsoft.IdentityModel.Tokens.LifetimeValidationError.GetException() -> System.Exception
 override Microsoft.IdentityModel.Tokens.SecurityTokenArgumentNullException.StackTrace.get -> string
 override Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.Equals(object obj) -> bool
 override Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.GetHashCode() -> int
 static Microsoft.IdentityModel.JsonWebTokens.JwtTokenUtilities.DecryptJwtToken(Microsoft.IdentityModel.JsonWebTokens.JsonWebToken jsonWebToken, Microsoft.IdentityModel.Tokens.ValidationParameters validationParameters, Microsoft.IdentityModel.JsonWebTokens.JwtTokenDecryptionParameters decryptionParameters, Microsoft.IdentityModel.Tokens.CallContext callContext) -> Microsoft.IdentityModel.Tokens.TokenDecryptionResult
-Microsoft.IdentityModel.Tokens.ResolveTokenDecryptionKeyDelegate
-Microsoft.IdentityModel.Tokens.ValidationParameters.TokenDecryptionKeyResolver.get -> Microsoft.IdentityModel.Tokens.ResolveTokenDecryptionKeyDelegate
 Microsoft.IdentityModel.Tokens.ValidationParameters.TokenDecryptionKeyResolver.set -> void
 Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler.DecryptToken(Microsoft.IdentityModel.JsonWebTokens.JsonWebToken jwtToken, Microsoft.IdentityModel.Tokens.ValidationParameters validationParameters, Microsoft.IdentityModel.Tokens.BaseConfiguration configuration, Microsoft.IdentityModel.Tokens.CallContext callContext) -> Microsoft.IdentityModel.Tokens.TokenDecryptionResult
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10215 = "IDX10215: Audience validation failed. Audiences: '{0}'. Did not match: validationParameters.ValidAudiences: '{1}'." -> string
@@ -826,6 +826,7 @@ virtual Microsoft.IdentityModel.Tokens.SecurityToken.CreateClaims(string issuer)
 virtual Microsoft.IdentityModel.Tokens.SignatureProvider.ObjectPoolSize.get -> int
 virtual Microsoft.IdentityModel.Tokens.TokenHandler.CreateClaimsIdentityInternal(Microsoft.IdentityModel.Tokens.SecurityToken securityToken, Microsoft.IdentityModel.Tokens.TokenValidationParameters tokenValidationParameters, string issuer) -> System.Security.Claims.ClaimsIdentity
 virtual Microsoft.IdentityModel.Tokens.ValidationError.AddAdditionalInformation(Microsoft.IdentityModel.Tokens.ISecurityTokenException exception) -> void
+virtual Microsoft.IdentityModel.Tokens.ValidationError.GetException() -> System.Exception
 virtual Microsoft.IdentityModel.Tokens.ValidationParameters.Clone() -> Microsoft.IdentityModel.Tokens.ValidationParameters
 virtual Microsoft.IdentityModel.Tokens.ValidationParameters.CreateClaimsIdentity(Microsoft.IdentityModel.Tokens.SecurityToken securityToken, string issuer) -> System.Security.Claims.ClaimsIdentity
 Microsoft.IdentityModel.Tokens.SecurityTokenException.SetValidationError(Microsoft.IdentityModel.Tokens.ValidationError validationError) -> void

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
-﻿abstract Microsoft.IdentityModel.Tokens.AsymmetricSecurityKey.HasPrivateKey.get -> bool
+abstract Microsoft.IdentityModel.Tokens.AsymmetricSecurityKey.HasPrivateKey.get -> bool
 abstract Microsoft.IdentityModel.Tokens.AsymmetricSecurityKey.PrivateKeyStatus.get -> Microsoft.IdentityModel.Tokens.PrivateKeyStatus
 abstract Microsoft.IdentityModel.Tokens.BaseConfigurationManager.RequestRefresh() -> void
 abstract Microsoft.IdentityModel.Tokens.CryptoProviderCache.GetCacheKey(Microsoft.IdentityModel.Tokens.SecurityKey securityKey, string algorithm, string typeofProvider) -> string
@@ -419,7 +419,6 @@ Microsoft.IdentityModel.Tokens.SecurityTokenException.SecurityTokenException() -
 Microsoft.IdentityModel.Tokens.SecurityTokenException.SecurityTokenException(string message) -> void
 Microsoft.IdentityModel.Tokens.SecurityTokenException.SecurityTokenException(string message, System.Exception innerException) -> void
 Microsoft.IdentityModel.Tokens.SecurityTokenException.SecurityTokenException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-Microsoft.IdentityModel.Tokens.SecurityTokenException.SetValidationError(Microsoft.IdentityModel.Tokens.ValidationError validationError) -> void
 Microsoft.IdentityModel.Tokens.SecurityTokenExpiredException
 Microsoft.IdentityModel.Tokens.SecurityTokenExpiredException.Expires.get -> System.DateTime
 Microsoft.IdentityModel.Tokens.SecurityTokenExpiredException.Expires.set -> void
@@ -444,6 +443,15 @@ Microsoft.IdentityModel.Tokens.SecurityTokenInvalidAudienceException.SecurityTok
 Microsoft.IdentityModel.Tokens.SecurityTokenInvalidAudienceException.SecurityTokenInvalidAudienceException(string message, System.Exception innerException) -> void
 Microsoft.IdentityModel.Tokens.SecurityTokenInvalidAudienceException.SecurityTokenInvalidAudienceException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException
+Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.ConfigurationCloudInstanceName.get -> string
+Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.ConfigurationCloudInstanceName.set -> void
+Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.SecurityTokenInvalidCloudInstanceException() -> void
+Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.SecurityTokenInvalidCloudInstanceException(string message) -> void
+Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.SecurityTokenInvalidCloudInstanceException(string message, System.Exception innerException) -> void
+Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.SecurityTokenInvalidCloudInstanceException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.SigningKeyCloudInstanceName.get -> string
+Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.SigningKeyCloudInstanceName.set -> void
+override Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
 Microsoft.IdentityModel.Tokens.SecurityTokenInvalidIssuerException
 Microsoft.IdentityModel.Tokens.SecurityTokenInvalidIssuerException.InvalidIssuer.get -> string
 Microsoft.IdentityModel.Tokens.SecurityTokenInvalidIssuerException.InvalidIssuer.set -> void
@@ -934,19 +942,3 @@ virtual Microsoft.IdentityModel.Tokens.TokenHandler.ValidateTokenAsync(Microsoft
 virtual Microsoft.IdentityModel.Tokens.TokenHandler.ValidateTokenAsync(string token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters) -> System.Threading.Tasks.Task<Microsoft.IdentityModel.Tokens.TokenValidationResult>
 virtual Microsoft.IdentityModel.Tokens.TokenValidationParameters.Clone() -> Microsoft.IdentityModel.Tokens.TokenValidationParameters
 virtual Microsoft.IdentityModel.Tokens.TokenValidationParameters.CreateClaimsIdentity(Microsoft.IdentityModel.Tokens.SecurityToken securityToken, string issuer) -> System.Security.Claims.ClaimsIdentity
-override Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.ConfigurationCloudInstanceName.get -> string
-Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.ConfigurationCloudInstanceName.set -> void
-Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.SecurityTokenInvalidCloudInstanceException() -> void
-Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.SecurityTokenInvalidCloudInstanceException(string message) -> void
-Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.SecurityTokenInvalidCloudInstanceException(string message, System.Exception innerException) -> void
-Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.SecurityTokenInvalidCloudInstanceException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
-Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.SigningKeyCloudInstanceName.get -> string
-Microsoft.IdentityModel.Tokens.SecurityTokenInvalidCloudInstanceException.SigningKeyCloudInstanceName.set -> void
-Microsoft.IdentityModel.Tokens.ValidationError
-Microsoft.IdentityModel.Tokens.ValidationError.AddStackFrame(System.Diagnostics.StackFrame stackFrame) -> Microsoft.IdentityModel.Tokens.ValidationError
-Microsoft.IdentityModel.Tokens.ValidationError.ExceptionType.get -> System.Type
-Microsoft.IdentityModel.Tokens.ValidationError.GetException() -> System.Exception
-Microsoft.IdentityModel.Tokens.ValidationError.InnerException.get -> System.Exception
-Microsoft.IdentityModel.Tokens.ValidationError.InnerValidationError.get -> Microsoft.IdentityModel.Tokens.ValidationError
-Microsoft.IdentityModel.Tokens.ValidationError.StackFrames.get -> System.Collections.Generic.IList<System.Diagnostics.StackFrame>

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/AudienceValidationError.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/AudienceValidationError.cs
@@ -27,6 +27,15 @@ namespace Microsoft.IdentityModel.Tokens
             if (exception is SecurityTokenInvalidAudienceException invalidAudienceException)
                 invalidAudienceException.InvalidAudience = Utility.SerializeAsSingleCommaDelimitedString(_invalidAudiences);
         }
+
+        /// <summary>
+        /// Creates an instance of an <see cref="Exception"/> using <see cref="ValidationError"/>
+        /// </summary>
+        /// <returns>An instance of an Exception.</returns>
+        public override Exception GetException()
+        {
+            return new SecurityTokenInvalidAudienceException(MessageDetail.Message) { InvalidAudience = Utility.SerializeAsSingleCommaDelimitedString(_invalidAudiences) };
+        }
     }
 }
 #nullable restore

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/LifetimeValidationError.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/LifetimeValidationError.cs
@@ -9,11 +9,8 @@ namespace Microsoft.IdentityModel.Tokens
 {
     internal class LifetimeValidationError : ValidationError
     {
-        internal record struct AdditionalInformation(
-            DateTime? NotBeforeDate,
-            DateTime? ExpirationDate);
-
-        private AdditionalInformation _additionalInformation;
+        DateTime _notBefore;
+        DateTime _expires;
 
         public LifetimeValidationError(
             MessageDetail messageDetail,
@@ -27,45 +24,58 @@ namespace Microsoft.IdentityModel.Tokens
             MessageDetail messageDetail,
             Type exceptionType,
             StackFrame stackFrame,
-            AdditionalInformation? additionalInformation)
+            DateTime notBefore,
+            DateTime expires)
             : base(messageDetail, ValidationFailureType.LifetimeValidationFailed, exceptionType, stackFrame)
         {
-            if (additionalInformation.HasValue)
-                _additionalInformation = additionalInformation.Value;
+            _notBefore = notBefore;
+            _expires = expires;
         }
 
         public LifetimeValidationError(
             MessageDetail messageDetail,
             Type exceptionType,
             StackFrame stackFrame,
-            Exception innerException,
-            AdditionalInformation? additionalInformation)
-            : base(messageDetail, ValidationFailureType.LifetimeValidationFailed, exceptionType, stackFrame, innerException)
+            DateTime expires)
+            : base(messageDetail, ValidationFailureType.LifetimeValidationFailed, exceptionType, stackFrame)
         {
-            if (additionalInformation.HasValue)
-                _additionalInformation = additionalInformation.Value;
+            _expires = expires;
         }
 
-        internal override void AddAdditionalInformation(ISecurityTokenException exception)
+        /// <summary>
+        /// Creates an instance of an <see cref="Exception"/> using <see cref="ValidationError"/>
+        /// </summary>
+        /// <returns>An instance of an Exception.</returns>
+        public override Exception GetException()
         {
-            if (exception is SecurityTokenExpiredException expiredException &&
-                _additionalInformation.ExpirationDate.HasValue)
+            if (ExceptionType == typeof(SecurityTokenNoExpirationException))
             {
-                expiredException.Expires = _additionalInformation.ExpirationDate.Value;
+                return new SecurityTokenNoExpirationException(MessageDetail.Message);
             }
-            else if (exception is SecurityTokenNotYetValidException notYetValidException &&
-                _additionalInformation.NotBeforeDate.HasValue)
+            else if (ExceptionType == typeof(SecurityTokenInvalidLifetimeException))
             {
-                notYetValidException.NotBefore = _additionalInformation.NotBeforeDate.Value;
+                return new SecurityTokenInvalidLifetimeException(MessageDetail.Message)
+                {
+                    NotBefore = _notBefore,
+                    Expires = _expires
+                };
             }
-            else if (exception is SecurityTokenInvalidLifetimeException invalidLifetimeException)
+            else if (ExceptionType == typeof(SecurityTokenNotYetValidException))
             {
-                if (_additionalInformation.NotBeforeDate.HasValue)
-                    invalidLifetimeException.NotBefore = _additionalInformation.NotBeforeDate.Value;
-
-                if (_additionalInformation.ExpirationDate.HasValue)
-                    invalidLifetimeException.Expires = _additionalInformation.ExpirationDate.Value;
+                return new SecurityTokenNotYetValidException(MessageDetail.Message)
+                {
+                    NotBefore = _notBefore
+                };
             }
+            else if (ExceptionType == typeof(SecurityTokenExpiredException))
+            {
+                return new SecurityTokenExpiredException(MessageDetail.Message)
+                {
+                    Expires = _expires
+                };
+            }
+            else
+                return base.GetException();
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/ValidationError.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/ValidationError.cs
@@ -15,7 +15,7 @@ namespace Microsoft.IdentityModel.Tokens
     /// <summary>
     /// Contains information so that Exceptions can be logged or thrown written as required.
     /// </summary>
-    public class ValidationError
+    internal class ValidationError
     {
         private Type _exceptionType;
 
@@ -81,7 +81,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// Creates an instance of an <see cref="Exception"/> using <see cref="ValidationError"/>
         /// </summary>
         /// <returns>An instance of an Exception.</returns>
-        public Exception GetException()
+        public virtual Exception GetException()
         {
             Exception exception = GetException(ExceptionType, InnerException);
 

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
@@ -452,7 +452,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <remarks>
         /// This <see cref="SecurityKey"/> will be used to decrypt the token. This can be helpful when the <see cref="SecurityToken"/> does not contain a key identifier.
         /// </remarks>
-        public DecryptionKeyResolverDelegate TokenDecryptionKeyResolver { get; set; }
+        internal DecryptionKeyResolverDelegate TokenDecryptionKeyResolver { get; set; }
 
         /// <summary>
         /// Gets the <see cref="IList{T}"/> that is to be used for decrypting inbound tokens.

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Lifetime.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.Lifetime.cs
@@ -77,7 +77,8 @@ namespace Microsoft.IdentityModel.Tokens
                         LogHelper.MarkAsNonPII(expires.Value)),
                     typeof(SecurityTokenInvalidLifetimeException),
                     new StackFrame(true),
-                    new(NotBeforeDate: notBefore, ExpirationDate: expires));
+                    notBefore.Value,
+                    expires.Value);
 
             DateTime utcNow = validationParameters.TimeProvider.GetUtcNow().UtcDateTime;
             if (notBefore.HasValue && (notBefore.Value > DateTimeUtil.Add(utcNow, validationParameters.ClockSkew)))
@@ -88,7 +89,8 @@ namespace Microsoft.IdentityModel.Tokens
                         LogHelper.MarkAsNonPII(utcNow)),
                     typeof(SecurityTokenNotYetValidException),
                     new StackFrame(true),
-                    new(NotBeforeDate: notBefore, ExpirationDate: expires));
+                    notBefore.Value,
+                    expires.Value);
 
             if (expires.HasValue && (expires.Value < DateTimeUtil.Add(utcNow, validationParameters.ClockSkew.Negate())))
                 return new LifetimeValidationError(
@@ -98,7 +100,7 @@ namespace Microsoft.IdentityModel.Tokens
                         LogHelper.MarkAsNonPII(utcNow)),
                     typeof(SecurityTokenExpiredException),
                     new StackFrame(true),
-                    new(NotBeforeDate: null, ExpirationDate: expires));
+                    expires.Value);
 
             // if it reaches here, that means lifetime of the token is valid
             return new ValidatedLifetime(notBefore, expires);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SecurityTokenExceptionTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SecurityTokenExceptionTests.cs
@@ -208,9 +208,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         {
                             if (!(ex is SecurityTokenUnableToValidateException securityTokenUnableToValidateException))
                                 throw new ArgumentException($"expected argument of type {nameof(SecurityTokenUnableToValidateException)} received type {ex.GetType()}");
-
-                            securityTokenUnableToValidateException.ValidationFailure = ValidationFailure.InvalidIssuer;
-                            securityTokenUnableToValidateException.ValidationFailure |= ValidationFailure.InvalidLifetime;
                         },
                     },
 #pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION
We inadvertently shipped some public api's that are not ready, some were breaking modifications.
We removed the interface ISecurityTokenException (breaking)
SecurityTokenException.SetValidationError(ValidationError validationError) was changed internal
public class ValidationError was changed to internal
classes AudienceValidationError and LifetimeValidationError were modified to accept specific values in ctor removing the need for AdditionalInfo.

