### PR TITLE
Fix bug with AadIssuerValidator

### DIFF
--- a/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
+++ b/src/Microsoft.IdentityModel.Validators/AadIssuerValidator/AadIssuerValidator.cs
@@ -399,7 +399,7 @@ namespace Microsoft.IdentityModel.Validators
                     return false;
 
                 // Ensure tokenIssuer is atleast as long as issuerTemplate with tenantIdTemplate replaced
-                if (tokenIssuer.Length <= templateTenantIdPosition + tenantId.Length)
+                if (tokenIssuer.Length < templateTenantIdPosition + tenantId.Length)
                     return false;
 
                 // Ensure the tenant ID in the token issuer matches the expected tenant ID

--- a/test/Microsoft.IdentityModel.Validators.Tests/AadIssuerValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/AadIssuerValidatorTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
                 new AadIssuerValidatorTheoryData("V1_TemplateWithoutTrailingSlash_Matches_V1_IssuerWithoutTrailingSlash_Success")
                 {
                     TemplatedIssuer = ValidatorConstants.AadIssuerV1CommonAuthorityWithoutTrailingSlash,
-                    TokenIssuer = ValidatorConstants.V1IssuerWithouTrailingSlash,
+                    TokenIssuer = ValidatorConstants.V1IssuerWithoutTrailingSlash,
                     TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
                     ExpectedResult = true,
                 },

--- a/test/Microsoft.IdentityModel.Validators.Tests/AadIssuerValidatorTests.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/AadIssuerValidatorTests.cs
@@ -26,6 +26,13 @@ namespace Microsoft.IdentityModel.Validators.Tests
             var theoryData = new TheoryData<AadIssuerValidatorTheoryData>
             {
                 // Success cases
+                new AadIssuerValidatorTheoryData("V1_TemplateWithoutTrailingSlash_Matches_V1_IssuerWithoutTrailingSlash_Success")
+                {
+                    TemplatedIssuer = ValidatorConstants.AadIssuerV1CommonAuthorityWithoutTrailingSlash,
+                    TokenIssuer = ValidatorConstants.V1IssuerWithouTrailingSlash,
+                    TenantIdClaim = ValidatorConstants.TenantIdAsGuid,
+                    ExpectedResult = true,
+                },
                 new AadIssuerValidatorTheoryData("V1_Template_Matches_V1_Issuer_Success")
                 {
                     TemplatedIssuer = ValidatorConstants.AadIssuerV1CommonAuthority,
@@ -106,7 +113,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
 
     public class AadIssuerValidatorTheoryData : TheoryDataBase
     {
-        public AadIssuerValidatorTheoryData() {}
+        public AadIssuerValidatorTheoryData() { }
 
         public AadIssuerValidatorTheoryData(string testId) : base(testId) { }
 

--- a/test/Microsoft.IdentityModel.Validators.Tests/ValidatorConstants.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/ValidatorConstants.cs
@@ -40,7 +40,7 @@ namespace Microsoft.IdentityModel.Validators.Tests
         public const string UsGovIssuer = "https://login.microsoftonline.us/" + UsGovTenantId + "/v2.0";
         public const string UsGovTenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";
         public const string V1Issuer = "https://sts.windows.net/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/";
-        public const string V1IssuerWithouTrailingSlash = "https://sts.windows.net/f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
+        public const string V1IssuerWithoutTrailingSlash = "https://sts.windows.net/f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
         public const string V1IssuerPPE = "https://sts.windows-ppe.net/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/";
         public const string AadIssuerV1CommonAuthority = "https://sts.windows.net/{tenantid}/";
         public const string AadIssuerV1CommonAuthorityWithoutTrailingSlash = "https://sts.windows.net/{tenantid}";

--- a/test/Microsoft.IdentityModel.Validators.Tests/ValidatorConstants.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/ValidatorConstants.cs
@@ -40,8 +40,10 @@ namespace Microsoft.IdentityModel.Validators.Tests
         public const string UsGovIssuer = "https://login.microsoftonline.us/" + UsGovTenantId + "/v2.0";
         public const string UsGovTenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";
         public const string V1Issuer = "https://sts.windows.net/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/";
+        public const string V1IssuerWithouTrailingSlash = "https://sts.windows.net/f645ad92-e38d-4d1a-b510-d1b09a74a8ca";
         public const string V1IssuerPPE = "https://sts.windows-ppe.net/f645ad92-e38d-4d1a-b510-d1b09a74a8ca/";
         public const string AadIssuerV1CommonAuthority = "https://sts.windows.net/{tenantid}/";
+        public const string AadIssuerV1CommonAuthorityWithoutTrailingSlash = "https://sts.windows.net/{tenantid}";
         public const string AadIssuerV11CommonAuthority = AadInstance + "/{tenantid}/v1.1";
         public const string AadIssuerV2CommonAuthority = AadInstance + "/{tenantid}/v2.0";
 


### PR DESCRIPTION
# Fix bug with AadIssuerValidator

#3047

## Description
The current implementation of AadIssuerValidator always expects that token issuer length should be greater than templateTenantIdPosition + tenantId's length.
It's not true for the case when Issuer in token and Issuer template in OIDC configuration match, but don't have a trailing slash.

### Example:
Issuer template in OIDC configuration: `https://sts.windows.net/{tenantid}`
Issuer in JWT token: `https://sts.windows.net/f645ad92-e38d-4d1a-b510-d1b09a74a8ca`

Condition `tokenIssuer.Length <= templateTenantIdPosition + tenantId.Length` of `IsValidIssuer` method results to true because `tokenIssuer.Length` equals to `templateTenantIdPosition` + `tenantId.Length`. As a result, the issuer is considered as invalid even when it matches to the issuer template from OIDC config.