### PR TITLE
Added properties to ValidationResult without throwing

### DIFF
--- a/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateTokenAsyncTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateTokenAsyncTests.cs
@@ -105,7 +105,7 @@ namespace Microsoft.IdentityModel.Benchmarks
             // Because ValidationResult is an internal type, we cannot return it in the benchmark.
             // We return a boolean instead until the type is made public.
             ValidationResult<ValidatedToken> result = await _jsonWebTokenHandler.ValidateTokenAsync(_jwsExtendedClaims, _validationParameters, _callContext, CancellationToken.None).ConfigureAwait(false);
-            return result.IsSuccess;
+            return result.IsValid;
         }
 
         [BenchmarkCategory("ValidateTokenAsync_FailTwiceBeforeSuccess"), Benchmark(Baseline = true)]
@@ -135,7 +135,7 @@ namespace Microsoft.IdentityModel.Benchmarks
             result = await _jsonWebTokenHandler.ValidateTokenAsync(_jwsExtendedClaims, _invalidValidationParameters, _callContext, CancellationToken.None).ConfigureAwait(false);
             result = await _jsonWebTokenHandler.ValidateTokenAsync(_jwsExtendedClaims, _validationParameters, _callContext, CancellationToken.None).ConfigureAwait(false);
 
-            return result.IsSuccess;
+            return result.IsValid;
         }
 
         [BenchmarkCategory("ValidateTokenAsync_FailFourTimesBeforeSuccess"), Benchmark(Baseline = true)]
@@ -171,7 +171,7 @@ namespace Microsoft.IdentityModel.Benchmarks
             result = await _jsonWebTokenHandler.ValidateTokenAsync(_jwsExtendedClaims, _invalidValidationParameters, _callContext, CancellationToken.None).ConfigureAwait(false);
             result = await _jsonWebTokenHandler.ValidateTokenAsync(_jwsExtendedClaims, _validationParameters, _callContext, CancellationToken.None).ConfigureAwait(false);
 
-            return result.IsSuccess;
+            return result.IsValid;
         }
 
         [BenchmarkCategory("ValidateTokenAsyncClaimAccess"), Benchmark(Baseline = true)]

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateSignature.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateSignature.cs
@@ -191,7 +191,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             {
                 SecurityKey key = keysList[i];
                 ValidationResult<SecurityKey> result = ValidateSignatureWithKey(jwtToken, key, validationParameters, callContext);
-                if (result.IsSuccess)
+                if (result.IsValid)
                 {
                     jwtToken.SigningKey = key;
                     return (result, true, null);
@@ -240,7 +240,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 validationParameters,
                 callContext);
 
-            if (!result.IsSuccess)
+            if (!result.IsValid)
                 return new ValidationError(
                     new MessageDetail(
                         TokenLogMessages.IDX10518,

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.DecryptTokenResult.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.DecryptTokenResult.cs
@@ -68,7 +68,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     }
 
                     ValidationResult<string> result = validationParameters.AlgorithmValidator(zipAlgorithm, key, jsonWebToken, validationParameters, callContext);
-                    if (!result.IsSuccess)
+                    if (!result.IsValid)
                     {
                         (exceptionStrings ??= new StringBuilder()).AppendLine(result.UnwrapError().MessageDetail.Message);
                         continue;

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateToken.Internal.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateToken.Internal.cs
@@ -42,7 +42,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
 
             var conditionsResult = ValidateConditions(samlToken, validationParameters, callContext);
 
-            if (!conditionsResult.IsSuccess)
+            if (!conditionsResult.IsValid)
             {
                 return conditionsResult.UnwrapError().AddStackFrame(new StackFrame(true));
             }
@@ -78,7 +78,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                 validationParameters,
                 callContext);
 
-            if (!lifetimeValidationResult.IsSuccess)
+            if (!lifetimeValidationResult.IsValid)
             {
                 StackFrames.LifetimeValidationFailed ??= new StackFrame(true);
                 return lifetimeValidationResult.UnwrapError().AddStackFrame(StackFrames.LifetimeValidationFailed);
@@ -94,7 +94,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                     validationParameters,
                     callContext);
 
-                if (!oneTimeUseValidationResult.IsSuccess)
+                if (!oneTimeUseValidationResult.IsValid)
                 {
                     StackFrames.OneTimeUseValidationFailed ??= new StackFrame(true);
                     return oneTimeUseValidationResult.UnwrapError().AddStackFrame(StackFrames.OneTimeUseValidationFailed);
@@ -128,7 +128,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                     samlToken,
                     validationParameters,
                     callContext);
-                if (!audienceValidationResult.IsSuccess)
+                if (!audienceValidationResult.IsValid)
                     return audienceValidationResult.UnwrapError();
 
                 // Audience is valid, save it for later.

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Shipped.txt
@@ -567,7 +567,6 @@ Microsoft.IdentityModel.Tokens.ValidationParameters.ValidIssuers.get -> System.C
 Microsoft.IdentityModel.Tokens.ValidationParameters.ValidTypes.get -> System.Collections.Generic.IList<string>
 Microsoft.IdentityModel.Tokens.ValidationResult<TResult>
 Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.Equals(Microsoft.IdentityModel.Tokens.ValidationResult<TResult> other) -> bool
-Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.IsSuccess.get -> bool
 Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.ToResult() -> Microsoft.IdentityModel.Tokens.ValidationResult<TResult>
 Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.UnwrapError() -> Microsoft.IdentityModel.Tokens.ValidationError
 Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.UnwrapResult() -> TResult

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -5,6 +5,9 @@ Microsoft.IdentityModel.Tokens.AudienceValidationError.TokenAudiences.get -> Sys
 Microsoft.IdentityModel.Tokens.IssuerValidationSource.IssuerMatchedConfiguration = 1 -> Microsoft.IdentityModel.Tokens.IssuerValidationSource
 Microsoft.IdentityModel.Tokens.IssuerValidationSource.IssuerMatchedValidationParameters = 2 -> Microsoft.IdentityModel.Tokens.IssuerValidationSource
 Microsoft.IdentityModel.Tokens.ValidationError.GetException(System.Type exceptionType, System.Exception innerException) -> System.Exception
+Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.Error.get -> Microsoft.IdentityModel.Tokens.ValidationError
+Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.IsValid.get -> bool
+Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.Result.get -> TResult
 static Microsoft.IdentityModel.Tokens.AudienceValidationError.AudiencesCountZero -> System.Diagnostics.StackFrame
 static Microsoft.IdentityModel.Tokens.AudienceValidationError.AudiencesNull -> System.Diagnostics.StackFrame
 static Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidateAudienceFailed -> System.Diagnostics.StackFrame

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/ValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/ValidationResult.cs
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 
 using System;
+using Microsoft.IdentityModel.Logging;
 
 #nullable enable
 namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
-    /// Represents a validation result that can be either successful or unsuccessful.
+    /// Represents a validation result that can be either valid or invalid.
     /// </summary>
     /// <typeparam name="TResult"></typeparam>
     internal readonly struct ValidationResult<TResult> : IEquatable<ValidationResult<TResult>>
@@ -16,25 +17,25 @@ namespace Microsoft.IdentityModel.Tokens
         readonly ValidationError? _error;
 
         /// <summary>
-        /// Creates a successful validation result.
+        /// Creates a successful, valid validation result.
         /// </summary>
         /// <param name="result">The value associated with the success.</param>
         public ValidationResult(TResult result)
         {
             _result = result;
             _error = null;
-            IsSuccess = true;
+            IsValid = true;
         }
 
         /// <summary>
-        /// Creates an error validation result.
+        /// Creates an error, invalid validation result.
         /// </summary>
         /// <param name="error">The error associated with the failure.</param>
         public ValidationResult(ValidationError error)
         {
             _result = default;
             _error = error;
-            IsSuccess = false;
+            IsValid = false;
         }
 
         /// <summary>
@@ -46,7 +47,7 @@ namespace Microsoft.IdentityModel.Tokens
         public ValidationResult() => throw new InvalidOperationException("Cannot create an empty validation result");
 
         /// <summary>
-        /// Creates a successful result implicitly from the value.
+        /// Creates a successful, valid result implicitly from the value.
         /// </summary>
         /// <param name="result">The value to be stored in the result.</param>
         public static implicit operator ValidationResult<TResult>(TResult result) => new(result);
@@ -58,25 +59,60 @@ namespace Microsoft.IdentityModel.Tokens
         public static implicit operator ValidationResult<TResult>(ValidationError error) => new(error);
 
         /// <summary>
-        /// Gets a value indicating whether the result is successful.
+        /// Gets a value indicating whether the result is valid.
         /// </summary>
-        public readonly bool IsSuccess { get; }
+        public readonly bool IsValid { get; }
 
         /// <summary>
         /// Unwraps the result.
         /// </summary>
         /// <returns>The wrapped result value.</returns>
-        /// <remarks>This method is only valid if the result type is successful.</remarks>
-        /// <exception cref="InvalidOperationException">Thrown if attempted to unwrap the value from a failed result.</exception>
-        public TResult UnwrapResult() => IsSuccess ? _result! : throw new InvalidOperationException("Cannot unwrap error result");
+        /// <remarks>This method is only valid if the result type is valid.</remarks>
+        /// <exception cref="InvalidOperationException">Thrown if attempted to unwrap the value from a non valid result.</exception>
+        internal TResult UnwrapResult() => IsValid ? _result! : throw new InvalidOperationException("Cannot unwrap error result");
 
         /// <summary>
         /// Unwraps the error.
         /// </summary>
         /// <returns>The wrapped error value.</returns>
-        /// <remarks>This method is only valid if the result type is unsuccessful.</remarks>
-        /// <exception cref="InvalidOperationException">Thrown if attempted to unwrap an error from a successful result.</exception>
-        public ValidationError UnwrapError() => IsSuccess ? throw new InvalidOperationException("Cannot unwrap success result") : _error!;
+        /// <remarks>This method is only valid if the result type is not valid.</remarks>
+        /// <exception cref="InvalidOperationException">Thrown if attempted to unwrap an error from a valid result.</exception>
+        internal ValidationError UnwrapError() => IsValid ? throw new InvalidOperationException("Cannot unwrap success result") : _error!;
+
+        /// <summary>
+        /// Gets the error associated with the validation result.
+        /// </summary>
+        /// <returns>The error associated with the validation result.</returns>
+        /// <remarks>This property is only valid if the result type is not valid.</remarks>
+        public ValidationError? Error
+        {
+            get
+            {
+                if (IsValid)
+                    LogHelper.LogWarning("Warning: Accessing the Error property in a valid result is invalid.");
+
+                return _error;
+            }
+        }
+
+        /// <summary>
+        /// Gets the result associated with the validation result.
+        /// </summary>
+        /// <returns>The result associated with the validation result.</returns>
+        /// <remarks>This property is only valid if the result type is valid.</remarks>
+        public TResult? Result
+        {
+            get
+            {
+                if (IsValid)
+                    return _result;
+                else
+                {
+                    LogHelper.LogWarning("Warning: Accessing the Result property in an invalid result may yield unexpected results.");
+                    return default;
+                }
+            }
+        }
 
         /// <summary>
         /// 
@@ -100,7 +136,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <exception cref="NotImplementedException"></exception>
         public override int GetHashCode()
         {
-            if (IsSuccess)
+            if (IsValid)
                 return _result!.GetHashCode();
             else
                 return _error!.GetHashCode();
@@ -135,10 +171,10 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns></returns>
         public bool Equals(ValidationResult<TResult> other)
         {
-            if (other.IsSuccess != IsSuccess)
+            if (other.IsValid != IsValid)
                 return false;
 
-            if (IsSuccess)
+            if (IsValid)
                 return _result!.Equals(other._result);
             else
                 return _error!.Equals(other._error);

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.DecryptTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.DecryptTokenTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 theoryData.Configuration,
                 new CallContext());
 
-            if (result.IsSuccess)
+            if (result.IsValid)
             {
                 IdentityComparer.AreStringsEqual(
                     result.UnwrapResult(),

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ReadTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ReadTokenTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 theoryData.Token,
                 new CallContext());
 
-            if (result.IsSuccess)
+            if (result.IsValid)
             {
                 IdentityComparer.AreEqual(result.UnwrapResult(),
                     theoryData.Result.UnwrapResult(),

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateSignatureTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateSignatureTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     DebugId = theoryData.TestId
                 });
 
-            if (result.IsSuccess)
+            if (result.IsValid)
             {
                 IdentityComparer.AreSecurityKeysEqual(
                     result.UnwrapResult(),

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Audience.Extensibility.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Audience.Extensibility.cs
@@ -44,10 +44,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 return;
             }
 
-            if (validationResult.IsSuccess != theoryData.ExpectedIsValid)
+            if (validationResult.IsValid != theoryData.ExpectedIsValid)
                 context.AddDiff($"validationResult.IsSuccess != theoryData.ExpectedIsValid");
 
-            if (validationResult.IsSuccess)
+            if (validationResult.IsValid)
             {
                 theoryData.ExpectedException.ProcessNoException(context);
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Common.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenAsyncTests.Common.cs
@@ -31,12 +31,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             if (legacyTokenValidationParametersResult.IsValid != theoryData.ExpectedIsValid)
                 context.AddDiff($"tokenValidationParametersResult.IsValid != theoryData.ExpectedIsValid");
 
-            if (validationParametersResult.IsSuccess != theoryData.ExpectedIsValid)
+            if (validationParametersResult.IsValid != theoryData.ExpectedIsValid)
                 context.AddDiff($"validationParametersResult.IsSuccess != theoryData.ExpectedIsValid");
 
             if (theoryData.ExpectedIsValid &&
                 legacyTokenValidationParametersResult.IsValid &&
-                validationParametersResult.IsSuccess)
+                validationParametersResult.IsValid)
             {
                 // Compare the ClaimsPrincipal and ClaimsIdentity from one result against the other
                 IdentityComparer.AreEqual(
@@ -53,7 +53,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 // Verify the exception provided by the TokenValidationParameters path
                 theoryData.ExpectedException.ProcessException(legacyTokenValidationParametersResult.Exception, context);
 
-                if (!validationParametersResult.IsSuccess)
+                if (!validationParametersResult.IsValid)
                 {
                     // Verify the exception provided by the ValidationParameters path
                     if (theoryData.ExpectedExceptionValidationParameters is not null)

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerValidationParametersTests.cs
@@ -55,12 +55,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             if (tokenValidationParametersResult.IsValid != theoryData.ExpectedIsValid)
                 context.AddDiff($"tokenValidationParametersResult.IsValid != theoryData.ExpectedIsValid");
 
-            if (validationParametersResult.IsSuccess != theoryData.ExpectedIsValid)
+            if (validationParametersResult.IsValid != theoryData.ExpectedIsValid)
                 context.AddDiff($"validationParametersResult.IsSuccess != theoryData.ExpectedIsValid");
 
             if (theoryData.ExpectedIsValid &&
                 tokenValidationParametersResult.IsValid &&
-                validationParametersResult.IsSuccess)
+                validationParametersResult.IsValid)
             {
                 IdentityComparer.AreEqual(
                     tokenValidationParametersResult.ClaimsIdentity,
@@ -75,7 +75,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             {
                 theoryData.ExpectedException.ProcessException(tokenValidationParametersResult.Exception, context);
 
-                if (!validationParametersResult.IsSuccess)
+                if (!validationParametersResult.IsValid)
                 {
                     // If there is a special case for the ValidationParameters path, use that.
                     if (theoryData.ExpectedExceptionValidationParameters != null)

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.ValidateTokenAsyncTests.Audience.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.ValidateTokenAsyncTests.Audience.cs
@@ -43,7 +43,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                     CancellationToken.None);
 
             // Ensure the validity of the results match the expected result.
-            if (tokenValidationResult.IsValid != validationResult.IsSuccess)
+            if (tokenValidationResult.IsValid != validationResult.IsValid)
             {
                 context.AddDiff($"tokenValidationResult.IsValid != validationResult.IsSuccess");
                 theoryData.ExpectedExceptionValidationParameters!.ProcessException(validationResult.UnwrapError().GetException(), context);

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.ValidateTokenAsyncTests.Lifetime.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandlerTests.ValidateTokenAsyncTests.Lifetime.cs
@@ -43,7 +43,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml.Tests
                     CancellationToken.None);
 
             // Ensure validity of the results match the expected result.
-            if (tokenValidationResult.IsValid != validationResult.IsSuccess)
+            if (tokenValidationResult.IsValid != validationResult.IsValid)
             {
                 context.AddDiff($"tokenValidationResult.IsValid != validationResult.IsSuccess");
                 theoryData.ExpectedExceptionValidationParameters!.ProcessException(validationResult.UnwrapError().GetException(), context);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AlgorithmValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AlgorithmValidationResultTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 theoryData.ValidationParameters,
                 new CallContext());
 
-            if (result.IsSuccess)
+            if (result.IsValid)
             {
                 IdentityComparer.AreStringsEqual(
                     result.UnwrapResult(),

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 theoryData.ValidationParameters,
                 theoryData.CallContext);
 
-            if (result.IsSuccess)
+            if (result.IsValid)
             {
                 IdentityComparer.AreStringsEqual(
                     result.UnwrapResult(),
@@ -151,7 +151,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 theoryData.ValidationParameters,
                 theoryData.CallContext);
 
-            if (result.IsSuccess)
+            if (result.IsValid)
             {
                 IdentityComparer.AreStringsEqual(
                     result.UnwrapResult(),

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/IssuerValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/IssuerValidationResultTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 new CallContext(),
                 CancellationToken.None);
 
-            if (result.IsSuccess)
+            if (result.IsValid)
             {
                 IdentityComparer.AreValidatedIssuersEqual(
                     theoryData.Result.UnwrapResult(),

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/LifetimeValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/LifetimeValidationResultTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 theoryData.ValidationParameters,
                 new CallContext());
 
-            if (result.IsSuccess)
+            if (result.IsValid)
             {
                 IdentityComparer.AreValidatedLifetimesEqual(
                     theoryData.Result.UnwrapResult(),

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ReplayValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ReplayValidationResultTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 theoryData.ValidationParameters,
                 new CallContext());
 
-            if (result.IsSuccess)
+            if (result.IsValid)
             {
                 IdentityComparer.AreDateTimesEqualWithEpsilon(
                     result.UnwrapResult(),

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/SigningKeyValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/SigningKeyValidationResultTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 theoryData.BaseConfiguration,
                 new CallContext());
 
-            if (result.IsSuccess)
+            if (result.IsValid)
             {
                 IdentityComparer.AreValidatedSigningKeyLifetimesEqual(
                     theoryData.Result.UnwrapResult(),

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/TokenTypeValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/TokenTypeValidationResultTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                 theoryData.ValidationParameters,
                 new CallContext());
 
-            if (result.IsSuccess)
+            if (result.IsValid)
             {
                 IdentityComparer.AreValidatedTokenTypesEqual(
                     result.UnwrapResult(),


### PR DESCRIPTION
# Added properties to ValidationResult without throwing

- Added new nullable properties to `ValidationResult` without throwing exceptions.
- Renamed IsSuccess to IsValid

Part of #2711 