### PR TITLE
Fix SignedHttpRequest flaky test

### DIFF
--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
@@ -813,7 +813,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                         {
                             RequireHttpsForJkuResourceRetrieval = false,
                         },
-                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPopKeyException), "IDX23022", typeof(ArgumentException)),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPopKeyException), "IDX23022", null, true),
                     },
                     new ResolvePopKeyTheoryData("Valid0KeysReturned")
                     {


### PR DESCRIPTION
# Fix SignedHttpRequest flaky test
- Removed the inner exception check in the test for the cases where the HTTP request is cancelled.

Fixes #3035 