### PR TITLE
 KeyID should be present in exception messages logs and should not be considered PII.

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
@@ -1299,13 +1299,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 if (key != null)
                 {
                     if (LogHelper.IsEnabled(EventLogLevel.Informational))
-                        LogHelper.LogInformation(TokenLogMessages.IDX10904, key);
+                        LogHelper.LogInformation(TokenLogMessages.IDX10904, LogHelper.MarkAsNonPII(key));
                 }
                 else if (configuration != null)
                 {
                     key = ResolveTokenDecryptionKeyFromConfig(jwtToken, configuration);
                     if (key != null && LogHelper.IsEnabled(EventLogLevel.Informational))
-                        LogHelper.LogInformation(TokenLogMessages.IDX10905, key);
+                        LogHelper.LogInformation(TokenLogMessages.IDX10905, LogHelper.MarkAsNonPII(key));
                 }
 
                 if (key != null)

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
@@ -1274,7 +1274,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 }
                 catch (Exception ex)
                 {
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenEncryptionFailedException(LogHelper.FormatInvariant(TokenLogMessages.IDX10616, LogHelper.MarkAsNonPII(encryptingCredentials.Enc), encryptingCredentials.Key), ex));
+                    throw LogHelper.LogExceptionMessage(
+                        new SecurityTokenEncryptionFailedException(
+                            LogHelper.FormatInvariant(TokenLogMessages.IDX10616, LogHelper.MarkAsNonPII(encryptingCredentials.Enc), LogHelper.MarkAsNonPII(encryptingCredentials.Key.ToString())),
+                            ex));
                 }
             }
         }
@@ -1389,7 +1392,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (unwrappedKeys.Count > 0 || exceptionStrings is null)
                 return unwrappedKeys;
             else
-                throw LogHelper.LogExceptionMessage(new SecurityTokenKeyWrapException(LogHelper.FormatInvariant(TokenLogMessages.IDX10618, (object)keysAttempted ?? "", (object)exceptionStrings ?? "", jwtToken)));
+                throw LogHelper.LogExceptionMessage(
+                    new SecurityTokenKeyWrapException(
+                        LogHelper.FormatInvariant(
+                            TokenLogMessages.IDX10618,
+                            LogHelper.MarkAsNonPII((object)keysAttempted ?? ""),
+                            LogHelper.MarkAsNonPII((object)exceptionStrings ?? ""),
+                            jwtToken)));
         }
     }
 }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
@@ -1276,7 +1276,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 {
                     throw LogHelper.LogExceptionMessage(
                         new SecurityTokenEncryptionFailedException(
-                            LogHelper.FormatInvariant(TokenLogMessages.IDX10616, LogHelper.MarkAsNonPII(encryptingCredentials.Enc), LogHelper.MarkAsNonPII(encryptingCredentials.Key.ToString())),
+                            LogHelper.FormatInvariant(TokenLogMessages.IDX10616, LogHelper.MarkAsNonPII(encryptingCredentials.Enc), LogHelper.MarkAsNonPII(encryptingCredentials.Key.KeyId)),
                             ex));
                 }
             }
@@ -1299,13 +1299,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 if (key != null)
                 {
                     if (LogHelper.IsEnabled(EventLogLevel.Informational))
-                        LogHelper.LogInformation(TokenLogMessages.IDX10904, LogHelper.MarkAsNonPII(key));
+                        LogHelper.LogInformation(TokenLogMessages.IDX10904, LogHelper.MarkAsNonPII(key.KeyId));
                 }
                 else if (configuration != null)
                 {
                     key = ResolveTokenDecryptionKeyFromConfig(jwtToken, configuration);
                     if (key != null && LogHelper.IsEnabled(EventLogLevel.Informational))
-                        LogHelper.LogInformation(TokenLogMessages.IDX10905, LogHelper.MarkAsNonPII(key));
+                        LogHelper.LogInformation(TokenLogMessages.IDX10905, LogHelper.MarkAsNonPII(key.KeyId));
                 }
 
                 if (key != null)
@@ -1386,7 +1386,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     (exceptionStrings ??= new StringBuilder()).AppendLine(ex.ToString());
                 }
 
-                (keysAttempted ??= new StringBuilder()).AppendLine(key.ToString());
+                (keysAttempted ??= new StringBuilder()).AppendLine(key.KeyId);
             }
 
             if (unwrappedKeys.Count > 0 || exceptionStrings is null)

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.DecryptToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.DecryptToken.cs
@@ -196,7 +196,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     (exceptionStrings ??= new StringBuilder()).AppendLine(ex.ToString());
                 }
 
-                (keysAttempted ??= new StringBuilder()).AppendLine(key.ToString());
+                (keysAttempted ??= new StringBuilder()).AppendLine(key.KeyId);
             }
 
             if (unwrappedKeys.Count > 0 || exceptionStrings is null)

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.DecryptToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.DecryptToken.cs
@@ -206,7 +206,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 ValidationError validationError = new(
                     new MessageDetail(
                         TokenLogMessages.IDX10618,
-                        keysAttempted?.ToString() ?? "",
+                        LogHelper.MarkAsNonPII(keysAttempted?.ToString() ?? ""),
                         exceptionStrings?.ToString() ?? "",
                         LogHelper.MarkAsSecurityArtifact(jwtToken, JwtTokenUtilities.SafeLogJwtToken)),
                     ValidationFailureType.TokenDecryptionFailed,

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateSignature.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateSignature.cs
@@ -297,7 +297,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     return new SignatureValidationError(
                         new MessageDetail(
                             TokenLogMessages.IDX10636,
-                            LogHelper.MarkAsNonPII(key?.ToString() ?? "Null"),
+                            LogHelper.MarkAsNonPII(key?.KeyId ?? "Null"),
                             LogHelper.MarkAsNonPII(jsonWebToken.Alg)),
                         ValidationFailureType.SignatureValidationFailed,
                         typeof(SecurityTokenInvalidOperationException),

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateSignature.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateSignature.cs
@@ -297,7 +297,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     return new SignatureValidationError(
                         new MessageDetail(
                             TokenLogMessages.IDX10636,
-                            key?.ToString() ?? "Null",
+                            LogHelper.MarkAsNonPII(key?.ToString() ?? "Null"),
                             LogHelper.MarkAsNonPII(jsonWebToken.Alg)),
                         ValidationFailureType.SignatureValidationFailed,
                         typeof(SecurityTokenInvalidOperationException),

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
@@ -320,7 +320,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (!cryptoProviderFactory.IsSupportedAlgorithm(jsonWebToken.Alg, key))
             {
                 if (LogHelper.IsEnabled(EventLogLevel.Informational))
-                    LogHelper.LogInformation(LogMessages.IDX14000, LogHelper.MarkAsNonPII(jsonWebToken.Alg), LogHelper.MarkAsNonPII(key.ToString()));
+                    LogHelper.LogInformation(LogMessages.IDX14000, LogHelper.MarkAsNonPII(jsonWebToken.Alg), LogHelper.MarkAsNonPII(key.KeyId));
 
                 return false;
             }
@@ -334,7 +334,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                         (new InvalidOperationException(
                             LogHelper.FormatInvariant(
                                 TokenLogMessages.IDX10636,
-                                LogHelper.MarkAsNonPII(key == null ? "Null" : key.ToString()),
+                                LogHelper.MarkAsNonPII(key == null ? "Null" : key.KeyId),
                                 LogHelper.MarkAsNonPII(jsonWebToken.Alg))));
 
                 return EncodingUtils.PerformEncodingDependentOperation<bool, string, int, SignatureProvider>(

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
@@ -320,7 +320,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (!cryptoProviderFactory.IsSupportedAlgorithm(jsonWebToken.Alg, key))
             {
                 if (LogHelper.IsEnabled(EventLogLevel.Informational))
-                    LogHelper.LogInformation(LogMessages.IDX14000, LogHelper.MarkAsNonPII(jsonWebToken.Alg), key);
+                    LogHelper.LogInformation(LogMessages.IDX14000, LogHelper.MarkAsNonPII(jsonWebToken.Alg), LogHelper.MarkAsNonPII(key.ToString()));
 
                 return false;
             }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
@@ -330,7 +330,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             try
             {
                 if (signatureProvider == null)
-                    throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(TokenLogMessages.IDX10636, key == null ? "Null" : key.ToString(), LogHelper.MarkAsNonPII(jsonWebToken.Alg))));
+                    throw LogHelper.LogExceptionMessage
+                        (new InvalidOperationException(
+                            LogHelper.FormatInvariant(
+                                TokenLogMessages.IDX10636,
+                                LogHelper.MarkAsNonPII(key == null ? "Null" : key.ToString()),
+                                LogHelper.MarkAsNonPII(jsonWebToken.Alg))));
 
                 return EncodingUtils.PerformEncodingDependentOperation<bool, string, int, SignatureProvider>(
                     jsonWebToken.EncodedToken,

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.DecryptTokenResult.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.DecryptTokenResult.cs
@@ -94,7 +94,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 }
 
                 if (key != null)
-                    (keysAttempted ??= new StringBuilder()).AppendLine(key.ToString());
+                    (keysAttempted ??= new StringBuilder()).AppendLine(key.KeyId);
             }
 
             if (!decryptionSucceeded)

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -77,7 +77,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     new InvalidOperationException(
                         LogHelper.FormatInvariant(
                             TokenLogMessages.IDX10637,
-                            LogHelper.MarkAsNonPII(signingCredentials.Key == null ? "Null" : signingCredentials.Key.ToString()),
+                            LogHelper.MarkAsNonPII(signingCredentials.Key == null ? "Null" : signingCredentials.Key.KeyId),
                             LogHelper.MarkAsNonPII(signingCredentials.Algorithm))));
 
             try
@@ -114,7 +114,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     new InvalidOperationException(
                         LogHelper.FormatInvariant(
                             TokenLogMessages.IDX10637,
-                            LogHelper.MarkAsNonPII(signingCredentials.Key == null ? "Null" : signingCredentials.Key.ToString()),
+                            LogHelper.MarkAsNonPII(signingCredentials.Key == null ? "Null" : signingCredentials.Key.KeyId),
                             LogHelper.MarkAsNonPII(signingCredentials.Algorithm))));
 
             try
@@ -148,7 +148,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     new InvalidOperationException(
                         LogHelper.FormatInvariant(
                             TokenLogMessages.IDX10637,
-                            LogHelper.MarkAsNonPII(signingCredentials.Key == null ? "Null" : signingCredentials.Key.ToString()),
+                            LogHelper.MarkAsNonPII(signingCredentials.Key == null ? "Null" : signingCredentials.Key.KeyId),
                             LogHelper.MarkAsNonPII(signingCredentials.Algorithm))));
 
             try
@@ -190,7 +190,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     new InvalidOperationException(
                         LogHelper.FormatInvariant(
                             TokenLogMessages.IDX10637,
-                            LogHelper.MarkAsNonPII(signingCredentials.Key == null ? "Null" : signingCredentials.Key.ToString()),
+                            LogHelper.MarkAsNonPII(signingCredentials.Key == null ? "Null" : signingCredentials.Key.KeyId),
                             LogHelper.MarkAsNonPII(signingCredentials.Algorithm))));
 
             try
@@ -268,7 +268,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 if (cryptoProviderFactory == null)
                 {
                     if (LogHelper.IsEnabled(EventLogLevel.Warning))
-                        LogHelper.LogWarning(TokenLogMessages.IDX10607, LogHelper.MarkAsNonPII(key.ToString()));
+                        LogHelper.LogWarning(TokenLogMessages.IDX10607, LogHelper.MarkAsNonPII(key.KeyId));
 
                     continue;
                 }
@@ -284,7 +284,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                         if (!cryptoProviderFactory.IsSupportedAlgorithm(jsonWebToken.Enc, key))
                         {
                             if (LogHelper.IsEnabled(EventLogLevel.Warning))
-                                LogHelper.LogWarning(TokenLogMessages.IDX10611, LogHelper.MarkAsNonPII(decryptionParameters.Enc), LogHelper.MarkAsNonPII(key.ToString()));
+                                LogHelper.LogWarning(TokenLogMessages.IDX10611, LogHelper.MarkAsNonPII(decryptionParameters.Enc), LogHelper.MarkAsNonPII(key.KeyId));
 
                             algorithmNotSupportedByCryptoProvider = true;
                             continue;
@@ -310,7 +310,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                         if (!cryptoProviderFactory.IsSupportedAlgorithm(decryptionParameters.Enc, key))
                         {
                             if (LogHelper.IsEnabled(EventLogLevel.Warning))
-                                LogHelper.LogWarning(TokenLogMessages.IDX10611, LogHelper.MarkAsNonPII(decryptionParameters.Enc), LogHelper.MarkAsNonPII(key.ToString()));
+                                LogHelper.LogWarning(TokenLogMessages.IDX10611, LogHelper.MarkAsNonPII(decryptionParameters.Enc), LogHelper.MarkAsNonPII(key.KeyId));
 
                             algorithmNotSupportedByCryptoProvider = true;
                             continue;
@@ -337,7 +337,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 }
 
                 if (key != null)
-                    (keysAttempted ??= new StringBuilder()).AppendLine(key.ToString());
+                    (keysAttempted ??= new StringBuilder()).AppendLine(key.KeyId);
             }
 
             if (!decryptionSucceeded)
@@ -408,7 +408,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             using (AuthenticatedEncryptionProvider decryptionProvider = cryptoProviderFactory.CreateAuthenticatedEncryptionProvider(key, encAlg))
             {
                 if (decryptionProvider == null)
-                    throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(TokenLogMessages.IDX10610, LogHelper.MarkAsNonPII(key.ToString()), LogHelper.MarkAsNonPII(encAlg))));
+                    throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(TokenLogMessages.IDX10610, LogHelper.MarkAsNonPII(key.KeyId), LogHelper.MarkAsNonPII(encAlg))));
 
                 return decryptionProvider.Decrypt(
                     ciphertext,
@@ -457,7 +457,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             {
                 if (!cryptoProviderFactory.IsSupportedAlgorithm(encryptingCredentials.Enc, encryptingCredentials.Key))
                     throw LogHelper.LogExceptionMessage(new SecurityTokenEncryptionFailedException(
-                        LogHelper.FormatInvariant(TokenLogMessages.IDX10615, LogHelper.MarkAsNonPII(encryptingCredentials.Enc), LogHelper.MarkAsNonPII(encryptingCredentials.Key.ToString()))));
+                        LogHelper.FormatInvariant(TokenLogMessages.IDX10615, LogHelper.MarkAsNonPII(encryptingCredentials.Enc), LogHelper.MarkAsNonPII(encryptingCredentials.Key.KeyId))));
 
                 securityKey = encryptingCredentials.Key;
             }
@@ -497,7 +497,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             {
                 if (!cryptoProviderFactory.IsSupportedAlgorithm(encryptingCredentials.Alg, encryptingCredentials.Key))
                     throw LogHelper.LogExceptionMessage(new SecurityTokenEncryptionFailedException(
-                        LogHelper.FormatInvariant(TokenLogMessages.IDX10615, LogHelper.MarkAsNonPII(encryptingCredentials.Alg), LogHelper.MarkAsNonPII(encryptingCredentials.Key.ToString()))));
+                        LogHelper.FormatInvariant(TokenLogMessages.IDX10615, LogHelper.MarkAsNonPII(encryptingCredentials.Alg), LogHelper.MarkAsNonPII(encryptingCredentials.Key.KeyId))));
 
                 // only 128, 384 and 512 AesCbcHmac for CEK algorithm
                 if (SecurityAlgorithms.Aes128CbcHmacSha256.Equals(encryptingCredentials.Enc))

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -257,7 +257,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 if (cryptoProviderFactory == null)
                 {
                     if (LogHelper.IsEnabled(EventLogLevel.Warning))
-                        LogHelper.LogWarning(TokenLogMessages.IDX10607, key);
+                        LogHelper.LogWarning(TokenLogMessages.IDX10607, LogHelper.MarkAsNonPII(key.ToString()));
 
                     continue;
                 }
@@ -273,7 +273,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                         if (!cryptoProviderFactory.IsSupportedAlgorithm(jsonWebToken.Enc, key))
                         {
                             if (LogHelper.IsEnabled(EventLogLevel.Warning))
-                                LogHelper.LogWarning(TokenLogMessages.IDX10611, LogHelper.MarkAsNonPII(decryptionParameters.Enc), key);
+                                LogHelper.LogWarning(TokenLogMessages.IDX10611, LogHelper.MarkAsNonPII(decryptionParameters.Enc), LogHelper.MarkAsNonPII(key.ToString()));
 
                             algorithmNotSupportedByCryptoProvider = true;
                             continue;
@@ -299,7 +299,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                         if (!cryptoProviderFactory.IsSupportedAlgorithm(decryptionParameters.Enc, key))
                         {
                             if (LogHelper.IsEnabled(EventLogLevel.Warning))
-                                LogHelper.LogWarning(TokenLogMessages.IDX10611, LogHelper.MarkAsNonPII(decryptionParameters.Enc), key);
+                                LogHelper.LogWarning(TokenLogMessages.IDX10611, LogHelper.MarkAsNonPII(decryptionParameters.Enc), LogHelper.MarkAsNonPII(key.ToString()));
 
                             algorithmNotSupportedByCryptoProvider = true;
                             continue;
@@ -397,7 +397,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             using (AuthenticatedEncryptionProvider decryptionProvider = cryptoProviderFactory.CreateAuthenticatedEncryptionProvider(key, encAlg))
             {
                 if (decryptionProvider == null)
-                    throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(TokenLogMessages.IDX10610, key, LogHelper.MarkAsNonPII(encAlg))));
+                    throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(TokenLogMessages.IDX10610, LogHelper.MarkAsNonPII(key.ToString()), LogHelper.MarkAsNonPII(encAlg))));
 
                 return decryptionProvider.Decrypt(
                     ciphertext,
@@ -445,7 +445,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (JwtConstants.DirectKeyUseAlg.Equals(encryptingCredentials.Alg))
             {
                 if (!cryptoProviderFactory.IsSupportedAlgorithm(encryptingCredentials.Enc, encryptingCredentials.Key))
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenEncryptionFailedException(LogHelper.FormatInvariant(TokenLogMessages.IDX10615, LogHelper.MarkAsNonPII(encryptingCredentials.Enc), encryptingCredentials.Key)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenEncryptionFailedException(
+                        LogHelper.FormatInvariant(TokenLogMessages.IDX10615, LogHelper.MarkAsNonPII(encryptingCredentials.Enc), LogHelper.MarkAsNonPII(encryptingCredentials.Key.ToString()))));
 
                 securityKey = encryptingCredentials.Key;
             }
@@ -484,7 +485,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             else
             {
                 if (!cryptoProviderFactory.IsSupportedAlgorithm(encryptingCredentials.Alg, encryptingCredentials.Key))
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenEncryptionFailedException(LogHelper.FormatInvariant(TokenLogMessages.IDX10615, LogHelper.MarkAsNonPII(encryptingCredentials.Alg), encryptingCredentials.Key)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenEncryptionFailedException(
+                        LogHelper.FormatInvariant(TokenLogMessages.IDX10615, LogHelper.MarkAsNonPII(encryptingCredentials.Alg), LogHelper.MarkAsNonPII(encryptingCredentials.Key.ToString()))));
 
                 // only 128, 384 and 512 AesCbcHmac for CEK algorithm
                 if (SecurityAlgorithms.Aes128CbcHmacSha256.Equals(encryptingCredentials.Enc))

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -73,7 +73,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             var cryptoProviderFactory = signingCredentials.CryptoProviderFactory ?? signingCredentials.Key.CryptoProviderFactory;
             var signatureProvider = cryptoProviderFactory.CreateForSigning(signingCredentials.Key, signingCredentials.Algorithm);
             if (signatureProvider == null)
-                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(TokenLogMessages.IDX10637, signingCredentials.Key == null ? "Null" : signingCredentials.Key.ToString(), LogHelper.MarkAsNonPII(signingCredentials.Algorithm))));
+                throw LogHelper.LogExceptionMessage(
+                    new InvalidOperationException(
+                        LogHelper.FormatInvariant(
+                            TokenLogMessages.IDX10637,
+                            LogHelper.MarkAsNonPII(signingCredentials.Key == null ? "Null" : signingCredentials.Key.ToString()),
+                            LogHelper.MarkAsNonPII(signingCredentials.Algorithm))));
 
             try
             {
@@ -105,7 +110,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             var cryptoProviderFactory = signingCredentials.CryptoProviderFactory ?? signingCredentials.Key.CryptoProviderFactory;
             var signatureProvider = cryptoProviderFactory.CreateForSigning(signingCredentials.Key, signingCredentials.Algorithm, cacheProvider);
             if (signatureProvider == null)
-                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(TokenLogMessages.IDX10637, signingCredentials.Key == null ? "Null" : signingCredentials.Key.ToString(), LogHelper.MarkAsNonPII(signingCredentials.Algorithm))));
+                throw LogHelper.LogExceptionMessage(
+                    new InvalidOperationException(
+                        LogHelper.FormatInvariant(
+                            TokenLogMessages.IDX10637,
+                            LogHelper.MarkAsNonPII(signingCredentials.Key == null ? "Null" : signingCredentials.Key.ToString()),
+                            LogHelper.MarkAsNonPII(signingCredentials.Algorithm))));
 
             try
             {
@@ -138,7 +148,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     new InvalidOperationException(
                         LogHelper.FormatInvariant(
                             TokenLogMessages.IDX10637,
-                            signingCredentials.Key == null ? "Null" : signingCredentials.Key.ToString(),
+                            LogHelper.MarkAsNonPII(signingCredentials.Key == null ? "Null" : signingCredentials.Key.ToString()),
                             LogHelper.MarkAsNonPII(signingCredentials.Algorithm))));
 
             try
@@ -179,7 +189,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 throw LogHelper.LogExceptionMessage(
                     new InvalidOperationException(
                         LogHelper.FormatInvariant(
-                            TokenLogMessages.IDX10637, signingCredentials.Key == null ? "Null" : signingCredentials.Key.ToString(),
+                            TokenLogMessages.IDX10637,
+                            LogHelper.MarkAsNonPII(signingCredentials.Key == null ? "Null" : signingCredentials.Key.ToString()),
                             LogHelper.MarkAsNonPII(signingCredentials.Algorithm))));
 
             try

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -367,7 +367,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 return new ValidationError(
                     new MessageDetail(
                         TokenLogMessages.IDX10603,
-                        keysAttempted.ToString(),
+                        LogHelper.MarkAsNonPII(keysAttempted.ToString()),
                         exceptionStrings?.ToString() ?? string.Empty,
                         LogHelper.MarkAsSecurityArtifact(decryptionParameters.EncodedToken, SafeLogJwtToken)),
                     ValidationFailureType.TokenDecryptionFailed,

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfigurationValidator.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Configuration/OpenIdConnectConfigurationValidator.cs
@@ -57,7 +57,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Configuration
                         LogMessages.IDX21818,
                         LogHelper.MarkAsNonPII(MinimumNumberOfKeys),
                         LogHelper.MarkAsNonPII(numberOfValidKeys),
-                        string.IsNullOrEmpty(convertKeyInfos) ? "None" : convertKeyInfos),
+                        string.IsNullOrEmpty(convertKeyInfos) ? "None" : LogHelper.MarkAsNonPII(convertKeyInfos)),
                     Succeeded = false
                 };
             }

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -658,7 +658,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                         if (signatureProvider == null)
                             throw LogHelper.LogExceptionMessage(
                                 new InvalidOperationException(
-                                    LogHelper.FormatInvariant(Tokens.LogMessages.IDX10636, LogHelper.MarkAsNonPII(popKey.ToString()), LogHelper.MarkAsNonPII(signedHttpRequest.Alg))));
+                                    LogHelper.FormatInvariant(Tokens.LogMessages.IDX10636, LogHelper.MarkAsNonPII(popKey.KeyId), LogHelper.MarkAsNonPII(signedHttpRequest.Alg))));
 
                         if (EncodingUtils.PerformEncodingDependentOperation<bool, string, int, SignatureProvider>(
                             signedHttpRequest.EncodedToken,
@@ -1101,7 +1101,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                     throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPopKeyException(LogHelper.FormatInvariant(LogMessages.IDX23015, LogHelper.MarkAsNonPII(key.GetType().ToString()))));
             }
             else
-                throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPopKeyException(LogHelper.FormatInvariant(LogMessages.IDX23016, LogHelper.MarkAsNonPII(jsonWebKey.ToString()))));
+                throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPopKeyException(LogHelper.FormatInvariant(LogMessages.IDX23016, LogHelper.MarkAsNonPII(jsonWebKey.KeyId))));
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -656,7 +656,9 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                     {
                         signatureProvider = popKey.CryptoProviderFactory.CreateForVerifying(popKey, signedHttpRequest.Alg, false);
                         if (signatureProvider == null)
-                            throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(Tokens.LogMessages.IDX10636, popKey.ToString(), LogHelper.MarkAsNonPII(signedHttpRequest.Alg))));
+                            throw LogHelper.LogExceptionMessage(
+                                new InvalidOperationException(
+                                    LogHelper.FormatInvariant(Tokens.LogMessages.IDX10636, LogHelper.MarkAsNonPII(popKey.ToString()), LogHelper.MarkAsNonPII(signedHttpRequest.Alg))));
 
                         if (EncodingUtils.PerformEncodingDependentOperation<bool, string, int, SignatureProvider>(
                             signedHttpRequest.EncodedToken,

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -1099,7 +1099,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                     throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPopKeyException(LogHelper.FormatInvariant(LogMessages.IDX23015, LogHelper.MarkAsNonPII(key.GetType().ToString()))));
             }
             else
-                throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPopKeyException(LogHelper.FormatInvariant(LogMessages.IDX23016, jsonWebKey.ToString())));
+                throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPopKeyException(LogHelper.FormatInvariant(LogMessages.IDX23016, LogHelper.MarkAsNonPII(jsonWebKey.ToString()))));
         }
 
         /// <summary>
@@ -1164,7 +1164,8 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                     new SignedHttpRequestInvalidPopKeyException(
                         LogHelper.FormatInvariant(
                             LogMessages.IDX23021,
-                            LogHelper.MarkAsNonPII(cnf.Kid), string.Join(", ", popKeys.Select(x => x.KeyId ?? "Null")))));
+                            LogHelper.MarkAsNonPII(cnf.Kid),
+                            LogHelper.MarkAsNonPII(string.Join(", ", popKeys.Select(x => x.KeyId ?? "Null"))))));
             }
             else
             {

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestUtilities.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestUtilities.cs
@@ -106,7 +106,12 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             }
             catch (Exception e)
             {
-                throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPopKeyException(LogHelper.FormatInvariant(LogMessages.IDX23018, string.Join(", ", decryptionKeys.Select(x => x?.KeyId ?? "Null")), e), e));
+                throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPopKeyException(
+                    LogHelper.FormatInvariant(
+                        LogMessages.IDX23018,
+                        LogHelper.MarkAsNonPII(string.Join(", ", decryptionKeys.Select(x => x?.KeyId ?? "Null"))),
+                        e),
+                    e));
             }
         }
     }

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.ValidateSignature.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.ValidateSignature.cs
@@ -121,7 +121,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
 
                     (errors ??= new()).Add(result.UnwrapError());
 
-                    (keysAttempted ??= new()).Append(key.ToString());
+                    (keysAttempted ??= new()).Append(key.KeyId);
                     if (canMatchKey && !keyMatched && key.KeyId is not null && samlToken.Assertion.Signature.KeyInfo is not null)
                         keyMatched = samlToken.Assertion.Signature.KeyInfo.MatchesKey(key);
                 }
@@ -141,7 +141,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
 
             string? keysAttemptedString = null;
             if (resolvedKey is not null)
-                keysAttemptedString = resolvedKey.ToString();
+                keysAttemptedString = resolvedKey.KeyId;
             else if ((keysAttempted?.Length ?? 0) > 0)
                 keysAttemptedString = keysAttempted!.ToString();
 

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.ValidateSignature.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.ValidateSignature.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.IdentityModel.Logging;
 using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
 
 #nullable enable
@@ -130,7 +131,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 return new SignatureValidationError(
                     new MessageDetail(
                         TokenLogMessages.IDX10514,
-                        keysAttempted?.ToString(),
+                        LogHelper.MarkAsNonPII(keysAttempted?.ToString()),
                         samlToken.Assertion.Signature.KeyInfo,
                         GetErrorString(errors),
                         samlToken),
@@ -148,7 +149,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
                 return new SignatureValidationError(
                     new MessageDetail(
                         TokenLogMessages.IDX10512,
-                        keysAttemptedString,
+                        LogHelper.MarkAsNonPII(keysAttemptedString),
                         GetErrorString(errors),
                         samlToken),
                     ValidationFailureType.SignatureValidationFailed,

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -1105,7 +1105,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
 
                     if (key != null)
                     {
-                        keysAttempted.Append(key.ToString()).Append(" , KeyId: ").AppendLine(key.KeyId);
+                        keysAttempted.Append("KeyId: ").AppendLine(key.KeyId);
                         if (canMatchKey && !keyMatched && key.KeyId != null)
                             keyMatched = samlToken.Assertion.Signature.KeyInfo.MatchesKey(key);
                     }

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -1115,14 +1115,15 @@ namespace Microsoft.IdentityModel.Tokens.Saml
             if (canMatchKey)
             {
                 if (keyMatched)
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10514, keysAttempted, samlToken.Assertion.Signature.KeyInfo, exceptionStrings, samlToken)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(
+                        LogHelper.FormatInvariant(TokenLogMessages.IDX10514, LogHelper.MarkAsNonPII(keysAttempted), samlToken.Assertion.Signature.KeyInfo, exceptionStrings, samlToken)));
 
                 ValidateIssuer(samlToken.Issuer, samlToken, validationParameters);
                 ValidateConditions(samlToken, validationParameters);
             }
 
             if (keysAttempted.Length > 0)
-                throw LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(FormatInvariant(TokenLogMessages.IDX10512, keysAttempted, exceptionStrings, samlToken)));
+                throw LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(FormatInvariant(TokenLogMessages.IDX10512, LogHelper.MarkAsNonPII(keysAttempted), exceptionStrings, samlToken)));
 
             throw LogHelper.LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(TokenLogMessages.IDX10500));
         }

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateSignature.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateSignature.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens.Saml;
 using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
 
@@ -128,7 +129,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                 return new SignatureValidationError(
                     new MessageDetail(
                         TokenLogMessages.IDX10514,
-                        keysAttempted?.ToString(),
+                        LogHelper.MarkAsNonPII(keysAttempted?.ToString()),
                         samlToken.Assertion.Signature.KeyInfo,
                         GetErrorStrings(errors),
                         samlToken),
@@ -146,7 +147,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                 return new SignatureValidationError(
                     new MessageDetail(
                         TokenLogMessages.IDX10512,
-                        keysAttemptedString,
+                        LogHelper.MarkAsNonPII(keysAttemptedString),
                         GetErrorStrings(errors),
                         samlToken),
                     ValidationFailureType.SignatureValidationFailed,

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateSignature.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.ValidateSignature.cs
@@ -119,7 +119,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
 
                     (errors ??= new()).Add(result.UnwrapError());
 
-                    (keysAttempted ??= new()).Append(key.ToString());
+                    (keysAttempted ??= new()).Append(key.KeyId);
                     if (canMatchKey && !keyMatched && key.KeyId is not null && samlToken.Assertion.Signature.KeyInfo is not null)
                         keyMatched = samlToken.Assertion.Signature.KeyInfo.MatchesKey(key);
                 }
@@ -139,7 +139,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
 
             string? keysAttemptedString = null;
             if (resolvedKey is not null)
-                keysAttemptedString = resolvedKey.ToString();
+                keysAttemptedString = resolvedKey.KeyId;
             else if ((keysAttempted?.Length ?? 0) > 0)
                 keysAttemptedString = keysAttempted!.ToString();
 

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -480,14 +480,15 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
             if (canMatchKey)
             {
                 if (keyMatched)
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10514, keysAttempted, samlToken.Assertion.Signature.KeyInfo, exceptionStrings, samlToken)));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(
+                        LogHelper.FormatInvariant(TokenLogMessages.IDX10514, LogHelper.MarkAsNonPII(keysAttempted), samlToken.Assertion.Signature.KeyInfo, exceptionStrings, samlToken)));
 
                 ValidateIssuer(samlToken.Issuer, samlToken, validationParameters);
                 ValidateConditions(samlToken, validationParameters);
             }
 
             if (keysAttempted.Length > 0)
-                throw LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(FormatInvariant(TokenLogMessages.IDX10512, keysAttempted, exceptionStrings, samlToken)));
+                throw LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(FormatInvariant(TokenLogMessages.IDX10512, LogHelper.MarkAsNonPII(keysAttempted), exceptionStrings, samlToken)));
 
             throw LogHelper.LogExceptionMessage(new SecurityTokenSignatureKeyNotFoundException(TokenLogMessages.IDX10500));
         }

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -470,7 +470,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
 
                     if (key != null)
                     {
-                        keysAttempted.Append(key.ToString()).Append(" , KeyId: ").AppendLine(key.KeyId);
+                        keysAttempted.Append("KeyId: ").AppendLine(key.KeyId);
                         if (canMatchKey && !keyMatched && key.KeyId != null)
                             keyMatched = samlToken.Assertion.Signature.KeyInfo.MatchesKey(key);
                     }

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -92,7 +92,7 @@ namespace Microsoft.IdentityModel.Tokens
                             new NotSupportedException(
                                 LogHelper.FormatInvariant(
                                     LogMessages.IDX10684,
-                                    LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key))));
+                                    LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key.KeyId))));
                 }
             }
             else if (key is ECDsaSecurityKey ecdsaKey)
@@ -104,7 +104,7 @@ namespace Microsoft.IdentityModel.Tokens
                     new NotSupportedException(
                         LogHelper.FormatInvariant(
                             LogMessages.IDX10684,
-                            LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key))));
+                            LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key.KeyId))));
         }
 
         internal byte[] Decrypt(byte[] data)

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricAdapter.cs
@@ -92,7 +92,7 @@ namespace Microsoft.IdentityModel.Tokens
                             new NotSupportedException(
                                 LogHelper.FormatInvariant(
                                     LogMessages.IDX10684,
-                                    LogHelper.MarkAsNonPII(algorithm), key)));
+                                    LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key))));
                 }
             }
             else if (key is ECDsaSecurityKey ecdsaKey)
@@ -104,7 +104,7 @@ namespace Microsoft.IdentityModel.Tokens
                     new NotSupportedException(
                         LogHelper.FormatInvariant(
                             LogMessages.IDX10684,
-                            LogHelper.MarkAsNonPII(algorithm), key)));
+                            LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key))));
         }
 
         internal byte[] Decrypt(byte[] data)

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -128,14 +128,15 @@ namespace Microsoft.IdentityModel.Tokens
             if (willCreateSignatures && FoundPrivateKey(key) == PrivateKeyStatus.DoesNotExist)
                 throw LogHelper.LogExceptionMessage(
                     new InvalidOperationException(
-                        LogHelper.FormatInvariant(LogMessages.IDX10638, key)));
+                        LogHelper.FormatInvariant(LogMessages.IDX10638, LogHelper.MarkAsNonPII(key))));
 
             if (!_cryptoProviderFactory.IsSupportedAlgorithm(algorithm, key))
                 throw LogHelper.LogExceptionMessage(
                     new NotSupportedException(
                         LogHelper.FormatInvariant(
                             LogMessages.IDX10634,
-                            LogHelper.MarkAsNonPII((algorithm)), key)));
+                            LogHelper.MarkAsNonPII((algorithm)),
+                            LogHelper.MarkAsNonPII(key))));
 
             WillCreateSignatures = willCreateSignatures;
             _asymmetricAdapterObjectPool = new DisposableObjectPool<AsymmetricAdapter>(
@@ -346,12 +347,12 @@ namespace Microsoft.IdentityModel.Tokens
                     keySize = convertedAsymmetricKey.KeySize;
                 else if (convertedSecurityKey is SymmetricSecurityKey)
                     throw LogHelper.LogExceptionMessage(
-                        new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10704, key)));
+                        new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10704, LogHelper.MarkAsNonPII(key))));
             }
             else
             {
                 throw LogHelper.LogExceptionMessage(
-                    new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10704, key)));
+                    new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10704, LogHelper.MarkAsNonPII(key))));
             }
 
             if (willCreateSignatures)
@@ -363,7 +364,7 @@ namespace Microsoft.IdentityModel.Tokens
                             nameof(key),
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10630,
-                                key,
+                                LogHelper.MarkAsNonPII(key),
                                 LogHelper.MarkAsNonPII(
                                     MinimumAsymmetricKeySizeInBitsForSigningMap[algorithm]),
                                 LogHelper.MarkAsNonPII(keySize))));

--- a/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AsymmetricSignatureProvider.cs
@@ -128,7 +128,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (willCreateSignatures && FoundPrivateKey(key) == PrivateKeyStatus.DoesNotExist)
                 throw LogHelper.LogExceptionMessage(
                     new InvalidOperationException(
-                        LogHelper.FormatInvariant(LogMessages.IDX10638, LogHelper.MarkAsNonPII(key))));
+                        LogHelper.FormatInvariant(LogMessages.IDX10638, LogHelper.MarkAsNonPII(key.KeyId))));
 
             if (!_cryptoProviderFactory.IsSupportedAlgorithm(algorithm, key))
                 throw LogHelper.LogExceptionMessage(
@@ -136,7 +136,7 @@ namespace Microsoft.IdentityModel.Tokens
                         LogHelper.FormatInvariant(
                             LogMessages.IDX10634,
                             LogHelper.MarkAsNonPII((algorithm)),
-                            LogHelper.MarkAsNonPII(key))));
+                            LogHelper.MarkAsNonPII(key.KeyId))));
 
             WillCreateSignatures = willCreateSignatures;
             _asymmetricAdapterObjectPool = new DisposableObjectPool<AsymmetricAdapter>(
@@ -347,12 +347,12 @@ namespace Microsoft.IdentityModel.Tokens
                     keySize = convertedAsymmetricKey.KeySize;
                 else if (convertedSecurityKey is SymmetricSecurityKey)
                     throw LogHelper.LogExceptionMessage(
-                        new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10704, LogHelper.MarkAsNonPII(key))));
+                        new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10704, LogHelper.MarkAsNonPII(key.KeyId))));
             }
             else
             {
                 throw LogHelper.LogExceptionMessage(
-                    new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10704, LogHelper.MarkAsNonPII(key))));
+                    new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10704, LogHelper.MarkAsNonPII(key.KeyId))));
             }
 
             if (willCreateSignatures)
@@ -364,7 +364,7 @@ namespace Microsoft.IdentityModel.Tokens
                             nameof(key),
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10630,
-                                LogHelper.MarkAsNonPII(key),
+                                LogHelper.MarkAsNonPII(key.KeyId),
                                 LogHelper.MarkAsNonPII(
                                     MinimumAsymmetricKeySizeInBitsForSigningMap[algorithm]),
                                 LogHelper.MarkAsNonPII(keySize))));

--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -168,7 +168,7 @@ namespace Microsoft.IdentityModel.Tokens
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10646,
                                 LogHelper.MarkAsNonPII(algorithm),
-                                LogHelper.MarkAsNonPII(key),
+                                LogHelper.MarkAsNonPII(key.KeyId),
                                 LogHelper.MarkAsNonPII(typeof(AuthenticatedEncryptionProvider)))));
 
                 return cryptoProvider;
@@ -247,7 +247,7 @@ namespace Microsoft.IdentityModel.Tokens
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10646,
                                 LogHelper.MarkAsNonPII(algorithm),
-                                LogHelper.MarkAsNonPII(key),
+                                LogHelper.MarkAsNonPII(key.KeyId),
                                 LogHelper.MarkAsNonPII(typeof(SignatureProvider)))));
 
                 return keyWrapProvider;
@@ -264,7 +264,7 @@ namespace Microsoft.IdentityModel.Tokens
                     LogHelper.FormatInvariant(
                         LogMessages.IDX10661,
                         LogHelper.MarkAsNonPII(algorithm),
-                        key)));
+                        LogHelper.MarkAsNonPII(key.KeyId))));
         }
 
         /// <summary>
@@ -605,7 +605,7 @@ namespace Microsoft.IdentityModel.Tokens
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10646,
                                 LogHelper.MarkAsNonPII(algorithm),
-                                LogHelper.MarkAsNonPII(key),
+                                LogHelper.MarkAsNonPII(key.KeyId),
                                 LogHelper.MarkAsNonPII(typeof(SignatureProvider)))));
 
                 return signatureProvider;
@@ -652,7 +652,7 @@ namespace Microsoft.IdentityModel.Tokens
                         new InvalidOperationException(
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10694,
-                                LogHelper.MarkAsNonPII(key),
+                                LogHelper.MarkAsNonPII(key.KeyId),
                                 ex),
                             ex));
                 }
@@ -693,7 +693,7 @@ namespace Microsoft.IdentityModel.Tokens
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10634,
                                 LogHelper.MarkAsNonPII(algorithm),
-                                LogHelper.MarkAsNonPII(key))));
+                                LogHelper.MarkAsNonPII(key.KeyId))));
 
                 if (createAsymmetric)
                     signatureProvider = new AsymmetricSignatureProvider(key, algorithm, willCreateSignatures, this);
@@ -718,7 +718,7 @@ namespace Microsoft.IdentityModel.Tokens
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10634,
                                 LogHelper.MarkAsNonPII(algorithm),
-                                LogHelper.MarkAsNonPII(key))));
+                                LogHelper.MarkAsNonPII(key.KeyId))));
 
                 if (createAsymmetric)
                 {

--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -168,7 +168,7 @@ namespace Microsoft.IdentityModel.Tokens
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10646,
                                 LogHelper.MarkAsNonPII(algorithm),
-                                key,
+                                LogHelper.MarkAsNonPII(key),
                                 LogHelper.MarkAsNonPII(typeof(AuthenticatedEncryptionProvider)))));
 
                 return cryptoProvider;
@@ -247,7 +247,7 @@ namespace Microsoft.IdentityModel.Tokens
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10646,
                                 LogHelper.MarkAsNonPII(algorithm),
-                                key,
+                                LogHelper.MarkAsNonPII(key),
                                 LogHelper.MarkAsNonPII(typeof(SignatureProvider)))));
 
                 return keyWrapProvider;
@@ -605,7 +605,7 @@ namespace Microsoft.IdentityModel.Tokens
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10646,
                                 LogHelper.MarkAsNonPII(algorithm),
-                                key,
+                                LogHelper.MarkAsNonPII(key),
                                 LogHelper.MarkAsNonPII(typeof(SignatureProvider)))));
 
                 return signatureProvider;
@@ -652,7 +652,7 @@ namespace Microsoft.IdentityModel.Tokens
                         new InvalidOperationException(
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10694,
-                                key,
+                                LogHelper.MarkAsNonPII(key),
                                 ex),
                             ex));
                 }
@@ -693,7 +693,7 @@ namespace Microsoft.IdentityModel.Tokens
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10634,
                                 LogHelper.MarkAsNonPII(algorithm),
-                                key)));
+                                LogHelper.MarkAsNonPII(key))));
 
                 if (createAsymmetric)
                     signatureProvider = new AsymmetricSignatureProvider(key, algorithm, willCreateSignatures, this);
@@ -718,7 +718,7 @@ namespace Microsoft.IdentityModel.Tokens
                             LogHelper.FormatInvariant(
                                 LogMessages.IDX10634,
                                 LogHelper.MarkAsNonPII(algorithm),
-                                key)));
+                                LogHelper.MarkAsNonPII(key))));
 
                 if (createAsymmetric)
                 {

--- a/src/Microsoft.IdentityModel.Tokens/Encryption/AuthenticatedEncryptionProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/AuthenticatedEncryptionProvider.cs
@@ -74,7 +74,7 @@ namespace Microsoft.IdentityModel.Tokens
                     InitializeUsingAesCbc();
             }
             else
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10668, LogHelper.MarkAsNonPII(_className), LogHelper.MarkAsNonPII(algorithm), key)));
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10668, LogHelper.MarkAsNonPII(_className), LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key))));
         }
 
         private void InitializeUsingAesGcm()
@@ -207,7 +207,7 @@ namespace Microsoft.IdentityModel.Tokens
         internal SymmetricSignatureProvider CreateSymmetricSignatureProvider()
         {
             if (!IsSupportedAlgorithm(Key, Algorithm))
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10668, LogHelper.MarkAsNonPII(_className), LogHelper.MarkAsNonPII(Algorithm), Key)));
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10668, LogHelper.MarkAsNonPII(_className), LogHelper.MarkAsNonPII(Algorithm), LogHelper.MarkAsNonPII(Key))));
 
             ValidateKeySize(Key, Algorithm);
 
@@ -370,7 +370,7 @@ namespace Microsoft.IdentityModel.Tokens
             else if (algorithm.Equals(SecurityAlgorithms.Aes128CbcHmacSha256))
                 keyLength = 16;
             else
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10668, LogHelper.MarkAsNonPII(_className), LogHelper.MarkAsNonPII(algorithm), key)));
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10668, LogHelper.MarkAsNonPII(_className), LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key))));
 
             var keyBytes = GetKeyBytes(key);
             byte[] aesKey = new byte[keyLength];
@@ -426,7 +426,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (key is JsonWebKey jsonWebKey && JsonWebKeyConverter.TryConvertToSymmetricSecurityKey(jsonWebKey, out SecurityKey securityKey))
                 return GetKeyBytes(securityKey);
 
-            throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10667, key)));
+            throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10667, LogHelper.MarkAsNonPII(key))));
         }
 
         internal static byte[] Transform(ICryptoTransform transform, byte[] input, int inputOffset, int inputLength)
@@ -464,7 +464,14 @@ namespace Microsoft.IdentityModel.Tokens
             if (SecurityAlgorithms.Aes128CbcHmacSha256.Equals(algorithm))
             {
                 if (key.KeySize < 256)
-                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(key), LogHelper.FormatInvariant(LogMessages.IDX10653, LogHelper.MarkAsNonPII(SecurityAlgorithms.Aes128CbcHmacSha256), LogHelper.MarkAsNonPII(256), key.KeyId, LogHelper.MarkAsNonPII(key.KeySize))));
+                    throw LogHelper.LogExceptionMessage(
+                        new ArgumentOutOfRangeException(
+                            nameof(key),
+                            LogHelper.FormatInvariant(LogMessages.IDX10653,
+                                LogHelper.MarkAsNonPII(SecurityAlgorithms.Aes128CbcHmacSha256),
+                                LogHelper.MarkAsNonPII(256),
+                                LogHelper.MarkAsNonPII(key.KeyId),
+                                LogHelper.MarkAsNonPII(key.KeySize))));
 
                 return;
             }
@@ -472,7 +479,15 @@ namespace Microsoft.IdentityModel.Tokens
             if (SecurityAlgorithms.Aes192CbcHmacSha384.Equals(algorithm))
             {
                 if (key.KeySize < 384)
-                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(key), LogHelper.FormatInvariant(LogMessages.IDX10653, LogHelper.MarkAsNonPII(SecurityAlgorithms.Aes192CbcHmacSha384), LogHelper.MarkAsNonPII(384), key.KeyId, LogHelper.MarkAsNonPII(key.KeySize))));
+                    throw LogHelper.LogExceptionMessage(
+                        new ArgumentOutOfRangeException(
+                            nameof(key),
+                            LogHelper.FormatInvariant(
+                                LogMessages.IDX10653,
+                                LogHelper.MarkAsNonPII(SecurityAlgorithms.Aes192CbcHmacSha384),
+                                LogHelper.MarkAsNonPII(384),
+                                LogHelper.MarkAsNonPII(key.KeyId),
+                                LogHelper.MarkAsNonPII(key.KeySize))));
 
                 return;
             }
@@ -480,7 +495,15 @@ namespace Microsoft.IdentityModel.Tokens
             if (SecurityAlgorithms.Aes256CbcHmacSha512.Equals(algorithm))
             {
                 if (key.KeySize < 512)
-                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(key), LogHelper.FormatInvariant(LogMessages.IDX10653, LogHelper.MarkAsNonPII(SecurityAlgorithms.Aes256CbcHmacSha512), LogHelper.MarkAsNonPII(512), key.KeyId, LogHelper.MarkAsNonPII(key.KeySize))));
+                    throw LogHelper.LogExceptionMessage(
+                        new ArgumentOutOfRangeException(
+                            nameof(key),
+                            LogHelper.FormatInvariant(
+                                LogMessages.IDX10653,
+                                LogHelper.MarkAsNonPII(SecurityAlgorithms.Aes256CbcHmacSha512),
+                                LogHelper.MarkAsNonPII(512),
+                                LogHelper.MarkAsNonPII(key.KeyId),
+                                LogHelper.MarkAsNonPII(key.KeySize))));
 
                 return;
             }
@@ -488,7 +511,15 @@ namespace Microsoft.IdentityModel.Tokens
             if (SecurityAlgorithms.Aes128Gcm.Equals(algorithm))
             {
                 if (key.KeySize < 128)
-                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(key), LogHelper.FormatInvariant(LogMessages.IDX10653, LogHelper.MarkAsNonPII(SecurityAlgorithms.Aes128Gcm), LogHelper.MarkAsNonPII(128), key.KeyId, LogHelper.MarkAsNonPII(key.KeySize))));
+                    throw LogHelper.LogExceptionMessage(
+                        new ArgumentOutOfRangeException(
+                            nameof(key),
+                            LogHelper.FormatInvariant(
+                                LogMessages.IDX10653,
+                                LogHelper.MarkAsNonPII(SecurityAlgorithms.Aes128Gcm),
+                                LogHelper.MarkAsNonPII(128),
+                                LogHelper.MarkAsNonPII(key.KeyId),
+                                LogHelper.MarkAsNonPII(key.KeySize))));
 
                 return;
             }
@@ -496,7 +527,15 @@ namespace Microsoft.IdentityModel.Tokens
             if (SecurityAlgorithms.Aes192Gcm.Equals(algorithm))
             {
                 if (key.KeySize < 192)
-                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(key), LogHelper.FormatInvariant(LogMessages.IDX10653, LogHelper.MarkAsNonPII(SecurityAlgorithms.Aes192Gcm), LogHelper.MarkAsNonPII(192), key.KeyId, LogHelper.MarkAsNonPII(key.KeySize))));
+                    throw LogHelper.LogExceptionMessage(
+                        new ArgumentOutOfRangeException(
+                            nameof(key),
+                            LogHelper.FormatInvariant(
+                                LogMessages.IDX10653,
+                                LogHelper.MarkAsNonPII(SecurityAlgorithms.Aes192Gcm),
+                                LogHelper.MarkAsNonPII(192),
+                                LogHelper.MarkAsNonPII(key.KeyId),
+                                LogHelper.MarkAsNonPII(key.KeySize))));
 
                 return;
             }
@@ -504,7 +543,15 @@ namespace Microsoft.IdentityModel.Tokens
             if (SecurityAlgorithms.Aes256Gcm.Equals(algorithm))
             {
                 if (key.KeySize < 256)
-                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(key), LogHelper.FormatInvariant(LogMessages.IDX10653, LogHelper.MarkAsNonPII(SecurityAlgorithms.Aes256Gcm), LogHelper.MarkAsNonPII(256), key.KeyId, LogHelper.MarkAsNonPII(key.KeySize))));
+                    throw LogHelper.LogExceptionMessage(
+                        new ArgumentOutOfRangeException(
+                            nameof(key),
+                            LogHelper.FormatInvariant(
+                                LogMessages.IDX10653,
+                                LogHelper.MarkAsNonPII(SecurityAlgorithms.Aes256Gcm),
+                                LogHelper.MarkAsNonPII(256),
+                                LogHelper.MarkAsNonPII(key.KeyId),
+                                LogHelper.MarkAsNonPII(key.KeySize))));
 
                 return;
             }

--- a/src/Microsoft.IdentityModel.Tokens/Encryption/AuthenticatedEncryptionProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/AuthenticatedEncryptionProvider.cs
@@ -74,7 +74,7 @@ namespace Microsoft.IdentityModel.Tokens
                     InitializeUsingAesCbc();
             }
             else
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10668, LogHelper.MarkAsNonPII(_className), LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key))));
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10668, LogHelper.MarkAsNonPII(_className), LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key.KeyId))));
         }
 
         private void InitializeUsingAesGcm()
@@ -207,7 +207,7 @@ namespace Microsoft.IdentityModel.Tokens
         internal SymmetricSignatureProvider CreateSymmetricSignatureProvider()
         {
             if (!IsSupportedAlgorithm(Key, Algorithm))
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10668, LogHelper.MarkAsNonPII(_className), LogHelper.MarkAsNonPII(Algorithm), LogHelper.MarkAsNonPII(Key))));
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10668, LogHelper.MarkAsNonPII(_className), LogHelper.MarkAsNonPII(Algorithm), LogHelper.MarkAsNonPII(Key.KeyId))));
 
             ValidateKeySize(Key, Algorithm);
 
@@ -370,7 +370,7 @@ namespace Microsoft.IdentityModel.Tokens
             else if (algorithm.Equals(SecurityAlgorithms.Aes128CbcHmacSha256))
                 keyLength = 16;
             else
-                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10668, LogHelper.MarkAsNonPII(_className), LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key))));
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10668, LogHelper.MarkAsNonPII(_className), LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key.KeyId))));
 
             var keyBytes = GetKeyBytes(key);
             byte[] aesKey = new byte[keyLength];
@@ -426,7 +426,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (key is JsonWebKey jsonWebKey && JsonWebKeyConverter.TryConvertToSymmetricSecurityKey(jsonWebKey, out SecurityKey securityKey))
                 return GetKeyBytes(securityKey);
 
-            throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10667, LogHelper.MarkAsNonPII(key))));
+            throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10667, LogHelper.MarkAsNonPII(key.KeyId))));
         }
 
         internal static byte[] Transform(ICryptoTransform transform, byte[] input, int inputOffset, int inputLength)

--- a/src/Microsoft.IdentityModel.Tokens/Encryption/RsaKeyWrapProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/RsaKeyWrapProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.IdentityModel.Tokens
         internal AsymmetricAdapter CreateAsymmetricAdapter()
         {
             if (!IsSupportedAlgorithm(Key, Algorithm))
-                throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10661, LogHelper.MarkAsNonPII(Algorithm), LogHelper.MarkAsNonPII(Key))));
+                throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10661, LogHelper.MarkAsNonPII(Algorithm), LogHelper.MarkAsNonPII(Key.KeyId))));
 
             return new AsymmetricAdapter(Key, Algorithm, _willUnwrap);
         }

--- a/src/Microsoft.IdentityModel.Tokens/Encryption/RsaKeyWrapProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/RsaKeyWrapProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.IdentityModel.Tokens
         internal AsymmetricAdapter CreateAsymmetricAdapter()
         {
             if (!IsSupportedAlgorithm(Key, Algorithm))
-                throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10661, LogHelper.MarkAsNonPII(Algorithm), Key)));
+                throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10661, LogHelper.MarkAsNonPII(Algorithm), LogHelper.MarkAsNonPII(Key))));
 
             return new AsymmetricAdapter(Key, Algorithm, _willUnwrap);
         }

--- a/src/Microsoft.IdentityModel.Tokens/Encryption/SymmetricKeyWrapProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/SymmetricKeyWrapProvider.cs
@@ -67,7 +67,7 @@ namespace Microsoft.IdentityModel.Tokens
         private SymmetricAlgorithm CreateSymmetricAlgorithm()
         {
             if (!IsSupportedAlgorithm(Key, Algorithm))
-                throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10661, LogHelper.MarkAsNonPII(Algorithm), LogHelper.MarkAsNonPII(Key))));
+                throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10661, LogHelper.MarkAsNonPII(Algorithm), LogHelper.MarkAsNonPII(Key.KeyId))));
 
             SymmetricAlgorithm symmetricAlgorithm = GetSymmetricAlgorithm(Key, Algorithm);
 
@@ -137,7 +137,7 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogArgumentNullException(nameof(key));
 
             if (!IsSupportedAlgorithm(key, algorithm))
-                throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10661, LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key))));
+                throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10661, LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key.KeyId))));
 
             byte[] keyBytes = null;
 
@@ -172,7 +172,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
             catch (Exception ex)
             {
-                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10663, LogHelper.MarkAsNonPII(key), LogHelper.MarkAsNonPII(algorithm)), ex));
+                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10663, LogHelper.MarkAsNonPII(key.KeyId), LogHelper.MarkAsNonPII(algorithm)), ex));
             }
         }
 

--- a/src/Microsoft.IdentityModel.Tokens/Encryption/SymmetricKeyWrapProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/SymmetricKeyWrapProvider.cs
@@ -67,7 +67,7 @@ namespace Microsoft.IdentityModel.Tokens
         private SymmetricAlgorithm CreateSymmetricAlgorithm()
         {
             if (!IsSupportedAlgorithm(Key, Algorithm))
-                throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10661, LogHelper.MarkAsNonPII(Algorithm), Key)));
+                throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10661, LogHelper.MarkAsNonPII(Algorithm), LogHelper.MarkAsNonPII(Key))));
 
             SymmetricAlgorithm symmetricAlgorithm = GetSymmetricAlgorithm(Key, Algorithm);
 
@@ -137,7 +137,7 @@ namespace Microsoft.IdentityModel.Tokens
                 throw LogHelper.LogArgumentNullException(nameof(key));
 
             if (!IsSupportedAlgorithm(key, algorithm))
-                throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10661, LogHelper.MarkAsNonPII(algorithm), key)));
+                throw LogHelper.LogExceptionMessage(new NotSupportedException(LogHelper.FormatInvariant(LogMessages.IDX10661, LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(key))));
 
             byte[] keyBytes = null;
 
@@ -172,7 +172,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
             catch (Exception ex)
             {
-                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10663, key, LogHelper.MarkAsNonPII(algorithm)), ex));
+                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10663, LogHelper.MarkAsNonPII(key), LogHelper.MarkAsNonPII(algorithm)), ex));
             }
         }
 
@@ -318,7 +318,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (SecurityAlgorithms.Aes128KW.Equals(algorithm) || SecurityAlgorithms.Aes128KeyWrap.Equals(algorithm))
             {
                 if (key.Length != 16)
-                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(key), LogHelper.FormatInvariant(LogMessages.IDX10662, LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(128), Key.KeyId, LogHelper.MarkAsNonPII(key.Length << 3))));
+                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(key), LogHelper.FormatInvariant(LogMessages.IDX10662, LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(128), LogHelper.MarkAsNonPII(Key.KeyId), LogHelper.MarkAsNonPII(key.Length << 3))));
 
                 return;
             }
@@ -326,7 +326,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (SecurityAlgorithms.Aes192KW.Equals(algorithm) || SecurityAlgorithms.Aes192KeyWrap.Equals(algorithm))
             {
                 if (key.Length != 24)
-                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(key), LogHelper.FormatInvariant(LogMessages.IDX10662, LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(128), Key.KeyId, LogHelper.MarkAsNonPII(key.Length << 3))));
+                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(key), LogHelper.FormatInvariant(LogMessages.IDX10662, LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(128), LogHelper.MarkAsNonPII(Key.KeyId), LogHelper.MarkAsNonPII(key.Length << 3))));
 
                 return;
             }
@@ -334,7 +334,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (SecurityAlgorithms.Aes256KW.Equals(algorithm) || (SecurityAlgorithms.Aes256KeyWrap.Equals(algorithm)))
             {
                 if (key.Length != 32)
-                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(key), LogHelper.FormatInvariant(LogMessages.IDX10662, LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(256), Key.KeyId, LogHelper.MarkAsNonPII(key.Length << 3))));
+                    throw LogHelper.LogExceptionMessage(new ArgumentOutOfRangeException(nameof(key), LogHelper.FormatInvariant(LogMessages.IDX10662, LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(256), LogHelper.MarkAsNonPII(Key.KeyId), LogHelper.MarkAsNonPII(key.Length << 3))));
 
                 return;
             }

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeyConverter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeyConverter.cs
@@ -238,11 +238,11 @@ namespace Microsoft.IdentityModel.Tokens
             catch (Exception ex)
             {
                 if (LogHelper.IsEnabled(EventLogLevel.Warning))
-                    LogHelper.LogWarning(LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(SecurityKey)), LogHelper.MarkAsNonPII(webKey), ex));
+                    LogHelper.LogWarning(LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(SecurityKey)), LogHelper.MarkAsNonPII(webKey.KeyId), ex));
             }
 
             if (LogHelper.IsEnabled(EventLogLevel.Warning))
-                LogHelper.LogWarning(LogHelper.FormatInvariant(LogMessages.IDX10812, LogHelper.MarkAsNonPII(typeof(SecurityKey)), LogHelper.MarkAsNonPII(webKey)));
+                LogHelper.LogWarning(LogHelper.FormatInvariant(LogMessages.IDX10812, LogHelper.MarkAsNonPII(typeof(SecurityKey)), LogHelper.MarkAsNonPII(webKey.KeyId)));
 
             return false;
         }
@@ -267,7 +267,7 @@ namespace Microsoft.IdentityModel.Tokens
             catch (Exception ex)
             {
                 if (LogHelper.IsEnabled(EventLogLevel.Error))
-                    LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(SymmetricSecurityKey)), LogHelper.MarkAsNonPII(webKey), ex), ex));
+                    LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(SymmetricSecurityKey)), LogHelper.MarkAsNonPII(webKey.KeyId), ex), ex));
             }
 
             return false;
@@ -294,7 +294,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
             catch (Exception ex)
             {
-                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(X509SecurityKey)), LogHelper.MarkAsNonPII(webKey), ex);
+                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(X509SecurityKey)), LogHelper.MarkAsNonPII(webKey.KeyId), ex);
                 webKey.ConvertKeyInfo = convertKeyInfo;
                 if (LogHelper.IsEnabled(EventLogLevel.Error))
                     LogHelper.LogExceptionMessage(new InvalidOperationException(convertKeyInfo, ex));
@@ -322,7 +322,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
             catch (Exception ex)
             {
-                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(RsaSecurityKey)), LogHelper.MarkAsNonPII(webKey), ex);
+                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(RsaSecurityKey)), LogHelper.MarkAsNonPII(webKey.KeyId), ex);
                 webKey.ConvertKeyInfo = convertKeyInfo;
                 if (LogHelper.IsEnabled(EventLogLevel.Error))
                     LogHelper.LogExceptionMessage(new InvalidOperationException(convertKeyInfo, ex));
@@ -352,7 +352,7 @@ namespace Microsoft.IdentityModel.Tokens
                 if (string.IsNullOrEmpty(webKey.Y))
                     missingComponent.Add(JsonWebKeyParameterNames.Y);
 
-                webKey.ConvertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(ECDsaSecurityKey)), LogHelper.MarkAsNonPII(webKey), string.Join(", ", missingComponent));
+                webKey.ConvertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(ECDsaSecurityKey)), LogHelper.MarkAsNonPII(webKey.KeyId), string.Join(", ", missingComponent));
                 return false;
             }
 
@@ -363,7 +363,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
             catch (Exception ex)
             {
-                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(ECDsaSecurityKey)), LogHelper.MarkAsNonPII(webKey), ex);
+                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(ECDsaSecurityKey)), LogHelper.MarkAsNonPII(webKey.KeyId), ex);
                 webKey.ConvertKeyInfo = convertKeyInfo;
                 if (LogHelper.IsEnabled(EventLogLevel.Error))
                     LogHelper.LogExceptionMessage(new InvalidOperationException(convertKeyInfo, ex));

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeyConverter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeyConverter.cs
@@ -238,11 +238,11 @@ namespace Microsoft.IdentityModel.Tokens
             catch (Exception ex)
             {
                 if (LogHelper.IsEnabled(EventLogLevel.Warning))
-                    LogHelper.LogWarning(LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(SecurityKey)), webKey, ex));
+                    LogHelper.LogWarning(LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(SecurityKey)), LogHelper.MarkAsNonPII(webKey), ex));
             }
 
             if (LogHelper.IsEnabled(EventLogLevel.Warning))
-                LogHelper.LogWarning(LogHelper.FormatInvariant(LogMessages.IDX10812, LogHelper.MarkAsNonPII(typeof(SecurityKey)), webKey));
+                LogHelper.LogWarning(LogHelper.FormatInvariant(LogMessages.IDX10812, LogHelper.MarkAsNonPII(typeof(SecurityKey)), LogHelper.MarkAsNonPII(webKey)));
 
             return false;
         }
@@ -267,7 +267,7 @@ namespace Microsoft.IdentityModel.Tokens
             catch (Exception ex)
             {
                 if (LogHelper.IsEnabled(EventLogLevel.Error))
-                    LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(SymmetricSecurityKey)), webKey, ex), ex));
+                    LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(SymmetricSecurityKey)), LogHelper.MarkAsNonPII(webKey), ex), ex));
             }
 
             return false;
@@ -294,7 +294,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
             catch (Exception ex)
             {
-                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(X509SecurityKey)), webKey, ex);
+                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(X509SecurityKey)), LogHelper.MarkAsNonPII(webKey), ex);
                 webKey.ConvertKeyInfo = convertKeyInfo;
                 if (LogHelper.IsEnabled(EventLogLevel.Error))
                     LogHelper.LogExceptionMessage(new InvalidOperationException(convertKeyInfo, ex));
@@ -322,7 +322,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
             catch (Exception ex)
             {
-                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(RsaSecurityKey)), webKey, ex);
+                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(RsaSecurityKey)), LogHelper.MarkAsNonPII(webKey), ex);
                 webKey.ConvertKeyInfo = convertKeyInfo;
                 if (LogHelper.IsEnabled(EventLogLevel.Error))
                     LogHelper.LogExceptionMessage(new InvalidOperationException(convertKeyInfo, ex));
@@ -352,7 +352,7 @@ namespace Microsoft.IdentityModel.Tokens
                 if (string.IsNullOrEmpty(webKey.Y))
                     missingComponent.Add(JsonWebKeyParameterNames.Y);
 
-                webKey.ConvertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(ECDsaSecurityKey)), webKey, string.Join(", ", missingComponent));
+                webKey.ConvertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(ECDsaSecurityKey)), LogHelper.MarkAsNonPII(webKey), string.Join(", ", missingComponent));
                 return false;
             }
 
@@ -363,7 +363,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
             catch (Exception ex)
             {
-                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(ECDsaSecurityKey)), webKey, ex);
+                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10813, LogHelper.MarkAsNonPII(typeof(ECDsaSecurityKey)), LogHelper.MarkAsNonPII(webKey), ex);
                 webKey.ConvertKeyInfo = convertKeyInfo;
                 if (LogHelper.IsEnabled(EventLogLevel.Error))
                     LogHelper.LogExceptionMessage(new InvalidOperationException(convertKeyInfo, ex));

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
@@ -131,7 +131,7 @@ namespace Microsoft.IdentityModel.Tokens
                 // https://datatracker.ietf.org/doc/html/rfc7517#section-4-2
                 if (!string.IsNullOrEmpty(webKey.Use) && !webKey.Use.Equals(JsonWebKeyUseNames.Sig))
                 {
-                    string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10808, webKey, webKey.Use);
+                    string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10808, LogHelper.MarkAsNonPII(webKey), webKey.Use);
                     webKey.ConvertKeyInfo = convertKeyInfo;
                     LogHelper.LogInformation(convertKeyInfo);
                     if (!SkipUnresolvedJsonWebKeys)
@@ -148,7 +148,7 @@ namespace Microsoft.IdentityModel.Tokens
                     if ((webKey.X5c == null || webKey.X5c.Count == 0) && (string.IsNullOrEmpty(webKey.E) && string.IsNullOrEmpty(webKey.N)))
                     {
                         var missingComponent = new List<string> { JsonWebKeyParameterNames.X5c, JsonWebKeyParameterNames.E, JsonWebKeyParameterNames.N };
-                        string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(RsaSecurityKey)), webKey, LogHelper.MarkAsNonPII(string.Join(", ", missingComponent)));
+                        string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(RsaSecurityKey)), LogHelper.MarkAsNonPII(webKey), LogHelper.MarkAsNonPII(string.Join(", ", missingComponent)));
                         webKey.ConvertKeyInfo = convertKeyInfo;
                         LogHelper.LogInformation(convertKeyInfo);
                         rsaKeyResolved = false;
@@ -182,7 +182,7 @@ namespace Microsoft.IdentityModel.Tokens
                 }
                 else
                 {
-                    string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10810, webKey);
+                    string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10810, LogHelper.MarkAsNonPII(webKey));
                     webKey.ConvertKeyInfo = convertKeyInfo;
                     LogHelper.LogInformation(convertKeyInfo);
 
@@ -198,7 +198,7 @@ namespace Microsoft.IdentityModel.Tokens
         {
             if (webKey.X5c == null || webKey.X5c.Count == 0)
             {
-                webKey.ConvertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(X509SecurityKey)), webKey, LogHelper.MarkAsNonPII(JsonWebKeyParameterNames.X5c));
+                webKey.ConvertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(X509SecurityKey)), LogHelper.MarkAsNonPII(webKey), LogHelper.MarkAsNonPII(JsonWebKeyParameterNames.X5c));
                 return false;
             }
 
@@ -216,7 +216,7 @@ namespace Microsoft.IdentityModel.Tokens
 
             if (missingComponent.Count > 0)
             {
-                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(RsaSecurityKey)), webKey, LogHelper.MarkAsNonPII(string.Join(", ", missingComponent)));
+                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(RsaSecurityKey)), LogHelper.MarkAsNonPII(webKey), LogHelper.MarkAsNonPII(string.Join(", ", missingComponent)));
                 if (string.IsNullOrEmpty(webKey.ConvertKeyInfo))
                     webKey.ConvertKeyInfo = convertKeyInfo;
                 else

--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeySet.cs
@@ -131,7 +131,7 @@ namespace Microsoft.IdentityModel.Tokens
                 // https://datatracker.ietf.org/doc/html/rfc7517#section-4-2
                 if (!string.IsNullOrEmpty(webKey.Use) && !webKey.Use.Equals(JsonWebKeyUseNames.Sig))
                 {
-                    string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10808, LogHelper.MarkAsNonPII(webKey), webKey.Use);
+                    string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10808, LogHelper.MarkAsNonPII(webKey.KeyId), webKey.Use);
                     webKey.ConvertKeyInfo = convertKeyInfo;
                     LogHelper.LogInformation(convertKeyInfo);
                     if (!SkipUnresolvedJsonWebKeys)
@@ -148,7 +148,7 @@ namespace Microsoft.IdentityModel.Tokens
                     if ((webKey.X5c == null || webKey.X5c.Count == 0) && (string.IsNullOrEmpty(webKey.E) && string.IsNullOrEmpty(webKey.N)))
                     {
                         var missingComponent = new List<string> { JsonWebKeyParameterNames.X5c, JsonWebKeyParameterNames.E, JsonWebKeyParameterNames.N };
-                        string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(RsaSecurityKey)), LogHelper.MarkAsNonPII(webKey), LogHelper.MarkAsNonPII(string.Join(", ", missingComponent)));
+                        string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(RsaSecurityKey)), LogHelper.MarkAsNonPII(webKey.KeyId), LogHelper.MarkAsNonPII(string.Join(", ", missingComponent)));
                         webKey.ConvertKeyInfo = convertKeyInfo;
                         LogHelper.LogInformation(convertKeyInfo);
                         rsaKeyResolved = false;
@@ -182,7 +182,7 @@ namespace Microsoft.IdentityModel.Tokens
                 }
                 else
                 {
-                    string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10810, LogHelper.MarkAsNonPII(webKey));
+                    string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10810, LogHelper.MarkAsNonPII(webKey.KeyId));
                     webKey.ConvertKeyInfo = convertKeyInfo;
                     LogHelper.LogInformation(convertKeyInfo);
 
@@ -198,7 +198,7 @@ namespace Microsoft.IdentityModel.Tokens
         {
             if (webKey.X5c == null || webKey.X5c.Count == 0)
             {
-                webKey.ConvertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(X509SecurityKey)), LogHelper.MarkAsNonPII(webKey), LogHelper.MarkAsNonPII(JsonWebKeyParameterNames.X5c));
+                webKey.ConvertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(X509SecurityKey)), LogHelper.MarkAsNonPII(webKey.KeyId), LogHelper.MarkAsNonPII(JsonWebKeyParameterNames.X5c));
                 return false;
             }
 
@@ -216,7 +216,7 @@ namespace Microsoft.IdentityModel.Tokens
 
             if (missingComponent.Count > 0)
             {
-                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(RsaSecurityKey)), LogHelper.MarkAsNonPII(webKey), LogHelper.MarkAsNonPII(string.Join(", ", missingComponent)));
+                string convertKeyInfo = LogHelper.FormatInvariant(LogMessages.IDX10814, LogHelper.MarkAsNonPII(typeof(RsaSecurityKey)), LogHelper.MarkAsNonPII(webKey.KeyId), LogHelper.MarkAsNonPII(string.Join(", ", missingComponent)));
                 if (string.IsNullOrEmpty(webKey.ConvertKeyInfo))
                     webKey.ConvertKeyInfo = convertKeyInfo;
                 else

--- a/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
@@ -77,7 +77,7 @@ namespace Microsoft.IdentityModel.Tokens
                     new NotSupportedException(
                         LogHelper.FormatInvariant(
                             LogMessages.IDX10634,
-                            LogHelper.MarkAsNonPII((algorithm)), key)));
+                            LogHelper.MarkAsNonPII((algorithm)), LogHelper.MarkAsNonPII(key))));
 
             if (key.KeySize < MinimumSymmetricKeySizeInBits)
                 throw LogHelper.LogExceptionMessage(
@@ -89,7 +89,7 @@ namespace Microsoft.IdentityModel.Tokens
                                 (algorithm)),
                             LogHelper.MarkAsNonPII(
                                 MinimumSymmetricKeySizeInBits),
-                            key,
+                            LogHelper.MarkAsNonPII(key),
                             LogHelper.MarkAsNonPII(key.KeySize))));
 
             WillCreateSignatures = willCreateSignatures;
@@ -144,7 +144,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (key is JsonWebKey jsonWebKey && jsonWebKey.K != null && jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.Octet)
                 return Base64UrlEncoder.DecodeBytes(jsonWebKey.K);
 
-            throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10667, key)));
+            throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10667, LogHelper.MarkAsNonPII(key))));
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SymmetricSignatureProvider.cs
@@ -77,7 +77,7 @@ namespace Microsoft.IdentityModel.Tokens
                     new NotSupportedException(
                         LogHelper.FormatInvariant(
                             LogMessages.IDX10634,
-                            LogHelper.MarkAsNonPII((algorithm)), LogHelper.MarkAsNonPII(key))));
+                            LogHelper.MarkAsNonPII((algorithm)), LogHelper.MarkAsNonPII(key.KeyId))));
 
             if (key.KeySize < MinimumSymmetricKeySizeInBits)
                 throw LogHelper.LogExceptionMessage(
@@ -89,7 +89,7 @@ namespace Microsoft.IdentityModel.Tokens
                                 (algorithm)),
                             LogHelper.MarkAsNonPII(
                                 MinimumSymmetricKeySizeInBits),
-                            LogHelper.MarkAsNonPII(key),
+                            LogHelper.MarkAsNonPII(key.KeyId),
                             LogHelper.MarkAsNonPII(key.KeySize))));
 
             WillCreateSignatures = willCreateSignatures;
@@ -144,7 +144,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (key is JsonWebKey jsonWebKey && jsonWebKey.K != null && jsonWebKey.Kty == JsonWebAlgorithmsKeyTypes.Octet)
                 return Base64UrlEncoder.DecodeBytes(jsonWebKey.K);
 
-            throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10667, LogHelper.MarkAsNonPII(key))));
+            throw LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(LogMessages.IDX10667, LogHelper.MarkAsNonPII(key.KeyId))));
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/Validators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validators.cs
@@ -365,7 +365,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters.IssuerSigningKeyValidatorUsingConfiguration != null)
             {
                 if (!validationParameters.IssuerSigningKeyValidatorUsingConfiguration(securityKey, securityToken, validationParameters, configuration))
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, securityKey)) { SigningKey = securityKey });
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, LogHelper.MarkAsNonPII(securityKey.ToString()))) { SigningKey = securityKey });
 
                 return;
             }
@@ -373,7 +373,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters.IssuerSigningKeyValidator != null)
             {
                 if (!validationParameters.IssuerSigningKeyValidator(securityKey, securityToken, validationParameters))
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, securityKey)) { SigningKey = securityKey });
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, LogHelper.MarkAsNonPII(securityKey.ToString()))) { SigningKey = securityKey });
 
                 return;
             }

--- a/src/Microsoft.IdentityModel.Tokens/Validators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validators.cs
@@ -32,7 +32,7 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 if (!validationParameters.AlgorithmValidator(algorithm, securityKey, securityToken, validationParameters))
                 {
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidAlgorithmException(LogHelper.FormatInvariant(LogMessages.IDX10697, LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(securityKey)))
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidAlgorithmException(LogHelper.FormatInvariant(LogMessages.IDX10697, LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(securityKey?.KeyId)))
                     {
                         InvalidAlgorithm = algorithm,
                     });
@@ -365,7 +365,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters.IssuerSigningKeyValidatorUsingConfiguration != null)
             {
                 if (!validationParameters.IssuerSigningKeyValidatorUsingConfiguration(securityKey, securityToken, validationParameters, configuration))
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, LogHelper.MarkAsNonPII(securityKey))) { SigningKey = securityKey });
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, LogHelper.MarkAsNonPII(securityKey?.KeyId))) { SigningKey = securityKey });
 
                 return;
             }
@@ -373,7 +373,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters.IssuerSigningKeyValidator != null)
             {
                 if (!validationParameters.IssuerSigningKeyValidator(securityKey, securityToken, validationParameters))
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, LogHelper.MarkAsNonPII(securityKey))) { SigningKey = securityKey });
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, LogHelper.MarkAsNonPII(securityKey?.KeyId))) { SigningKey = securityKey });
 
                 return;
             }

--- a/src/Microsoft.IdentityModel.Tokens/Validators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validators.cs
@@ -32,7 +32,7 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 if (!validationParameters.AlgorithmValidator(algorithm, securityKey, securityToken, validationParameters))
                 {
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidAlgorithmException(LogHelper.FormatInvariant(LogMessages.IDX10697, LogHelper.MarkAsNonPII(algorithm), securityKey))
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidAlgorithmException(LogHelper.FormatInvariant(LogMessages.IDX10697, LogHelper.MarkAsNonPII(algorithm), LogHelper.MarkAsNonPII(securityKey)))
                     {
                         InvalidAlgorithm = algorithm,
                     });
@@ -365,7 +365,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters.IssuerSigningKeyValidatorUsingConfiguration != null)
             {
                 if (!validationParameters.IssuerSigningKeyValidatorUsingConfiguration(securityKey, securityToken, validationParameters, configuration))
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, LogHelper.MarkAsNonPII(securityKey.ToString()))) { SigningKey = securityKey });
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, LogHelper.MarkAsNonPII(securityKey))) { SigningKey = securityKey });
 
                 return;
             }
@@ -373,7 +373,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (validationParameters.IssuerSigningKeyValidator != null)
             {
                 if (!validationParameters.IssuerSigningKeyValidator(securityKey, securityToken, validationParameters))
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, LogHelper.MarkAsNonPII(securityKey.ToString()))) { SigningKey = securityKey });
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSigningKeyException(LogHelper.FormatInvariant(LogMessages.IDX10232, LogHelper.MarkAsNonPII(securityKey))) { SigningKey = securityKey });
 
                 return;
             }

--- a/src/Microsoft.IdentityModel.Xml/Signature.cs
+++ b/src/Microsoft.IdentityModel.Xml/Signature.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
 using static Microsoft.IdentityModel.Logging.LogHelper;
 using static Microsoft.IdentityModel.Xml.XmlUtil;
@@ -105,7 +106,7 @@ namespace Microsoft.IdentityModel.Xml
 
             var signatureProvider = cryptoProviderFactory.CreateForVerifying(key, SignedInfo.SignatureMethod);
             if (signatureProvider == null)
-                throw LogValidationException(LogMessages.IDX30203, cryptoProviderFactory, key, SignedInfo.SignatureMethod);
+                throw LogValidationException(LogMessages.IDX30203, cryptoProviderFactory, LogHelper.MarkAsNonPII(key), SignedInfo.SignatureMethod);
 
             try
             {
@@ -113,7 +114,7 @@ namespace Microsoft.IdentityModel.Xml
                 {
                     SignedInfo.GetCanonicalBytes(memoryStream);
                     if (!signatureProvider.Verify(memoryStream.ToArray(), Convert.FromBase64String(SignatureValue)))
-                        throw LogValidationException(LogMessages.IDX30200, cryptoProviderFactory, key);
+                        throw LogValidationException(LogMessages.IDX30200, cryptoProviderFactory, LogHelper.MarkAsNonPII(key));
                 }
 
                 SignedInfo.Verify(cryptoProviderFactory);
@@ -160,7 +161,7 @@ namespace Microsoft.IdentityModel.Xml
             var signatureProvider = cryptoProviderFactory.CreateForVerifying(key, SignedInfo.SignatureMethod);
             if (signatureProvider is null)
                 return new SignatureValidationError(
-                    new MessageDetail(LogMessages.IDX30203, cryptoProviderFactory, key, SignedInfo.SignatureMethod),
+                    new MessageDetail(LogMessages.IDX30203, cryptoProviderFactory, LogHelper.MarkAsNonPII(key), SignedInfo.SignatureMethod),
                     ValidationFailureType.XmlValidationFailed,
                     typeof(SecurityTokenInvalidSignatureException),
                     ValidationError.GetCurrentStackFrame());
@@ -175,7 +176,7 @@ namespace Microsoft.IdentityModel.Xml
                     if (!signatureProvider.Verify(memoryStream.ToArray(), Convert.FromBase64String(SignatureValue)))
                     {
                         validationError = new SignatureValidationError(
-                            new MessageDetail(LogMessages.IDX30200, cryptoProviderFactory, key),
+                            new MessageDetail(LogMessages.IDX30200, cryptoProviderFactory, LogHelper.MarkAsNonPII(key)),
                             ValidationFailureType.XmlValidationFailed,
                             typeof(SecurityTokenInvalidSignatureException),
                             ValidationError.GetCurrentStackFrame());

--- a/src/Microsoft.IdentityModel.Xml/Signature.cs
+++ b/src/Microsoft.IdentityModel.Xml/Signature.cs
@@ -106,7 +106,7 @@ namespace Microsoft.IdentityModel.Xml
 
             var signatureProvider = cryptoProviderFactory.CreateForVerifying(key, SignedInfo.SignatureMethod);
             if (signatureProvider == null)
-                throw LogValidationException(LogMessages.IDX30203, cryptoProviderFactory, LogHelper.MarkAsNonPII(key), SignedInfo.SignatureMethod);
+                throw LogValidationException(LogMessages.IDX30203, cryptoProviderFactory, LogHelper.MarkAsNonPII(key.KeyId), SignedInfo.SignatureMethod);
 
             try
             {
@@ -114,7 +114,7 @@ namespace Microsoft.IdentityModel.Xml
                 {
                     SignedInfo.GetCanonicalBytes(memoryStream);
                     if (!signatureProvider.Verify(memoryStream.ToArray(), Convert.FromBase64String(SignatureValue)))
-                        throw LogValidationException(LogMessages.IDX30200, cryptoProviderFactory, LogHelper.MarkAsNonPII(key));
+                        throw LogValidationException(LogMessages.IDX30200, cryptoProviderFactory, LogHelper.MarkAsNonPII(key.KeyId));
                 }
 
                 SignedInfo.Verify(cryptoProviderFactory);
@@ -161,7 +161,7 @@ namespace Microsoft.IdentityModel.Xml
             var signatureProvider = cryptoProviderFactory.CreateForVerifying(key, SignedInfo.SignatureMethod);
             if (signatureProvider is null)
                 return new SignatureValidationError(
-                    new MessageDetail(LogMessages.IDX30203, cryptoProviderFactory, LogHelper.MarkAsNonPII(key), SignedInfo.SignatureMethod),
+                    new MessageDetail(LogMessages.IDX30203, cryptoProviderFactory, LogHelper.MarkAsNonPII(key.KeyId), SignedInfo.SignatureMethod),
                     ValidationFailureType.XmlValidationFailed,
                     typeof(SecurityTokenInvalidSignatureException),
                     ValidationError.GetCurrentStackFrame());
@@ -176,7 +176,7 @@ namespace Microsoft.IdentityModel.Xml
                     if (!signatureProvider.Verify(memoryStream.ToArray(), Convert.FromBase64String(SignatureValue)))
                     {
                         validationError = new SignatureValidationError(
-                            new MessageDetail(LogMessages.IDX30200, cryptoProviderFactory, LogHelper.MarkAsNonPII(key)),
+                            new MessageDetail(LogMessages.IDX30200, cryptoProviderFactory, LogHelper.MarkAsNonPII(key.KeyId)),
                             ValidationFailureType.XmlValidationFailed,
                             typeof(SecurityTokenInvalidSignatureException),
                             ValidationError.GetCurrentStackFrame());

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -690,7 +690,7 @@ namespace System.IdentityModel.Tokens.Jwt
                 catch (Exception ex)
                 {
                     throw LogHelper.LogExceptionMessage(new SecurityTokenEncryptionFailedException(
-                        LogHelper.FormatInvariant(TokenLogMessages.IDX10616, LogHelper.MarkAsNonPII(encryptingCredentials.Enc), LogHelper.MarkAsNonPII(encryptingCredentials.Key.ToString())), ex));
+                        LogHelper.FormatInvariant(TokenLogMessages.IDX10616, LogHelper.MarkAsNonPII(encryptingCredentials.Enc), LogHelper.MarkAsNonPII(encryptingCredentials.Key.KeyId)), ex));
                 }
             }
         }
@@ -1256,7 +1256,7 @@ namespace System.IdentityModel.Tokens.Jwt
             if (signatureProvider == null)
                 throw LogHelper.LogExceptionMessage(
                     new InvalidOperationException(
-                        LogHelper.FormatInvariant(TokenLogMessages.IDX10636, LogHelper.MarkAsNonPII(key == null ? "Null" : key.ToString()), LogHelper.MarkAsNonPII(algorithm))));
+                        LogHelper.FormatInvariant(TokenLogMessages.IDX10636, LogHelper.MarkAsNonPII(key == null ? "Null" : key.KeyId), LogHelper.MarkAsNonPII(algorithm))));
 
             try
             {
@@ -1855,7 +1855,7 @@ namespace System.IdentityModel.Tokens.Jwt
                 {
                     exceptionStrings.AppendLine(ex.ToString());
                 }
-                keysAttempted.AppendLine(key.ToString());
+                keysAttempted.AppendLine(key.KeyId);
             }
 
             if (unwrappedKeys.Count > 0 || exceptionStrings.Length == 0)

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -689,7 +689,8 @@ namespace System.IdentityModel.Tokens.Jwt
                 }
                 catch (Exception ex)
                 {
-                    throw LogHelper.LogExceptionMessage(new SecurityTokenEncryptionFailedException(LogHelper.FormatInvariant(TokenLogMessages.IDX10616, LogHelper.MarkAsNonPII(encryptingCredentials.Enc), encryptingCredentials.Key), ex));
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenEncryptionFailedException(
+                        LogHelper.FormatInvariant(TokenLogMessages.IDX10616, LogHelper.MarkAsNonPII(encryptingCredentials.Enc), LogHelper.MarkAsNonPII(encryptingCredentials.Key.ToString())), ex));
                 }
             }
         }
@@ -1858,7 +1859,7 @@ namespace System.IdentityModel.Tokens.Jwt
             if (unwrappedKeys.Count > 0 || exceptionStrings.Length == 0)
                 return unwrappedKeys;
             else
-                throw LogHelper.LogExceptionMessage(new SecurityTokenKeyWrapException(LogHelper.FormatInvariant(TokenLogMessages.IDX10618, keysAttempted, exceptionStrings, jwtToken)));
+                throw LogHelper.LogExceptionMessage(new SecurityTokenKeyWrapException(LogHelper.FormatInvariant(TokenLogMessages.IDX10618, LogHelper.MarkAsNonPII(keysAttempted.ToString()), exceptionStrings, jwtToken)));
         }
 
         private static byte[] GetSymmetricSecurityKey(SecurityKey key)

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1254,7 +1254,9 @@ namespace System.IdentityModel.Tokens.Jwt
             var cryptoProviderFactory = validationParameters.CryptoProviderFactory ?? key.CryptoProviderFactory;
             var signatureProvider = cryptoProviderFactory.CreateForVerifying(key, algorithm);
             if (signatureProvider == null)
-                throw LogHelper.LogExceptionMessage(new InvalidOperationException(LogHelper.FormatInvariant(TokenLogMessages.IDX10636, key == null ? "Null" : key.ToString(), LogHelper.MarkAsNonPII(algorithm))));
+                throw LogHelper.LogExceptionMessage(
+                    new InvalidOperationException(
+                        LogHelper.FormatInvariant(TokenLogMessages.IDX10636, LogHelper.MarkAsNonPII(key == null ? "Null" : key.ToString()), LogHelper.MarkAsNonPII(algorithm))));
 
             try
             {


### PR DESCRIPTION
Fixes #3104