### PR TITLE
Add additional condition before requesting update.

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -269,8 +269,8 @@ namespace Microsoft.IdentityModel.Protocols
                         try
                         {
                             TelemetryClient.IncrementConfigurationRefreshRequestCounter(
-                            MetadataAddress,
-                            TelemetryConstants.Protocols.Automatic);
+                                MetadataAddress,
+                                TelemetryConstants.Protocols.Automatic);
                         }
 #pragma warning disable CA1031 // Do not catch general exception types
                         catch

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -249,18 +249,33 @@ namespace Microsoft.IdentityModel.Protocols
                     if (_refreshRequested)
                     {
                         _refreshRequested = false;
-                        // Log as manual because RequestRefresh was called
-                        TelemetryClient.IncrementConfigurationRefreshRequestCounter(
-                            MetadataAddress,
-                            TelemetryConstants.Protocols.Manual);
+
+                        try
+                        {
+                            // Log as manual because RequestRefresh was called
+                            TelemetryClient.IncrementConfigurationRefreshRequestCounter(
+                                MetadataAddress,
+                                TelemetryConstants.Protocols.Manual);
+                        }
+#pragma warning disable CA1031 // Do not catch general exception types
+                        catch
+                        { }
+#pragma warning restore CA1031 // Do not catch general exception types
 
                         UpdateCurrentConfiguration();
                     }
                     else if (SyncAfter <= _timeProvider.GetUtcNow())
                     {
-                        TelemetryClient.IncrementConfigurationRefreshRequestCounter(
-                        MetadataAddress,
-                        TelemetryConstants.Protocols.Automatic);
+                        try
+                        {
+                            TelemetryClient.IncrementConfigurationRefreshRequestCounter(
+                            MetadataAddress,
+                            TelemetryConstants.Protocols.Automatic);
+                        }
+#pragma warning disable CA1031 // Do not catch general exception types
+                        catch
+                        { }
+#pragma warning restore CA1031 // Do not catch general exception types
 
                         _ = Task.Run(UpdateCurrentConfiguration, CancellationToken.None);
                     }

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -248,21 +248,25 @@ namespace Microsoft.IdentityModel.Protocols
                 {
                     if (_refreshRequested)
                     {
+                        _refreshRequested = false;
                         // Log as manual because RequestRefresh was called
                         TelemetryClient.IncrementConfigurationRefreshRequestCounter(
                             MetadataAddress,
                             TelemetryConstants.Protocols.Manual);
 
                         UpdateCurrentConfiguration();
-                        _refreshRequested = false;
+                    }
+                    else if (SyncAfter <= _timeProvider.GetUtcNow())
+                    {
+                        TelemetryClient.IncrementConfigurationRefreshRequestCounter(
+                        MetadataAddress,
+                        TelemetryConstants.Protocols.Automatic);
+
+                        _ = Task.Run(UpdateCurrentConfiguration, CancellationToken.None);
                     }
                     else
                     {
-                        TelemetryClient.IncrementConfigurationRefreshRequestCounter(
-                            MetadataAddress,
-                            TelemetryConstants.Protocols.Automatic);
-
-                        _ = Task.Run(UpdateCurrentConfiguration, CancellationToken.None);
+                        Interlocked.Exchange(ref _configurationRetrieverState, ConfigurationRetrieverIdle);
                     }
                 }
             }


### PR DESCRIPTION
It was possible that request pass the guard: SyncAfter >_timeProvider.GetUtcNow() while a Refresh was underway. Before reaching the Interlock.CompareExchange, the Refresh finishes setting _configurationRetrieverState to ConfigurationRetrieverIdle and another refresh occurs.

This was found with a stress test with 128 tasks running concurrently and calling ConfigurationManger.GetConfigurationAsync.
The change was tested and the correct number of Refreshes were requested.

_refreshRequested was placed before UpdateCurrentConfiguration was called to reduce the chance of a race condition.