### PR TITLE
Extensibility tests: Token Type - JWT

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.Internal.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.Internal.cs
@@ -336,12 +336,28 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 actorValidationResult = innerActorValidationResult;
             }
 
-            ValidationResult<ValidatedTokenType> typeValidationResult = validationParameters.TokenTypeValidator(
-                jsonWebToken.Typ, jsonWebToken, validationParameters, callContext);
-            if (!typeValidationResult.IsValid)
+            ValidationResult<ValidatedTokenType> typeValidationResult;
+
+            try
             {
-                StackFrame typeValidationFailureStackFrame = StackFrames.TypeValidationFailed ??= new StackFrame(true);
-                return typeValidationResult.UnwrapError().AddStackFrame(typeValidationFailureStackFrame);
+                typeValidationResult = validationParameters.TokenTypeValidator(
+                    jsonWebToken.Typ, jsonWebToken, validationParameters, callContext);
+
+                if (!typeValidationResult.IsValid)
+                    return typeValidationResult.UnwrapError().AddCurrentStackFrame();
+            }
+
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return new TokenTypeValidationError(
+                    new MessageDetail(TokenLogMessages.IDX10275),
+                    typeof(SecurityTokenInvalidTypeException),
+                    ValidationError.GetCurrentStackFrame(),
+                    jsonWebToken.Typ,
+                    ValidationFailureType.TokenTypeValidatorThrew,
+                    ex);
             }
 
             // The signature validation delegate is yet to be migrated to ValidationParameters.

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -20,8 +20,9 @@ Microsoft.IdentityModel.Tokens.LifetimeValidationError.LifetimeValidationError(M
 Microsoft.IdentityModel.Tokens.LifetimeValidationError.NotBefore.get -> System.DateTime
 Microsoft.IdentityModel.Tokens.LifetimeValidationError.NotBefore.set -> void
 Microsoft.IdentityModel.Tokens.TokenTypeValidationError
+Microsoft.IdentityModel.Tokens.TokenTypeValidationError.InvalidTokenType.get -> string
+Microsoft.IdentityModel.Tokens.TokenTypeValidationError.InvalidTokenType.set -> void
 Microsoft.IdentityModel.Tokens.TokenTypeValidationError.TokenTypeValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, string invalidTokenType, Microsoft.IdentityModel.Tokens.ValidationFailureType validationFailureType = null, System.Exception innerException = null) -> void
-Microsoft.IdentityModel.Tokens.TokenTypeValidationError._invalidTokenType -> string
 Microsoft.IdentityModel.Tokens.TokenValidationParameters.TimeProvider.get -> System.TimeProvider
 Microsoft.IdentityModel.Tokens.TokenValidationParameters.TimeProvider.set -> void
 Microsoft.IdentityModel.Tokens.ValidationError.AddCurrentStackFrame(string filePath = "", int lineNumber = 0, int skipFrames = 1) -> Microsoft.IdentityModel.Tokens.ValidationError
@@ -39,6 +40,7 @@ static Microsoft.IdentityModel.Tokens.AudienceValidationError.AudiencesNull -> S
 static Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidateAudienceFailed -> System.Diagnostics.StackFrame
 static Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidationParametersAudiencesCountZero -> System.Diagnostics.StackFrame
 static Microsoft.IdentityModel.Tokens.AudienceValidationError.ValidationParametersNull -> System.Diagnostics.StackFrame
+static Microsoft.IdentityModel.Tokens.TokenTypeValidationError.NullParameter(string parameterName, System.Diagnostics.StackFrame stackFrame) -> Microsoft.IdentityModel.Tokens.TokenTypeValidationError
 static Microsoft.IdentityModel.Tokens.Utility.SerializeAsSingleCommaDelimitedString(System.Collections.Generic.IList<string> strings) -> string
 static Microsoft.IdentityModel.Tokens.ValidationError.GetCurrentStackFrame(string filePath = "", int lineNumber = 0, int skipFrames = 1) -> System.Diagnostics.StackFrame
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.IssuerValidatorThrew -> Microsoft.IdentityModel.Tokens.ValidationFailureType

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10002 = "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10268 = "IDX10268: Unable to validate audience, validationParameters.ValidAudiences.Count == 0." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10269 = "IDX10269: IssuerValidationDelegate threw an exception, see inner exception." -> string
+const Microsoft.IdentityModel.Tokens.LogMessages.IDX10275 = "IDX10275: TokenTypeValidationDelegate threw an exception, see inner exception." -> string
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError.AlgorithmValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, string invalidAlgorithm, Microsoft.IdentityModel.Tokens.ValidationFailureType validationFailureType = null, System.Exception innerException = null) -> void
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError.InvalidAlgorithm.get -> string
@@ -49,4 +50,5 @@ static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.NoValidatio
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.SignatureAlgorithmValidationFailed -> Microsoft.IdentityModel.Tokens.ValidationFailureType
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.TokenExceedsMaximumSize -> Microsoft.IdentityModel.Tokens.ValidationFailureType
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.TokenIsNotSigned -> Microsoft.IdentityModel.Tokens.ValidationFailureType
+static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.TokenTypeValidatorThrew -> Microsoft.IdentityModel.Tokens.ValidationFailureType
 static readonly Microsoft.IdentityModel.Tokens.ValidationFailureType.XmlValidationFailed -> Microsoft.IdentityModel.Tokens.ValidationFailureType

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -88,7 +88,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10267 = "IDX10267: '{0}' has been called by a derived class '{1}' which has not implemented this method. For this call graph to succeed, '{1}' will need to implement '{0}'.";
         public const string IDX10268 = "IDX10268: Unable to validate audience, validationParameters.ValidAudiences.Count == 0.";
         public const string IDX10269 = "IDX10269: IssuerValidationDelegate threw an exception, see inner exception.";
-
+        public const string IDX10275 = "IDX10275: TokenTypeValidationDelegate threw an exception, see inner exception.";
 
         // 10500 - SignatureValidation
         public const string IDX10500 = "IDX10500: Signature validation failed. No security keys were provided to validate the signature.";

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/TokenTypeValidationError.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/TokenTypeValidationError.cs
@@ -9,8 +9,6 @@ namespace Microsoft.IdentityModel.Tokens
 {
     internal class TokenTypeValidationError : ValidationError
     {
-        protected string? _invalidTokenType;
-
         internal TokenTypeValidationError(
             MessageDetail messageDetail,
             Type exceptionType,
@@ -20,7 +18,7 @@ namespace Microsoft.IdentityModel.Tokens
             Exception? innerException = null)
             : base(messageDetail, exceptionType, stackFrame, validationFailureType ?? ValidationFailureType.TokenTypeValidationFailed, innerException)
         {
-            _invalidTokenType = invalidTokenType;
+            InvalidTokenType = invalidTokenType;
         }
 
         internal override Exception GetException()
@@ -29,14 +27,24 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 SecurityTokenInvalidTypeException exception = new(MessageDetail.Message, InnerException)
                 {
-                    InvalidType = _invalidTokenType
+                    InvalidType = InvalidTokenType
                 };
+                exception.SetValidationError(this);
 
                 return exception;
             }
 
             return base.GetException();
         }
+
+        internal static new TokenTypeValidationError NullParameter(string parameterName, StackFrame stackFrame) => new(
+            MessageDetail.NullParameter(parameterName),
+            typeof(SecurityTokenArgumentNullException),
+            stackFrame,
+            null, // invalidTokenType
+            ValidationFailureType.NullArgument);
+
+        protected string? InvalidTokenType { get; set; }
     }
 }
 #nullable restore

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationFailureType.cs
@@ -134,5 +134,10 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         public static readonly ValidationFailureType IssuerValidatorThrew = new IssuerValidatorFailure("IssuerValidatorThrew");
         private class IssuerValidatorFailure : ValidationFailureType { internal IssuerValidatorFailure(string name) : base(name) { } }
+
+        /// <summary>
+        /// Defines a type that represents that the token type validation delegate threw and exception.
+        /// </summary>
+        public static readonly ValidationFailureType TokenTypeValidatorThrew = new TokenTypeValidationFailure("TokenTypeValidatorThrew");
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Validators.TokenType.cs
@@ -45,14 +45,14 @@ namespace Microsoft.IdentityModel.Tokens
 #pragma warning restore CA1801 // TODO: remove pragma disable once callContext is used for logging
         {
             if (securityToken == null)
-                return ValidationError.NullParameter(
+                return TokenTypeValidationError.NullParameter(
                     nameof(securityToken),
-                    new StackFrame(true));
+                    ValidationError.GetCurrentStackFrame());
 
             if (validationParameters == null)
-                return ValidationError.NullParameter(
+                return TokenTypeValidationError.NullParameter(
                     nameof(validationParameters),
-                    new StackFrame(true));
+                    ValidationError.GetCurrentStackFrame());
 
             if (validationParameters.ValidTypes.Count == 0)
             {
@@ -65,7 +65,7 @@ namespace Microsoft.IdentityModel.Tokens
                 return new TokenTypeValidationError(
                     new MessageDetail(LogMessages.IDX10256),
                     typeof(SecurityTokenInvalidTypeException),
-                    new StackFrame(true),
+                    ValidationError.GetCurrentStackFrame(),
                     null); // even if it is empty, we report null to match the original behaviour.
 
             if (!validationParameters.ValidTypes.Contains(type, StringComparer.Ordinal))
@@ -76,7 +76,7 @@ namespace Microsoft.IdentityModel.Tokens
                         LogHelper.MarkAsNonPII(type),
                         LogHelper.MarkAsNonPII(Utility.SerializeAsSingleCommaDelimitedString(validationParameters.ValidTypes))),
                     typeof(SecurityTokenInvalidTypeException),
-                    new StackFrame(true),
+                    ValidationError.GetCurrentStackFrame(),
                     type);
             }
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.Extensibility.TokenType.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.Extensibility.TokenType.cs
@@ -1,0 +1,263 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.JsonWebTokens.Tests;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Json.Tests;
+using Xunit;
+
+#nullable enable
+namespace Microsoft.IdentityModel.JsonWebTokens.Extensibility.Tests
+{
+    public partial class JsonWebTokenHandlerValidateTokenAsyncTests
+    {
+        [Theory, MemberData(nameof(TokenType_ExtensibilityTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task ValidateTokenAsync_TokenTypeValidator_Extensibility(TokenTypeExtensibilityTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.{nameof(ValidateTokenAsync_TokenTypeValidator_Extensibility)}", theoryData);
+            context.IgnoreType = false;
+            for (int i = 0; i < theoryData.ExtraStackFrames; i++)
+                theoryData.TokenTypeValidationError!.AddStackFrame(new StackFrame(false));
+
+            try
+            {
+                ValidationResult<ValidatedToken> validationResult = await theoryData.JsonWebTokenHandler.ValidateTokenAsync(
+                    theoryData.JsonWebToken!,
+                    theoryData.ValidationParameters!,
+                    theoryData.CallContext,
+                    CancellationToken.None);
+
+                if (validationResult.IsValid)
+                {
+                    context.Diffs.Add("validationResult.IsValid is true, expected false");
+                }
+                else
+                {
+                    ValidationError validationError = validationResult.UnwrapError();
+                    IdentityComparer.AreValidationErrorsEqual(validationError, theoryData.TokenTypeValidationError, context);
+                    theoryData.ExpectedException.ProcessException(validationError.GetException(), context);
+                }
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<TokenTypeExtensibilityTheoryData> TokenType_ExtensibilityTestCases
+        {
+            get
+            {
+                var theoryData = new TheoryData<TokenTypeExtensibilityTheoryData>();
+                CallContext callContext = new CallContext();
+
+                #region return CustomTokenTypeValidationError
+                // Test cases where delegate is overridden and return a CustomTokenTypeValidationError
+                // CustomTokenTypeValidationError : TokenTypeValidationError, ExceptionType: SecurityTokenInvalidTypeException
+                theoryData.Add(new TokenTypeExtensibilityTheoryData(
+                    "CustomTokenTypeValidatorDelegate",
+                    CustomTokenTypeValidationDelegates.CustomTokenTypeValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidTypeException),
+                        nameof(CustomTokenTypeValidationDelegates.CustomTokenTypeValidatorDelegate)),
+                    TokenTypeValidationError = new CustomTokenTypeValidationError(
+                        new MessageDetail(
+                            nameof(CustomTokenTypeValidationDelegates.CustomTokenTypeValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidTypeException),
+                        new StackFrame("CustomTokenTypeValidationDelegates.cs", 160),
+                        "JWT",
+                        ValidationFailureType.TokenTypeValidationFailed)
+                });
+
+                // CustomTokenTypeValidationError : TokenTypeValidationError, ExceptionType: CustomSecurityTokenInvalidTypeException : SecurityTokenInvalidTypeException
+                theoryData.Add(new TokenTypeExtensibilityTheoryData(
+                    "CustomTokenTypeValidatorCustomExceptionDelegate",
+                    CustomTokenTypeValidationDelegates.CustomTokenTypeValidatorCustomExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidTypeException),
+                        nameof(CustomTokenTypeValidationDelegates.CustomTokenTypeValidatorCustomExceptionDelegate)),
+                    TokenTypeValidationError = new CustomTokenTypeValidationError(
+                        new MessageDetail(
+                            nameof(CustomTokenTypeValidationDelegates.CustomTokenTypeValidatorCustomExceptionDelegate), null),
+                        typeof(CustomSecurityTokenInvalidTypeException),
+                        new StackFrame("CustomTokenTypeValidationDelegates.cs", 175),
+                        "JWT",
+                        ValidationFailureType.TokenTypeValidationFailed),
+                });
+
+                // CustomTokenTypeValidationError : TokenTypeValidationError, ExceptionType: NotSupportedException : SystemException
+                theoryData.Add(new TokenTypeExtensibilityTheoryData(
+                    "CustomTokenTypeValidatorUnknownExceptionDelegate",
+                    CustomTokenTypeValidationDelegates.CustomTokenTypeValidatorUnknownExceptionDelegate,
+                    extraStackFrames: 2)
+                {
+                    // CustomTokenTypeValidationError does not handle the exception type 'NotSupportedException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(NotSupportedException),
+                            nameof(CustomTokenTypeValidationDelegates.CustomTokenTypeValidatorUnknownExceptionDelegate))),
+                    TokenTypeValidationError = new CustomTokenTypeValidationError(
+                        new MessageDetail(
+                            nameof(CustomTokenTypeValidationDelegates.CustomTokenTypeValidatorUnknownExceptionDelegate), null),
+                        typeof(NotSupportedException),
+                        new StackFrame("CustomTokenTypeValidationDelegates.cs", 205),
+                        "JWT",
+                        ValidationFailureType.TokenTypeValidationFailed),
+                });
+
+                // CustomTokenTypeValidationError : TokenTypeValidationError, ExceptionType: NotSupportedException : SystemException, ValidationFailureType: CustomAudienceValidationFailureType
+                theoryData.Add(new TokenTypeExtensibilityTheoryData(
+                    "CustomTokenTypeValidatorCustomExceptionCustomFailureTypeDelegate",
+                    CustomTokenTypeValidationDelegates.CustomTokenTypeValidatorCustomExceptionCustomFailureTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(CustomSecurityTokenInvalidTypeException),
+                        nameof(CustomTokenTypeValidationDelegates.CustomTokenTypeValidatorCustomExceptionCustomFailureTypeDelegate)),
+                    TokenTypeValidationError = new CustomTokenTypeValidationError(
+                        new MessageDetail(
+                            nameof(CustomTokenTypeValidationDelegates.CustomTokenTypeValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidTypeException),
+                        new StackFrame("CustomTokenTypeValidationDelegates.cs", 190),
+                        "JWT",
+                        CustomTokenTypeValidationError.CustomTokenTypeValidationFailureType),
+                });
+                #endregion
+
+                #region return TokenTypeValidationError
+                // Test cases where delegate is overridden and return an TokenTypeValidationError
+                // TokenTypeValidationError : ValidationError, ExceptionType:  SecurityTokenInvalidTypeException
+                theoryData.Add(new TokenTypeExtensibilityTheoryData(
+                    "TokenTypeValidatorDelegate",
+                    CustomTokenTypeValidationDelegates.TokenTypeValidatorDelegate,
+                    extraStackFrames: 2)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidTypeException),
+                        nameof(CustomTokenTypeValidationDelegates.TokenTypeValidatorDelegate)),
+                    TokenTypeValidationError = new TokenTypeValidationError(
+                        new MessageDetail(
+                            nameof(CustomTokenTypeValidationDelegates.TokenTypeValidatorDelegate), null),
+                        typeof(SecurityTokenInvalidTypeException),
+                        new StackFrame("CustomTokenTypeValidationDelegates.cs", 235),
+                        "JWT",
+                        ValidationFailureType.TokenTypeValidationFailed)
+                });
+
+                // TokenTypeValidationError : ValidationError, ExceptionType:  CustomSecurityTokenInvalidTypeException : SecurityTokenInvalidTypeException
+                theoryData.Add(new TokenTypeExtensibilityTheoryData(
+                    "TokenTypeValidatorCustomTokenTypeExceptionTypeDelegate",
+                    CustomTokenTypeValidationDelegates.TokenTypeValidatorCustomTokenTypeExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // TokenTypeValidationError does not handle the exception type 'CustomSecurityTokenInvalidTypeException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenInvalidTypeException),
+                            nameof(CustomTokenTypeValidationDelegates.TokenTypeValidatorCustomTokenTypeExceptionTypeDelegate))),
+                    TokenTypeValidationError = new TokenTypeValidationError(
+                        new MessageDetail(
+                            nameof(CustomTokenTypeValidationDelegates.TokenTypeValidatorCustomTokenTypeExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenInvalidTypeException),
+                        new StackFrame("CustomTokenTypeValidationDelegates.cs", 259),
+                        "JWT",
+                        ValidationFailureType.TokenTypeValidationFailed)
+                });
+
+                // TokenTypeValidationError : ValidationError, ExceptionType:  CustomSecurityTokenException : SystemException
+                theoryData.Add(new TokenTypeExtensibilityTheoryData(
+                    "TokenTypeValidatorCustomExceptionTypeDelegate",
+                    CustomTokenTypeValidationDelegates.TokenTypeValidatorCustomExceptionTypeDelegate,
+                    extraStackFrames: 2)
+                {
+                    // TokenTypeValidationError does not handle the exception type 'CustomSecurityTokenException'
+                    ExpectedException = ExpectedException.SecurityTokenException(
+                        LogHelper.FormatInvariant(
+                            Tokens.LogMessages.IDX10002, // "IDX10002: Unknown exception type returned. Type: '{0}'. Message: '{1}'.";
+                            typeof(CustomSecurityTokenException),
+                            nameof(CustomTokenTypeValidationDelegates.TokenTypeValidatorCustomExceptionTypeDelegate))),
+                    TokenTypeValidationError = new TokenTypeValidationError(
+                        new MessageDetail(
+                            nameof(CustomTokenTypeValidationDelegates.TokenTypeValidatorCustomExceptionTypeDelegate), null),
+                        typeof(CustomSecurityTokenException),
+                        new StackFrame("CustomTokenTypeValidationDelegates.cs", 274),
+                        "JWT",
+                        ValidationFailureType.TokenTypeValidationFailed)
+                });
+
+                // TokenTypeValidationError : ValidationError, ExceptionType: SecurityTokenInvalidTypeException, inner: CustomSecurityTokenInvalidTypeException
+                theoryData.Add(new TokenTypeExtensibilityTheoryData(
+                    "TokenTypeValidatorThrows",
+                    CustomTokenTypeValidationDelegates.TokenTypeValidatorThrows,
+                    extraStackFrames: 1)
+                {
+                    ExpectedException = new ExpectedException(
+                        typeof(SecurityTokenInvalidTypeException),
+                        string.Format(Tokens.LogMessages.IDX10275),
+                        typeof(CustomSecurityTokenInvalidTypeException)),
+                    TokenTypeValidationError = new TokenTypeValidationError(
+                        new MessageDetail(
+                            string.Format(Tokens.LogMessages.IDX10275), null),
+                        typeof(SecurityTokenInvalidTypeException),
+                        new StackFrame("JsonWebTokenHandler.ValidateToken.Internal.cs", 250),
+                        "JWT",
+                        ValidationFailureType.TokenTypeValidatorThrew,
+                        new SecurityTokenInvalidTypeException(nameof(CustomTokenTypeValidationDelegates.TokenTypeValidatorThrows))
+                    )
+                });
+                #endregion
+
+                return theoryData;
+            }
+        }
+
+        public class TokenTypeExtensibilityTheoryData : ValidateTokenAsyncBaseTheoryData
+        {
+            internal TokenTypeExtensibilityTheoryData(string testId, TokenTypeValidationDelegate tokenTypeValidator, int extraStackFrames) : base(testId)
+            {
+                JsonWebToken = JsonUtilities.CreateUnsignedJsonWebToken("iss", "issuer");
+
+                ValidationParameters = new ValidationParameters
+                {
+                    AlgorithmValidator = SkipValidationDelegates.SkipAlgorithmValidation,
+                    AudienceValidator = SkipValidationDelegates.SkipAudienceValidation,
+                    IssuerValidatorAsync = SkipValidationDelegates.SkipIssuerValidation,
+                    IssuerSigningKeyValidator = SkipValidationDelegates.SkipIssuerSigningKeyValidation,
+                    LifetimeValidator = SkipValidationDelegates.SkipLifetimeValidation,
+                    SignatureValidator = SkipValidationDelegates.SkipSignatureValidation,
+                    TokenReplayValidator = SkipValidationDelegates.SkipTokenReplayValidation,
+                    TokenTypeValidator = tokenTypeValidator
+                };
+
+                ExtraStackFrames = extraStackFrames;
+            }
+
+            public JsonWebToken JsonWebToken { get; }
+
+            public JsonWebTokenHandler JsonWebTokenHandler { get; } = new JsonWebTokenHandler();
+
+            public bool IsValid { get; set; }
+
+            internal ValidatedTokenType ValidatedTokenType { get; set; }
+
+            internal TokenTypeValidationError? TokenTypeValidationError { get; set; }
+
+            internal int ExtraStackFrames { get; }
+        }
+    }
+}
+#nullable restore

--- a/test/Microsoft.IdentityModel.TestUtils/TokenValidationExtensibility/CustomTokenTypeValidationDelegates.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/TokenValidationExtensibility/CustomTokenTypeValidationDelegates.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.IdentityModel.Tokens;
+
+#nullable enable
+namespace Microsoft.IdentityModel.TestUtils
+{
+    internal class CustomTokenTypeValidationDelegates
+    {
+        internal static ValidationResult<ValidatedTokenType> CustomTokenTypeValidatorDelegate(
+            string? type,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            // Returns a CustomTokenTypeValidationError : TokenTypeValidationError
+            return new CustomTokenTypeValidationError(
+                new MessageDetail(nameof(CustomTokenTypeValidatorDelegate), null),
+                typeof(SecurityTokenInvalidTypeException),
+                ValidationError.GetCurrentStackFrame(),
+                type,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedTokenType> CustomTokenTypeValidatorCustomExceptionDelegate(
+            string? type,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new CustomTokenTypeValidationError(
+                new MessageDetail(nameof(CustomTokenTypeValidatorCustomExceptionDelegate), null),
+                typeof(CustomSecurityTokenInvalidTypeException),
+                ValidationError.GetCurrentStackFrame(),
+                type,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedTokenType> CustomTokenTypeValidatorCustomExceptionCustomFailureTypeDelegate(
+            string? type,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new CustomTokenTypeValidationError(
+                new MessageDetail(nameof(CustomTokenTypeValidatorCustomExceptionCustomFailureTypeDelegate), null),
+                typeof(CustomSecurityTokenInvalidTypeException),
+                ValidationError.GetCurrentStackFrame(),
+                type,
+                CustomTokenTypeValidationError.CustomTokenTypeValidationFailureType);
+        }
+
+        internal static ValidationResult<ValidatedTokenType> CustomTokenTypeValidatorUnknownExceptionDelegate(
+            string? type,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new CustomTokenTypeValidationError(
+                new MessageDetail(nameof(CustomTokenTypeValidatorUnknownExceptionDelegate), null),
+                typeof(NotSupportedException),
+                ValidationError.GetCurrentStackFrame(),
+                type,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedTokenType> CustomTokenTypeValidatorWithoutGetExceptionOverrideDelegate(
+            string? type,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new CustomTokenTypeWithoutGetExceptionValidationOverrideError(
+                new MessageDetail(nameof(CustomTokenTypeValidatorWithoutGetExceptionOverrideDelegate), null),
+                typeof(CustomSecurityTokenInvalidTypeException),
+                ValidationError.GetCurrentStackFrame(),
+                type,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedTokenType> TokenTypeValidatorDelegate(
+            string? type,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new TokenTypeValidationError(
+                new MessageDetail(nameof(TokenTypeValidatorDelegate), null),
+                typeof(SecurityTokenInvalidTypeException),
+                ValidationError.GetCurrentStackFrame(),
+                type,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedTokenType> TokenTypeValidatorThrows(
+            string? type,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            throw new CustomSecurityTokenInvalidTypeException(nameof(TokenTypeValidatorThrows), null);
+        }
+
+        internal static ValidationResult<ValidatedTokenType> TokenTypeValidatorCustomTokenTypeExceptionTypeDelegate(
+            string? type,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new TokenTypeValidationError(
+                new MessageDetail(nameof(TokenTypeValidatorCustomTokenTypeExceptionTypeDelegate), null),
+                typeof(CustomSecurityTokenInvalidTypeException),
+                ValidationError.GetCurrentStackFrame(),
+                type,
+                null);
+        }
+
+        internal static ValidationResult<ValidatedTokenType> TokenTypeValidatorCustomExceptionTypeDelegate(
+            string? type,
+            SecurityToken? securityToken,
+            ValidationParameters validationParameters,
+            CallContext callContext)
+        {
+            return new TokenTypeValidationError(
+                new MessageDetail(nameof(TokenTypeValidatorCustomExceptionTypeDelegate), null),
+                typeof(CustomSecurityTokenException),
+                ValidationError.GetCurrentStackFrame(),
+                type,
+                null);
+        }
+    }
+}
+#nullable restore

--- a/test/Microsoft.IdentityModel.TestUtils/TokenValidationExtensibility/CustomValidationErrors.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/TokenValidationExtensibility/CustomValidationErrors.cs
@@ -157,6 +157,52 @@ namespace Microsoft.IdentityModel.TestUtils
     }
     #endregion
 
+    #region TokenTypeValidationErrors
+    internal class CustomTokenTypeValidationError : TokenTypeValidationError
+    {
+        /// <summary>
+        /// A custom validation failure type.
+        /// </summary>
+        public static readonly ValidationFailureType CustomTokenTypeValidationFailureType = new TokenTypeValidationFailure("CustomTokenTypeValidationFailureType");
+        private class TokenTypeValidationFailure : ValidationFailureType { internal TokenTypeValidationFailure(string name) : base(name) { } }
+
+        public CustomTokenTypeValidationError(
+            MessageDetail messageDetail,
+            Type exceptionType,
+            StackFrame stackFrame,
+            string? invalidTokenType,
+            ValidationFailureType? validationFailureType = null,
+            Exception? innerException = null)
+            : base(messageDetail, exceptionType, stackFrame, invalidTokenType, validationFailureType, innerException)
+        {
+        }
+        internal override Exception GetException()
+        {
+            if (ExceptionType == typeof(CustomSecurityTokenInvalidTypeException))
+            {
+                var exception = new CustomSecurityTokenInvalidTypeException(MessageDetail.Message, InnerException) { InvalidType = InvalidTokenType };
+                exception.SetValidationError(this);
+                return exception;
+            }
+            return base.GetException();
+        }
+    }
+
+    internal class CustomTokenTypeWithoutGetExceptionValidationOverrideError : TokenTypeValidationError
+    {
+        public CustomTokenTypeWithoutGetExceptionValidationOverrideError(
+            MessageDetail messageDetail,
+            Type exceptionType,
+            StackFrame stackFrame,
+            string? invalidTokenType,
+            ValidationFailureType? validationFailureType = null,
+            Exception? innerException = null)
+            : base(messageDetail, exceptionType, stackFrame, invalidTokenType, validationFailureType, innerException)
+        {
+        }
+    }
+    #endregion // TokenTypeValidationErrors
+
     // Other custom validation errors to be added here for signature validation, issuer signing key, etc.
 }
 #nullable restore


### PR DESCRIPTION
# Extensibility tests: Token Type - JWT
- Updated `TokenTypeValidationError` and updated the default token type validation delegate to use it
- Added log message and validation failure type for the case where the token type validation delegate throws
- Added custom validation error and validation delegates for token type validation
- Handle the case where the token type validation delegate throws in `JsonWebTokenHandler`
- Added extensibility tests for token type validation on JWT


Part of #2711 