### PR TITLE
Microsoft.Rest.ClientRuntime has been deprecated, which results in so…

### DIFF
--- a/build/dependenciesTest.props
+++ b/build/dependenciesTest.props
@@ -5,7 +5,6 @@
     <DotNetCoreAppRuntimeVersion>2.1.30</DotNetCoreAppRuntimeVersion>
     <MicrosoftAzureKeyVaultCryptographyVersion>3.0.5</MicrosoftAzureKeyVaultCryptographyVersion>
     <MicrosoftNETTestSdkVersion>17.11.0</MicrosoftNETTestSdkVersion>
-    <MicrosoftRestClientRuntime>2.3.24</MicrosoftRestClientRuntime>
     <NetStandardVersion>2.0.3</NetStandardVersion>
     <NewtonsoftVersion>13.0.3</NewtonsoftVersion>
     <SystemNetHttp>4.3.4</SystemNetHttp>

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/Microsoft.IdentityModel.JsonWebTokens.Tests.csproj
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/Microsoft.IdentityModel.JsonWebTokens.Tests.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressions)"/>
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttp)"/>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntime)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests.csproj
@@ -27,7 +27,6 @@
   <ItemGroup>
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressions)"/>
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttp)"/>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntime)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests.csproj
@@ -23,7 +23,6 @@
   <ItemGroup>
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressions)"/>
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttp)"/>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntime)"/>
   </ItemGroup>
   
   <ItemGroup>

--- a/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/Microsoft.IdentityModel.Protocols.WsFederation.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Protocols.WsFederation.Tests/Microsoft.IdentityModel.Protocols.WsFederation.Tests.csproj
@@ -25,7 +25,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressions)"/>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntime)"/>
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Microsoft.IdentityModel.Tokens.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Microsoft.IdentityModel.Tokens.Tests.csproj
@@ -22,7 +22,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault.Cryptography" Version="$(MicrosoftAzureKeyVaultCryptographyVersion)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressions)"/>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntime)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.IdentityModel.Validators.Tests/Microsoft.IdentityModel.Validators.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Validators.Tests/Microsoft.IdentityModel.Validators.Tests.csproj
@@ -31,7 +31,6 @@
   <ItemGroup>
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressions)"/>
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttp)"/>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntime)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.IdentityModel.Xml.Tests/Microsoft.IdentityModel.Xml.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Xml.Tests/Microsoft.IdentityModel.Xml.Tests.csproj
@@ -17,7 +17,6 @@
   
   <ItemGroup>
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressions)"/>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntime)"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/System.IdentityModel.Tokens.Jwt.Tests.csproj
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/System.IdentityModel.Tokens.Jwt.Tests.csproj
@@ -22,7 +22,6 @@
   <ItemGroup>
     <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressions)"/>
     <PackageReference Include="System.Net.Http" Version="$(SystemNetHttp)"/>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntime)"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some of the nightly internal builds were breaking because we are including a deprecated package.
This package is not used anymore.