### PR TITLE
For net4.6.2 select RSACng for PSS support.

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -241,6 +241,9 @@ namespace Microsoft.IdentityModel.Tokens
             {
 #if NET472 || NET6_0_OR_GREATER
                 var rsa = RSA.Create(rsaSecurityKey.Parameters);
+#elif  NET462
+                var rsa = new RSACng();
+                rsa.ImportParameters(rsaSecurityKey.Parameters);
 #else
                 var rsa = RSA.Create();
                 rsa.ImportParameters(rsaSecurityKey.Parameters);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SignatureProviderTests.cs
@@ -1307,7 +1307,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             {
                 Bytes = bytes,
                 Count = -1,
-                ExpectedException = ExpectedException.ArgumentException(),
+                ExpectedException = prefix == "RSA" ? ExpectedException.ArgumentOutOfRangeException() : ExpectedException.ArgumentException(),
                 Offset = 0,
                 SignatureProvider = CreateProvider(securityKey, algorithm)
             });
@@ -1316,7 +1316,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             {
                 Bytes = bytes,
                 Count = bytes.Length + 1,
-                ExpectedException = ExpectedException.ArgumentException(),
+                ExpectedException = prefix == "RSA" ? ExpectedException.ArgumentOutOfRangeException() : ExpectedException.ArgumentException(),
                 Offset = 0,
                 SignatureProvider = CreateProvider(securityKey, algorithm)
             });
@@ -1325,7 +1325,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             {
                 Bytes = bytes,
                 Count = 10,
-                ExpectedException = ExpectedException.ArgumentException(),
+                ExpectedException = prefix == "RSA" ? ExpectedException.ArgumentOutOfRangeException() : ExpectedException.ArgumentException(),
                 Offset = bytes.Length - 1,
                 SignatureProvider = CreateProvider(securityKey, algorithm)
             });


### PR DESCRIPTION
For net4.6.2 select RSACng for PSS support.
RSACreate() returns a RsaCryptoServiceProvider which does not support PSS.

The exception thrown is ArgumentOutOfRangeException which is not breaking as ArgumentOutOfRangeException derives from ArgumentException.