### PR TITLE
Enable long paths in GitHubActions

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Create symbolic link to avoid overlong paths
       run: |
-        mklink /D D:\a\w D:\a\azure-activedirectory-identitymodel-extensions-for-dotnet\azure-activedirectory-identitymodel-extensions-for-dotnet
+        cmd /c mklink /D D:\a\w D:\a\azure-activedirectory-identitymodel-extensions-for-dotnet\azure-activedirectory-identitymodel-extensions-for-dotnet
         dir D:\a\w
 
     - name: Checkout repository

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -27,9 +27,10 @@ jobs:
     name: "Build and run unit tests"
     steps:
 
-    - name: Enable long paths
+    - name: Create symbolic link to avoid overlong paths
       run: |
-        New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+        mklink /D D:\a\w D:\a\azure-activedirectory-identitymodel-extensions-for-dotnet\azure-activedirectory-identitymodel-extensions-for-dotnet
+        dir D:\a\w
 
     - name: Checkout repository
       uses: actions/checkout@v4.1.1

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -26,6 +26,11 @@ jobs:
     continue-on-error: false
     name: "Build and run unit tests"
     steps:
+
+    - name: Enable long paths
+      run: |
+        New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+
     - name: Checkout repository
       uses: actions/checkout@v4.1.1
         


### PR DESCRIPTION
Added a step to run a cli prompt enabling long paths to avoid max path length errors
