### PR TITLE
Update template-Build-run-tests-sign.yml

### DIFF
--- a/build/template-Build-run-tests-sign.yml
+++ b/build/template-Build-run-tests-sign.yml
@@ -212,7 +212,7 @@ steps:
     PathtoPublish: '$(Build.SourcesDirectory)\artifacts'
     ArtifactName: '$(Build.BuildNumber)-nuget-package'
 
- - task: BuildQualityChecks@9
+- task: BuildQualityChecks@9
   displayName: 'Check Warnings'
   inputs:
     checkWarnings: true


### PR DESCRIPTION
Fix one branch build:
https://identitydivision.visualstudio.com/IDDP/_build?definitionId=1594

Error message:
/build/template-Build-run-tests-sign.yml@IdentityModel (Line: 215, Col: 2): While parsing a block mapping, did not find expected key.

The extra space from the new added step break the YAML file