### PR TITLE
Extensibility tests: Issuer signing key - JWT, SAML and SAML2

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.Internal.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.Internal.cs
@@ -353,13 +353,27 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 return signatureValidationResult.UnwrapError().AddStackFrame(signatureValidationFailureStackFrame);
             }
 
-            ValidationResult<ValidatedSigningKeyLifetime> issuerSigningKeyValidationResult =
-                validationParameters.IssuerSigningKeyValidator(
-                    jsonWebToken.SigningKey, jsonWebToken, validationParameters, configuration, callContext);
-            if (!issuerSigningKeyValidationResult.IsValid)
+            ValidationResult<ValidatedSigningKeyLifetime> issuerSigningKeyValidationResult;
+
+            try
             {
-                StackFrame issuerSigningKeyValidationFailureStackFrame = StackFrames.IssuerSigningKeyValidationFailed ??= new StackFrame(true);
-                return issuerSigningKeyValidationResult.UnwrapError().AddStackFrame(issuerSigningKeyValidationFailureStackFrame);
+                issuerSigningKeyValidationResult = validationParameters.IssuerSigningKeyValidator(
+                    jsonWebToken.SigningKey, jsonWebToken, validationParameters, configuration, callContext);
+
+                if (!issuerSigningKeyValidationResult.IsValid)
+                    return issuerSigningKeyValidationResult.UnwrapError().AddCurrentStackFrame();
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return new IssuerSigningKeyValidationError(
+                    new MessageDetail(TokenLogMessages.IDX10274),
+                    typeof(SecurityTokenInvalidSigningKeyException),
+                    ValidationError.GetCurrentStackFrame(),
+                    jsonWebToken.SigningKey,
+                    ValidationFailureType.IssuerSigningKeyValidatorThrew,
+                    ex);
             }
 
             return new ValidatedToken(jsonWebToken, this, validationParameters)

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.ValidateToken.Internal.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.ValidateToken.Internal.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -86,17 +87,31 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 return signatureValidationResult.UnwrapError().AddStackFrame(StackFrames.SignatureValidationFailed);
             }
 
-            ValidationResult<ValidatedSigningKeyLifetime> issuerSigningKeyValidationResult = validationParameters.IssuerSigningKeyValidator(
-                samlToken.SigningKey,
-                samlToken,
-                validationParameters,
-                null,
-                callContext);
+            ValidationResult<ValidatedSigningKeyLifetime> issuerSigningKeyValidationResult;
 
-            if (!issuerSigningKeyValidationResult.IsValid)
+            try
             {
-                StackFrames.IssuerSigningKeyValidationFailed ??= new StackFrame(true);
-                return issuerSigningKeyValidationResult.UnwrapError().AddStackFrame(StackFrames.IssuerSigningKeyValidationFailed);
+                issuerSigningKeyValidationResult = validationParameters.IssuerSigningKeyValidator(
+                    samlToken.SigningKey,
+                    samlToken,
+                    validationParameters,
+                    null,
+                    callContext);
+
+                if (!issuerSigningKeyValidationResult.IsValid)
+                    return issuerSigningKeyValidationResult.UnwrapError().AddCurrentStackFrame();
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return new IssuerSigningKeyValidationError(
+                    new MessageDetail(Tokens.LogMessages.IDX10274),
+                    typeof(SecurityTokenInvalidSigningKeyException),
+                    ValidationError.GetCurrentStackFrame(),
+                    samlToken.SigningKey,
+                    ValidationFailureType.IssuerSigningKeyValidatorThrew,
+                    ex);
             }
 
             return new ValidatedToken(samlToken, this, validationParameters);

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateToken.Internal.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateToken.Internal.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
@@ -89,17 +90,31 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                 return signatureValidationResult.UnwrapError().AddStackFrame(StackFrames.SignatureValidationFailed);
             }
 
-            var issuerSigningKeyValidationResult = validationParameters.IssuerSigningKeyValidator(
-                samlToken.SigningKey,
-                samlToken,
-                validationParameters,
-                null,
-                callContext);
+            ValidationResult<ValidatedSigningKeyLifetime> issuerSigningKeyValidationResult;
 
-            if (!issuerSigningKeyValidationResult.IsValid)
+            try
             {
-                StackFrames.IssuerSigningKeyValidationFailed ??= new StackFrame(true);
-                return issuerSigningKeyValidationResult.UnwrapError().AddStackFrame(StackFrames.IssuerSigningKeyValidationFailed);
+                issuerSigningKeyValidationResult = validationParameters.IssuerSigningKeyValidator(
+                    samlToken.SigningKey,
+                    samlToken,
+                    validationParameters,
+                    null,
+                    callContext);
+
+                if (!issuerSigningKeyValidationResult.IsValid)
+                    return issuerSigningKeyValidationResult.UnwrapError().AddCurrentStackFrame();
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return new IssuerSigningKeyValidationError(
+                    new MessageDetail(Tokens.LogMessages.IDX10274),
+                    typeof(SecurityTokenInvalidSigningKeyException),
+                    ValidationError.GetCurrentStackFrame(),
+                    samlToken.SigningKey,
+                    ValidationFailureType.IssuerSigningKeyValidatorThrew,
+                    ex);
             }
 
             return new ValidatedToken(samlToken, this, validationParameters);

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -11,6 +11,10 @@ Microsoft.IdentityModel.Tokens.AudienceValidationError.TokenAudiences.get -> Sys
 Microsoft.IdentityModel.Tokens.AudienceValidationError.TokenAudiences.set -> void
 Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidAudiences.get -> System.Collections.Generic.IList<string>
 Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidAudiences.set -> void
+Microsoft.IdentityModel.Tokens.IssuerSigningKeyValidationError
+Microsoft.IdentityModel.Tokens.IssuerSigningKeyValidationError.InvalidSigningKey.get -> Microsoft.IdentityModel.Tokens.SecurityKey
+Microsoft.IdentityModel.Tokens.IssuerSigningKeyValidationError.InvalidSigningKey.set -> void
+Microsoft.IdentityModel.Tokens.IssuerSigningKeyValidationError.IssuerSigningKeyValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, Microsoft.IdentityModel.Tokens.SecurityKey invalidSigningKey, Microsoft.IdentityModel.Tokens.ValidationFailureType failureType = null, System.Exception innerException = null) -> void
 Microsoft.IdentityModel.Tokens.IssuerValidationError.InvalidIssuer.get -> string
 Microsoft.IdentityModel.Tokens.IssuerValidationError.IssuerValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, string invalidIssuer, Microsoft.IdentityModel.Tokens.ValidationFailureType validationFailureType = null, System.Exception innerException = null) -> void
 Microsoft.IdentityModel.Tokens.IssuerValidationSource.IssuerMatchedConfiguration = 1 -> Microsoft.IdentityModel.Tokens.IssuerValidationSource
@@ -34,12 +38,14 @@ Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.Error.get -> Microsoft.
 Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.IsValid.get -> bool
 Microsoft.IdentityModel.Tokens.ValidationResult<TResult>.Result.get -> TResult
 override Microsoft.IdentityModel.Tokens.AlgorithmValidationError.GetException() -> System.Exception
+override Microsoft.IdentityModel.Tokens.IssuerSigningKeyValidationError.GetException() -> System.Exception
 override Microsoft.IdentityModel.Tokens.TokenTypeValidationError.GetException() -> System.Exception
 static Microsoft.IdentityModel.Tokens.AudienceValidationError.AudiencesCountZero -> System.Diagnostics.StackFrame
 static Microsoft.IdentityModel.Tokens.AudienceValidationError.AudiencesNull -> System.Diagnostics.StackFrame
 static Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidateAudienceFailed -> System.Diagnostics.StackFrame
 static Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidationParametersAudiencesCountZero -> System.Diagnostics.StackFrame
 static Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidationParametersNull -> System.Diagnostics.StackFrame
+static Microsoft.IdentityModel.Tokens.IssuerSigningKeyValidationError.NullParameter(string parameterName, System.Diagnostics.StackFrame stackFrame) -> Microsoft.IdentityModel.Tokens.IssuerSigningKeyValidationError
 static Microsoft.IdentityModel.Tokens.Utility.SerializeAsSingleCommaDelimitedString(System.Collections.Generic.IList<string> strings) -> string
 static Microsoft.IdentityModel.Tokens.ValidationError.GetCurrentStackFrame(string filePath = "", int lineNumber = 0, int skipFrames = 1) -> System.Diagnostics.StackFrame
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.IssuerSigningKeyValidatorThrew -> Microsoft.IdentityModel.Tokens.ValidationFailureType

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10002 = "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10268 = "IDX10268: Unable to validate audience, validationParameters.ValidAudiences.Count == 0." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10269 = "IDX10269: IssuerValidationDelegate threw an exception, see inner exception." -> string
+const Microsoft.IdentityModel.Tokens.LogMessages.IDX10274 = "IDX10274: IssuerSigningKeyValidationDelegate threw an exception, see inner exception." -> string
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError.AlgorithmValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, string invalidAlgorithm, Microsoft.IdentityModel.Tokens.ValidationFailureType validationFailureType = null, System.Exception innerException = null) -> void
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError.InvalidAlgorithm.get -> string
@@ -41,6 +42,7 @@ static Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidationParamete
 static Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidationParametersNull -> System.Diagnostics.StackFrame
 static Microsoft.IdentityModel.Tokens.Utility.SerializeAsSingleCommaDelimitedString(System.Collections.Generic.IList<string> strings) -> string
 static Microsoft.IdentityModel.Tokens.ValidationError.GetCurrentStackFrame(string filePath = "", int lineNumber = 0, int skipFrames = 1) -> System.Diagnostics.StackFrame
+static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.IssuerSigningKeyValidatorThrew -> Microsoft.IdentityModel.Tokens.ValidationFailureType
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.IssuerValidatorThrew -> Microsoft.IdentityModel.Tokens.ValidationFailureType
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.NoTokenAudiencesProvided -> Microsoft.IdentityModel.Tokens.ValidationFailureType
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.NoValidationParameterAudiencesProvided -> Microsoft.IdentityModel.Tokens.ValidationFailureType

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -88,7 +88,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10267 = "IDX10267: '{0}' has been called by a derived class '{1}' which has not implemented this method. For this call graph to succeed, '{1}' will need to implement '{0}'.";
         public const string IDX10268 = "IDX10268: Unable to validate audience, validationParameters.ValidAudiences.Count == 0.";
         public const string IDX10269 = "IDX10269: IssuerValidationDelegate threw an exception, see inner exception.";
-
+        public const string IDX10274 = "IDX10274: IssuerSigningKeyValidationDelegate threw an exception, see inner exception.";
 
         // 10500 - SignatureValidation
         public const string IDX10500 = "IDX10500: Signature validation failed. No security keys were provided to validate the signature.";

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/IssuerSigningKeyValidationError.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/IssuerSigningKeyValidationError.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+
+using System.Diagnostics;
+using System;
+
+#nullable enable
+namespace Microsoft.IdentityModel.Tokens
+{
+    internal class IssuerSigningKeyValidationError : ValidationError
+    {
+        internal IssuerSigningKeyValidationError(
+            MessageDetail messageDetail,
+            Type exceptionType,
+            StackFrame stackFrame,
+            SecurityKey? invalidSigningKey,
+            ValidationFailureType? failureType = null,
+            Exception? innerException = null)
+            : base(messageDetail, exceptionType, stackFrame, failureType ?? ValidationFailureType.SigningKeyValidationFailed, innerException)
+        {
+            InvalidSigningKey = invalidSigningKey;
+        }
+
+        internal override Exception GetException()
+        {
+            if (ExceptionType == typeof(SecurityTokenInvalidSigningKeyException))
+            {
+                SecurityTokenInvalidSigningKeyException? exception = new(MessageDetail.Message, InnerException)
+                {
+                    SigningKey = InvalidSigningKey
+                };
+                exception.SetValidationError(this);
+
+                return exception;
+            }
+
+            return base.GetException();
+        }
+
+
+        internal static new IssuerSigningKeyValidationError NullParameter(string parameterName, StackFrame stackFrame) => new(
+            MessageDetail.NullParameter(parameterName),
+            typeof(SecurityTokenArgumentNullException),
+            stackFrame,
+            null, // InvalidSigningKey
+            ValidationFailureType.NullArgument);
+
+        protected SecurityKey? InvalidSigningKey { get; set; }
+    }
+}
+#nullable restore

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
@@ -84,8 +84,8 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Defines a type that represents that signing key validation failed.
         /// </summary>
-        public static readonly ValidationFailureType SigningKeyValidationFailed = new SigningKeyValidationFailure("SigningKeyValidationFailed");
-        private class SigningKeyValidationFailure : ValidationFailureType { internal SigningKeyValidationFailure(string name) : base(name) { } }
+        public static readonly ValidationFailureType SigningKeyValidationFailed = new IssuerSigningKeyValidationFailure("IssuerSigningKeyValidationFailed");
+        private class IssuerSigningKeyValidationFailure : ValidationFailureType { internal IssuerSigningKeyValidationFailure(string name) : base(name) { } }
 
         /// <summary>
         /// Defines a type that represents that lifetime validation failed.
@@ -134,5 +134,10 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         public static readonly ValidationFailureType IssuerValidatorThrew = new IssuerValidatorFailure("IssuerValidatorThrew");
         private class IssuerValidatorFailure : ValidationFailureType { internal IssuerValidatorFailure(string name) : base(name) { } }
+
+        /// <summary>
+        /// Defines a type that represents that the issuer signing key validation delegate threw an exception.
+        /// </summary>
+        public static readonly ValidationFailureType IssuerSigningKeyValidatorThrew = new IssuerSigningKeyValidationFailure("IssuerSigningKeyValidatorThrew");
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
@@ -25,7 +25,7 @@ namespace Microsoft.IdentityModel.Tokens
         SecurityToken securityToken,
         ValidationParameters validationParameters,
         BaseConfiguration? configuration,
-        CallContext? callContext);
+        CallContext callContext);
 
     /// <summary>
     /// SigningKeyValidation

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.IssuerSigningKey.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.IdentityModel.Logging;
 
@@ -57,19 +56,20 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters == null)
                 return ValidationError.NullParameter(
                     nameof(validationParameters),
-                    new StackFrame(true));
+                    ValidationError.GetCurrentStackFrame());
 
             if (securityKey == null)
-                return new ValidationError(
+                return new IssuerSigningKeyValidationError(
                     new MessageDetail(LogMessages.IDX10253, nameof(securityKey)),
                     typeof(SecurityTokenArgumentNullException),
-                    new StackFrame(true),
+                    ValidationError.GetCurrentStackFrame(),
+                    securityKey,
                     ValidationFailureType.SigningKeyValidationFailed);
 
             if (securityToken == null)
-                return ValidationError.NullParameter(
+                return IssuerSigningKeyValidationError.NullParameter(
                     nameof(securityToken),
-                    new StackFrame(true));
+                    ValidationError.GetCurrentStackFrame());
 
             return ValidateIssuerSigningKeyLifeTime(securityKey, validationParameters, callContext);
         }
@@ -98,13 +98,14 @@ namespace Microsoft.IdentityModel.Tokens
                 notAfterUtc = cert.NotAfter.ToUniversalTime();
 
                 if (notBeforeUtc > DateTimeUtil.Add(utcNow, validationParameters.ClockSkew))
-                    return new ValidationError(
+                    return new IssuerSigningKeyValidationError(
                         new MessageDetail(
                             LogMessages.IDX10248,
                             LogHelper.MarkAsNonPII(notBeforeUtc),
                             LogHelper.MarkAsNonPII(utcNow)),
                         typeof(SecurityTokenInvalidSigningKeyException),
-                        new StackFrame(true),
+                        ValidationError.GetCurrentStackFrame(),
+                        securityKey,
                         ValidationFailureType.SigningKeyValidationFailed);
 
                 //TODO: Move to CallContext
@@ -112,13 +113,14 @@ namespace Microsoft.IdentityModel.Tokens
                 //    LogHelper.LogInformation(LogMessages.IDX10250, LogHelper.MarkAsNonPII(notBeforeUtc), LogHelper.MarkAsNonPII(utcNow));
 
                 if (notAfterUtc < DateTimeUtil.Add(utcNow, validationParameters.ClockSkew.Negate()))
-                    return new ValidationError(
+                    return new IssuerSigningKeyValidationError(
                         new MessageDetail(
                             LogMessages.IDX10249,
                             LogHelper.MarkAsNonPII(notAfterUtc),
                             LogHelper.MarkAsNonPII(utcNow)),
                         typeof(SecurityTokenInvalidSigningKeyException),
-                        new StackFrame(true),
+                        ValidationError.GetCurrentStackFrame(),
+                        securityKey,
                         ValidationFailureType.SigningKeyValidationFailed);
 
                 // TODO: Move to CallContext

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.Extensibility.IssuerSigningKey.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.Extensibility.IssuerSigningKey.cs
@@ -1,0 +1,284 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.JsonWebTokens.Tests;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+#nullable enable
+namespace Microsoft.IdentityModel.JsonWebTokens.Extensibility.Tests
+{
+    public partial class JsonWebTokenHandlerValidateTokenAsyncTests
+    {
+        [Theory, MemberData(nameof(IssuerSigningKey_ExtensibilityTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task ValidateTokenAsync_IssuerSigningKeyValidator_Extensibility(IssuerSigningKeyExtensibilityTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(ValidateTokenAsync_IssuerSigningKeyValidator_Extensibility)}", theoryData);
+            context.IgnoreType = false;
+            for (int i = 0; i < theoryData.ExtraStackFrames; i++)
+                theoryData.IssuerSigningKeyValidationError!.AddStackFrame(new StackFrame(false));
+
+            try
+            {
+                ValidationResult<ValidatedToken> validationResult = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(
+                    theoryData.JsonWebToken!,
+                    theoryData.ValidationParameters!,
+                    theoryData.CallContext,
+                    CancellationToken.None);
+
+                if (validationResult.IsValid)
+                {
+                    context.AddDiff("validationResult.IsValid is true, expected false");
+                }
+                else
+                {
+                    ValidationError validationError = validationResult.UnwrapError();
+                    IdentityComparer.AreValidationErrorsEqual(validationError, theoryData.IssuerSigningKeyValidationError, context);
+                    theoryData.ExpectedException.ProcessException(validationError.GetException(), context);
+                }
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<IssuerSigningKeyExtensibilityTheoryData> IssuerSigningKey_ExtensibilityTestCases
+        {
+            get
+            {
+                var theoryData = new TheoryData<IssuerSigningKeyExtensibilityTheoryData>();
+                CallContext callContext = new CallContext();
+                var utcNow = DateTime.UtcNow;
+                var utcPlusOneHour = utcNow + TimeSpan.FromHours(1);
+
+                #region return CustomIssuerSigningKeyValidationError
+                // Test cases where delegate is overridden and return a CustomIssuerSigningKeyValidationError
+                // CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError, ExceptionType: SecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "CustomIssuerSigningKeyValidatorDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorDelegate)),
+                    IssuerSigningKeyValidationError = new CustomIssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 160),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed)
+                });
+
+                // CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError, ExceptionType: CustomSecurityTokenInvalidIssuerSigningKeyException : SecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "CustomIssuerSigningKeyValidatorCustomExceptionDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionDelegate)),
+                    IssuerSigningKeyValidationError = new CustomIssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionDelegate), null),
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 175),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed),
+                });
+
+                // CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError, ExceptionType: NotSupportedException : SystemException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "CustomIssuerSigningKeyValidatorUnknownExceptionDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorUnknownExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    // CustomIssuerSigningKeyValidationError does not handle the exception type 'NotSupportedException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(NotSupportedException),
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorUnknownExceptionDelegate))),
+                    IssuerSigningKeyValidationError = new CustomIssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorUnknownExceptionDelegate), null),
+                        typeof(NotSupportedException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 205),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed),
+                });
+
+                // CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError, ExceptionType: NotSupportedException : SystemException, ValidationFailureType: CustomAudienceValidationFailureType
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate)),
+                    IssuerSigningKeyValidationError = new CustomIssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 190),
+                        null,
+                        CustomIssuerSigningKeyValidationError.CustomIssuerSigningKeyValidationFailureType),
+                });
+                #endregion
+
+                #region return IssuerSigningKeyValidationError
+                // Test cases where delegate is overridden and return an IssuerSigningKeyValidationError
+                // IssuerSigningKeyValidationError : ValidationError, ExceptionType:  SecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "IssuerSigningKeyValidatorDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorDelegate)),
+                    IssuerSigningKeyValidationError = new IssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 235),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed)
+                });
+
+                // IssuerSigningKeyValidationError : ValidationError, ExceptionType:  CustomSecurityTokenInvalidIssuerSigningKeyException : SecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // IssuerSigningKeyValidationError does not handle the exception type 'CustomSecurityTokenInvalidIssuerSigningKeyException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenInvalidSigningKeyException),
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate))),
+                    IssuerSigningKeyValidationError = new IssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 259),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed)
+                });
+
+                // IssuerSigningKeyValidationError : ValidationError, ExceptionType:  CustomSecurityTokenException : SystemException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "IssuerSigningKeyValidatorCustomExceptionTypeDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // IssuerSigningKeyValidationError does not handle the exception type 'CustomSecurityTokenException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenException),
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomExceptionTypeDelegate))),
+                    IssuerSigningKeyValidationError = new IssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 274),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed)
+                });
+
+                // IssuerSigningKeyValidationError : ValidationError, ExceptionType: SecurityTokenInvalidIssuerSigningKeyException, inner: CustomSecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "IssuerSigningKeyValidatorThrows",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorThrows,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        string.Format(Tokens.LogMessages.IDX10274),
+                        typeof(CustomSecurityTokenInvalidSigningKeyException)),
+                    IssuerSigningKeyValidationError = new IssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            string.Format(Tokens.LogMessages.IDX10274), null),
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        new StackFrame("JsonWebTokenHandler.ValidateToken.Internal.cs", 250),
+                        null,
+                        ValidationFailureType.IssuerSigningKeyValidatorThrew,
+                        new SecurityTokenInvalidSigningKeyException(nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorThrows))
+                    )
+                });
+                #endregion
+
+                return theoryData;
+            }
+        }
+
+        public class IssuerSigningKeyExtensibilityTheoryData : ValidateTokenAsyncBaseTheoryData
+        {
+            internal IssuerSigningKeyExtensibilityTheoryData(string testId, DateTime utcNow, IssuerSigningKeyValidationDelegate issuerSigningKeyValidator, int extraStackFrames) : base(testId)
+            {
+                JsonWebToken = JsonWebTokenHandler.ReadJsonWebToken(
+                    JsonWebTokenHandler.CreateToken(
+                        new SecurityTokenDescriptor()
+                        {
+                            IssuedAt = utcNow,
+                            NotBefore = utcNow,
+                            Expires = utcNow + TimeSpan.FromHours(1),
+                        }));
+
+                ValidationParameters = new ValidationParameters
+                {
+                    AlgorithmValidator = SkipValidationDelegates.SkipAlgorithmValidation,
+                    AudienceValidator = SkipValidationDelegates.SkipAudienceValidation,
+                    IssuerValidatorAsync = SkipValidationDelegates.SkipIssuerValidation,
+                    IssuerSigningKeyValidator = issuerSigningKeyValidator,
+                    LifetimeValidator = SkipValidationDelegates.SkipLifetimeValidation,
+                    SignatureValidator = (SecurityToken token, ValidationParameters validationParameters, BaseConfiguration? configuration, CallContext? callContext) =>
+                    {
+                        token.SigningKey = SigningKey;
+
+                        return SigningKey;
+                    },
+                    TokenReplayValidator = SkipValidationDelegates.SkipTokenReplayValidation,
+                    TokenTypeValidator = SkipValidationDelegates.SkipTokenTypeValidation
+                };
+
+                ExtraStackFrames = extraStackFrames;
+            }
+
+            public JsonWebToken JsonWebToken { get; }
+
+            public JsonWebTokenHandler JsonWebTokenHandler { get; } = new JsonWebTokenHandler();
+
+            public bool IsValid { get; set; }
+
+            public SecurityKey SigningKey { get; set; } = KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2.Key;
+
+            internal IssuerSigningKeyValidationError? IssuerSigningKeyValidationError { get; set; }
+
+            internal int ExtraStackFrames { get; }
+        }
+    }
+}
+#nullable restore

--- a/test/Microsoft.IdentityModel.TestUtils/SkipValidationDelegates.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/SkipValidationDelegates.cs
@@ -48,7 +48,7 @@ namespace Microsoft.IdentityModel.TestUtils
             SecurityToken securityToken,
             ValidationParameters validationParameters,
             BaseConfiguration? configuration,
-            CallContext? callContext)
+            CallContext callContext)
         {
             return new ValidatedSigningKeyLifetime(
                 null, // ValidFrom

--- a/test/Microsoft.IdentityModel.TestUtils/TokenValidationExtensibility/CustomIssuerSigningKeyValidationDelegates.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/TokenValidationExtensibility/CustomIssuerSigningKeyValidationDelegates.cs
@@ -1,0 +1,144 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.IdentityModel.Tokens;
+
+#nullable enable
+namespace Microsoft.IdentityModel.TestUtils
+{
+    internal class CustomIssuerSigningKeyValidationDelegates
+    {
+        internal static ValidationResult<ValidatedSigningKeyLifetime> CustomIssuerSigningKeyValidatorDelegate(
+            SecurityKey signingKey,
+            SecurityToken securityToken,
+            ValidationParameters validationParameters,
+            BaseConfiguration? configuration,
+            CallContext callContext)
+        {
+            // Returns a CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError
+            return new CustomIssuerSigningKeyValidationError(
+                new MessageDetail(nameof(CustomIssuerSigningKeyValidatorDelegate), null),
+                typeof(SecurityTokenInvalidSigningKeyException),
+                ValidationError.GetCurrentStackFrame(),
+                signingKey,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedSigningKeyLifetime> CustomIssuerSigningKeyValidatorCustomExceptionDelegate(
+            SecurityKey signingKey,
+            SecurityToken securityToken,
+            ValidationParameters validationParameters,
+            BaseConfiguration? configuration,
+            CallContext callContext)
+        {
+            return new CustomIssuerSigningKeyValidationError(
+                new MessageDetail(nameof(CustomIssuerSigningKeyValidatorCustomExceptionDelegate), null),
+                typeof(CustomSecurityTokenInvalidSigningKeyException),
+                ValidationError.GetCurrentStackFrame(),
+                signingKey,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedSigningKeyLifetime> CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate(
+            SecurityKey signingKey,
+            SecurityToken securityToken,
+            ValidationParameters validationParameters,
+            BaseConfiguration? configuration,
+            CallContext callContext)
+        {
+            return new CustomIssuerSigningKeyValidationError(
+                new MessageDetail(nameof(CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                typeof(CustomSecurityTokenInvalidSigningKeyException),
+                ValidationError.GetCurrentStackFrame(),
+                signingKey,
+                CustomIssuerSigningKeyValidationError.CustomIssuerSigningKeyValidationFailureType);
+        }
+
+        internal static ValidationResult<ValidatedSigningKeyLifetime> CustomIssuerSigningKeyValidatorUnknownExceptionDelegate(
+            SecurityKey signingKey,
+            SecurityToken securityToken,
+            ValidationParameters validationParameters,
+            BaseConfiguration? configuration,
+            CallContext callContext)
+        {
+            return new CustomIssuerSigningKeyValidationError(
+                new MessageDetail(nameof(CustomIssuerSigningKeyValidatorUnknownExceptionDelegate), null),
+                typeof(NotSupportedException),
+                ValidationError.GetCurrentStackFrame(),
+                signingKey,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedSigningKeyLifetime> CustomIssuerSigningKeyValidatorWithoutGetExceptionOverrideDelegate(
+            SecurityKey signingKey,
+            SecurityToken securityToken,
+            ValidationParameters validationParameters,
+            BaseConfiguration? configuration,
+            CallContext callContext)
+        {
+            return new CustomIssuerSigningKeyWithoutGetExceptionValidationOverrideError(
+                new MessageDetail(nameof(CustomIssuerSigningKeyValidatorWithoutGetExceptionOverrideDelegate), null),
+                typeof(CustomSecurityTokenInvalidSigningKeyException),
+                ValidationError.GetCurrentStackFrame(),
+                signingKey,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedSigningKeyLifetime> IssuerSigningKeyValidatorDelegate(
+            SecurityKey signingKey,
+            SecurityToken securityToken,
+            ValidationParameters validationParameters,
+            BaseConfiguration? configuration,
+            CallContext callContext)
+        {
+            return new IssuerSigningKeyValidationError(
+                new MessageDetail(nameof(IssuerSigningKeyValidatorDelegate), null),
+                typeof(SecurityTokenInvalidSigningKeyException),
+                ValidationError.GetCurrentStackFrame(),
+                signingKey,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedSigningKeyLifetime> IssuerSigningKeyValidatorThrows(
+            SecurityKey signingKey,
+            SecurityToken securityToken,
+            ValidationParameters validationParameters,
+            BaseConfiguration? configuration,
+            CallContext callContext)
+        {
+            throw new CustomSecurityTokenInvalidSigningKeyException(nameof(IssuerSigningKeyValidatorThrows), null);
+        }
+
+        internal static ValidationResult<ValidatedSigningKeyLifetime> IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate(
+            SecurityKey signingKey,
+            SecurityToken securityToken,
+            ValidationParameters validationParameters,
+            BaseConfiguration? configuration,
+            CallContext callContext)
+        {
+            return new IssuerSigningKeyValidationError(
+                new MessageDetail(nameof(IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate), null),
+                typeof(CustomSecurityTokenInvalidSigningKeyException),
+                ValidationError.GetCurrentStackFrame(),
+                signingKey,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedSigningKeyLifetime> IssuerSigningKeyValidatorCustomExceptionTypeDelegate(
+            SecurityKey signingKey,
+            SecurityToken securityToken,
+            ValidationParameters validationParameters,
+            BaseConfiguration? configuration,
+            CallContext callContext)
+        {
+            return new IssuerSigningKeyValidationError(
+                new MessageDetail(nameof(IssuerSigningKeyValidatorCustomExceptionTypeDelegate), null),
+                typeof(CustomSecurityTokenException),
+                ValidationError.GetCurrentStackFrame(),
+                signingKey,
+                null);
+        }
+    }
+}
+#nullable restore

--- a/test/Microsoft.IdentityModel.TestUtils/TokenValidationExtensibility/CustomValidationErrors.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/TokenValidationExtensibility/CustomValidationErrors.cs
@@ -157,6 +157,53 @@ namespace Microsoft.IdentityModel.TestUtils
     }
     #endregion
 
+    #region IssuerSigningKeyValidationErrors
+    internal class CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError
+    {
+        /// <summary>
+        /// A custom validation failure type.
+        /// </summary>
+        public static readonly ValidationFailureType CustomIssuerSigningKeyValidationFailureType = new IssuerSigningKeyValidationFailure("CustomIssuerSigningKeyValidationFailureType");
+        private class IssuerSigningKeyValidationFailure : ValidationFailureType { internal IssuerSigningKeyValidationFailure(string name) : base(name) { } }
+
+        public CustomIssuerSigningKeyValidationError(
+            MessageDetail messageDetail,
+            Type exceptionType,
+            StackFrame stackFrame,
+            SecurityKey? securityKey,
+            ValidationFailureType? validationFailureType = null,
+            Exception? innerException = null)
+            : base(messageDetail, exceptionType, stackFrame, securityKey, validationFailureType, innerException)
+        {
+        }
+
+        internal override Exception GetException()
+        {
+            if (ExceptionType == typeof(CustomSecurityTokenInvalidSigningKeyException))
+            {
+                var exception = new CustomSecurityTokenInvalidSigningKeyException(MessageDetail.Message, InnerException) { SigningKey = InvalidSigningKey };
+                exception.SetValidationError(this);
+                return exception;
+            }
+            return base.GetException();
+        }
+    }
+
+    internal class CustomIssuerSigningKeyWithoutGetExceptionValidationOverrideError : IssuerSigningKeyValidationError
+    {
+        public CustomIssuerSigningKeyWithoutGetExceptionValidationOverrideError(
+            MessageDetail messageDetail,
+            Type exceptionType,
+            StackFrame stackFrame,
+            SecurityKey? securityKey,
+            ValidationFailureType? failureType = null,
+            Exception? innerException = null)
+            : base(messageDetail, exceptionType, stackFrame, securityKey, failureType, innerException)
+        {
+        }
+    }
+    #endregion // IssuerSigningKeyValidationErrors
+
     // Other custom validation errors to be added here for signature validation, issuer signing key, etc.
 }
 #nullable restore

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandler.Extensibility.IssuerSigningKey.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2SecurityTokenHandler.Extensibility.IssuerSigningKey.cs
@@ -1,0 +1,283 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.TestUtils;
+
+using Xunit;
+
+#nullable enable
+namespace Microsoft.IdentityModel.Tokens.Saml2.Extensibility.Tests
+{
+    public partial class Saml2SecurityTokenHandlerValidateTokenAsyncTests
+    {
+        [Theory, MemberData(nameof(IssuerSigningKey_ExtensibilityTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task ValidateTokenAsync_IssuerSigningKeyValidator_Extensibility(IssuerSigningKeyExtensibilityTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(ValidateTokenAsync_IssuerSigningKeyValidator_Extensibility)}", theoryData);
+            context.IgnoreType = false;
+            for (int i = 0; i < theoryData.ExtraStackFrames; i++)
+                theoryData.IssuerSigningKeyValidationError!.AddStackFrame(new StackFrame(false));
+
+            try
+            {
+                ValidationResult<ValidatedToken> validationResult = await theoryData.Saml2SecurityTokenHandler.ValidateTokenAsync(
+                    theoryData.Saml2Token!,
+                    theoryData.ValidationParameters!,
+                    theoryData.CallContext,
+                    CancellationToken.None);
+
+                if (validationResult.IsValid)
+                {
+                    context.AddDiff("validationResult.IsValid is true, expected false");
+                }
+                else
+                {
+                    ValidationError validationError = validationResult.UnwrapError();
+                    IdentityComparer.AreValidationErrorsEqual(validationError, theoryData.IssuerSigningKeyValidationError, context);
+                    theoryData.ExpectedException.ProcessException(validationError.GetException(), context);
+                }
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<IssuerSigningKeyExtensibilityTheoryData> IssuerSigningKey_ExtensibilityTestCases
+        {
+            get
+            {
+                var theoryData = new TheoryData<IssuerSigningKeyExtensibilityTheoryData>();
+                CallContext callContext = new CallContext();
+                var utcNow = DateTime.UtcNow;
+                var utcPlusOneHour = utcNow + TimeSpan.FromHours(1);
+
+                #region return CustomIssuerSigningKeyValidationError
+                // Test cases where delegate is overridden and return a CustomIssuerSigningKeyValidationError
+                // CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError, ExceptionType: SecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "CustomIssuerSigningKeyValidatorDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorDelegate,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorDelegate)),
+                    IssuerSigningKeyValidationError = new CustomIssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 160),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed)
+                });
+
+                // CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError, ExceptionType: CustomSecurityTokenInvalidIssuerSigningKeyException : SecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "CustomIssuerSigningKeyValidatorCustomExceptionDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionDelegate,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionDelegate)),
+                    IssuerSigningKeyValidationError = new CustomIssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionDelegate), null),
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 175),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed),
+                });
+
+                // CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError, ExceptionType: NotSupportedException : SystemException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "CustomIssuerSigningKeyValidatorUnknownExceptionDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorUnknownExceptionDelegate,
+                    extraStackFrames: 1)
+                {
+                    // CustomIssuerSigningKeyValidationError does not handle the exception type 'NotSupportedException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(NotSupportedException),
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorUnknownExceptionDelegate))),
+                    IssuerSigningKeyValidationError = new CustomIssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorUnknownExceptionDelegate), null),
+                        typeof(NotSupportedException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 205),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed),
+                });
+
+                // CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError, ExceptionType: NotSupportedException : SystemException, ValidationFailureType: CustomAudienceValidationFailureType
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate)),
+                    IssuerSigningKeyValidationError = new CustomIssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 190),
+                        null,
+                        CustomIssuerSigningKeyValidationError.CustomIssuerSigningKeyValidationFailureType),
+                });
+                #endregion
+
+                #region return IssuerSigningKeyValidationError
+                // Test cases where delegate is overridden and return an IssuerSigningKeyValidationError
+                // IssuerSigningKeyValidationError : ValidationError, ExceptionType:  SecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "IssuerSigningKeyValidatorDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorDelegate,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorDelegate)),
+                    IssuerSigningKeyValidationError = new IssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 235),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed)
+                });
+
+                // IssuerSigningKeyValidationError : ValidationError, ExceptionType:  CustomSecurityTokenInvalidIssuerSigningKeyException : SecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate,
+                    extraStackFrames: 1)
+                {
+                    // IssuerSigningKeyValidationError does not handle the exception type 'CustomSecurityTokenInvalidIssuerSigningKeyException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenInvalidSigningKeyException),
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate))),
+                    IssuerSigningKeyValidationError = new IssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 259),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed)
+                });
+
+                // IssuerSigningKeyValidationError : ValidationError, ExceptionType:  CustomSecurityTokenException : SystemException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "IssuerSigningKeyValidatorCustomExceptionTypeDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomExceptionTypeDelegate,
+                    extraStackFrames: 1)
+                {
+                    // IssuerSigningKeyValidationError does not handle the exception type 'CustomSecurityTokenException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenException),
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomExceptionTypeDelegate))),
+                    IssuerSigningKeyValidationError = new IssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 274),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed)
+                });
+
+                // IssuerSigningKeyValidationError : ValidationError, ExceptionType: SecurityTokenInvalidIssuerSigningKeyException, inner: CustomSecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "IssuerSigningKeyValidatorThrows",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorThrows,
+                    extraStackFrames: 0)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        string.Format(Tokens.LogMessages.IDX10274),
+                        typeof(CustomSecurityTokenInvalidSigningKeyException)),
+                    IssuerSigningKeyValidationError = new IssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            string.Format(Tokens.LogMessages.IDX10274), null),
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        new StackFrame("Saml2SecurityTokenHandler.ValidateToken.Internal.cs", 250),
+                        null,
+                        ValidationFailureType.IssuerSigningKeyValidatorThrew,
+                        new SecurityTokenInvalidSigningKeyException(nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorThrows))
+                    )
+                });
+                #endregion
+
+                return theoryData;
+            }
+        }
+
+        public class IssuerSigningKeyExtensibilityTheoryData : TheoryDataBase
+        {
+            internal IssuerSigningKeyExtensibilityTheoryData(string testId, DateTime utcNow, IssuerSigningKeyValidationDelegate issuerSigningKeyValidator, int extraStackFrames) : base(testId)
+            {
+                Saml2Token = (Saml2SecurityToken)Saml2SecurityTokenHandler.CreateToken(
+                    new SecurityTokenDescriptor()
+                    {
+                        Subject = Default.SamlClaimsIdentity,
+                        Issuer = Default.Issuer,
+                    });
+
+                ValidationParameters = new ValidationParameters
+                {
+                    AlgorithmValidator = SkipValidationDelegates.SkipAlgorithmValidation,
+                    AudienceValidator = SkipValidationDelegates.SkipAudienceValidation,
+                    IssuerValidatorAsync = SkipValidationDelegates.SkipIssuerValidation,
+                    IssuerSigningKeyValidator = issuerSigningKeyValidator,
+                    LifetimeValidator = SkipValidationDelegates.SkipLifetimeValidation,
+                    SignatureValidator = (SecurityToken token, ValidationParameters validationParameters, BaseConfiguration? configuration, CallContext? callContext) =>
+                    {
+                        token.SigningKey = SigningKey;
+
+                        return SigningKey;
+                    },
+                    TokenReplayValidator = SkipValidationDelegates.SkipTokenReplayValidation,
+                    TokenTypeValidator = SkipValidationDelegates.SkipTokenTypeValidation
+                };
+
+                ExtraStackFrames = extraStackFrames;
+            }
+
+            public Saml2SecurityToken Saml2Token { get; }
+
+            public Saml2SecurityTokenHandler Saml2SecurityTokenHandler { get; } = new Saml2SecurityTokenHandler();
+
+            public bool IsValid { get; set; }
+
+            public SecurityKey SigningKey { get; set; } = KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2.Key;
+
+            internal ValidationParameters? ValidationParameters { get; set; }
+
+            internal IssuerSigningKeyValidationError? IssuerSigningKeyValidationError { get; set; }
+
+            internal int ExtraStackFrames { get; }
+        }
+    }
+}
+#nullable restore

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandler.Extensibility.IssuerSigningKey.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/SamlSecurityTokenHandler.Extensibility.IssuerSigningKey.cs
@@ -1,0 +1,283 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.TestUtils;
+
+using Xunit;
+
+#nullable enable
+namespace Microsoft.IdentityModel.Tokens.Saml.Extensibility.Tests
+{
+    public partial class SamlSecurityTokenHandlerValidateTokenAsyncTests
+    {
+        [Theory, MemberData(nameof(IssuerSigningKey_ExtensibilityTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task ValidateTokenAsync_IssuerSigningKeyValidator_Extensibility(IssuerSigningKeyExtensibilityTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(ValidateTokenAsync_IssuerSigningKeyValidator_Extensibility)}", theoryData);
+            context.IgnoreType = false;
+            for (int i = 0; i < theoryData.ExtraStackFrames; i++)
+                theoryData.IssuerSigningKeyValidationError!.AddStackFrame(new StackFrame(false));
+
+            try
+            {
+                ValidationResult<ValidatedToken> validationResult = await theoryData.SamlSecurityTokenHandler.ValidateTokenAsync(
+                    theoryData.SamlToken!,
+                    theoryData.ValidationParameters!,
+                    theoryData.CallContext,
+                    CancellationToken.None);
+
+                if (validationResult.IsValid)
+                {
+                    context.AddDiff("validationResult.IsValid is true, expected false");
+                }
+                else
+                {
+                    ValidationError validationError = validationResult.UnwrapError();
+                    IdentityComparer.AreValidationErrorsEqual(validationError, theoryData.IssuerSigningKeyValidationError, context);
+                    theoryData.ExpectedException.ProcessException(validationError.GetException(), context);
+                }
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<IssuerSigningKeyExtensibilityTheoryData> IssuerSigningKey_ExtensibilityTestCases
+        {
+            get
+            {
+                var theoryData = new TheoryData<IssuerSigningKeyExtensibilityTheoryData>();
+                CallContext callContext = new CallContext();
+                var utcNow = DateTime.UtcNow;
+                var utcPlusOneHour = utcNow + TimeSpan.FromHours(1);
+
+                #region return CustomIssuerSigningKeyValidationError
+                // Test cases where delegate is overridden and return a CustomIssuerSigningKeyValidationError
+                // CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError, ExceptionType: SecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "CustomIssuerSigningKeyValidatorDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorDelegate,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorDelegate)),
+                    IssuerSigningKeyValidationError = new CustomIssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 160),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed)
+                });
+
+                // CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError, ExceptionType: CustomSecurityTokenInvalidIssuerSigningKeyException : SecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "CustomIssuerSigningKeyValidatorCustomExceptionDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionDelegate,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionDelegate)),
+                    IssuerSigningKeyValidationError = new CustomIssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionDelegate), null),
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 175),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed),
+                });
+
+                // CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError, ExceptionType: NotSupportedException : SystemException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "CustomIssuerSigningKeyValidatorUnknownExceptionDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorUnknownExceptionDelegate,
+                    extraStackFrames: 1)
+                {
+                    // CustomIssuerSigningKeyValidationError does not handle the exception type 'NotSupportedException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(NotSupportedException),
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorUnknownExceptionDelegate))),
+                    IssuerSigningKeyValidationError = new CustomIssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorUnknownExceptionDelegate), null),
+                        typeof(NotSupportedException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 205),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed),
+                });
+
+                // CustomIssuerSigningKeyValidationError : IssuerSigningKeyValidationError, ExceptionType: NotSupportedException : SystemException, ValidationFailureType: CustomAudienceValidationFailureType
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate)),
+                    IssuerSigningKeyValidationError = new CustomIssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.CustomIssuerSigningKeyValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 190),
+                        null,
+                        CustomIssuerSigningKeyValidationError.CustomIssuerSigningKeyValidationFailureType),
+                });
+                #endregion
+
+                #region return IssuerSigningKeyValidationError
+                // Test cases where delegate is overridden and return an IssuerSigningKeyValidationError
+                // IssuerSigningKeyValidationError : ValidationError, ExceptionType:  SecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "IssuerSigningKeyValidatorDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorDelegate,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorDelegate)),
+                    IssuerSigningKeyValidationError = new IssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 235),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed)
+                });
+
+                // IssuerSigningKeyValidationError : ValidationError, ExceptionType:  CustomSecurityTokenInvalidIssuerSigningKeyException : SecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate,
+                    extraStackFrames: 1)
+                {
+                    // IssuerSigningKeyValidationError does not handle the exception type 'CustomSecurityTokenInvalidIssuerSigningKeyException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenInvalidSigningKeyException),
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate))),
+                    IssuerSigningKeyValidationError = new IssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomIssuerSigningKeyExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidSigningKeyException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 259),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed)
+                });
+
+                // IssuerSigningKeyValidationError : ValidationError, ExceptionType:  CustomSecurityTokenException : SystemException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "IssuerSigningKeyValidatorCustomExceptionTypeDelegate",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomExceptionTypeDelegate,
+                    extraStackFrames: 1)
+                {
+                    // IssuerSigningKeyValidationError does not handle the exception type 'CustomSecurityTokenException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenException),
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomExceptionTypeDelegate))),
+                    IssuerSigningKeyValidationError = new IssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorCustomExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenException),
+                        new StackFrame("CustomIssuerSigningKeyValidationDelegates.cs", 274),
+                        null,
+                        ValidationFailureType.SigningKeyValidationFailed)
+                });
+
+                // IssuerSigningKeyValidationError : ValidationError, ExceptionType: SecurityTokenInvalidIssuerSigningKeyException, inner: CustomSecurityTokenInvalidIssuerSigningKeyException
+                theoryData.Add(new IssuerSigningKeyExtensibilityTheoryData(
+                    "IssuerSigningKeyValidatorThrows",
+                    utcNow,
+                    CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorThrows,
+                    extraStackFrames: 0)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        string.Format(Tokens.LogMessages.IDX10274),
+                        typeof(CustomSecurityTokenInvalidSigningKeyException)),
+                    IssuerSigningKeyValidationError = new IssuerSigningKeyValidationError(
+                        new MessageDetail(
+                            string.Format(Tokens.LogMessages.IDX10274), null),
+                        typeof(SecurityTokenInvalidSigningKeyException),
+                        new StackFrame("SamlSecurityTokenHandler.ValidateToken.Internal.cs", 250),
+                        null,
+                        ValidationFailureType.IssuerSigningKeyValidatorThrew,
+                        new SecurityTokenInvalidSigningKeyException(nameof(CustomIssuerSigningKeyValidationDelegates.IssuerSigningKeyValidatorThrows))
+                    )
+                });
+                #endregion
+
+                return theoryData;
+            }
+        }
+
+        public class IssuerSigningKeyExtensibilityTheoryData : TheoryDataBase
+        {
+            internal IssuerSigningKeyExtensibilityTheoryData(string testId, DateTime utcNow, IssuerSigningKeyValidationDelegate issuerSigningKeyValidator, int extraStackFrames) : base(testId)
+            {
+                SamlToken = (SamlSecurityToken)SamlSecurityTokenHandler.CreateToken(
+                    new SecurityTokenDescriptor()
+                    {
+                        Subject = Default.SamlClaimsIdentity,
+                        Issuer = Default.Issuer,
+                    });
+
+                ValidationParameters = new ValidationParameters
+                {
+                    AlgorithmValidator = SkipValidationDelegates.SkipAlgorithmValidation,
+                    AudienceValidator = SkipValidationDelegates.SkipAudienceValidation,
+                    IssuerValidatorAsync = SkipValidationDelegates.SkipIssuerValidation,
+                    IssuerSigningKeyValidator = issuerSigningKeyValidator,
+                    LifetimeValidator = SkipValidationDelegates.SkipLifetimeValidation,
+                    SignatureValidator = (SecurityToken token, ValidationParameters validationParameters, BaseConfiguration? configuration, CallContext? callContext) =>
+                    {
+                        token.SigningKey = SigningKey;
+
+                        return SigningKey;
+                    },
+                    TokenReplayValidator = SkipValidationDelegates.SkipTokenReplayValidation,
+                    TokenTypeValidator = SkipValidationDelegates.SkipTokenTypeValidation
+                };
+
+                ExtraStackFrames = extraStackFrames;
+            }
+
+            public SamlSecurityToken SamlToken { get; }
+
+            public SamlSecurityTokenHandler SamlSecurityTokenHandler { get; } = new SamlSecurityTokenHandler();
+
+            public bool IsValid { get; set; }
+
+            public SecurityKey SigningKey { get; set; } = KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2.Key;
+
+            internal ValidationParameters? ValidationParameters { get; set; }
+
+            internal IssuerSigningKeyValidationError? IssuerSigningKeyValidationError { get; set; }
+
+            internal int ExtraStackFrames { get; }
+        }
+    }
+}
+#nullable restore


### PR DESCRIPTION
# Extensibility tests: Issuer signing key - JWT, SAML and SAML2
- Handle potential exception thrown by the  issuer signing key validation delegate in JWT, SAML, and SAML2
- Added custom issuer signing key validation delegates for testing
- Added lifetime extensibility tests for JWT, SAML, and SAML2

Note: Targeting the base extensibility branch to avoid showing those changes again. Once merged, I will move this to target dev and take out of draft.

Part of #2711 