### PR TITLE
Extensibility tests: Audience - JWT, SAML and SAML2

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.ValidateToken.Internal.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.ValidateToken.Internal.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateToken.Internal.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateToken.Internal.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10002 = "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10268 = "IDX10268: Unable to validate audience, validationParameters.ValidAudiences.Count == 0." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10269 = "IDX10269: IssuerValidationDelegate threw an exception, see inner exception." -> string
+const Microsoft.IdentityModel.Tokens.LogMessages.IDX10270 = "IDX10270: AudienceValidationDelegate threw an exception, see inner exception." -> string
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError.AlgorithmValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, string invalidAlgorithm, Microsoft.IdentityModel.Tokens.ValidationFailureType validationFailureType = null, System.Exception innerException = null) -> void
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError.InvalidAlgorithm.get -> string
@@ -34,13 +35,9 @@ Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.IsValid.get -> bool
 Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.Result.get -> TResult
 override Microsoft.IdentityModel.Tokens.AlgorithmValidationError.GetException() -> System.Exception
 override Microsoft.IdentityModel.Tokens.TokenTypeValidationError.GetException() -> System.Exception
-static Microsoft.IdentityModel.Tokens.AudienceValidationError.AudiencesCountZero -> System.Diagnostics.StackFrame
-static Microsoft.IdentityModel.Tokens.AudienceValidationError.AudiencesNull -> System.Diagnostics.StackFrame
-static Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidateAudienceFailed -> System.Diagnostics.StackFrame
-static Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidationParametersAudiencesCountZero -> System.Diagnostics.StackFrame
-static Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidationParametersNull -> System.Diagnostics.StackFrame
 static Microsoft.IdentityModel.Tokens.Utility.SerializeAsSingleCommaDelimitedString(System.Collections.Generic.IList<string> strings) -> string
 static Microsoft.IdentityModel.Tokens.ValidationError.GetCurrentStackFrame(string filePath = "", int lineNumber = 0, int skipFrames = 1) -> System.Diagnostics.StackFrame
+static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.AudienceValidatorThrew -> Microsoft.IdentityModel.Tokens.ValidationFailureType
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.IssuerValidatorThrew -> Microsoft.IdentityModel.Tokens.ValidationFailureType
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.NoTokenAudiencesProvided -> Microsoft.IdentityModel.Tokens.ValidationFailureType
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.NoValidationParameterAudiencesProvided -> Microsoft.IdentityModel.Tokens.ValidationFailureType

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -88,7 +88,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10267 = "IDX10267: '{0}' has been called by a derived class '{1}' which has not implemented this method. For this call graph to succeed, '{1}' will need to implement '{0}'.";
         public const string IDX10268 = "IDX10268: Unable to validate audience, validationParameters.ValidAudiences.Count == 0.";
         public const string IDX10269 = "IDX10269: IssuerValidationDelegate threw an exception, see inner exception.";
-
+        public const string IDX10270 = "IDX10270: AudienceValidationDelegate threw an exception, see inner exception.";
 
         // 10500 - SignatureValidation
         public const string IDX10500 = "IDX10500: Signature validation failed. No security keys were provided to validate the signature.";

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
@@ -134,5 +134,10 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         public static readonly ValidationFailureType IssuerValidatorThrew = new IssuerValidatorFailure("IssuerValidatorThrew");
         private class IssuerValidatorFailure : ValidationFailureType { internal IssuerValidatorFailure(string name) : base(name) { } }
+
+        /// <summary>
+        /// Defines a type that represents that the audience validation delegate threw and exception.
+        /// </summary>
+        public static readonly ValidationFailureType AudienceValidatorThrew = new AudienceValidationFailure("AudienceValidatorThrew");
     }
 }

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.Extensibility.Audience.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.Extensibility.Audience.cs
@@ -1,0 +1,283 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.JsonWebTokens.Tests;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Json.Tests;
+using Xunit;
+
+#nullable enable
+namespace Microsoft.IdentityModel.JsonWebTokens.Extensibility.Tests
+{
+    public partial class JsonWebTokenHandlerValidateTokenAsyncTests
+    {
+        [Theory, MemberData(nameof(Audience_ExtensibilityTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task ValidateTokenAsync_AudienceValidator_Extensibility(AudienceExtensibilityTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(ValidateTokenAsync_AudienceValidator_Extensibility)}", theoryData);
+            context.IgnoreType = false;
+            for (int i = 0; i < theoryData.ExtraStackFrames; i++)
+                theoryData.AudienceValidationError!.AddStackFrame(new StackFrame(false));
+
+            try
+            {
+                ValidationResult<ValidatedToken> validationResult = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(
+                    theoryData.JsonWebToken!,
+                    theoryData.ValidationParameters!,
+                    theoryData.CallContext,
+                    CancellationToken.None);
+
+                if (validationResult.IsValid)
+                {
+                    ValidatedToken validatedToken = validationResult.UnwrapResult();
+                    if (validatedToken.ValidatedAudience is not null)
+                        IdentityComparer.AreStringsEqual(validatedToken.ValidatedAudience, theoryData.ValidatedAudience, context);
+                }
+                else
+                {
+                    ValidationError validationError = validationResult.UnwrapError();
+                    IdentityComparer.AreValidationErrorsEqual(validationError, theoryData.AudienceValidationError, context);
+                    theoryData.ExpectedException.ProcessException(validationError.GetException(), context);
+                }
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<AudienceExtensibilityTheoryData> Audience_ExtensibilityTestCases
+        {
+            get
+            {
+                var theoryData = new TheoryData<AudienceExtensibilityTheoryData>();
+                CallContext callContext = new CallContext();
+                string audience = "CustomAudience";
+                List<string> tokenAudiences = [audience];
+
+                #region return CustomAudienceValidationError
+                // Test cases where delegate is overridden and return a CustomAudienceValidationError
+                // CustomAudienceValidationError : AudienceValidationError, ExceptionType: SecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "CustomAudienceValidatorDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.CustomAudienceValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidAudienceException),
+                        nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorDelegate)),
+                    AudienceValidationError = new CustomAudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 160),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed)
+                });
+
+                // CustomAudienceValidationError : AudienceValidationError, ExceptionType: CustomSecurityTokenInvalidAudienceException : SecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "CustomAudienceValidatorCustomExceptionDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionDelegate)),
+                    AudienceValidationError = new CustomAudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionDelegate), null),
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 175),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed),
+                });
+
+                // CustomAudienceValidationError : AudienceValidationError, ExceptionType: NotSupportedException : SystemException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "CustomAudienceValidatorUnknownExceptionDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.CustomAudienceValidatorUnknownExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    // CustomAudienceValidationError does not handle the exception type 'NotSupportedException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(NotSupportedException),
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorUnknownExceptionDelegate))),
+                    AudienceValidationError = new CustomAudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorUnknownExceptionDelegate), null),
+                        typeof(NotSupportedException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 205),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed),
+                });
+
+                // CustomAudienceValidationError : AudienceValidationError, ExceptionType: NotSupportedException : SystemException, ValidationFailureType: CustomAudienceValidationFailureType
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate)),
+                    AudienceValidationError = new CustomAudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 190),
+                        tokenAudiences,
+                        null, // validAudiences
+                        CustomAudienceValidationError.CustomAudienceValidationFailureType),
+                });
+                #endregion
+
+                #region return AudienceValidationError
+                // Test cases where delegate is overridden and return an AudienceValidationError
+                // AudienceValidationError : ValidationError, ExceptionType:  SecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "AudienceValidatorDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.AudienceValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidAudienceException),
+                        nameof(CustomAudienceValidationDelegates.AudienceValidatorDelegate)),
+                    AudienceValidationError = new AudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 235),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed)
+                });
+
+                // AudienceValidationError : ValidationError, ExceptionType:  CustomSecurityTokenInvalidAudienceException : SecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "AudienceValidatorCustomAudienceExceptionTypeDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.AudienceValidatorCustomAudienceExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // AudienceValidationError does not handle the exception type 'CustomSecurityTokenInvalidAudienceException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenInvalidAudienceException),
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorCustomAudienceExceptionTypeDelegate))),
+                    AudienceValidationError = new AudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorCustomAudienceExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 259),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed)
+                });
+
+                // AudienceValidationError : ValidationError, ExceptionType:  CustomSecurityTokenException : SystemException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "AudienceValidatorCustomExceptionTypeDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.AudienceValidatorCustomExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // AudienceValidationError does not handle the exception type 'CustomSecurityTokenException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenException),
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorCustomExceptionTypeDelegate))),
+                    AudienceValidationError = new AudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorCustomExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 274),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed)
+                });
+
+                // AudienceValidationError : ValidationError, ExceptionType: SecurityTokenInvalidAudienceException, inner: CustomSecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "AudienceValidatorThrows",
+                    audience,
+                    CustomAudienceValidationDelegates.AudienceValidatorThrows,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidAudienceException),
+                        string.Format(Tokens.LogMessages.IDX10270),
+                        typeof(CustomSecurityTokenInvalidAudienceException)),
+                    AudienceValidationError = new AudienceValidationError(
+                        new MessageDetail(
+                            string.Format(Tokens.LogMessages.IDX10270), null),
+                        typeof(SecurityTokenInvalidAudienceException),
+                        new StackFrame("JsonWebTokenHandler.ValidateToken.Internal.cs", 250),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidatorThrew,
+                        new SecurityTokenInvalidAudienceException(nameof(CustomAudienceValidationDelegates.AudienceValidatorThrows))
+                    )
+                });
+                #endregion
+
+                return theoryData;
+            }
+        }
+
+        public class AudienceExtensibilityTheoryData : ValidateTokenAsyncBaseTheoryData
+        {
+            internal AudienceExtensibilityTheoryData(string testId, string audience, AudienceValidationDelegate audienceValidator, int extraStackFrames) : base(testId)
+            {
+                JsonWebToken = JsonUtilities.CreateUnsignedJsonWebToken("aud", audience);
+                ValidationParameters = new ValidationParameters
+                {
+                    AlgorithmValidator = SkipValidationDelegates.SkipAlgorithmValidation,
+                    AudienceValidator = audienceValidator,
+                    IssuerValidatorAsync = SkipValidationDelegates.SkipIssuerValidation,
+                    IssuerSigningKeyValidator = SkipValidationDelegates.SkipIssuerSigningKeyValidation,
+                    LifetimeValidator = SkipValidationDelegates.SkipLifetimeValidation,
+                    SignatureValidator = SkipValidationDelegates.SkipSignatureValidation,
+                    TokenReplayValidator = SkipValidationDelegates.SkipTokenReplayValidation,
+                    TokenTypeValidator = SkipValidationDelegates.SkipTokenTypeValidation
+                };
+
+                ExtraStackFrames = extraStackFrames;
+            }
+
+            public JsonWebToken JsonWebToken { get; }
+
+            public JsonWebTokenHandler JsonWebTokenHandler { get; } = new JsonWebTokenHandler();
+
+            public bool IsValid { get; set; }
+
+            internal string? ValidatedAudience { get; set; }
+
+            internal AudienceValidationError? AudienceValidationError { get; set; }
+
+            internal int ExtraStackFrames { get; }
+        }
+    }
+}
+#nullable restore

--- a/test/Microsoft.IdentityModel.TestUtils/TokenValidationExtensibility/CustomAudienceValidationDelegates.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/TokenValidationExtensibility/CustomAudienceValidationDelegates.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.IdentityModel.Tokens;
+
+#nullable enable
+namespace Microsoft.IdentityModel.TestUtils
+{
+    internal class CustomAudienceValidationDelegates
+    {
+        internal static ValidationResult<string> CustomAudienceValidatorDelegate(
+            IList<string> tokenAudiences,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            // Returns a CustomAudienceValidationError : AudienceValidationError
+            return new CustomAudienceValidationError(
+                new MessageDetail(nameof(CustomAudienceValidatorDelegate), null),
+                typeof(SecurityTokenInvalidAudienceException),
+                ValidationError.GetCurrentStackFrame(),
+                tokenAudiences,
+                null);
+        }
+
+        internal static ValidationResult<string> CustomAudienceValidatorCustomExceptionDelegate(
+            IList<string> tokenAudiences,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new CustomAudienceValidationError(
+                new MessageDetail(nameof(CustomAudienceValidatorCustomExceptionDelegate), null),
+                typeof(CustomSecurityTokenInvalidAudienceException),
+                ValidationError.GetCurrentStackFrame(),
+                tokenAudiences,
+                null);
+        }
+
+        internal static ValidationResult<string> CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate(
+            IList<string> tokenAudiences,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new CustomAudienceValidationError(
+                new MessageDetail(nameof(CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                typeof(CustomSecurityTokenInvalidAudienceException),
+                ValidationError.GetCurrentStackFrame(),
+                tokenAudiences,
+                null,
+                CustomAudienceValidationError.CustomAudienceValidationFailureType);
+        }
+
+        internal static ValidationResult<string> CustomAudienceValidatorUnknownExceptionDelegate(
+            IList<string> tokenAudiences,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new CustomAudienceValidationError(
+                new MessageDetail(nameof(CustomAudienceValidatorUnknownExceptionDelegate), null),
+                typeof(NotSupportedException),
+                ValidationError.GetCurrentStackFrame(),
+                tokenAudiences,
+                null);
+        }
+
+        internal static ValidationResult<string> CustomAudienceValidatorWithoutGetExceptionOverrideDelegate(
+            IList<string> tokenAudiences,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new CustomAudienceWithoutGetExceptionValidationOverrideError(
+                new MessageDetail(nameof(CustomAudienceValidatorWithoutGetExceptionOverrideDelegate), null),
+                typeof(CustomSecurityTokenInvalidAudienceException),
+                ValidationError.GetCurrentStackFrame(),
+                tokenAudiences,
+                null);
+        }
+
+        internal static ValidationResult<string> AudienceValidatorDelegate(
+            IList<string> tokenAudiences,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new AudienceValidationError(
+                new MessageDetail(nameof(AudienceValidatorDelegate), null),
+                typeof(SecurityTokenInvalidAudienceException),
+                ValidationError.GetCurrentStackFrame(),
+                tokenAudiences,
+                null);
+        }
+
+        internal static ValidationResult<string> AudienceValidatorThrows(
+            IList<string> tokenAudiences,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            throw new CustomSecurityTokenInvalidAudienceException(nameof(AudienceValidatorThrows), null);
+        }
+
+        internal static ValidationResult<string> AudienceValidatorCustomAudienceExceptionTypeDelegate(
+            IList<string> tokenAudiences,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new AudienceValidationError(
+                new MessageDetail(nameof(AudienceValidatorCustomAudienceExceptionTypeDelegate), null),
+                typeof(CustomSecurityTokenInvalidAudienceException),
+                ValidationError.GetCurrentStackFrame(),
+                tokenAudiences,
+                null);
+        }
+
+        internal static ValidationResult<string> AudienceValidatorCustomExceptionTypeDelegate(
+            IList<string> tokenAudiences,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new AudienceValidationError(
+                new MessageDetail(nameof(AudienceValidatorCustomExceptionTypeDelegate), null),
+                typeof(CustomSecurityTokenException),
+                ValidationError.GetCurrentStackFrame(),
+                tokenAudiences,
+                null);
+        }
+    }
+}
+#nullable restore

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandler.Extensibility.Audience.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandler.Extensibility.Audience.cs
@@ -1,0 +1,288 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.TestUtils;
+
+using Xunit;
+
+#nullable enable
+namespace Microsoft.IdentityModel.Tokens.Saml2.Extensibility.Tests
+{
+    public partial class Saml2SecurityTokenHandlerValidateTokenAsyncTests
+    {
+        [Theory, MemberData(nameof(Audience_ExtensibilityTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task ValidateTokenAsync_AudienceValidator_Extensibility(AudienceExtensibilityTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(ValidateTokenAsync_AudienceValidator_Extensibility)}", theoryData);
+            context.IgnoreType = false;
+            for (int i = 0; i < theoryData.ExtraStackFrames; i++)
+                theoryData.AudienceValidationError!.AddStackFrame(new StackFrame(false));
+
+            try
+            {
+                ValidationResult<ValidatedToken> validationResult = await theoryData.Saml2SecurityTokenHandler.ValidateTokenAsync(
+                    theoryData.Saml2Token!,
+                    theoryData.ValidationParameters!,
+                    theoryData.CallContext,
+                    CancellationToken.None);
+
+                if (validationResult.IsValid)
+                {
+                    ValidatedToken validatedToken = validationResult.UnwrapResult();
+                    if (validatedToken.ValidatedAudience is not null)
+                        IdentityComparer.AreStringsEqual(validatedToken.ValidatedAudience, theoryData.ValidatedAudience, context);
+                }
+                else
+                {
+                    ValidationError validationError = validationResult.UnwrapError();
+                    IdentityComparer.AreValidationErrorsEqual(validationError, theoryData.AudienceValidationError, context);
+                    theoryData.ExpectedException.ProcessException(validationError.GetException(), context);
+                }
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<AudienceExtensibilityTheoryData> Audience_ExtensibilityTestCases
+        {
+            get
+            {
+                var theoryData = new TheoryData<AudienceExtensibilityTheoryData>();
+                CallContext callContext = new CallContext();
+                string audience = Default.Audience;
+                List<string> tokenAudiences = [audience];
+
+                #region return CustomAudienceValidationError
+                // Test cases where delegate is overridden and return a CustomAudienceValidationError
+                // CustomAudienceValidationError : AudienceValidationError, ExceptionType: SecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "CustomAudienceValidatorDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.CustomAudienceValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidAudienceException),
+                        nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorDelegate)),
+                    AudienceValidationError = new CustomAudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 160),
+                        tokenAudiences,
+                        null, // validAudiences
+                        ValidationFailureType.AudienceValidationFailed)
+                });
+
+                // CustomAudienceValidationError : AudienceValidationError, ExceptionType: CustomSecurityTokenInvalidAudienceException : SecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "CustomAudienceValidatorCustomExceptionDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionDelegate)),
+                    AudienceValidationError = new CustomAudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionDelegate), null),
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 175),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed),
+                });
+
+                // CustomAudienceValidationError : AudienceValidationError, ExceptionType: NotSupportedException : SystemException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "CustomAudienceValidatorUnknownExceptionDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.CustomAudienceValidatorUnknownExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    // CustomAudienceValidationError does not handle the exception type 'NotSupportedException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(NotSupportedException),
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorUnknownExceptionDelegate))),
+                    AudienceValidationError = new CustomAudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorUnknownExceptionDelegate), null),
+                        typeof(NotSupportedException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 205),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed),
+                });
+
+                // CustomAudienceValidationError : AudienceValidationError, ExceptionType: NotSupportedException : SystemException, ValidationFailureType: CustomAudienceValidationFailureType
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate)),
+                    AudienceValidationError = new CustomAudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 190),
+                        tokenAudiences,
+                        null,
+                        CustomAudienceValidationError.CustomAudienceValidationFailureType),
+                });
+                #endregion
+
+                #region return AudienceValidationError
+                // Test cases where delegate is overridden and return an AudienceValidationError
+                // AudienceValidationError : ValidationError, ExceptionType:  SecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "AudienceValidatorDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.AudienceValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidAudienceException),
+                        nameof(CustomAudienceValidationDelegates.AudienceValidatorDelegate)),
+                    AudienceValidationError = new AudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 235),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed)
+                });
+
+                // AudienceValidationError : ValidationError, ExceptionType:  CustomSecurityTokenInvalidAudienceException : SecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "AudienceValidatorCustomAudienceExceptionTypeDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.AudienceValidatorCustomAudienceExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // AudienceValidationError does not handle the exception type 'CustomSecurityTokenInvalidAudienceException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenInvalidAudienceException),
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorCustomAudienceExceptionTypeDelegate))),
+                    AudienceValidationError = new AudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorCustomAudienceExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 259),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed)
+                });
+
+                // AudienceValidationError : ValidationError, ExceptionType:  CustomSecurityTokenException : SystemException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "AudienceValidatorCustomExceptionTypeDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.AudienceValidatorCustomExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // AudienceValidationError does not handle the exception type 'CustomSecurityTokenException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenException),
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorCustomExceptionTypeDelegate))),
+                    AudienceValidationError = new AudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorCustomExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 274),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed)
+                });
+
+                // AudienceValidationError : ValidationError, ExceptionType: SecurityTokenInvalidAudienceException, inner: CustomSecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "AudienceValidatorThrows",
+                    audience,
+                    CustomAudienceValidationDelegates.AudienceValidatorThrows,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidAudienceException),
+                        string.Format(Tokens.LogMessages.IDX10270),
+                        typeof(CustomSecurityTokenInvalidAudienceException)),
+                    AudienceValidationError = new AudienceValidationError(
+                        new MessageDetail(
+                            string.Format(Tokens.LogMessages.IDX10270), null),
+                        typeof(SecurityTokenInvalidAudienceException),
+                        new StackFrame("Saml2SecurityTokenHandler.ValidateToken.Internal.cs", 250),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidatorThrew,
+                        new SecurityTokenInvalidAudienceException(nameof(CustomAudienceValidationDelegates.AudienceValidatorThrows))
+                    )
+                });
+                #endregion
+
+                return theoryData;
+            }
+        }
+
+        public class AudienceExtensibilityTheoryData : TheoryDataBase
+        {
+            internal AudienceExtensibilityTheoryData(string testId, string audience, AudienceValidationDelegate audienceValidator, int extraStackFrames) : base(testId)
+            {
+                Saml2Token = (Saml2SecurityToken)Saml2SecurityTokenHandler.CreateToken(new()
+                {
+                    Subject = Default.SamlClaimsIdentity,
+                    Audience = audience,
+                    Issuer = Default.Issuer,
+                });
+                ValidationParameters = new ValidationParameters
+                {
+                    AlgorithmValidator = SkipValidationDelegates.SkipAlgorithmValidation,
+                    AudienceValidator = audienceValidator,
+                    IssuerValidatorAsync = SkipValidationDelegates.SkipIssuerValidation,
+                    IssuerSigningKeyValidator = SkipValidationDelegates.SkipIssuerSigningKeyValidation,
+                    LifetimeValidator = SkipValidationDelegates.SkipLifetimeValidation,
+                    SignatureValidator = SkipValidationDelegates.SkipSignatureValidation,
+                    TokenReplayValidator = SkipValidationDelegates.SkipTokenReplayValidation,
+                    TokenTypeValidator = SkipValidationDelegates.SkipTokenTypeValidation
+                };
+
+                ExtraStackFrames = extraStackFrames;
+            }
+
+            public Saml2SecurityToken Saml2Token { get; }
+
+            public Saml2SecurityTokenHandler Saml2SecurityTokenHandler { get; } = new Saml2SecurityTokenHandler();
+
+            public bool IsValid { get; set; }
+
+            internal string? ValidatedAudience { get; set; }
+
+            internal ValidationParameters? ValidationParameters { get; set; }
+
+            internal AudienceValidationError? AudienceValidationError { get; set; }
+
+            internal int ExtraStackFrames { get; }
+        }
+    }
+}
+#nullable restore

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandler.Extensibility.Audience.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandler.Extensibility.Audience.cs
@@ -1,0 +1,288 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.TestUtils;
+
+using Xunit;
+
+#nullable enable
+namespace Microsoft.IdentityModel.Tokens.Saml.Extensibility.Tests
+{
+    public partial class SamlSecurityTokenHandlerValidateTokenAsyncTests
+    {
+        [Theory, MemberData(nameof(Audience_ExtensibilityTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task ValidateTokenAsync_AudienceValidator_Extensibility(AudienceExtensibilityTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(ValidateTokenAsync_AudienceValidator_Extensibility)}", theoryData);
+            context.IgnoreType = false;
+            for (int i = 0; i < theoryData.ExtraStackFrames; i++)
+                theoryData.AudienceValidationError!.AddStackFrame(new StackFrame(false));
+
+            try
+            {
+                ValidationResult<ValidatedToken> validationResult = await theoryData.SamlSecurityTokenHandler.ValidateTokenAsync(
+                    theoryData.SamlToken!,
+                    theoryData.ValidationParameters!,
+                    theoryData.CallContext,
+                    CancellationToken.None);
+
+                if (validationResult.IsValid)
+                {
+                    ValidatedToken validatedToken = validationResult.UnwrapResult();
+                    if (validatedToken.ValidatedAudience is not null)
+                        IdentityComparer.AreStringsEqual(validatedToken.ValidatedAudience, theoryData.ValidatedAudience, context);
+                }
+                else
+                {
+                    ValidationError validationError = validationResult.UnwrapError();
+                    IdentityComparer.AreValidationErrorsEqual(validationError, theoryData.AudienceValidationError, context);
+                    theoryData.ExpectedException.ProcessException(validationError.GetException(), context);
+                }
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<AudienceExtensibilityTheoryData> Audience_ExtensibilityTestCases
+        {
+            get
+            {
+                var theoryData = new TheoryData<AudienceExtensibilityTheoryData>();
+                CallContext callContext = new CallContext();
+                string audience = Default.Audience;
+                List<string> tokenAudiences = [audience];
+
+                #region return CustomAudienceValidationError
+                // Test cases where delegate is overridden and return a CustomAudienceValidationError
+                // CustomAudienceValidationError : AudienceValidationError, ExceptionType: SecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "CustomAudienceValidatorDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.CustomAudienceValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidAudienceException),
+                        nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorDelegate)),
+                    AudienceValidationError = new CustomAudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 160),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed)
+                });
+
+                // CustomAudienceValidationError : AudienceValidationError, ExceptionType: CustomSecurityTokenInvalidAudienceException : SecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "CustomAudienceValidatorCustomExceptionDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionDelegate)),
+                    AudienceValidationError = new CustomAudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionDelegate), null),
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 175),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed),
+                });
+
+                // CustomAudienceValidationError : AudienceValidationError, ExceptionType: NotSupportedException : SystemException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "CustomAudienceValidatorUnknownExceptionDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.CustomAudienceValidatorUnknownExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    // CustomAudienceValidationError does not handle the exception type 'NotSupportedException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(NotSupportedException),
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorUnknownExceptionDelegate))),
+                    AudienceValidationError = new CustomAudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorUnknownExceptionDelegate), null),
+                        typeof(NotSupportedException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 205),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed),
+                });
+
+                // CustomAudienceValidationError : AudienceValidationError, ExceptionType: NotSupportedException : SystemException, ValidationFailureType: CustomAudienceValidationFailureType
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate)),
+                    AudienceValidationError = new CustomAudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.CustomAudienceValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 190),
+                        tokenAudiences,
+                        null,
+                        CustomAudienceValidationError.CustomAudienceValidationFailureType),
+                });
+                #endregion
+
+                #region return AudienceValidationError
+                // Test cases where delegate is overridden and return an AudienceValidationError
+                // AudienceValidationError : ValidationError, ExceptionType:  SecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "AudienceValidatorDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.AudienceValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidAudienceException),
+                        nameof(CustomAudienceValidationDelegates.AudienceValidatorDelegate)),
+                    AudienceValidationError = new AudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 235),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed),
+                });
+
+                // AudienceValidationError : ValidationError, ExceptionType:  CustomSecurityTokenInvalidAudienceException : SecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "AudienceValidatorCustomAudienceExceptionTypeDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.AudienceValidatorCustomAudienceExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // AudienceValidationError does not handle the exception type 'CustomSecurityTokenInvalidAudienceException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenInvalidAudienceException),
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorCustomAudienceExceptionTypeDelegate))),
+                    AudienceValidationError = new AudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorCustomAudienceExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidAudienceException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 259),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed),
+                });
+
+                // AudienceValidationError : ValidationError, ExceptionType:  CustomSecurityTokenException : SystemException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "AudienceValidatorCustomExceptionTypeDelegate",
+                    audience,
+                    CustomAudienceValidationDelegates.AudienceValidatorCustomExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // AudienceValidationError does not handle the exception type 'CustomSecurityTokenException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenException),
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorCustomExceptionTypeDelegate))),
+                    AudienceValidationError = new AudienceValidationError(
+                        new MessageDetail(
+                            nameof(CustomAudienceValidationDelegates.AudienceValidatorCustomExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenException),
+                        new StackFrame("CustomAudienceValidationDelegates.cs", 274),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidationFailed),
+                });
+
+                // AudienceValidationError : ValidationError, ExceptionType: SecurityTokenInvalidAudienceException, inner: CustomSecurityTokenInvalidAudienceException
+                theoryData.Add(new AudienceExtensibilityTheoryData(
+                    "AudienceValidatorThrows",
+                    audience,
+                    CustomAudienceValidationDelegates.AudienceValidatorThrows,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidAudienceException),
+                        string.Format(Tokens.LogMessages.IDX10270),
+                        typeof(CustomSecurityTokenInvalidAudienceException)),
+                    AudienceValidationError = new AudienceValidationError(
+                        new MessageDetail(
+                            string.Format(Tokens.LogMessages.IDX10270), null),
+                        typeof(SecurityTokenInvalidAudienceException),
+                        new StackFrame("SamlSecurityTokenHandler.ValidateToken.Internal.cs", 250),
+                        tokenAudiences,
+                        null,
+                        ValidationFailureType.AudienceValidatorThrew,
+                        new SecurityTokenInvalidAudienceException(nameof(CustomAudienceValidationDelegates.AudienceValidatorThrows))
+                    )
+                });
+                #endregion
+
+                return theoryData;
+            }
+        }
+
+        public class AudienceExtensibilityTheoryData : TheoryDataBase
+        {
+            internal AudienceExtensibilityTheoryData(string testId, string audience, AudienceValidationDelegate audienceValidator, int extraStackFrames) : base(testId)
+            {
+                SamlToken = (SamlSecurityToken)SamlSecurityTokenHandler.CreateToken(new()
+                {
+                    Subject = Default.SamlClaimsIdentity,
+                    Audience = audience,
+                    Issuer = Default.Issuer,
+                });
+                ValidationParameters = new ValidationParameters
+                {
+                    AlgorithmValidator = SkipValidationDelegates.SkipAlgorithmValidation,
+                    AudienceValidator = audienceValidator,
+                    IssuerValidatorAsync = SkipValidationDelegates.SkipIssuerValidation,
+                    IssuerSigningKeyValidator = SkipValidationDelegates.SkipIssuerSigningKeyValidation,
+                    LifetimeValidator = SkipValidationDelegates.SkipLifetimeValidation,
+                    SignatureValidator = SkipValidationDelegates.SkipSignatureValidation,
+                    TokenReplayValidator = SkipValidationDelegates.SkipTokenReplayValidation,
+                    TokenTypeValidator = SkipValidationDelegates.SkipTokenTypeValidation
+                };
+
+                ExtraStackFrames = extraStackFrames;
+            }
+
+            public SamlSecurityToken SamlToken { get; }
+
+            public SamlSecurityTokenHandler SamlSecurityTokenHandler { get; } = new SamlSecurityTokenHandler();
+
+            public bool IsValid { get; set; }
+
+            internal string? ValidatedAudience { get; set; }
+
+            internal ValidationParameters? ValidationParameters { get; set; }
+
+            internal AudienceValidationError? AudienceValidationError { get; set; }
+
+            internal int ExtraStackFrames { get; }
+        }
+    }
+}
+#nullable restore


### PR DESCRIPTION
# Extensibility tests: Audience - JWT, SAML and SAML2
- Handle potential exceptions thrown by the audience validation delegate on JWT, SAML, and SAML2
- Added custom audience validation delegates for testing
- Added audience extensibility tests for JWT, SAML and SAML2

Note: Targeting the base extensibility branch to avoid showing those changes again. Once merged, I will move this to target dev and take out of draft.

Part of #2711 