### PR TITLE
Add Warning Quality Check Build Task 🔨

### DIFF
--- a/build/template-Build-run-tests-sign.yml
+++ b/build/template-Build-run-tests-sign.yml
@@ -213,11 +213,11 @@ steps:
     ArtifactName: '$(Build.BuildNumber)-nuget-package'
 
  - task: BuildQualityChecks@9
-    displayName: 'Check Warnings'
-    inputs:
-      checkWarnings: true
-      warningFailOption: 'build'
-      showStatistics: true
+  displayName: 'Check Warnings'
+  inputs:
+    checkWarnings: true
+    warningFailOption: 'build'
+    showStatistics: true
 
 - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
   displayName: 'Clean Agent Directories'

--- a/build/template-Build-run-tests-sign.yml
+++ b/build/template-Build-run-tests-sign.yml
@@ -212,6 +212,13 @@ steps:
     PathtoPublish: '$(Build.SourcesDirectory)\artifacts'
     ArtifactName: '$(Build.BuildNumber)-nuget-package'
 
+ - task: BuildQualityChecks@9
+    displayName: 'Check Warnings'
+    inputs:
+      checkWarnings: true
+      warningFailOption: 'build'
+      showStatistics: true
+
 - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
   displayName: 'Clean Agent Directories'
   condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))


### PR DESCRIPTION
With the new task, I've configured the build to:

- fail if the number of warnings has increased since the previous build - no new warnings!
- show warning statistics to show the changes in number of warnings grouped by task/code file/object

I have not selected this option:
- Force fewer warnings 
- Allow Variance - we don't want the number of warnings to creep up. 

Build Quality Checks Warnings Policy documentation: https://github.com/MicrosoftPremier/VstsExtensions/blob/master/BuildQualityChecks/en-US/WarningsPolicy.md#evaluateTaskWarnings 