### PR TITLE
Restore skipped test: ReferenceCountingTest_MultiThreaded

### DIFF
--- a/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderFactoryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderFactoryTests.cs
@@ -923,7 +923,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Fact(Skip = "too long")]
+        [Fact]
         public async Task ReferenceCountingTest_MultiThreaded()
         {
             var context = new CompareContext($"{this}.ReferenceCountingTest_MultiThreaded");


### PR DESCRIPTION
This test was previously skipped due to "too long". How long is too long? This takes an average of 300 ms to complete when I run it locally, aka 0.3 s.