### PR TITLE
Update common.props

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -29,10 +29,12 @@
     <NetStandardImplicitPackageVersion>$(NetStandardVersion)</NetStandardImplicitPackageVersion>
     <LangVersion>13</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <!-- Suprpess the "Microsoft.Bcl.Memory 9.0.0 doesn't support net6.0 and has not been tested with it" warning -->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
-
 
   <PropertyGroup>
     <EnablePackageValidation>false</EnablePackageValidation>

--- a/build/common.props
+++ b/build/common.props
@@ -29,6 +29,8 @@
     <NetStandardImplicitPackageVersion>$(NetStandardVersion)</NetStandardImplicitPackageVersion>
     <LangVersion>13</LangVersion>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <!-- Suprpess the "Microsoft.Bcl.Memory 9.0.0 doesn't support net6.0 and has not been tested with it" warning -->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
 


### PR DESCRIPTION
Suppress warning:
##[warning]C:\Users\ContainerAdministrator\.nuget\packages\microsoft.bcl.memory\9.0.0\buildTransitive\netcoreapp2.0\Microsoft.Bcl.Memory.targets(4,5): Warning : Microsoft.Bcl.Memory 9.0.0 doesn't support net6.0 and has not been tested with it. Consider upgrading your TargetFramework to net8.0 or later. You may also set <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings> in the project file to ignore this warning and attempt to run in this unsupported configuration at your own risk.

https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1410786&view=logs&j=15dfcb1a-0989-5cf6-3160-3e181e44de87&t=32ee994e-3d32-5011-f0cb-438d28090217

