### PR TITLE
Prevent inlining to guarantee stack frames in test

### DIFF
--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationErrorTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationErrorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace Microsoft.IdentityModel.Tokens.Tests
@@ -22,11 +23,13 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         }
         class ValidationErrorReturningClass
         {
+            [MethodImpl(MethodImplOptions.NoInlining)]
             public ValidationError firstMethod()
             {
                 return secondMethod().AddCurrentStackFrame();
             }
 
+            [MethodImpl(MethodImplOptions.NoInlining)]
             public ValidationError secondMethod()
             {
                 return thirdMethod().AddCurrentStackFrame();

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationErrorTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationErrorTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         [Fact]
         public void ExceptionCreatedFromValidationError_ContainsTheRightStackTrace()
         {
-            var validationError = new ValidationErrorReturningClass().firstMethod();
+            var validationError = new ValidationErrorReturningClass().FirstMethod();
             Assert.NotNull(validationError);
             Assert.NotNull(validationError.StackFrames);
             Assert.Equal(3, validationError.StackFrames.Count);
@@ -24,18 +24,19 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         class ValidationErrorReturningClass
         {
             [MethodImpl(MethodImplOptions.NoInlining)]
-            public ValidationError firstMethod()
+            public ValidationError FirstMethod()
             {
-                return secondMethod().AddCurrentStackFrame();
+                return SecondMethod().AddCurrentStackFrame();
             }
 
             [MethodImpl(MethodImplOptions.NoInlining)]
-            public ValidationError secondMethod()
+            public ValidationError SecondMethod()
             {
-                return thirdMethod().AddCurrentStackFrame();
+                return ThirdMethod().AddCurrentStackFrame();
             }
 
-            public ValidationError thirdMethod()
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public ValidationError ThirdMethod()
             {
                 return new ValidationError(
                     new MessageDetail("This is a test error"),

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationErrorTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationErrorTests.cs
@@ -17,10 +17,11 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Assert.Equal(3, validationError.StackFrames.Count);
             Assert.NotNull(validationError.GetException());
             Assert.NotNull(validationError.GetException().StackTrace);
-            Assert.Equal("thirdMethod", validationError.StackFrames[0].GetMethod().Name);
-            Assert.Equal("secondMethod", validationError.StackFrames[1].GetMethod().Name);
-            Assert.Equal("firstMethod", validationError.StackFrames[2].GetMethod().Name);
+            Assert.Equal("ThirdMethod", validationError.StackFrames[0].GetMethod().Name);
+            Assert.Equal("SecondMethod", validationError.StackFrames[1].GetMethod().Name);
+            Assert.Equal("FirstMethod", validationError.StackFrames[2].GetMethod().Name);
         }
+
         class ValidationErrorReturningClass
         {
             [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
Addresses #2999 

In release builds, the compiler was inlining the methods that only contained call to other methods. This was causing the stack trace to be different than expected. Specifying no inlining will prevent this. 