### PR TITLE
Restore CacheOverflowTestSequential - takes 1.5s

### DIFF
--- a/test/Microsoft.IdentityModel.Tokens.Tests/EventBasedLRUCacheTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/EventBasedLRUCacheTests.cs
@@ -386,7 +386,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        [Fact(Skip = "Large test meant to be run manually.")]
+        [Fact]
         public void CacheOverflowTestSequential()
         {
             TestUtilities.WriteHeader($"{this}.CacheOverflowTestSequential");


### PR DESCRIPTION
This test must have taken longer than before - currently takes 1.5s

Part of #2954 