### PR TITLE
Fix builds on macOS / Linux using the build.sh script

### DIFF
--- a/WilsonUnix.sln
+++ b/WilsonUnix.sln
@@ -82,8 +82,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.IdentityModel.Val
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.IdentityModel.Abstractions.Tests", "test\Microsoft.IdentityModel.Abstractions.Tests\Microsoft.IdentityModel.Abstractions.Tests.csproj", "{4D6D09F9-5343-4831-9623-32089ADB27A0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.IdentityModel.SampleTests", "test\Microsoft.IdentityModel.SampleTests\Microsoft.IdentityModel.SampleTests.csproj", "{A9A9E808-16A3-4351-A213-09D46883C0F3}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.IdentityModel.Validators.Tests", "test\Microsoft.IdentityModel.Validators.Tests\Microsoft.IdentityModel.Validators.Tests.csproj", "{17116E4B-B3FE-40A9-A733-1BC00FF5963D}"
 EndProject
 Global
@@ -196,10 +194,6 @@ Global
 		{4D6D09F9-5343-4831-9623-32089ADB27A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4D6D09F9-5343-4831-9623-32089ADB27A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4D6D09F9-5343-4831-9623-32089ADB27A0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A9A9E808-16A3-4351-A213-09D46883C0F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A9A9E808-16A3-4351-A213-09D46883C0F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A9A9E808-16A3-4351-A213-09D46883C0F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A9A9E808-16A3-4351-A213-09D46883C0F3}.Release|Any CPU.Build.0 = Release|Any CPU
 		{17116E4B-B3FE-40A9-A733-1BC00FF5963D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{17116E4B-B3FE-40A9-A733-1BC00FF5963D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{17116E4B-B3FE-40A9-A733-1BC00FF5963D}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -236,7 +230,6 @@ Global
 		{6EAA7FED-C053-4AD0-A73B-B96A5593BC49} = {BD2706C5-6C57-484D-89C8-A0CF5F8E3D19}
 		{BD223874-759C-41AF-BA9E-F4E5D024F395} = {BD2706C5-6C57-484D-89C8-A0CF5F8E3D19}
 		{4D6D09F9-5343-4831-9623-32089ADB27A0} = {8905D2E3-4499-4A86-BF3E-F098F228DD59}
-		{A9A9E808-16A3-4351-A213-09D46883C0F3} = {8905D2E3-4499-4A86-BF3E-F098F228DD59}
 		{17116E4B-B3FE-40A9-A733-1BC00FF5963D} = {8905D2E3-4499-4A86-BF3E-F098F228DD59}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,7 @@ pack() {
   echo -e "Pack ...... "
   echo -e "===========================================================\n"
 
-  dotnet pack --no-build WilsonUnix.sln
+  dotnet pack --no-build WilsonUnix.sln -c Debug
   
   echo -e "\n"
   echo -e "==========================================================="

--- a/build/common.props
+++ b/build/common.props
@@ -25,8 +25,7 @@
     <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(SrcTargets)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">$(SrcStandardTargets)</TargetFrameworks>
+    <TargetFrameworks>$(SrcTargets)</TargetFrameworks>
     <NetStandardImplicitPackageVersion>$(NetStandardVersion)</NetStandardImplicitPackageVersion>
     <LangVersion>12</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/build/commonTest.props
+++ b/build/commonTest.props
@@ -13,8 +13,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>0618</WarningsNotAsErrors>
     <IsTestProject>true</IsTestProject>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TestTargets)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">$(TestOnlyCoreTargets)</TargetFrameworks>
+    <TargetFrameworks>$(TestTargets)</TargetFrameworks>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">$(DotNetCoreAppRuntimeVersion)</RuntimeFrameworkVersion>
     <IsPackable>false</IsPackable>
     <LangVersion>12</LangVersion>

--- a/build/targets.props
+++ b/build/targets.props
@@ -3,6 +3,5 @@
     <SrcTargets Condition="'$(LocalBuild)' != 'True'">net462;net472;netstandard2.0;net6.0;net8.0</SrcTargets>
     <SrcTargets Condition="'$(LocalBuild)' == 'True'">netstandard2.0;net8.0</SrcTargets>
     <SrcTargets Condition="'$(TargetNet9)' == 'True'">$(SrcTargets);net9.0</SrcTargets>
-    <SrcStandardTargets>netstandard2.0</SrcStandardTargets>
   </PropertyGroup>
 </Project>

--- a/build/targetsTest.props
+++ b/build/targetsTest.props
@@ -3,6 +3,5 @@
     <TestTargets Condition="'$(LocalBuild)' != 'True'">net462;net472;net6.0;net8.0</TestTargets>
     <TestTargets Condition="'$(LocalBuild)' == 'True'">net8.0</TestTargets>
     <TestTargets Condition="'$(TargetNet9)' == 'True'">$(TestTargets);net9.0</TestTargets>
-    <TestOnlyCoreTargets>net6.0</TestOnlyCoreTargets>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.IdentityModel.AotCompatibility.Tests/Microsoft.IdentityModel.AotCompatibility.Tests.csproj
+++ b/test/Microsoft.IdentityModel.AotCompatibility.Tests/Microsoft.IdentityModel.AotCompatibility.Tests.csproj
@@ -4,8 +4,8 @@
 
   <PropertyGroup>
     <!-- This test only needs to run on .NET -->
-    <TargetFramework>net8.0</TargetFramework>
-    <TargetFrameworks Condition="'$(TargetNet9)'== 'True'">$(TargetFramework); net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetNet9)'== 'True'">$(TargetFrameworks);net9.0</TargetFrameworks>
     <langversion>12</langversion>
     <Version>1.0.0-preview</Version>
   </PropertyGroup>


### PR DESCRIPTION
# Fix builds on macOS / Linux using the build.sh script

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

The builds are broken on macOS / Linux due to references to non-existing files and tests being compiled against wrong assets (eg. net6+ tests with `Span` APIs trying to use netstandard2.0 assets).
