### PR TITLE
Install all .NET versions in pipeline to fix run tests task

### DIFF
--- a/build/template-Build-run-tests-sign.yml
+++ b/build/template-Build-run-tests-sign.yml
@@ -8,6 +8,24 @@ steps:
   displayName: 'display MicrosoftIdentityModelVersion'
 
 - task: UseDotNet@2
+  displayName: 'Use .Net Core SDK 2.x'
+  inputs:
+    version: 2.x
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+
+- task: UseDotNet@2
+  displayName: 'Use .Net Core SDK 6.x'
+  inputs:
+    version: 6.x
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+
+- task: UseDotNet@2
+  displayName: 'Use .Net Core SDK 8.x'
+  inputs:
+    version: 8.x
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+
+- task: UseDotNet@2
   displayName: 'Use .Net Core SDK 9.x'
   inputs:
     version: 9.x


### PR DESCRIPTION
Install all .NET versions in pipeline to fix run tests task. Partially reverts f604488aba411d76bd59f9590bbc2385e0d9e6fa.