### PR TITLE
Respect TVP.RequireAudience when set to false

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -8,6 +8,7 @@ const Microsoft.IdentityModel.Tokens.LogMessages.IDX10273 = "IDX10273: Algorithm
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10274 = "IDX10274: IssuerSigningKeyValidationDelegate threw an exception, see inner exception." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10275 = "IDX10275: TokenTypeValidationDelegate threw an exception, see inner exception." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10276 = "IDX10276: TokenReplayValidationDelegate threw an exception, see inner exception." -> string
+const Microsoft.IdentityModel.Tokens.LogMessages.IDX10277 = "IDX10277: RequireAudience property on ValidationParameters is set to false. Exiting without validating the audience." -> string
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError.AlgorithmValidationError(Microsoft.IdentityModel.Tokens.MessageDetail messageDetail, Microsoft.IdentityModel.Tokens.ValidationFailureType validationFailureType, System.Type exceptionType, System.Diagnostics.StackFrame stackFrame, string invalidAlgorithm, System.Exception innerException = null) -> void
 Microsoft.IdentityModel.Tokens.AlgorithmValidationError.InvalidAlgorithm.get -> string

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -95,6 +95,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10274 = "IDX10274: IssuerSigningKeyValidationDelegate threw an exception, see inner exception.";
         public const string IDX10275 = "IDX10275: TokenTypeValidationDelegate threw an exception, see inner exception.";
         public const string IDX10276 = "IDX10276: TokenReplayValidationDelegate threw an exception, see inner exception.";
+        public const string IDX10277 = "IDX10277: RequireAudience property on ValidationParameters is set to false. Exiting without validating the audience.";
 
         // 10500 - SignatureValidation
         public const string IDX10500 = "IDX10500: Signature validation failed. No security keys were provided to validate the signature.";

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -462,6 +462,10 @@ namespace Microsoft.IdentityModel.Tokens
         /// Gets or sets a value indicating whether SAML tokens must have at least one AudienceRestriction.
         /// The default is <c>true</c>.
         /// </summary>
+        /// <remarks>
+        /// If set to false and the Audience is null, Audience validation will be skipped.
+        /// If set to false and the Audience is not null, the Audience will still be validated.
+        /// </remarks>
         [DefaultValue(true)]
         public bool RequireAudience { get; set; }
 

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -459,7 +459,7 @@ namespace Microsoft.IdentityModel.Tokens
         public bool RefreshBeforeValidation { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether SAML tokens must have at least one AudienceRestriction.
+        /// Gets or sets a value indicating whether SAML or JWT tokens must have at least one AudienceRestriction.
         /// The default is <c>true</c>.
         /// </summary>
         /// <remarks>

--- a/src/Microsoft.IdentityModel.Tokens/Validators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validators.cs
@@ -87,6 +87,12 @@ namespace Microsoft.IdentityModel.Tokens
                 return;
             }
 
+            if (!validationParameters.RequireAudience && !audiences.Any())
+            {
+                LogHelper.LogWarning(LogMessages.IDX10277);
+                return;
+            }
+
             if (audiences == null)
                 throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidAudienceException(LogMessages.IDX10207) { InvalidAudience = null });
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidatorsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidatorsTests.cs
@@ -104,9 +104,25 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208:"),
                     },
                     new AudienceValidationTheoryData("AudiencesEmpty_RequireAudienceFalse_NoException")
-                    // default value of TVP.RequireAudience is true.
                     {
                         Audiences = new List<string> { },
+                        TokenValidationParameters = new TokenValidationParameters{
+                            RequireAudience = false
+                            // default value of TVP.RequireAudience is true.
+                        }
+                    },
+                    new AudienceValidationTheoryData("ValidAudience_RequireAudienceFalse_NoException")
+                    {
+                        Audiences = new List<string> { "audience" },
+                        TokenValidationParameters = new TokenValidationParameters{
+                            ValidAudience = "audience",
+                            RequireAudience = false
+                        }
+                    },
+                    new AudienceValidationTheoryData("InvalidAudience_RequireAudienceFalse_ExceptionThrown")
+                    {
+                        Audiences = new List<string> { "audience1" },
+                        ExpectedException =  ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TokenValidationParameters = new TokenValidationParameters{
                             ValidAudience = "audience",
                             RequireAudience = false

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidatorsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidatorsTests.cs
@@ -103,6 +103,15 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         Audiences = new List<string> { "audience1" },
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208:"),
                     },
+                    new AudienceValidationTheoryData("AudiencesEmpty_RequireAudienceFalse_NoException")
+                    // default value of TVP.RequireAudience is true.
+                    {
+                        Audiences = new List<string> { },
+                        TokenValidationParameters = new TokenValidationParameters{
+                            ValidAudience = "audience",
+                            RequireAudience = false
+                        }
+                    }
                 };
             }
         }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidatorsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidatorsTests.cs
@@ -28,92 +28,81 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
             TestUtilities.AssertFailIfErrors(context);
         }
+
         public static TheoryData<AudienceValidationTheoryData> ValidateAudienceParametersTheoryData
         {
             get
             {
                 return new TheoryData<AudienceValidationTheoryData>
                 {
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("TokenValidationParametersNull")
                     {
                         Audiences = new List<string> { "audience1" },
                         ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
-                        TestId = "TokenValidationParametersNull",
                         TokenValidationParameters = null
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("AudiencesEmptyString")
                     {
                         Audiences = new List<string> { "" },
                         ExpectedException =  ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "AudiencesEmptyString",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = "audience"}
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("AudiencesWhiteSpace")
                     {
                         Audiences = new List<string> { "    " },
                         ExpectedException =  ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "AudiencesWhiteSpace",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = "audience"}
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("AudiencesNull")
                     {
                         Audiences = null,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10207:"),
-                        TestId = "AudiencesNull"
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("AudiencesEmptyList")
                     {
                         Audiences = new List<string>{ },
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10206:"),
-                        TestId = "AudiencesEmptyList",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = "audience"}
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidateAudienceFalseAudiencesEmptyList")
                     {
                         Audiences = new List<string>{ },
-                        TestId = "ValidateAudienceFalseAudiencesEmptyList",
                         TokenValidationParameters = new TokenValidationParameters{ ValidateAudience = false }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidateAudienceFalseAudiencesNull")
                     {
                         Audiences = null,
-                        TestId = "ValidateAudienceFalseAudiencesNull",
                         TokenValidationParameters = new TokenValidationParameters{ ValidateAudience = false }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidAudienceEmptyString")
                     {
                         Audiences = new List<string> { "audience1" },
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208:"),
-                        TestId = "ValidAudienceEmptyString",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = "" }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidAudienceWhiteSpace")
                     {
                         Audiences = new List<string> { "audience1" },
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208:"),
-                        TestId = "ValidAudienceWhiteSpace",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = "    " }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidAudiencesEmptyString")
                     {
                         Audiences = new List<string> { "audience1" },
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "ValidAudiencesEmptyString",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudiences = new List<string>{ "" } }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidAudiencesWhiteSpace")
                     {
                         Audiences = new List<string> { "audience1" },
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "ValidAudiencesWhiteSpace",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudiences = new List<string>{ "    " } }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidateAudienceTrueValidAudienceAndValidAudiencesNull")
                     {
                         Audiences = new List<string> { "audience1" },
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10208:"),
-                        TestId = "ValidateAudienceTrueValidAudienceAndValidAudiencesNull"
-                    }
+                    },
                 };
             }
         }
@@ -149,131 +138,112 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
                 return new TheoryData<AudienceValidationTheoryData>
                 {
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("SameLengthMatched")
                     {
                         Audiences = audiences1,
-                        TestId = "SameLengthMatched",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("SameLengthNotMatched")
                     {
                         Audiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "SameLengthNotMatched",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience2 }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("NoMatchTVPValidateFalse")
                     {
                         Audiences = audiences1,
-                        TestId = "NoMatchTVPValidateFalse",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience2, ValidateAudience = false }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("AudiencesValidAudienceWithSlashNotMatched")
                     {
                         Audiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "AudiencesValidAudienceWithSlashNotMatched",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience2 + "/" }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("AudiencesWithSlashValidAudienceSameLengthNotMatched")
                     {
                         Audiences = audiences2WithSlash,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "AudiencesWithSlashValidAudienceSameLengthNotMatched",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidAudienceWithSlashTVPFalse")
                     {
                         Audiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "ValidAudienceWithSlashTVPFalse",
                         TokenValidationParameters = new TokenValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false, ValidAudience = audience1 + "/" }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidAudienceWithSlashTVPTrue")
                     {
                         Audiences = audiences1,
-                        TestId = "ValidAudienceWithSlashTVPTrue",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 + "/" }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidAudiencesWithSlashTVPFalse")
                     {
                         Audiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "ValidAudiencesWithSlashTVPFalse",
                         TokenValidationParameters = new TokenValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false, ValidAudiences = audiences1WithSlash }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidAudiencesWithSlashTVPTrue")
                     {
                         Audiences = audiences1,
-                        TestId = "ValidAudiencesWithSlashTVPTrue",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudiences = audiences1WithSlash }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidAudienceWithExtraChar")
                     {
                         Audiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "ValidAudienceWithExtraChar",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 + "A" }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidAudienceWithDoubleSlashTVPTrue")
                     {
                         Audiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "ValidAudienceWithDoubleSlashTVPTrue",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 + "//" }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("ValidAudiencesWithDoubleSlashTVPTrue")
                     {
                         Audiences = audiences1,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "ValidAudiencesWithDoubleSlashTVPTrue",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudiences = audiences1WithTwoSlashes }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("TokenAudienceWithSlashTVPFalse")
                     {
                         Audiences = audiences1WithSlash,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "TokenAudienceWithSlashTVPFalse",
                         TokenValidationParameters = new TokenValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false, ValidAudience = audience1 }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("TokenAudienceWithSlashTVPTrue")
                     {
                         Audiences = audiences1WithSlash,
-                        TestId = "TokenAudienceWithSlashTVPTrue",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("TokenAudienceWithSlashNotEqual")
                     {
                         Audiences = audiences2WithSlash,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "TokenAudienceWithSlashNotEqual",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 },
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("TokenAudiencesWithSlashTVPFalse")
                     {
                         Audiences = audiences1WithSlash,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "TokenAudiencesWithSlashTVPFalse",
                         TokenValidationParameters = new TokenValidationParameters{ IgnoreTrailingSlashWhenValidatingAudience = false, ValidAudience = audience1 }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("TokenAudiencesWithSlashTVPTrue")
                     {
                         Audiences = audiences1WithSlash,
-                        TestId = "TokenAudiencesWithSlashTVPTrue",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("TokenAudiencesWithSlashValidAudiencesNotMatchedTVPTrue")
                     {
                         Audiences = audiences1WithSlash,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "TokenAudiencesWithSlashValidAudiencesNotMatchedTVPTrue",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudiences = audiences2 }
                     },
-                    new AudienceValidationTheoryData
+                    new AudienceValidationTheoryData("TokenAudienceWithTwoSlashesTVPTrue")
                     {
                         Audiences = audiences1WithTwoSlashes,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
-                        TestId = "TokenAudienceWithTwoSlashesTVPTrue",
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 }
                     }
                 };
@@ -500,6 +470,9 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
         public class AudienceValidationTheoryData : TheoryDataBase
         {
+            public AudienceValidationTheoryData(string testId) : base(testId)
+            { }
+
             public List<string> Audiences { get; set; }
 
             public SecurityToken SecurityToken { get; set; }


### PR DESCRIPTION
Addresses #1547 

Since I was modifying the tests that used `AudienceValidationTheoryData`, I updated it to include `testId` parameter in the ctor.