### PR TITLE
Extensibility tests: Lifetime - JWT, SAML and SAML2

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.Internal.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.Internal.cs
@@ -255,13 +255,28 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             DateTime? expires = jsonWebToken.HasPayloadClaim(JwtRegisteredClaimNames.Exp) ? jsonWebToken.ValidTo : null;
             DateTime? notBefore = jsonWebToken.HasPayloadClaim(JwtRegisteredClaimNames.Nbf) ? jsonWebToken.ValidFrom : null;
 
-            ValidationResult<ValidatedLifetime> lifetimeValidationResult = validationParameters.LifetimeValidator(
-                notBefore, expires, jsonWebToken, validationParameters, callContext);
+            ValidationResult<ValidatedLifetime> lifetimeValidationResult;
 
-            if (!lifetimeValidationResult.IsValid)
+            try
             {
-                StackFrame lifetimeValidationFailureStackFrame = StackFrames.LifetimeValidationFailed ??= new StackFrame(true);
-                return lifetimeValidationResult.UnwrapError().AddStackFrame(lifetimeValidationFailureStackFrame);
+                lifetimeValidationResult = validationParameters.LifetimeValidator(
+                    notBefore, expires, jsonWebToken, validationParameters, callContext);
+
+                if (!lifetimeValidationResult.IsValid)
+                    return lifetimeValidationResult.UnwrapError().AddCurrentStackFrame();
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return new LifetimeValidationError(
+                    new MessageDetail(TokenLogMessages.IDX10271),
+                    typeof(SecurityTokenInvalidLifetimeException),
+                    ValidationError.GetCurrentStackFrame(),
+                    notBefore,
+                    expires,
+                    ValidationFailureType.LifetimeValidatorThrew,
+                    ex);
             }
 
             if (jsonWebToken.Audiences is not IList<string> tokenAudiences)

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.ValidateToken.Internal.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.ValidateToken.Internal.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.ValidateToken.Internal.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.ValidateToken.Internal.cs
@@ -126,17 +126,32 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                     StackFrames.AssertionConditionsNull);
             }
 
-            var lifetimeValidationResult = validationParameters.LifetimeValidator(
-                samlToken.Assertion.Conditions.NotBefore,
-                samlToken.Assertion.Conditions.NotOnOrAfter,
-                samlToken,
-                validationParameters,
-                callContext);
+            ValidationResult<ValidatedLifetime> lifetimeValidationResult;
 
-            if (!lifetimeValidationResult.IsValid)
+            try
             {
-                StackFrames.LifetimeValidationFailed ??= new StackFrame(true);
-                return lifetimeValidationResult.UnwrapError().AddStackFrame(StackFrames.LifetimeValidationFailed);
+                lifetimeValidationResult = validationParameters.LifetimeValidator(
+                    samlToken.Assertion.Conditions.NotBefore,
+                    samlToken.Assertion.Conditions.NotOnOrAfter,
+                    samlToken,
+                    validationParameters,
+                    callContext);
+
+                if (!lifetimeValidationResult.IsValid)
+                    return lifetimeValidationResult.UnwrapError().AddCurrentStackFrame();
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return new LifetimeValidationError(
+                    new MessageDetail(Tokens.LogMessages.IDX10271),
+                    typeof(SecurityTokenInvalidLifetimeException),
+                    ValidationError.GetCurrentStackFrame(),
+                    samlToken.Assertion.Conditions.NotBefore,
+                    samlToken.Assertion.Conditions.NotOnOrAfter,
+                    ValidationFailureType.LifetimeValidatorThrew,
+                    ex);
             }
 
             string? validatedAudience = null;

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateToken.Internal.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateToken.Internal.cs
@@ -129,17 +129,32 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                     StackFrames.AssertionConditionsNull);
             }
 
-            var lifetimeValidationResult = validationParameters.LifetimeValidator(
-                samlToken.Assertion.Conditions.NotBefore,
-                samlToken.Assertion.Conditions.NotOnOrAfter,
-                samlToken,
-                validationParameters,
-                callContext);
+            ValidationResult<ValidatedLifetime> lifetimeValidationResult;
 
-            if (!lifetimeValidationResult.IsValid)
+            try
             {
-                StackFrames.LifetimeValidationFailed ??= new StackFrame(true);
-                return lifetimeValidationResult.UnwrapError().AddStackFrame(StackFrames.LifetimeValidationFailed);
+                lifetimeValidationResult = validationParameters.LifetimeValidator(
+                    samlToken.Assertion.Conditions.NotBefore,
+                    samlToken.Assertion.Conditions.NotOnOrAfter,
+                    samlToken,
+                    validationParameters,
+                    callContext);
+
+                if (!lifetimeValidationResult.IsValid)
+                    return lifetimeValidationResult.UnwrapError().AddCurrentStackFrame();
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return new LifetimeValidationError(
+                    new MessageDetail(Tokens.LogMessages.IDX10271),
+                    typeof(SecurityTokenInvalidLifetimeException),
+                    ValidationError.GetCurrentStackFrame(),
+                    samlToken.Assertion.Conditions.NotBefore,
+                    samlToken.Assertion.Conditions.NotOnOrAfter,
+                    ValidationFailureType.LifetimeValidatorThrew,
+                    ex);
             }
 
             if (samlToken.Assertion.Conditions.OneTimeUse)

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateToken.Internal.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateToken.Internal.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10002 = "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10268 = "IDX10268: Unable to validate audience, validationParameters.ValidAudiences.Count == 0." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10269 = "IDX10269: IssuerValidationDelegate threw an exception, see inner exception." -> string
+const Microsoft.IdentityModel.Tokens.LogMessages.IDX10271 = "IDX10271: LifetimeValidationDelegate threw an exception, see inner exception." -> string
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError.AlgorithmValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, string invalidAlgorithm, Microsoft.IdentityModel.Tokens.ValidationFailureType validationFailureType = null, System.Exception innerException = null) -> void
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError.InvalidAlgorithm.get -> string
@@ -42,6 +43,7 @@ static Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidationParamete
 static Microsoft.IdentityModel.Tokens.Utility.SerializeAsSingleCommaDelimitedString(System.Collections.Generic.IList<string> strings) -> string
 static Microsoft.IdentityModel.Tokens.ValidationError.GetCurrentStackFrame(string filePath = "", int lineNumber = 0, int skipFrames = 1) -> System.Diagnostics.StackFrame
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.IssuerValidatorThrew -> Microsoft.IdentityModel.Tokens.ValidationFailureType
+static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.LifetimeValidatorThrew -> Microsoft.IdentityModel.Tokens.ValidationFailureType
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.NoTokenAudiencesProvided -> Microsoft.IdentityModel.Tokens.ValidationFailureType
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.NoValidationParameterAudiencesProvided -> Microsoft.IdentityModel.Tokens.ValidationFailureType
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.SignatureAlgorithmValidationFailed -> Microsoft.IdentityModel.Tokens.ValidationFailureType

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -88,7 +88,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10267 = "IDX10267: '{0}' has been called by a derived class '{1}' which has not implemented this method. For this call graph to succeed, '{1}' will need to implement '{0}'.";
         public const string IDX10268 = "IDX10268: Unable to validate audience, validationParameters.ValidAudiences.Count == 0.";
         public const string IDX10269 = "IDX10269: IssuerValidationDelegate threw an exception, see inner exception.";
-
+        public const string IDX10271 = "IDX10271: LifetimeValidationDelegate threw an exception, see inner exception.";
 
         // 10500 - SignatureValidation
         public const string IDX10500 = "IDX10500: Signature validation failed. No security keys were provided to validate the signature.";

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
@@ -134,5 +134,10 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         public static readonly ValidationFailureType IssuerValidatorThrew = new IssuerValidatorFailure("IssuerValidatorThrew");
         private class IssuerValidatorFailure : ValidationFailureType { internal IssuerValidatorFailure(string name) : base(name) { } }
+
+        /// <summary>
+        /// Defines a type that represents that the audience validation delegate threw and exception.
+        /// </summary>
+        public static readonly ValidationFailureType LifetimeValidatorThrew = new LifetimeValidationFailure("LifetimeValidatorThrew");
     }
 }

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.Extensibility.Lifetime.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.Extensibility.Lifetime.cs
@@ -1,0 +1,289 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.JsonWebTokens.Tests;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+#nullable enable
+namespace Microsoft.IdentityModel.JsonWebTokens.Extensibility.Tests
+{
+    public partial class JsonWebTokenHandlerValidateTokenAsyncTests
+    {
+        [Theory, MemberData(nameof(Lifetime_ExtensibilityTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task ValidateTokenAsync_LifetimeValidator_Extensibility(LifetimeExtensibilityTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(ValidateTokenAsync_LifetimeValidator_Extensibility)}", theoryData);
+            context.IgnoreType = false;
+            for (int i = 0; i < theoryData.ExtraStackFrames; i++)
+                theoryData.LifetimeValidationError!.AddStackFrame(new StackFrame(false));
+
+            try
+            {
+                ValidationResult<ValidatedToken> validationResult = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(
+                    theoryData.JsonWebToken!,
+                    theoryData.ValidationParameters!,
+                    theoryData.CallContext,
+                    CancellationToken.None);
+
+                if (validationResult.IsValid)
+                {
+                    ValidatedToken validatedToken = validationResult.UnwrapResult();
+                    if (validatedToken.ValidatedLifetime is not null)
+                        IdentityComparer.AreValidatedLifetimesEqual((ValidatedLifetime)validatedToken.ValidatedLifetime, theoryData.ValidatedLifetime, context);
+                }
+                else
+                {
+                    ValidationError validationError = validationResult.UnwrapError();
+                    IdentityComparer.AreValidationErrorsEqual(validationError, theoryData.LifetimeValidationError, context);
+                    theoryData.ExpectedException.ProcessException(validationError.GetException(), context);
+                }
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<LifetimeExtensibilityTheoryData> Lifetime_ExtensibilityTestCases
+        {
+            get
+            {
+                var theoryData = new TheoryData<LifetimeExtensibilityTheoryData>();
+                CallContext callContext = new CallContext();
+                var utcNow = DateTime.UtcNow;
+                var utcPlusOneHour = utcNow + TimeSpan.FromHours(1);
+
+                #region return CustomLifetimeValidationError
+                // Test cases where delegate is overridden and return a CustomLifetimeValidationError
+                // CustomLifetimeValidationError : LifetimeValidationError, ExceptionType: SecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "CustomLifetimeValidatorDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.CustomLifetimeValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorDelegate)),
+                    LifetimeValidationError = new CustomLifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 160),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed)
+                });
+
+                // CustomLifetimeValidationError : LifetimeValidationError, ExceptionType: CustomSecurityTokenInvalidLifetimeException : SecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "CustomLifetimeValidatorCustomExceptionDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionDelegate)),
+                    LifetimeValidationError = new CustomLifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionDelegate), null),
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 175),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed),
+                });
+
+                // CustomLifetimeValidationError : LifetimeValidationError, ExceptionType: NotSupportedException : SystemException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "CustomLifetimeValidatorUnknownExceptionDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.CustomLifetimeValidatorUnknownExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    // CustomLifetimeValidationError does not handle the exception type 'NotSupportedException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(NotSupportedException),
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorUnknownExceptionDelegate))),
+                    LifetimeValidationError = new CustomLifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorUnknownExceptionDelegate), null),
+                        typeof(NotSupportedException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 205),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed),
+                });
+
+                // CustomLifetimeValidationError : LifetimeValidationError, ExceptionType: NotSupportedException : SystemException, ValidationFailureType: CustomAudienceValidationFailureType
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate)),
+                    LifetimeValidationError = new CustomLifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 190),
+                        utcNow,
+                        utcPlusOneHour,
+                        CustomLifetimeValidationError.CustomLifetimeValidationFailureType),
+                });
+                #endregion
+
+                #region return LifetimeValidationError
+                // Test cases where delegate is overridden and return an LifetimeValidationError
+                // LifetimeValidationError : ValidationError, ExceptionType:  SecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "LifetimeValidatorDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.LifetimeValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        nameof(CustomLifetimeValidationDelegates.LifetimeValidatorDelegate)),
+                    LifetimeValidationError = new LifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 235),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed)
+                });
+
+                // LifetimeValidationError : ValidationError, ExceptionType:  CustomSecurityTokenInvalidLifetimeException : SecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "LifetimeValidatorCustomLifetimeExceptionTypeDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.LifetimeValidatorCustomLifetimeExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // LifetimeValidationError does not handle the exception type 'CustomSecurityTokenInvalidLifetimeException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenInvalidLifetimeException),
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorCustomLifetimeExceptionTypeDelegate))),
+                    LifetimeValidationError = new LifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorCustomLifetimeExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 259),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed)
+                });
+
+                // LifetimeValidationError : ValidationError, ExceptionType:  CustomSecurityTokenException : SystemException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "LifetimeValidatorCustomExceptionTypeDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.LifetimeValidatorCustomExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // LifetimeValidationError does not handle the exception type 'CustomSecurityTokenException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenException),
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorCustomExceptionTypeDelegate))),
+                    LifetimeValidationError = new LifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorCustomExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 274),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed)
+                });
+
+                // LifetimeValidationError : ValidationError, ExceptionType: SecurityTokenInvalidLifetimeException, inner: CustomSecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "LifetimeValidatorThrows",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.LifetimeValidatorThrows,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        string.Format(Tokens.LogMessages.IDX10271),
+                        typeof(CustomSecurityTokenInvalidLifetimeException)),
+                    LifetimeValidationError = new LifetimeValidationError(
+                        new MessageDetail(
+                            string.Format(Tokens.LogMessages.IDX10271), null),
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        new StackFrame("JsonWebTokenHandler.ValidateToken.Internal.cs", 250),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidatorThrew,
+                        new SecurityTokenInvalidLifetimeException(nameof(CustomLifetimeValidationDelegates.LifetimeValidatorThrows))
+                    )
+                });
+                #endregion
+
+                return theoryData;
+            }
+        }
+
+        public class LifetimeExtensibilityTheoryData : ValidateTokenAsyncBaseTheoryData
+        {
+            internal LifetimeExtensibilityTheoryData(string testId, DateTime utcNow, LifetimeValidationDelegate lifetimeValidator, int extraStackFrames) : base(testId)
+            {
+                JsonWebToken = JsonWebTokenHandler.ReadJsonWebToken(
+                    JsonWebTokenHandler.CreateToken(
+                        new SecurityTokenDescriptor()
+                        {
+                            IssuedAt = utcNow,
+                            NotBefore = utcNow,
+                            Expires = utcNow + TimeSpan.FromHours(1),
+                        }));
+
+                ValidationParameters = new ValidationParameters
+                {
+                    AlgorithmValidator = SkipValidationDelegates.SkipAlgorithmValidation,
+                    AudienceValidator = SkipValidationDelegates.SkipAudienceValidation,
+                    IssuerValidatorAsync = SkipValidationDelegates.SkipIssuerValidation,
+                    IssuerSigningKeyValidator = SkipValidationDelegates.SkipIssuerSigningKeyValidation,
+                    LifetimeValidator = lifetimeValidator,
+                    SignatureValidator = SkipValidationDelegates.SkipSignatureValidation,
+                    TokenReplayValidator = SkipValidationDelegates.SkipTokenReplayValidation,
+                    TokenTypeValidator = SkipValidationDelegates.SkipTokenTypeValidation
+                };
+
+                ExtraStackFrames = extraStackFrames;
+            }
+
+            public JsonWebToken JsonWebToken { get; }
+
+            public JsonWebTokenHandler JsonWebTokenHandler { get; } = new JsonWebTokenHandler();
+
+            public bool IsValid { get; set; }
+
+            internal ValidatedLifetime ValidatedLifetime { get; set; }
+
+            internal LifetimeValidationError? LifetimeValidationError { get; set; }
+
+            internal int ExtraStackFrames { get; }
+        }
+    }
+}
+#nullable restore

--- a/test/Microsoft.IdentityModel.TestUtils/TokenValidationExtensibility/CustomLifetimeValidationDelegates.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/TokenValidationExtensibility/CustomLifetimeValidationDelegates.cs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.IdentityModel.Tokens;
+
+#nullable enable
+namespace Microsoft.IdentityModel.TestUtils
+{
+    internal class CustomLifetimeValidationDelegates
+    {
+        internal static ValidationResult<ValidatedLifetime> CustomLifetimeValidatorDelegate(
+            DateTime? notBefore,
+            DateTime? expires,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            // Returns a CustomLifetimeValidationError : LifetimeValidationError
+            return new CustomLifetimeValidationError(
+                new MessageDetail(nameof(CustomLifetimeValidatorDelegate), null),
+                typeof(SecurityTokenInvalidLifetimeException),
+                ValidationError.GetCurrentStackFrame(),
+                notBefore,
+                expires,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedLifetime> CustomLifetimeValidatorCustomExceptionDelegate(
+            DateTime? notBefore,
+            DateTime? expires,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new CustomLifetimeValidationError(
+                new MessageDetail(nameof(CustomLifetimeValidatorCustomExceptionDelegate), null),
+                typeof(CustomSecurityTokenInvalidLifetimeException),
+                ValidationError.GetCurrentStackFrame(),
+                notBefore,
+                expires,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedLifetime> CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate(
+            DateTime? notBefore,
+            DateTime? expires,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new CustomLifetimeValidationError(
+                new MessageDetail(nameof(CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                typeof(CustomSecurityTokenInvalidLifetimeException),
+                ValidationError.GetCurrentStackFrame(),
+                notBefore,
+                expires,
+                CustomLifetimeValidationError.CustomLifetimeValidationFailureType);
+        }
+
+        internal static ValidationResult<ValidatedLifetime> CustomLifetimeValidatorUnknownExceptionDelegate(
+            DateTime? notBefore,
+            DateTime? expires,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new CustomLifetimeValidationError(
+                new MessageDetail(nameof(CustomLifetimeValidatorUnknownExceptionDelegate), null),
+                typeof(NotSupportedException),
+                ValidationError.GetCurrentStackFrame(),
+                notBefore,
+                expires,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedLifetime> CustomLifetimeValidatorWithoutGetExceptionOverrideDelegate(
+            DateTime? notBefore,
+            DateTime? expires,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new CustomLifetimeWithoutGetExceptionValidationOverrideError(
+                new MessageDetail(nameof(CustomLifetimeValidatorWithoutGetExceptionOverrideDelegate), null),
+                typeof(CustomSecurityTokenInvalidLifetimeException),
+                ValidationError.GetCurrentStackFrame(),
+                notBefore,
+                expires,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedLifetime> LifetimeValidatorDelegate(
+            DateTime? notBefore,
+            DateTime? expires,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new LifetimeValidationError(
+                new MessageDetail(nameof(LifetimeValidatorDelegate), null),
+                typeof(SecurityTokenInvalidLifetimeException),
+                ValidationError.GetCurrentStackFrame(),
+                notBefore,
+                expires,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedLifetime> LifetimeValidatorThrows(
+            DateTime? notBefore,
+            DateTime? expires,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            throw new CustomSecurityTokenInvalidLifetimeException(nameof(LifetimeValidatorThrows), null);
+        }
+
+        internal static ValidationResult<ValidatedLifetime> LifetimeValidatorCustomLifetimeExceptionTypeDelegate(
+            DateTime? notBefore,
+            DateTime? expires,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new LifetimeValidationError(
+                new MessageDetail(nameof(LifetimeValidatorCustomLifetimeExceptionTypeDelegate), null),
+                typeof(CustomSecurityTokenInvalidLifetimeException),
+                ValidationError.GetCurrentStackFrame(),
+                notBefore,
+                expires,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedLifetime> LifetimeValidatorCustomExceptionTypeDelegate(
+            DateTime? notBefore,
+            DateTime? expires,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new LifetimeValidationError(
+                new MessageDetail(nameof(LifetimeValidatorCustomExceptionTypeDelegate), null),
+                typeof(CustomSecurityTokenException),
+                ValidationError.GetCurrentStackFrame(),
+                notBefore,
+                expires,
+                null);
+        }
+    }
+}
+#nullable restore

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandler.Extensibility.Lifetime.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandler.Extensibility.Lifetime.cs
@@ -1,0 +1,291 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.TestUtils;
+
+using Xunit;
+
+#nullable enable
+namespace Microsoft.IdentityModel.Tokens.Saml2.Extensibility.Tests
+{
+    public partial class Saml2SecurityTokenHandlerValidateTokenAsyncTests
+    {
+        [Theory, MemberData(nameof(Lifetime_ExtensibilityTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task ValidateTokenAsync_LifetimeValidator_Extensibility(LifetimeExtensibilityTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(ValidateTokenAsync_LifetimeValidator_Extensibility)}", theoryData);
+            context.IgnoreType = false;
+            for (int i = 0; i < theoryData.ExtraStackFrames; i++)
+                theoryData.LifetimeValidationError!.AddStackFrame(new StackFrame(false));
+
+            try
+            {
+                ValidationResult<ValidatedToken> validationResult = await theoryData.Saml2SecurityTokenHandler.ValidateTokenAsync(
+                    theoryData.Saml2Token!,
+                    theoryData.ValidationParameters!,
+                    theoryData.CallContext,
+                    CancellationToken.None);
+
+                if (validationResult.IsValid)
+                {
+                    ValidatedToken validatedToken = validationResult.UnwrapResult();
+                    if (validatedToken.ValidatedLifetime is not null)
+                        IdentityComparer.AreValidatedLifetimesEqual((ValidatedLifetime)validatedToken.ValidatedLifetime, theoryData.ValidatedLifetime, context);
+                }
+                else
+                {
+                    ValidationError validationError = validationResult.UnwrapError();
+                    IdentityComparer.AreValidationErrorsEqual(validationError, theoryData.LifetimeValidationError, context);
+                    theoryData.ExpectedException.ProcessException(validationError.GetException(), context);
+                }
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<LifetimeExtensibilityTheoryData> Lifetime_ExtensibilityTestCases
+        {
+            get
+            {
+                var theoryData = new TheoryData<LifetimeExtensibilityTheoryData>();
+                CallContext callContext = new CallContext();
+                var utcNow = DateTime.UtcNow;
+                var utcPlusOneHour = utcNow + TimeSpan.FromHours(1);
+
+                #region return CustomLifetimeValidationError
+                // Test cases where delegate is overridden and return a CustomLifetimeValidationError
+                // CustomLifetimeValidationError : LifetimeValidationError, ExceptionType: SecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "CustomLifetimeValidatorDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.CustomLifetimeValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorDelegate)),
+                    LifetimeValidationError = new CustomLifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 160),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed)
+                });
+
+                // CustomLifetimeValidationError : LifetimeValidationError, ExceptionType: CustomSecurityTokenInvalidLifetimeException : SecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "CustomLifetimeValidatorCustomExceptionDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionDelegate)),
+                    LifetimeValidationError = new CustomLifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionDelegate), null),
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 175),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed),
+                });
+
+                // CustomLifetimeValidationError : LifetimeValidationError, ExceptionType: NotSupportedException : SystemException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "CustomLifetimeValidatorUnknownExceptionDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.CustomLifetimeValidatorUnknownExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    // CustomLifetimeValidationError does not handle the exception type 'NotSupportedException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(NotSupportedException),
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorUnknownExceptionDelegate))),
+                    LifetimeValidationError = new CustomLifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorUnknownExceptionDelegate), null),
+                        typeof(NotSupportedException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 205),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed),
+                });
+
+                // CustomLifetimeValidationError : LifetimeValidationError, ExceptionType: NotSupportedException : SystemException, ValidationFailureType: CustomAudienceValidationFailureType
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate)),
+                    LifetimeValidationError = new CustomLifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 190),
+                        utcNow,
+                        utcPlusOneHour,
+                        CustomLifetimeValidationError.CustomLifetimeValidationFailureType),
+                });
+                #endregion
+
+                #region return LifetimeValidationError
+                // Test cases where delegate is overridden and return an LifetimeValidationError
+                // LifetimeValidationError : ValidationError, ExceptionType:  SecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "LifetimeValidatorDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.LifetimeValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        nameof(CustomLifetimeValidationDelegates.LifetimeValidatorDelegate)),
+                    LifetimeValidationError = new LifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 235),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed)
+                });
+
+                // LifetimeValidationError : ValidationError, ExceptionType:  CustomSecurityTokenInvalidLifetimeException : SecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "LifetimeValidatorCustomLifetimeExceptionTypeDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.LifetimeValidatorCustomLifetimeExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // LifetimeValidationError does not handle the exception type 'CustomSecurityTokenInvalidLifetimeException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenInvalidLifetimeException),
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorCustomLifetimeExceptionTypeDelegate))),
+                    LifetimeValidationError = new LifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorCustomLifetimeExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 259),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed)
+                });
+
+                // LifetimeValidationError : ValidationError, ExceptionType:  CustomSecurityTokenException : SystemException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "LifetimeValidatorCustomExceptionTypeDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.LifetimeValidatorCustomExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // LifetimeValidationError does not handle the exception type 'CustomSecurityTokenException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenException),
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorCustomExceptionTypeDelegate))),
+                    LifetimeValidationError = new LifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorCustomExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 274),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed)
+                });
+
+                // LifetimeValidationError : ValidationError, ExceptionType: SecurityTokenInvalidLifetimeException, inner: CustomSecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "LifetimeValidatorThrows",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.LifetimeValidatorThrows,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        string.Format(Tokens.LogMessages.IDX10271),
+                        typeof(CustomSecurityTokenInvalidLifetimeException)),
+                    LifetimeValidationError = new LifetimeValidationError(
+                        new MessageDetail(
+                            string.Format(Tokens.LogMessages.IDX10271), null),
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        new StackFrame("Saml2SecurityTokenHandler.ValidateToken.Internal.cs", 250),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidatorThrew,
+                        new SecurityTokenInvalidLifetimeException(nameof(CustomLifetimeValidationDelegates.LifetimeValidatorThrows))
+                    )
+                });
+                #endregion
+
+                return theoryData;
+            }
+        }
+
+        public class LifetimeExtensibilityTheoryData : TheoryDataBase
+        {
+            internal LifetimeExtensibilityTheoryData(string testId, DateTime utcNow, LifetimeValidationDelegate lifetimeValidator, int extraStackFrames) : base(testId)
+            {
+                Saml2Token = (Saml2SecurityToken)Saml2SecurityTokenHandler.CreateToken(
+                    new SecurityTokenDescriptor()
+                    {
+                        Subject = Default.SamlClaimsIdentity,
+                        Issuer = Default.Issuer,
+                        IssuedAt = utcNow,
+                        NotBefore = utcNow,
+                        Expires = utcNow + TimeSpan.FromHours(1),
+                    });
+
+                ValidationParameters = new ValidationParameters
+                {
+                    AlgorithmValidator = SkipValidationDelegates.SkipAlgorithmValidation,
+                    AudienceValidator = SkipValidationDelegates.SkipAudienceValidation,
+                    IssuerValidatorAsync = SkipValidationDelegates.SkipIssuerValidation,
+                    IssuerSigningKeyValidator = SkipValidationDelegates.SkipIssuerSigningKeyValidation,
+                    LifetimeValidator = lifetimeValidator,
+                    SignatureValidator = SkipValidationDelegates.SkipSignatureValidation,
+                    TokenReplayValidator = SkipValidationDelegates.SkipTokenReplayValidation,
+                    TokenTypeValidator = SkipValidationDelegates.SkipTokenTypeValidation
+                };
+
+                ExtraStackFrames = extraStackFrames;
+            }
+
+            public Saml2SecurityToken Saml2Token { get; }
+
+            public Saml2SecurityTokenHandler Saml2SecurityTokenHandler { get; } = new Saml2SecurityTokenHandler();
+
+            public bool IsValid { get; set; }
+
+            internal ValidatedLifetime ValidatedLifetime { get; set; }
+
+            internal ValidationParameters ValidationParameters { get; }
+
+            internal LifetimeValidationError? LifetimeValidationError { get; set; }
+
+            internal int ExtraStackFrames { get; }
+        }
+    }
+}
+#nullable restore

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandler.Extensibility.Lifetime.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandler.Extensibility.Lifetime.cs
@@ -1,0 +1,291 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.TestUtils;
+
+using Xunit;
+
+#nullable enable
+namespace Microsoft.IdentityModel.Tokens.Saml.Extensibility.Tests
+{
+    public partial class SamlSecurityTokenHandlerValidateTokenAsyncTests
+    {
+        [Theory, MemberData(nameof(Lifetime_ExtensibilityTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task ValidateTokenAsync_LifetimeValidator_Extensibility(LifetimeExtensibilityTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(ValidateTokenAsync_LifetimeValidator_Extensibility)}", theoryData);
+            context.IgnoreType = false;
+            for (int i = 0; i < theoryData.ExtraStackFrames; i++)
+                theoryData.LifetimeValidationError!.AddStackFrame(new StackFrame(false));
+
+            try
+            {
+                ValidationResult<ValidatedToken> validationResult = await theoryData.SamlSecurityTokenHandler.ValidateTokenAsync(
+                    theoryData.SamlToken!,
+                    theoryData.ValidationParameters!,
+                    theoryData.CallContext,
+                    CancellationToken.None);
+
+                if (validationResult.IsValid)
+                {
+                    ValidatedToken validatedToken = validationResult.UnwrapResult();
+                    if (validatedToken.ValidatedLifetime is not null)
+                        IdentityComparer.AreValidatedLifetimesEqual((ValidatedLifetime)validatedToken.ValidatedLifetime, theoryData.ValidatedLifetime, context);
+                }
+                else
+                {
+                    ValidationError validationError = validationResult.UnwrapError();
+                    IdentityComparer.AreValidationErrorsEqual(validationError, theoryData.LifetimeValidationError, context);
+                    theoryData.ExpectedException.ProcessException(validationError.GetException(), context);
+                }
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<LifetimeExtensibilityTheoryData> Lifetime_ExtensibilityTestCases
+        {
+            get
+            {
+                var theoryData = new TheoryData<LifetimeExtensibilityTheoryData>();
+                CallContext callContext = new CallContext();
+                var utcNow = DateTime.UtcNow;
+                var utcPlusOneHour = utcNow + TimeSpan.FromHours(1);
+
+                #region return CustomLifetimeValidationError
+                // Test cases where delegate is overridden and return a CustomLifetimeValidationError
+                // CustomLifetimeValidationError : LifetimeValidationError, ExceptionType: SecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "CustomLifetimeValidatorDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.CustomLifetimeValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorDelegate)),
+                    LifetimeValidationError = new CustomLifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 160),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed),
+                });
+
+                // CustomLifetimeValidationError : LifetimeValidationError, ExceptionType: CustomSecurityTokenInvalidLifetimeException : SecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "CustomLifetimeValidatorCustomExceptionDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionDelegate)),
+                    LifetimeValidationError = new CustomLifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionDelegate), null),
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 175),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed),
+                });
+
+                // CustomLifetimeValidationError : LifetimeValidationError, ExceptionType: NotSupportedException : SystemException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "CustomLifetimeValidatorUnknownExceptionDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.CustomLifetimeValidatorUnknownExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    // CustomLifetimeValidationError does not handle the exception type 'NotSupportedException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(NotSupportedException),
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorUnknownExceptionDelegate))),
+                    LifetimeValidationError = new CustomLifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorUnknownExceptionDelegate), null),
+                        typeof(NotSupportedException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 205),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed),
+                });
+
+                // CustomLifetimeValidationError : LifetimeValidationError, ExceptionType: NotSupportedException : SystemException, ValidationFailureType: CustomAudienceValidationFailureType
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate)),
+                    LifetimeValidationError = new CustomLifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.CustomLifetimeValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 190),
+                        utcNow,
+                        utcPlusOneHour,
+                        CustomLifetimeValidationError.CustomLifetimeValidationFailureType),
+                });
+                #endregion
+
+                #region return LifetimeValidationError
+                // Test cases where delegate is overridden and return an LifetimeValidationError
+                // LifetimeValidationError : ValidationError, ExceptionType:  SecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "LifetimeValidatorDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.LifetimeValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        nameof(CustomLifetimeValidationDelegates.LifetimeValidatorDelegate)),
+                    LifetimeValidationError = new LifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 235),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed),
+                });
+
+                // LifetimeValidationError : ValidationError, ExceptionType:  CustomSecurityTokenInvalidLifetimeException : SecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "LifetimeValidatorCustomLifetimeExceptionTypeDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.LifetimeValidatorCustomLifetimeExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // LifetimeValidationError does not handle the exception type 'CustomSecurityTokenInvalidLifetimeException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenInvalidLifetimeException),
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorCustomLifetimeExceptionTypeDelegate))),
+                    LifetimeValidationError = new LifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorCustomLifetimeExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidLifetimeException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 259),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed),
+                });
+
+                // LifetimeValidationError : ValidationError, ExceptionType:  CustomSecurityTokenException : SystemException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "LifetimeValidatorCustomExceptionTypeDelegate",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.LifetimeValidatorCustomExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // LifetimeValidationError does not handle the exception type 'CustomSecurityTokenException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenException),
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorCustomExceptionTypeDelegate))),
+                    LifetimeValidationError = new LifetimeValidationError(
+                        new MessageDetail(
+                            nameof(CustomLifetimeValidationDelegates.LifetimeValidatorCustomExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenException),
+                        new StackFrame("CustomLifetimeValidationDelegates.cs", 274),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidationFailed),
+                });
+
+                // LifetimeValidationError : ValidationError, ExceptionType: SecurityTokenInvalidLifetimeException, inner: CustomSecurityTokenInvalidLifetimeException
+                theoryData.Add(new LifetimeExtensibilityTheoryData(
+                    "LifetimeValidatorThrows",
+                    utcNow,
+                    CustomLifetimeValidationDelegates.LifetimeValidatorThrows,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        string.Format(Tokens.LogMessages.IDX10271),
+                        typeof(CustomSecurityTokenInvalidLifetimeException)),
+                    LifetimeValidationError = new LifetimeValidationError(
+                        new MessageDetail(
+                            string.Format(Tokens.LogMessages.IDX10271), null),
+                        typeof(SecurityTokenInvalidLifetimeException),
+                        new StackFrame("SamlSecurityTokenHandler.ValidateToken.Internal.cs", 250),
+                        utcNow,
+                        utcPlusOneHour,
+                        ValidationFailureType.LifetimeValidatorThrew,
+                        new SecurityTokenInvalidLifetimeException(nameof(CustomLifetimeValidationDelegates.LifetimeValidatorThrows))
+                    )
+                });
+                #endregion
+
+                return theoryData;
+            }
+        }
+
+        public class LifetimeExtensibilityTheoryData : TheoryDataBase
+        {
+            internal LifetimeExtensibilityTheoryData(string testId, DateTime utcNow, LifetimeValidationDelegate lifetimeValidator, int extraStackFrames) : base(testId)
+            {
+                SamlToken = (SamlSecurityToken)SamlSecurityTokenHandler.CreateToken(
+                    new SecurityTokenDescriptor()
+                    {
+                        Subject = Default.SamlClaimsIdentity,
+                        Issuer = Default.Issuer,
+                        IssuedAt = utcNow,
+                        NotBefore = utcNow,
+                        Expires = utcNow + TimeSpan.FromHours(1),
+                    });
+
+                ValidationParameters = new ValidationParameters
+                {
+                    AlgorithmValidator = SkipValidationDelegates.SkipAlgorithmValidation,
+                    AudienceValidator = SkipValidationDelegates.SkipAudienceValidation,
+                    IssuerValidatorAsync = SkipValidationDelegates.SkipIssuerValidation,
+                    IssuerSigningKeyValidator = SkipValidationDelegates.SkipIssuerSigningKeyValidation,
+                    LifetimeValidator = lifetimeValidator,
+                    SignatureValidator = SkipValidationDelegates.SkipSignatureValidation,
+                    TokenReplayValidator = SkipValidationDelegates.SkipTokenReplayValidation,
+                    TokenTypeValidator = SkipValidationDelegates.SkipTokenTypeValidation
+                };
+
+                ExtraStackFrames = extraStackFrames;
+            }
+
+            public SamlSecurityToken SamlToken { get; }
+
+            public SamlSecurityTokenHandler SamlSecurityTokenHandler { get; } = new SamlSecurityTokenHandler();
+
+            public bool IsValid { get; set; }
+
+            internal ValidatedLifetime ValidatedLifetime { get; set; }
+
+            internal ValidationParameters ValidationParameters { get; }
+
+            internal LifetimeValidationError? LifetimeValidationError { get; set; }
+
+            internal int ExtraStackFrames { get; }
+        }
+    }
+}
+#nullable restore


### PR DESCRIPTION
# Extensibility tests: Lifetime - JWT, SAML and SAML2
- Handle potential exception thrown by the lifetime validation delegate in JWT, SAML, and SAML2
- Added custom lifetime validation delegates for testing
- Added lifetime extensibility tests for JWT, SAML, and SAML2

Note: Targeting the base extensibility branch to avoid showing those changes again. Once merged, I will move this to target dev and take out of draft.

Part of #2711 