### PR TITLE
App context switch to allow blocking or non-blocking GetConfiguration

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -18,17 +18,21 @@ namespace Microsoft.IdentityModel.Protocols
     /// </summary>
     /// <typeparam name="T">The type of <see cref="IDocumentRetriever"/>.</typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable")]
-    public class ConfigurationManager<T> : BaseConfigurationManager, IConfigurationManager<T> where T : class
+    public partial class ConfigurationManager<T> : BaseConfigurationManager, IConfigurationManager<T> where T : class
     {
-        // To prevent tearing, this needs to be only updated through AtomicUpdateSyncAfter.
-        // Reads should be done through the property SyncAfter.
         private DateTime _syncAfter = DateTime.MinValue;
-        private DateTime SyncAfter => _syncAfter;
+        private DateTime SyncAfter
+        {
+            get => _syncAfter;
+            set => AtomicUpdateDateTime(ref _syncAfter, ref value);
+        }
 
-        // See comment above, this should only be updated through AtomicUpdateLastRequestRefresh,
-        // read through LastRequestRefresh.
         private DateTime _lastRequestRefresh = DateTime.MinValue;
-        private DateTime LastRequestRefresh => _lastRequestRefresh;
+        private DateTime LastRequestRefresh
+        {
+            get => _lastRequestRefresh;
+            set => AtomicUpdateDateTime(ref _lastRequestRefresh, ref value);
+        }
 
         private bool _isFirstRefreshRequest = true;
         private readonly SemaphoreSlim _configurationNullLock = new SemaphoreSlim(1);
@@ -55,6 +59,8 @@ namespace Microsoft.IdentityModel.Protocols
         // refresh interval has passed.
         bool _refreshRequested;
 
+        private readonly AutoResetEvent _updateMetadata = new(false);
+        Task _updateMetadataTask;
 
         /// <summary>
         /// Instantiates a new <see cref="ConfigurationManager{T}"/> that manages automatic and controls refreshing on configuration data.
@@ -117,6 +123,7 @@ namespace Microsoft.IdentityModel.Protocols
             MetadataAddress = metadataAddress;
             _docRetriever = docRetriever;
             _configRetriever = configRetriever;
+            EnsureBackgroundTaskIsRunning();
         }
 
         /// <summary>
@@ -171,6 +178,14 @@ namespace Microsoft.IdentityModel.Protocols
             if (_currentConfiguration != null && SyncAfter > _timeProvider.GetUtcNow())
                 return _currentConfiguration;
 
+            if (AppContextSwitches.UpdateConfigAsBlocking)
+                return await GetConfigurationWithBlockingAsync(cancel).ConfigureAwait(false);
+            else
+                return await GetConfigurationWithBackgroundTaskUpdatesAsync(cancel).ConfigureAwait(false);
+        }
+
+        private async Task<T> GetConfigurationWithBackgroundTaskUpdatesAsync(CancellationToken cancel)
+        {
             Exception fetchMetadataFailure = null;
 
             // LOGIC
@@ -246,38 +261,10 @@ namespace Microsoft.IdentityModel.Protocols
             {
                 if (Interlocked.CompareExchange(ref _configurationRetrieverState, ConfigurationRetrieverRunning, ConfigurationRetrieverIdle) == ConfigurationRetrieverIdle)
                 {
-                    if (_refreshRequested)
+                    if (SyncAfter <= _timeProvider.GetUtcNow())
                     {
-                        _refreshRequested = false;
-
-                        try
-                        {
-                            // Log as manual because RequestRefresh was called
-                            TelemetryClient.IncrementConfigurationRefreshRequestCounter(
-                                MetadataAddress,
-                                TelemetryConstants.Protocols.Manual);
-                        }
-#pragma warning disable CA1031 // Do not catch general exception types
-                        catch
-                        { }
-#pragma warning restore CA1031 // Do not catch general exception types
-
-                        UpdateCurrentConfiguration();
-                    }
-                    else if (SyncAfter <= _timeProvider.GetUtcNow())
-                    {
-                        try
-                        {
-                            TelemetryClient.IncrementConfigurationRefreshRequestCounter(
-                                MetadataAddress,
-                                TelemetryConstants.Protocols.Automatic);
-                        }
-#pragma warning disable CA1031 // Do not catch general exception types
-                        catch
-                        { }
-#pragma warning restore CA1031 // Do not catch general exception types
-
-                        _ = Task.Run(UpdateCurrentConfiguration, CancellationToken.None);
+                        EnsureBackgroundTaskIsRunning();
+                        _updateMetadata.Set();
                     }
                     else
                     {
@@ -300,6 +287,40 @@ namespace Microsoft.IdentityModel.Protocols
                     fetchMetadataFailure));
         }
 
+        private void EnsureBackgroundTaskIsRunning()
+        {
+            if (_updateMetadataTask == null || _updateMetadataTask.Status != TaskStatus.Running)
+                _updateMetadataTask = Task.Run(UpdateCurrentConfigurationUsingSignals, CancellationToken.None);
+        }
+
+        private void TelemetryForUpdate()
+        {
+            var updateMode = _refreshRequested ? TelemetryConstants.Protocols.Manual : TelemetryConstants.Protocols.Automatic;
+
+            if (_refreshRequested)
+                _refreshRequested = false;
+
+            try
+            {
+                TelemetryClient.IncrementConfigurationRefreshRequestCounter(
+                    MetadataAddress,
+                    updateMode);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch
+            { }
+#pragma warning restore CA1031 // Do not catch general exception types
+        }
+
+        private void UpdateCurrentConfigurationUsingSignals()
+        {
+            while (true)
+            {
+                _updateMetadata.WaitOne();
+                UpdateCurrentConfiguration();
+            }
+        }
+
         /// <summary>
         /// This should be called when the configuration needs to be updated either from RequestRefresh or AutomaticRefresh
         /// The Caller should first check the state checking state using:
@@ -307,6 +328,7 @@ namespace Microsoft.IdentityModel.Protocols
         /// </summary>
         private void UpdateCurrentConfiguration()
         {
+            TelemetryForUpdate();
 #pragma warning disable CA1031 // Do not catch general exception types
             long startTimestamp = _timeProvider.GetTimestamp();
 
@@ -368,25 +390,17 @@ namespace Microsoft.IdentityModel.Protocols
             _currentConfiguration = configuration;
             var newSyncTime = DateTimeUtil.Add(_timeProvider.GetUtcNow().UtcDateTime, AutomaticRefreshInterval +
                 TimeSpan.FromSeconds(new Random().Next((int)AutomaticRefreshInterval.TotalSeconds / 20)));
-            AtomicUpdateSyncAfter(newSyncTime);
+            SyncAfter = newSyncTime;
         }
 
-        private void AtomicUpdateSyncAfter(DateTime syncAfter)
+        private static void AtomicUpdateDateTime(ref DateTime field, ref DateTime value)
         {
             // DateTime's backing data is safe to treat as a long if the Kind is not local.
-            // _syncAfter will always be updated to a UTC time.
+            // time will always be updated to a UTC time.
             // See the implementation of ToBinary on DateTime.
             Interlocked.Exchange(
-                ref Unsafe.As<DateTime, long>(ref _syncAfter),
-                Unsafe.As<DateTime, long>(ref syncAfter));
-        }
-
-        private void AtomicUpdateLastRequestRefresh(DateTime lastRequestRefresh)
-        {
-            // See the comment in AtomicUpdateSyncAfter.
-            Interlocked.Exchange(
-                ref Unsafe.As<DateTime, long>(ref _lastRequestRefresh),
-                Unsafe.As<DateTime, long>(ref lastRequestRefresh));
+                ref Unsafe.As<DateTime, long>(ref field),
+                Unsafe.As<DateTime, long>(ref value));
         }
 
         /// <summary>
@@ -409,14 +423,30 @@ namespace Microsoft.IdentityModel.Protocols
         /// </summary>
         public override void RequestRefresh()
         {
+            if (AppContextSwitches.UpdateConfigAsBlocking)
+            {
+                RequestRefreshBlocking();
+            }
+            else
+            {
+                RequestRefreshBackgroundThread();
+            }
+        }
+
+        private void RequestRefreshBackgroundThread()
+        {
             DateTime now = _timeProvider.GetUtcNow().UtcDateTime;
 
             if (now >= DateTimeUtil.Add(LastRequestRefresh, RefreshInterval) || _isFirstRefreshRequest)
             {
                 _isFirstRefreshRequest = false;
-                AtomicUpdateSyncAfter(now);
-                AtomicUpdateLastRequestRefresh(now);
-                _refreshRequested = true;
+
+                if (Interlocked.CompareExchange(ref _configurationRetrieverState, ConfigurationRetrieverRunning, ConfigurationRetrieverIdle) == ConfigurationRetrieverIdle)
+                {
+                    _refreshRequested = true;
+                    LastRequestRefresh = now;
+                    _updateMetadata.Set();
+                }
             }
         }
 

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -22,7 +22,7 @@ namespace Microsoft.IdentityModel.Protocols
     {
 #pragma warning disable IDE0044 // Add readonly modifier
 #pragma warning disable CS0649 // Unused, it gets used in tests.
-        private Action _onBackgroundTaskFinish;
+        internal Action _onBackgroundTaskFinish;
 #pragma warning restore CS0649 // Unused
 #pragma warning restore IDE0044 // Add readonly modifier
 
@@ -65,7 +65,13 @@ namespace Microsoft.IdentityModel.Protocols
         // refresh interval has passed.
         bool _refreshRequested;
 
-        private readonly AutoResetEvent _updateMetadata = new(false);
+        // Wait handle used to signal a background task to update the configuration.
+        // Handle starts unset, and AutoResetEvent.Set() sets it, this indicates that
+        // the background refresh task should immediately run.
+        private readonly AutoResetEvent _updateMetadataEvent = new(false);
+
+        // Background task that updates the configuration. Signaled with _updateMetadataEvent.
+        // Task should be started with EnsureBackgroundRefreshTaskIsRunning.
         Task _updateMetadataTask;
 
         /// <summary>
@@ -74,7 +80,7 @@ namespace Microsoft.IdentityModel.Protocols
         /// then this will not be used.
         /// Note that this does not influence <see cref="GetConfigurationAsync(CancellationToken)"/>.
         /// </summary>
-        public CancellationToken BackgroundTaskCancellationToken { get; set; }
+        public CancellationToken BackgroundRefreshTaskCancellationToken { get; set; }
 
         /// <summary>
         /// Instantiates a new <see cref="ConfigurationManager{T}"/> that manages automatic and controls refreshing on configuration data.
@@ -139,7 +145,7 @@ namespace Microsoft.IdentityModel.Protocols
             _configRetriever = configRetriever;
 
             if (!AppContextSwitches.UpdateConfigAsBlocking)
-                EnsureBackgroundTaskIsRunning();
+                EnsureBackgroundRefreshTaskIsRunning();
         }
 
         /// <summary>
@@ -279,8 +285,8 @@ namespace Microsoft.IdentityModel.Protocols
                 {
                     if (SyncAfter <= _timeProvider.GetUtcNow())
                     {
-                        EnsureBackgroundTaskIsRunning();
-                        _updateMetadata.Set();
+                        EnsureBackgroundRefreshTaskIsRunning();
+                        _updateMetadataEvent.Set();
                     }
                     else
                     {
@@ -303,9 +309,9 @@ namespace Microsoft.IdentityModel.Protocols
                     fetchMetadataFailure));
         }
 
-        private void EnsureBackgroundTaskIsRunning()
+        private void EnsureBackgroundRefreshTaskIsRunning()
         {
-            if (BackgroundTaskCancellationToken.IsCancellationRequested)
+            if (BackgroundRefreshTaskCancellationToken.IsCancellationRequested)
                 return;
 
             if (_updateMetadataTask == null || _updateMetadataTask.Status != TaskStatus.Running)
@@ -335,9 +341,9 @@ namespace Microsoft.IdentityModel.Protocols
         {
             try
             {
-                while (!BackgroundTaskCancellationToken.IsCancellationRequested)
+                while (!BackgroundRefreshTaskCancellationToken.IsCancellationRequested)
                 {
-                    if (_updateMetadata.WaitOne(500))
+                    if (_updateMetadataEvent.WaitOne(500))
                     {
                         UpdateCurrentConfiguration();
                         _onBackgroundTaskFinish?.Invoke();
@@ -473,8 +479,8 @@ namespace Microsoft.IdentityModel.Protocols
                 {
                     _refreshRequested = true;
                     LastRequestRefresh = now;
-                    EnsureBackgroundTaskIsRunning();
-                    _updateMetadata.Set();
+                    EnsureBackgroundRefreshTaskIsRunning();
+                    _updateMetadataEvent.Set();
                 }
             }
         }

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -191,8 +191,14 @@ namespace Microsoft.IdentityModel.Protocols
         /// <summary>
         /// Obtains an updated version of Configuration.
         /// </summary>
-        /// <returns>Configuration of type T.</returns>
-        /// <remarks>If the time since the last call is less than <see cref="BaseConfigurationManager.AutomaticRefreshInterval"/> then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.</remarks>
+        /// <returns>Configuration of type <typeparamref name="T"/>.</returns>
+        /// <remarks>
+        /// If the time since the last call is less than <see cref="BaseConfigurationManager.AutomaticRefreshInterval"/>
+        /// then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.
+        /// If the configuration is not able to be updated, but a previous configuration was previously retrieved, the previous configuration is returned.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException" >Throw if the configuration is unable to be retrieved.</exception>
+        /// <exception cref="InvalidConfigurationException" >Throw if the configuration fails to be validated by the <see cref="IConfigurationValidator{T}"/>.</exception>
         public async Task<T> GetConfigurationAsync()
         {
             return await GetConfigurationAsync(CancellationToken.None).ConfigureAwait(false);
@@ -202,8 +208,14 @@ namespace Microsoft.IdentityModel.Protocols
         /// Obtains an updated version of Configuration.
         /// </summary>
         /// <param name="cancel">CancellationToken</param>
-        /// <returns>Configuration of type T.</returns>
-        /// <remarks>If the time since the last call is less than <see cref="BaseConfigurationManager.AutomaticRefreshInterval"/> then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.</remarks>
+        /// <returns>Configuration of type <typeparamref name="T"/>.</returns>
+        /// <remarks>
+        /// If the time since the last call is less than <see cref="BaseConfigurationManager.AutomaticRefreshInterval"/>
+        /// then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.
+        /// If the configuration is not able to be updated, but a previous configuration was previously retrieved, the previous configuration is returned.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException" >Throw if the configuration is unable to be retrieved.</exception>
+        /// <exception cref="InvalidConfigurationException" >Throw if the configuration fails to be validated by the <see cref="IConfigurationValidator{T}"/>.</exception>
         public virtual async Task<T> GetConfigurationAsync(CancellationToken cancel)
         {
             if (_currentConfiguration != null && SyncAfter > _timeProvider.GetUtcNow())

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -26,8 +26,6 @@ namespace Microsoft.IdentityModel.Protocols
 #pragma warning restore CS0649 // Unused
 #pragma warning restore IDE0044 // Add readonly modifier
 
-        private CancellationToken _BackgroundTaskCancellationToken = CancellationToken.None;
-
         private DateTime _syncAfter = DateTime.MinValue;
         private DateTime SyncAfter
         {
@@ -69,6 +67,14 @@ namespace Microsoft.IdentityModel.Protocols
 
         private readonly AutoResetEvent _updateMetadata = new(false);
         Task _updateMetadataTask;
+
+        /// <summary>
+        /// Cancellation token to control cancelling the background task.
+        /// If 'Switch.Microsoft.IdentityModel.UpdateConfigAsBlocking' is set to true,
+        /// then this will not be used.
+        /// Note that this does not influence <see cref="GetConfigurationAsync(CancellationToken)"/>.
+        /// </summary>
+        public CancellationToken BackgroundTaskCancellationToken { get; set; }
 
         /// <summary>
         /// Instantiates a new <see cref="ConfigurationManager{T}"/> that manages automatic and controls refreshing on configuration data.
@@ -131,7 +137,9 @@ namespace Microsoft.IdentityModel.Protocols
             MetadataAddress = metadataAddress;
             _docRetriever = docRetriever;
             _configRetriever = configRetriever;
-            EnsureBackgroundTaskIsRunning();
+
+            if (!AppContextSwitches.UpdateConfigAsBlocking)
+                EnsureBackgroundTaskIsRunning();
         }
 
         /// <summary>
@@ -297,6 +305,9 @@ namespace Microsoft.IdentityModel.Protocols
 
         private void EnsureBackgroundTaskIsRunning()
         {
+            if (BackgroundTaskCancellationToken.IsCancellationRequested)
+                return;
+
             if (_updateMetadataTask == null || _updateMetadataTask.Status != TaskStatus.Running)
                 _updateMetadataTask = Task.Run(UpdateCurrentConfigurationUsingSignals);
         }
@@ -322,13 +333,19 @@ namespace Microsoft.IdentityModel.Protocols
 
         private void UpdateCurrentConfigurationUsingSignals()
         {
-            while (!_BackgroundTaskCancellationToken.IsCancellationRequested)
+            try
             {
-                if (_updateMetadata.WaitOne(500))
+                while (!BackgroundTaskCancellationToken.IsCancellationRequested)
                 {
-                    UpdateCurrentConfiguration();
-                    _onBackgroundTaskFinish?.Invoke();
+                    if (_updateMetadata.WaitOne(500))
+                    {
+                        UpdateCurrentConfiguration();
+                        _onBackgroundTaskFinish?.Invoke();
+                    }
                 }
+            }
+            catch (Exception)
+            {
             }
         }
 

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -26,7 +26,7 @@ namespace Microsoft.IdentityModel.Protocols
 #pragma warning restore CS0649 // Unused
 #pragma warning restore IDE0044 // Add readonly modifier
 
-        private CancellationToken _cancellationToken = CancellationToken.None;
+        private CancellationToken _BackgroundTaskCancellationToken = CancellationToken.None;
 
         private DateTime _syncAfter = DateTime.MinValue;
         private DateTime SyncAfter
@@ -322,7 +322,7 @@ namespace Microsoft.IdentityModel.Protocols
 
         private void UpdateCurrentConfigurationUsingSignals()
         {
-            while (!_cancellationToken.IsCancellationRequested)
+            while (!_BackgroundTaskCancellationToken.IsCancellationRequested)
             {
                 if (_updateMetadata.WaitOne(500))
                 {
@@ -456,6 +456,7 @@ namespace Microsoft.IdentityModel.Protocols
                 {
                     _refreshRequested = true;
                     LastRequestRefresh = now;
+                    EnsureBackgroundTaskIsRunning();
                     _updateMetadata.Set();
                 }
             }

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -26,6 +26,8 @@ namespace Microsoft.IdentityModel.Protocols
 #pragma warning restore CS0649 // Unused
 #pragma warning restore IDE0044 // Add readonly modifier
 
+        private CancellationToken _cancellationToken = CancellationToken.None;
+
         private DateTime _syncAfter = DateTime.MinValue;
         private DateTime SyncAfter
         {
@@ -296,7 +298,7 @@ namespace Microsoft.IdentityModel.Protocols
         private void EnsureBackgroundTaskIsRunning()
         {
             if (_updateMetadataTask == null || _updateMetadataTask.Status != TaskStatus.Running)
-                _updateMetadataTask = Task.Run(UpdateCurrentConfigurationUsingSignals, CancellationToken.None);
+                _updateMetadataTask = Task.Run(UpdateCurrentConfigurationUsingSignals);
         }
 
         private void TelemetryForUpdate()
@@ -320,11 +322,13 @@ namespace Microsoft.IdentityModel.Protocols
 
         private void UpdateCurrentConfigurationUsingSignals()
         {
-            while (true)
+            while (!_cancellationToken.IsCancellationRequested)
             {
-                _updateMetadata.WaitOne();
-                UpdateCurrentConfiguration();
-                _onBackgroundTaskFinish?.Invoke();
+                if (_updateMetadata.WaitOne(500))
+                {
+                    UpdateCurrentConfiguration();
+                    _onBackgroundTaskFinish?.Invoke();
+                }
             }
         }
 

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -63,7 +63,7 @@ namespace Microsoft.IdentityModel.Protocols
         // requesting a refresh, so it should be done immediately so the next
         // call to GetConfiguration will return new configuration if the minimum
         // refresh interval has passed.
-        bool _refreshRequested;
+        private bool _refreshRequested;
 
         // Wait handle used to signal a background task to update the configuration.
         // Handle starts unset, and AutoResetEvent.Set() sets it, this indicates that
@@ -72,14 +72,18 @@ namespace Microsoft.IdentityModel.Protocols
 
         // Background task that updates the configuration. Signaled with _updateMetadataEvent.
         // Task should be started with EnsureBackgroundRefreshTaskIsRunning.
-        Task _updateMetadataTask;
+        private Task _updateMetadataTask;
 
         private readonly CancellationTokenSource _backgroundRefreshTaskCancellationTokenSource;
 
         /// <summary>
         /// Requests that background tasks be shutdown.
-        /// This only applies if 'Switch.Microsoft.IdentityModel.UpdateConfigAsBlocking' is set to true.
+        /// This only applies if 'Switch.Microsoft.IdentityModel.UpdateConfigAsBlocking' is not set or set to false.
         /// Note that this does not influence <see cref="GetConfigurationAsync(CancellationToken)"/>.
+        /// If the background task stops, the next time the task would be signaled, the task will be
+        /// restarted unless <see cref="ShutdownBackgroundTask"/> is called.
+        /// If using a background task, the <see cref="Configuration"/> cannot
+        /// be used after calling this method.
         /// </summary>
         public void ShutdownBackgroundTask()
         {
@@ -357,7 +361,7 @@ namespace Microsoft.IdentityModel.Protocols
             }
             catch (Exception ex)
             {
-                TelemetryClient.LogBackgroundRefreshFailure(MetadataAddress, ex);
+                TelemetryClient.LogBackgroundConfigurationRefreshFailure(MetadataAddress, ex);
             }
         }
 

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -350,8 +350,9 @@ namespace Microsoft.IdentityModel.Protocols
                     }
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                TelemetryClient.LogBackgroundRefreshFailure(MetadataAddress, ex);
             }
         }
 

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -20,6 +20,12 @@ namespace Microsoft.IdentityModel.Protocols
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable")]
     public partial class ConfigurationManager<T> : BaseConfigurationManager, IConfigurationManager<T> where T : class
     {
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable CS0649 // Unused, it gets used in tests.
+        private Action _onBackgroundTaskFinish;
+#pragma warning restore CS0649 // Unused
+#pragma warning restore IDE0044 // Add readonly modifier
+
         private DateTime _syncAfter = DateTime.MinValue;
         private DateTime SyncAfter
         {
@@ -318,6 +324,7 @@ namespace Microsoft.IdentityModel.Protocols
             {
                 _updateMetadata.WaitOne();
                 UpdateCurrentConfiguration();
+                _onBackgroundTaskFinish?.Invoke();
             }
         }
 

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -74,13 +74,17 @@ namespace Microsoft.IdentityModel.Protocols
         // Task should be started with EnsureBackgroundRefreshTaskIsRunning.
         Task _updateMetadataTask;
 
+        private readonly CancellationTokenSource _backgroundRefreshTaskCancellationTokenSource;
+
         /// <summary>
-        /// Cancellation token to control cancelling the background task.
-        /// If 'Switch.Microsoft.IdentityModel.UpdateConfigAsBlocking' is set to true,
-        /// then this will not be used.
+        /// Requests that background tasks be shutdown.
+        /// This only applies if 'Switch.Microsoft.IdentityModel.UpdateConfigAsBlocking' is set to true.
         /// Note that this does not influence <see cref="GetConfigurationAsync(CancellationToken)"/>.
         /// </summary>
-        public CancellationToken BackgroundRefreshTaskCancellationToken { get; set; }
+        public void ShutdownBackgroundTask()
+        {
+            _backgroundRefreshTaskCancellationTokenSource.Cancel();
+        }
 
         /// <summary>
         /// Instantiates a new <see cref="ConfigurationManager{T}"/> that manages automatic and controls refreshing on configuration data.
@@ -143,6 +147,7 @@ namespace Microsoft.IdentityModel.Protocols
             MetadataAddress = metadataAddress;
             _docRetriever = docRetriever;
             _configRetriever = configRetriever;
+            _backgroundRefreshTaskCancellationTokenSource = new CancellationTokenSource();
 
             if (!AppContextSwitches.UpdateConfigAsBlocking)
                 EnsureBackgroundRefreshTaskIsRunning();
@@ -311,7 +316,7 @@ namespace Microsoft.IdentityModel.Protocols
 
         private void EnsureBackgroundRefreshTaskIsRunning()
         {
-            if (BackgroundRefreshTaskCancellationToken.IsCancellationRequested)
+            if (_backgroundRefreshTaskCancellationTokenSource.IsCancellationRequested)
                 return;
 
             if (_updateMetadataTask == null || _updateMetadataTask.Status != TaskStatus.Running)
@@ -341,7 +346,7 @@ namespace Microsoft.IdentityModel.Protocols
         {
             try
             {
-                while (!BackgroundRefreshTaskCancellationToken.IsCancellationRequested)
+                while (!_backgroundRefreshTaskCancellationTokenSource.IsCancellationRequested)
                 {
                     if (_updateMetadataEvent.WaitOne(500))
                     {

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager_Blocking.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager_Blocking.cs
@@ -17,13 +17,6 @@ namespace Microsoft.IdentityModel.Protocols
 
         private TimeSpan _bootstrapRefreshInterval = TimeSpan.FromSeconds(1);
 
-        private DateTime _lastRefresh = DateTime.MinValue;
-        private DateTime LastRefresh
-        {
-            get => _lastRefresh;
-            set => AtomicUpdateDateTime(ref _lastRefresh, ref value);
-        }
-
         private async Task<T> GetConfigurationWithBlockingAsync(CancellationToken cancel)
         {
             Exception _fetchMetadataFailure = null;
@@ -53,7 +46,7 @@ namespace Microsoft.IdentityModel.Protocols
                                 throw LogHelper.LogExceptionMessage(new InvalidConfigurationException(LogHelper.FormatInvariant(LogMessages.IDX20810, result.ErrorMessage)));
                         }
 
-                        LastRefresh = _timeProvider.GetUtcNow().UtcDateTime;
+                        LastRequestRefresh = _timeProvider.GetUtcNow().UtcDateTime;
                         TelemetryForUpdateBlocking();
                         UpdateConfiguration(configuration);
                     }
@@ -129,7 +122,7 @@ namespace Microsoft.IdentityModel.Protocols
         {
             DateTime now = _timeProvider.GetUtcNow().UtcDateTime;
 
-            if (now >= DateTimeUtil.Add(LastRefresh, RefreshInterval) || _isFirstRefreshRequest)
+            if (now >= DateTimeUtil.Add(LastRequestRefresh, RefreshInterval) || _isFirstRefreshRequest)
             {
                 _refreshRequested = true;
                 _syncAfter = now;

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager_Blocking.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager_Blocking.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.Protocols.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.IdentityModel.Protocols
+{
+    partial class ConfigurationManager<T> where T : class
+    {
+        private readonly SemaphoreSlim _refreshLock = new(1);
+
+        private TimeSpan _bootstrapRefreshInterval = TimeSpan.FromSeconds(1);
+
+        private DateTime _lastRefresh = DateTime.MinValue;
+        private DateTime LastRefresh
+        {
+            get => _lastRefresh;
+            set => AtomicUpdateDateTime(ref _lastRefresh, ref value);
+        }
+
+        private async Task<T> GetConfigurationWithBlockingAsync(CancellationToken cancel)
+        {
+            Exception _fetchMetadataFailure = null;
+            await _refreshLock.WaitAsync(cancel).ConfigureAwait(false);
+            try
+            {
+                if (SyncAfter <= _timeProvider.GetUtcNow())
+                {
+                    try
+                    {
+                        // Don't use the individual CT here, this is a shared operation that shouldn't be affected by an individual's cancellation.
+                        // The transport should have it's own timeouts, etc..
+                        var configuration = await _configRetriever.GetConfigurationAsync(MetadataAddress, _docRetriever, CancellationToken.None).ConfigureAwait(false);
+                        if (_configValidator != null)
+                        {
+                            ConfigurationValidationResult result = _configValidator.Validate(configuration);
+                            if (!result.Succeeded)
+                                throw LogHelper.LogExceptionMessage(new InvalidConfigurationException(LogHelper.FormatInvariant(LogMessages.IDX20810, result.ErrorMessage)));
+                        }
+
+                        LastRefresh = _timeProvider.GetUtcNow().UtcDateTime;
+                        TelemetryForUpdate();
+                        UpdateConfiguration(configuration);
+                    }
+                    catch (Exception ex)
+                    {
+                        _fetchMetadataFailure = ex;
+
+                        if (_currentConfiguration == null) // Throw an exception if there's no configuration to return.
+                        {
+                            if (_bootstrapRefreshInterval < RefreshInterval)
+                            {
+                                // Adopt exponential backoff for bootstrap refresh interval with a decorrelated jitter if it is not longer than the refresh interval.
+                                TimeSpan _bootstrapRefreshIntervalWithJitter = TimeSpan.FromSeconds(new Random().Next((int)_bootstrapRefreshInterval.TotalSeconds));
+                                _bootstrapRefreshInterval += _bootstrapRefreshInterval;
+                                _syncAfter = DateTimeUtil.Add(DateTime.UtcNow, _bootstrapRefreshIntervalWithJitter);
+                            }
+                            else
+                            {
+                                _syncAfter = DateTimeUtil.Add(
+                                    _timeProvider.GetUtcNow().UtcDateTime,
+                                    AutomaticRefreshInterval < RefreshInterval ? AutomaticRefreshInterval : RefreshInterval);
+                            }
+
+                            throw LogHelper.LogExceptionMessage(
+                                new InvalidOperationException(
+                                    LogHelper.FormatInvariant(LogMessages.IDX20803, LogHelper.MarkAsNonPII(MetadataAddress ?? "null"), LogHelper.MarkAsNonPII(_syncAfter), LogHelper.MarkAsNonPII(ex)), ex));
+                        }
+                        else
+                        {
+                            _syncAfter = DateTimeUtil.Add(
+                                _timeProvider.GetUtcNow().UtcDateTime,
+                                AutomaticRefreshInterval < RefreshInterval ? AutomaticRefreshInterval : RefreshInterval);
+
+                            LogHelper.LogExceptionMessage(
+                                new InvalidOperationException(
+                                    LogHelper.FormatInvariant(LogMessages.IDX20806, LogHelper.MarkAsNonPII(MetadataAddress ?? "null"), LogHelper.MarkAsNonPII(ex)), ex));
+                        }
+                    }
+                }
+
+                // Stale metadata is better than no metadata
+                if (_currentConfiguration != null)
+                    return _currentConfiguration;
+                else
+                    throw LogHelper.LogExceptionMessage(
+                        new InvalidOperationException(
+                            LogHelper.FormatInvariant(
+                                LogMessages.IDX20803,
+                                LogHelper.MarkAsNonPII(MetadataAddress ?? "null"),
+                                LogHelper.MarkAsNonPII(_syncAfter),
+                                LogHelper.MarkAsNonPII(_fetchMetadataFailure)),
+                            _fetchMetadataFailure));
+            }
+            finally
+            {
+                _refreshLock.Release();
+            }
+        }
+
+        private void RequestRefreshBlocking()
+        {
+            DateTime now = _timeProvider.GetUtcNow().UtcDateTime;
+
+            if (now >= DateTimeUtil.Add(LastRefresh, RefreshInterval) || _isFirstRefreshRequest)
+            {
+                _refreshRequested = true;
+                _syncAfter = now;
+                _isFirstRefreshRequest = false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager_Blocking.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager_Blocking.cs
@@ -7,6 +7,7 @@ using System;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Protocols.Configuration;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Telemetry;
 
 namespace Microsoft.IdentityModel.Protocols
 {
@@ -27,6 +28,9 @@ namespace Microsoft.IdentityModel.Protocols
         {
             Exception _fetchMetadataFailure = null;
             await _refreshLock.WaitAsync(cancel).ConfigureAwait(false);
+
+            long startTimestamp = _timeProvider.GetTimestamp();
+
             try
             {
                 if (SyncAfter <= _timeProvider.GetUtcNow())
@@ -36,6 +40,12 @@ namespace Microsoft.IdentityModel.Protocols
                         // Don't use the individual CT here, this is a shared operation that shouldn't be affected by an individual's cancellation.
                         // The transport should have it's own timeouts, etc..
                         var configuration = await _configRetriever.GetConfigurationAsync(MetadataAddress, _docRetriever, CancellationToken.None).ConfigureAwait(false);
+
+                        var elapsedTime = _timeProvider.GetElapsedTime(startTimestamp);
+                        TelemetryClient.LogConfigurationRetrievalDuration(
+                            MetadataAddress,
+                            elapsedTime);
+
                         if (_configValidator != null)
                         {
                             ConfigurationValidationResult result = _configValidator.Validate(configuration);
@@ -44,7 +54,7 @@ namespace Microsoft.IdentityModel.Protocols
                         }
 
                         LastRefresh = _timeProvider.GetUtcNow().UtcDateTime;
-                        TelemetryForUpdate();
+                        TelemetryForUpdateBlocking();
                         UpdateConfiguration(configuration);
                     }
                     catch (Exception ex)
@@ -67,6 +77,11 @@ namespace Microsoft.IdentityModel.Protocols
                                     AutomaticRefreshInterval < RefreshInterval ? AutomaticRefreshInterval : RefreshInterval);
                             }
 
+                            TelemetryClient.IncrementConfigurationRefreshRequestCounter(
+                                MetadataAddress,
+                                TelemetryConstants.Protocols.FirstRefresh,
+                                ex);
+
                             throw LogHelper.LogExceptionMessage(
                                 new InvalidOperationException(
                                     LogHelper.FormatInvariant(LogMessages.IDX20803, LogHelper.MarkAsNonPII(MetadataAddress ?? "null"), LogHelper.MarkAsNonPII(_syncAfter), LogHelper.MarkAsNonPII(ex)), ex));
@@ -76,6 +91,13 @@ namespace Microsoft.IdentityModel.Protocols
                             _syncAfter = DateTimeUtil.Add(
                                 _timeProvider.GetUtcNow().UtcDateTime,
                                 AutomaticRefreshInterval < RefreshInterval ? AutomaticRefreshInterval : RefreshInterval);
+
+                            var elapsedTime = _timeProvider.GetElapsedTime(startTimestamp);
+
+                            TelemetryClient.LogConfigurationRetrievalDuration(
+                                MetadataAddress,
+                                elapsedTime,
+                                ex);
 
                             LogHelper.LogExceptionMessage(
                                 new InvalidOperationException(
@@ -113,6 +135,34 @@ namespace Microsoft.IdentityModel.Protocols
                 _syncAfter = now;
                 _isFirstRefreshRequest = false;
             }
+        }
+
+        private void TelemetryForUpdateBlocking()
+        {
+            string updateMode;
+
+            if (_currentConfiguration is null)
+            {
+                updateMode = TelemetryConstants.Protocols.FirstRefresh;
+            }
+            else
+            {
+                updateMode = _refreshRequested ? TelemetryConstants.Protocols.Manual : TelemetryConstants.Protocols.Automatic;
+
+                if (_refreshRequested)
+                    _refreshRequested = false;
+            }
+
+            try
+            {
+                TelemetryClient.IncrementConfigurationRefreshRequestCounter(
+                    MetadataAddress,
+                    updateMode);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch
+            { }
+#pragma warning restore CA1031 // Do not catch general exception types
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Protocols/GlobalSuppressions.cs
+++ b/src/Microsoft.IdentityModel.Protocols/GlobalSuppressions.cs
@@ -12,3 +12,8 @@ using System.Diagnostics.CodeAnalysis;
 #if NET6_0_OR_GREATER
 [assembly: SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "Adding StringComparison.Ordinal adds a performance penalty.", Scope = "member", Target = "~M:Microsoft.IdentityModel.Protocols.AuthenticationProtocolMessage.BuildRedirectUrl~System.String")]
 #endif
+
+[assembly: SuppressMessage("Design", "CA1031:Do not catch general exception types",
+    Justification = "Background thread needs to never throw an unhandled exception.",
+    Scope = "member",
+    Target = "~M:Microsoft.IdentityModel.Protocols.ConfigurationManager`1.UpdateCurrentConfigurationUsingSignals")]

--- a/src/Microsoft.IdentityModel.Protocols/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Protocols/InternalAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 Microsoft.IdentityModel.Protocols.ConfigurationManager<T>.TelemetryClient -> Microsoft.IdentityModel.Telemetry.ITelemetryClient
-Microsoft.IdentityModel.Protocols.ConfigurationManager<T>.TimeProvider -> System.TimeProvider
+Microsoft.IdentityModel.Protocols.ConfigurationManager<T>._onBackgroundTaskFinish -> System.Action

--- a/src/Microsoft.IdentityModel.Protocols/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Protocols/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
-Microsoft.IdentityModel.Protocols.ConfigurationManager<T>.BackgroundTaskCancellationToken.get -> System.Threading.CancellationToken
-Microsoft.IdentityModel.Protocols.ConfigurationManager<T>.BackgroundTaskCancellationToken.set -> void
+Microsoft.IdentityModel.Protocols.ConfigurationManager<T>.BackgroundRefreshTaskCancellationToken.get -> System.Threading.CancellationToken
+Microsoft.IdentityModel.Protocols.ConfigurationManager<T>.BackgroundRefreshTaskCancellationToken.set -> void

--- a/src/Microsoft.IdentityModel.Protocols/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Protocols/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.IdentityModel.Protocols.ConfigurationManager<T>.BackgroundTaskCancellationToken.get -> System.Threading.CancellationToken
+Microsoft.IdentityModel.Protocols.ConfigurationManager<T>.BackgroundTaskCancellationToken.set -> void

--- a/src/Microsoft.IdentityModel.Protocols/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Protocols/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
-Microsoft.IdentityModel.Protocols.ConfigurationManager<T>.BackgroundRefreshTaskCancellationToken.get -> System.Threading.CancellationToken
-Microsoft.IdentityModel.Protocols.ConfigurationManager<T>.BackgroundRefreshTaskCancellationToken.set -> void
+Microsoft.IdentityModel.Protocols.ConfigurationManager<T>.ShutdownBackgroundTask() -> void

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -72,7 +72,7 @@ namespace Microsoft.IdentityModel.Tokens
 
         /// <summary>
         /// Enabling this switch will cause the configuration manager to block other requests to GetConfigurationAsync if a request is already in progress.
-        /// The default behavior is if a request is already in progress, the current configuration will be returned until the request is completed on
+        /// The default configuration refresh behavior is if a request is already in progress, the current configuration will be returned until the ongoing request is completed on
         /// a background thread.
         /// </summary>
         internal const string UpdateConfigAsBlockingSwitch = "Switch.Microsoft.IdentityModel.UpdateConfigAsBlocking";

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -71,6 +71,17 @@ namespace Microsoft.IdentityModel.Tokens
         internal static bool UseRfcDefinitionOfEpkAndKid => _useRfcDefinitionOfEpkAndKid ??= (AppContext.TryGetSwitch(UseRfcDefinitionOfEpkAndKidSwitch, out bool isEnabled) && isEnabled);
 
         /// <summary>
+        /// Enabling this switch will cause the configuration manager to block other requests to GetConfigurationAsync if a request is already in progress.
+        /// The default behavior is if a request is already in progress, the current configuration will be returned until the request is completed on
+        /// a background thread.
+        /// </summary>
+        internal const string UpdateConfigAsBlockingSwitch = "Switch.Microsoft.IdentityModel.UpdateConfigAsBlocking";
+
+        private static bool? _updateConfigAsBlockingCall;
+
+        internal static bool UpdateConfigAsBlocking => _updateConfigAsBlockingCall ??= (AppContext.TryGetSwitch(UpdateConfigAsBlockingSwitch, out bool blockingCall) && blockingCall);
+
+        /// <summary>
         /// Used for testing to reset all switches to its default value.
         /// </summary>
         internal static void ResetAllSwitches()
@@ -86,6 +97,9 @@ namespace Microsoft.IdentityModel.Tokens
 
             _useRfcDefinitionOfEpkAndKid = null;
             AppContext.SetSwitch(UseRfcDefinitionOfEpkAndKidSwitch, false);
+
+            _updateConfigAsBlockingCall = null;
+            AppContext.SetSwitch(UpdateConfigAsBlockingSwitch, false);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Telemetry/ITelemetryClient.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Telemetry/ITelemetryClient.cs
@@ -24,5 +24,9 @@ namespace Microsoft.IdentityModel.Telemetry
             string metadataAddress,
             string operationStatus,
             Exception exception);
+
+        internal void LogBackgroundRefreshFailure(
+            string metadataAddress,
+            Exception exception);
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Telemetry/ITelemetryClient.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Telemetry/ITelemetryClient.cs
@@ -25,7 +25,7 @@ namespace Microsoft.IdentityModel.Telemetry
             string operationStatus,
             Exception exception);
 
-        internal void LogBackgroundRefreshFailure(
+        internal void LogBackgroundConfigurationRefreshFailure(
             string metadataAddress,
             Exception exception);
     }

--- a/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryClient.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryClient.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.Telemetry
 {
@@ -14,13 +16,19 @@ namespace Microsoft.IdentityModel.Telemetry
     {
         public string ClientVer = IdentityModelTelemetryUtil.ClientVer;
 
+        private KeyValuePair<string, object> _BlockingTagValue = new(
+            TelemetryConstants.BlockingTypeTag,
+            AppContextSwitches.UpdateConfigAsBlocking.ToString()
+        );
+
         public void IncrementConfigurationRefreshRequestCounter(string metadataAddress, string operationStatus)
         {
             var tagList = new TagList()
             {
                 { TelemetryConstants.IdentityModelVersionTag, ClientVer },
                 { TelemetryConstants.MetadataAddressTag, metadataAddress },
-                { TelemetryConstants.OperationStatusTag, operationStatus }
+                { TelemetryConstants.OperationStatusTag, operationStatus },
+                _BlockingTagValue
             };
 
             TelemetryDataRecorder.IncrementConfigurationRefreshRequestCounter(tagList);
@@ -33,7 +41,8 @@ namespace Microsoft.IdentityModel.Telemetry
                 { TelemetryConstants.IdentityModelVersionTag, ClientVer },
                 { TelemetryConstants.MetadataAddressTag, metadataAddress },
                 { TelemetryConstants.OperationStatusTag, operationStatus },
-                { TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString() }
+                { TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString() },
+                _BlockingTagValue
             };
 
             TelemetryDataRecorder.IncrementConfigurationRefreshRequestCounter(tagList);
@@ -45,6 +54,7 @@ namespace Microsoft.IdentityModel.Telemetry
             {
                 { TelemetryConstants.IdentityModelVersionTag, ClientVer },
                 { TelemetryConstants.MetadataAddressTag, metadataAddress },
+                _BlockingTagValue
             };
 
             long durationInMilliseconds = (long)operationDuration.TotalMilliseconds;
@@ -57,11 +67,27 @@ namespace Microsoft.IdentityModel.Telemetry
             {
                 { TelemetryConstants.IdentityModelVersionTag, ClientVer },
                 { TelemetryConstants.MetadataAddressTag, metadataAddress },
-                { TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString() }
+                { TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString() },
+                _BlockingTagValue
             };
 
             long durationInMilliseconds = (long)operationDuration.TotalMilliseconds;
             TelemetryDataRecorder.RecordConfigurationRetrievalDurationHistogram(durationInMilliseconds, tagList);
+        }
+
+        public void LogBackgroundRefreshFailure(
+            string metadataAddress,
+            Exception exception)
+        {
+            var tagList = new TagList()
+            {
+                { TelemetryConstants.IdentityModelVersionTag, ClientVer },
+                { TelemetryConstants.MetadataAddressTag, metadataAddress },
+                { TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString() },
+                _BlockingTagValue
+            };
+
+            TelemetryDataRecorder.IncrementConfigurationBackgroundRefreshFailureCounter(tagList);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryClient.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryClient.cs
@@ -16,7 +16,7 @@ namespace Microsoft.IdentityModel.Telemetry
     {
         public string ClientVer = IdentityModelTelemetryUtil.ClientVer;
 
-        private KeyValuePair<string, object> _BlockingTagValue = new(
+        private KeyValuePair<string, object> _blockingTagValue = new(
             TelemetryConstants.BlockingTypeTag,
             AppContextSwitches.UpdateConfigAsBlocking.ToString()
         );
@@ -28,7 +28,7 @@ namespace Microsoft.IdentityModel.Telemetry
                 { TelemetryConstants.IdentityModelVersionTag, ClientVer },
                 { TelemetryConstants.MetadataAddressTag, metadataAddress },
                 { TelemetryConstants.OperationStatusTag, operationStatus },
-                _BlockingTagValue
+                _blockingTagValue
             };
 
             TelemetryDataRecorder.IncrementConfigurationRefreshRequestCounter(tagList);
@@ -42,7 +42,7 @@ namespace Microsoft.IdentityModel.Telemetry
                 { TelemetryConstants.MetadataAddressTag, metadataAddress },
                 { TelemetryConstants.OperationStatusTag, operationStatus },
                 { TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString() },
-                _BlockingTagValue
+                _blockingTagValue
             };
 
             TelemetryDataRecorder.IncrementConfigurationRefreshRequestCounter(tagList);
@@ -54,7 +54,7 @@ namespace Microsoft.IdentityModel.Telemetry
             {
                 { TelemetryConstants.IdentityModelVersionTag, ClientVer },
                 { TelemetryConstants.MetadataAddressTag, metadataAddress },
-                _BlockingTagValue
+                _blockingTagValue
             };
 
             long durationInMilliseconds = (long)operationDuration.TotalMilliseconds;
@@ -68,14 +68,14 @@ namespace Microsoft.IdentityModel.Telemetry
                 { TelemetryConstants.IdentityModelVersionTag, ClientVer },
                 { TelemetryConstants.MetadataAddressTag, metadataAddress },
                 { TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString() },
-                _BlockingTagValue
+                _blockingTagValue
             };
 
             long durationInMilliseconds = (long)operationDuration.TotalMilliseconds;
             TelemetryDataRecorder.RecordConfigurationRetrievalDurationHistogram(durationInMilliseconds, tagList);
         }
 
-        public void LogBackgroundRefreshFailure(
+        public void LogBackgroundConfigurationRefreshFailure(
             string metadataAddress,
             Exception exception)
         {
@@ -84,10 +84,10 @@ namespace Microsoft.IdentityModel.Telemetry
                 { TelemetryConstants.IdentityModelVersionTag, ClientVer },
                 { TelemetryConstants.MetadataAddressTag, metadataAddress },
                 { TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString() },
-                _BlockingTagValue
+                _blockingTagValue
             };
 
-            TelemetryDataRecorder.IncrementConfigurationBackgroundRefreshFailureCounter(tagList);
+            TelemetryDataRecorder.IncrementBackgroundConfigurationRefreshFailureCounter(tagList);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryConstants.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryConstants.cs
@@ -27,6 +27,11 @@ namespace Microsoft.IdentityModel.Telemetry
         /// </summary>
         public const string ExceptionTypeTag = "ExceptionType";
 
+        /// <summary>
+        /// Telemetry tag indicating if the update was blocking.
+        /// </summary>
+        public const string BlockingTypeTag = "Blocking";
+
         public static class Protocols
         {
             // Configuration manager refresh statuses

--- a/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryDataRecorder.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryDataRecorder.cs
@@ -26,9 +26,16 @@ namespace Microsoft.IdentityModel.Telemetry
         /// <summary>
         /// Counter to capture configuration refresh requests to ConfigurationManager.
         /// </summary>
+        internal static readonly Counter<long> ConfigurationManagerCounter = IdentityModelMeter.CreateCounter<long>(IdentityModelConfigurationManagerCounterName, description: IdentityModelConfigurationManagerCounterDescription);
         internal const string IdentityModelConfigurationManagerCounterName = "IdentityModelConfigurationManager";
         internal const string IdentityModelConfigurationManagerCounterDescription = "Counter capturing configuration manager operations.";
-        internal static readonly Counter<long> ConfigurationManagerCounter = IdentityModelMeter.CreateCounter<long>(IdentityModelConfigurationManagerCounterName, description: IdentityModelConfigurationManagerCounterDescription);
+
+        /// <summary>
+        /// Counter to capture background refresh failures in the ConfigurationManager.
+        /// </summary>
+        internal static readonly Counter<long> BackgroundRefreshFailureCounter = IdentityModelMeter.CreateCounter<long>(BackgroundRefreshFailureCounterName, description: BackgroundRefreshFailureCounterDescription);
+        internal const string BackgroundRefreshFailureCounterName = "IdentityModelConfigurationManagerBackgroundRefreshFailure";
+        internal const string BackgroundRefreshFailureCounterDescription = "Counter capturing configuration manager background refresh failures.";
 
         /// <summary>
         /// Histogram to capture total duration of configuration retrieval by ConfigurationManager in milliseconds.
@@ -46,6 +53,11 @@ namespace Microsoft.IdentityModel.Telemetry
         internal static void IncrementConfigurationRefreshRequestCounter(in TagList tagList)
         {
             ConfigurationManagerCounter.Add(1, tagList);
+        }
+
+        internal static void IncrementConfigurationBackgroundRefreshFailureCounter(in TagList tagList)
+        {
+            BackgroundRefreshFailureCounter.Add(1, tagList);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryDataRecorder.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryDataRecorder.cs
@@ -33,9 +33,9 @@ namespace Microsoft.IdentityModel.Telemetry
         /// <summary>
         /// Counter to capture background refresh failures in the ConfigurationManager.
         /// </summary>
-        internal static readonly Counter<long> BackgroundRefreshFailureCounter = IdentityModelMeter.CreateCounter<long>(BackgroundRefreshFailureCounterName, description: BackgroundRefreshFailureCounterDescription);
-        internal const string BackgroundRefreshFailureCounterName = "IdentityModelConfigurationManagerBackgroundRefreshFailure";
-        internal const string BackgroundRefreshFailureCounterDescription = "Counter capturing configuration manager background refresh failures.";
+        internal static readonly Counter<long> BackgroundConfigurationRefreshFailureCounter = IdentityModelMeter.CreateCounter<long>(BackgroundConfigurationRefreshFailureCounterName, description: BackgroundConfigurationRefreshFailureCounterDescription);
+        internal const string BackgroundConfigurationRefreshFailureCounterName = "IdentityModelConfigurationManagerBackgroundRefreshFailure";
+        internal const string BackgroundConfigurationRefreshFailureCounterDescription = "Counter capturing configuration manager background refresh failures.";
 
         /// <summary>
         /// Histogram to capture total duration of configuration retrieval by ConfigurationManager in milliseconds.
@@ -55,9 +55,9 @@ namespace Microsoft.IdentityModel.Telemetry
             ConfigurationManagerCounter.Add(1, tagList);
         }
 
-        internal static void IncrementConfigurationBackgroundRefreshFailureCounter(in TagList tagList)
+        internal static void IncrementBackgroundConfigurationRefreshFailureCounter(in TagList tagList)
         {
-            BackgroundRefreshFailureCounter.Add(1, tagList);
+            BackgroundConfigurationRefreshFailureCounter.Add(1, tagList);
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
@@ -56,8 +56,10 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             configurationManager.RequestRefresh();
             await configurationManager.GetConfigurationAsync(cancel);
 
+            AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
+
             if (!blocking)
-                Thread.Sleep(250);
+                ConfigurationManagerTests.WaitOrFail(resetEvent);
 
             // assert
             var expectedCounterTagList = new Dictionary<string, object>
@@ -105,6 +107,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 TelemetryClient = testTelemetryClient
             };
 
+            AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
+
             try
             {
                 await configurationManager.GetConfigurationAsync();
@@ -116,7 +120,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 }
 
                 if (!blocking)
-                    Thread.Sleep(250);
+                    ConfigurationManagerTests.WaitOrFail(resetEvent);
             }
             catch (Exception)
             {

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 TelemetryClient = testTelemetryClient
             };
 
-            TestUtilities.SetField(configurationManager, "_cancellationToken", cts.Token);
+            TestUtilities.SetField(configurationManager, "_BackgroundTaskCancellationToken", cts.Token);
 
             var cancel = new CancellationToken();
             AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
@@ -83,9 +83,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             cts.Cancel();
 
             await ConfigurationManagerTests.PollForConditionAsync(
-                () => expectedCounterTagList.SequenceEqual(testTelemetryClient.ExportedItems) &&
-                    expectedHistogramTagList.SequenceEqual(testTelemetryClient.ExportedHistogramItems),
-                TimeSpan.FromMilliseconds(100),
+                () => expectedCounterTagList.Count == testTelemetryClient.ExportedItems.Count &&
+                    expectedHistogramTagList.Count == testTelemetryClient.ExportedHistogramItems.Count,
+                TimeSpan.FromMilliseconds(250),
                 TimeSpan.FromSeconds(10));
 
             Assert.Equal(expectedCounterTagList, testTelemetryClient.ExportedItems);
@@ -121,7 +121,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 TelemetryClient = testTelemetryClient
             };
 
-            TestUtilities.SetField(configurationManager, "_cancellationToken", cts.Token);
+            TestUtilities.SetField(configurationManager, "_BackgroundTaskCancellationToken", cts.Token);
             AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
 
             try
@@ -147,7 +147,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
 
             await ConfigurationManagerTests.PollForConditionAsync(
-                () => theoryData.ExpectedTagList.SequenceEqual(testTelemetryClient.ExportedItems),
+                () => theoryData.ExpectedTagList.Count == testTelemetryClient.ExportedItems.Count,
                 TimeSpan.FromMilliseconds(100),
                 TimeSpan.FromSeconds(10));
 

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 TelemetryClient = testTelemetryClient
             };
 
-            TestUtilities.SetField(configurationManager, "_BackgroundTaskCancellationToken", cts.Token);
+            configurationManager.BackgroundTaskCancellationToken = cts.Token;
 
             var cancel = new CancellationToken();
             AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
@@ -122,7 +122,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 TelemetryClient = testTelemetryClient
             };
 
-            TestUtilities.SetField(configurationManager, "_BackgroundTaskCancellationToken", cts.Token);
+            configurationManager.BackgroundTaskCancellationToken = cts.Token;
             AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
 
             var timeProvider = new FakeTimeProvider();

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
@@ -4,16 +4,17 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Protocols.Configuration;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect.Configuration;
-using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Telemetry;
 using Microsoft.IdentityModel.Telemetry.Tests;
-using Xunit;
+using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
+using Xunit;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 {
@@ -35,6 +36,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
         private static async Task RequestRefresh_ExpectedTagsBody(bool blocking = false)
         {
+            var cts = new CancellationTokenSource();
+
             // arrange
             var testTelemetryClient = new MockTelemetryClient();
             var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
@@ -45,7 +48,11 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             {
                 TelemetryClient = testTelemetryClient
             };
+
+            TestUtilities.SetField(configurationManager, "_cancellationToken", cts.Token);
+
             var cancel = new CancellationToken();
+            AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
 
             // act
             // Retrieve the configuration for the first time
@@ -55,8 +62,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             // Manually request a config refresh
             configurationManager.RequestRefresh();
             await configurationManager.GetConfigurationAsync(cancel);
-
-            AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
 
             if (!blocking)
                 ConfigurationManagerTests.WaitOrFail(resetEvent);
@@ -74,6 +79,14 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 { TelemetryConstants.MetadataAddressTag, OpenIdConfigData.AccountsGoogle },
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer }
             };
+
+            cts.Cancel();
+
+            await ConfigurationManagerTests.PollForConditionAsync(
+                () => expectedCounterTagList.SequenceEqual(testTelemetryClient.ExportedItems) &&
+                    expectedHistogramTagList.SequenceEqual(testTelemetryClient.ExportedHistogramItems),
+                TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromSeconds(10));
 
             Assert.Equal(expectedCounterTagList, testTelemetryClient.ExportedItems);
             Assert.Equal(expectedHistogramTagList, testTelemetryClient.ExportedHistogramItems);
@@ -97,6 +110,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             bool blocking = false)
         {
             var testTelemetryClient = new MockTelemetryClient();
+            var cts = new CancellationTokenSource();
 
             var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                 theoryData.MetadataAddress,
@@ -107,6 +121,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 TelemetryClient = testTelemetryClient
             };
 
+            TestUtilities.SetField(configurationManager, "_cancellationToken", cts.Token);
             AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
 
             try
@@ -117,15 +132,24 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     testTelemetryClient.ClearExportedItems();
                     TestUtilities.SetField(configurationManager, "_syncAfter", theoryData.SyncAfter);
                     await configurationManager.GetConfigurationAsync();
-                }
 
-                if (!blocking)
-                    ConfigurationManagerTests.WaitOrFail(resetEvent);
+                    if (!blocking)
+                        ConfigurationManagerTests.WaitOrFail(resetEvent);
+                }
             }
             catch (Exception)
             {
                 // Ignore exceptions
             }
+            finally
+            {
+                cts.Cancel();
+            }
+
+            await ConfigurationManagerTests.PollForConditionAsync(
+                () => theoryData.ExpectedTagList.SequenceEqual(testTelemetryClient.ExportedItems),
+                TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromSeconds(10));
 
             Assert.Equal(theoryData.ExpectedTagList, testTelemetryClient.ExportedItems);
         }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Protocols.Configuration;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect.Configuration;
@@ -19,6 +19,7 @@ using Xunit;
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 {
     [ResetAppContextSwitches]
+    [Collection(nameof(AppContextSwitches.UpdateConfigAsBlocking))]
     public class ConfigurationManagerTelemetryTests
     {
         [Fact]
@@ -86,7 +87,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 () => expectedCounterTagList.Count == testTelemetryClient.ExportedItems.Count &&
                     expectedHistogramTagList.Count == testTelemetryClient.ExportedHistogramItems.Count,
                 TimeSpan.FromMilliseconds(250),
-                TimeSpan.FromSeconds(10));
+                TimeSpan.FromSeconds(20));
 
             Assert.Equal(expectedCounterTagList, testTelemetryClient.ExportedItems);
             Assert.Equal(expectedHistogramTagList, testTelemetryClient.ExportedHistogramItems);
@@ -124,14 +125,20 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             TestUtilities.SetField(configurationManager, "_BackgroundTaskCancellationToken", cts.Token);
             AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
 
+            var timeProvider = new FakeTimeProvider();
+            TestUtilities.SetField(configurationManager, "_timeProvider", timeProvider);
+
+            OpenIdConnectConfiguration firstConfig = null;
+            OpenIdConnectConfiguration secondConfig = null;
+
             try
             {
-                await configurationManager.GetConfigurationAsync();
-                if (theoryData.SyncAfter != null)
+                firstConfig = await configurationManager.GetConfigurationAsync();
+                if (theoryData.AdjustTime.HasValue)
                 {
                     testTelemetryClient.ClearExportedItems();
-                    TestUtilities.SetField(configurationManager, "_syncAfter", theoryData.SyncAfter);
-                    await configurationManager.GetConfigurationAsync();
+                    timeProvider.Advance(theoryData.AdjustTime.Value);
+                    secondConfig = await configurationManager.GetConfigurationAsync();
 
                     if (!blocking)
                         ConfigurationManagerTests.WaitOrFail(resetEvent);
@@ -148,10 +155,19 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             await ConfigurationManagerTests.PollForConditionAsync(
                 () => theoryData.ExpectedTagList.Count == testTelemetryClient.ExportedItems.Count,
-                TimeSpan.FromMilliseconds(100),
-                TimeSpan.FromSeconds(10));
+                TimeSpan.FromMilliseconds(250),
+                TimeSpan.FromSeconds(20));
 
-            Assert.Equal(theoryData.ExpectedTagList, testTelemetryClient.ExportedItems);
+            DateTime syncAfter = (DateTime)TestUtilities.GetField(configurationManager, "_syncAfter");
+
+            try
+            {
+                Assert.Equal(theoryData.ExpectedTagList, testTelemetryClient.ExportedItems);
+            }
+            catch (Exception)
+            {
+                throw new Exception(syncAfter.ToString() + "-" + (object.ReferenceEquals(firstConfig, secondConfig).ToString() + "-" + AppContextSwitches.UpdateConfigAsBlocking.ToString()));
+            }
         }
 
         public static TheoryData<ConfigurationManagerTelemetryTheoryData<OpenIdConnectConfiguration>> GetConfiguration_ExpectedTagList_TheoryData()
@@ -199,7 +215,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 {
                     MetadataAddress = OpenIdConfigData.AADCommonUrl,
                     ConfigurationValidator = new OpenIdConnectConfigurationValidator(),
-                    SyncAfter = DateTime.UtcNow - TimeSpan.FromDays(2),
+                    AdjustTime = TimeSpan.FromDays(1),
                     ExpectedTagList = new Dictionary<string, object>
                     {
                         { TelemetryConstants.MetadataAddressTag, OpenIdConfigData.AADCommonUrl },
@@ -221,7 +237,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
         public IConfigurationValidator<T> ConfigurationValidator { get; set; }
 
-        public DateTime? SyncAfter { get; set; } = null;
+        public TimeSpan? AdjustTime { get; set; }
 
         public Dictionary<string, object> ExpectedTagList { get; set; }
     }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
@@ -160,14 +160,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             DateTime syncAfter = (DateTime)TestUtilities.GetField(configurationManager, "_syncAfter");
 
-            try
-            {
-                Assert.Equal(theoryData.ExpectedTagList, testTelemetryClient.ExportedItems);
-            }
-            catch (Exception)
-            {
-                throw new Exception(syncAfter.ToString() + "-" + (object.ReferenceEquals(firstConfig, secondConfig).ToString() + "-" + AppContextSwitches.UpdateConfigAsBlocking.ToString()));
-            }
+            Assert.Equal(theoryData.ExpectedTagList, testTelemetryClient.ExportedItems);
         }
 
         public static TheoryData<ConfigurationManagerTelemetryTheoryData<OpenIdConnectConfiguration>> GetConfiguration_ExpectedTagList_TheoryData()

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
@@ -37,8 +37,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
         private static async Task RequestRefresh_ExpectedTagsBody(bool blocking = false)
         {
-            var cts = new CancellationTokenSource();
-
             // arrange
             var testTelemetryClient = new MockTelemetryClient();
             var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
@@ -50,19 +48,16 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 TelemetryClient = testTelemetryClient
             };
 
-            configurationManager.BackgroundRefreshTaskCancellationToken = cts.Token;
-
-            var cancel = new CancellationToken();
             AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
 
             // act
             // Retrieve the configuration for the first time
-            await configurationManager.GetConfigurationAsync(cancel);
+            await configurationManager.GetConfigurationAsync();
             testTelemetryClient.ClearExportedItems();
 
             // Manually request a config refresh
             configurationManager.RequestRefresh();
-            await configurationManager.GetConfigurationAsync(cancel);
+            await configurationManager.GetConfigurationAsync();
 
             if (!blocking)
                 ConfigurationManagerTests.WaitOrFail(resetEvent);
@@ -81,7 +76,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer }
             };
 
-            cts.Cancel();
+            configurationManager.ShutdownBackgroundTask();
 
             await ConfigurationManagerTests.PollForConditionAsync(
                 () => expectedCounterTagList.Count == testTelemetryClient.ExportedItems.Count &&
@@ -111,7 +106,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             bool blocking = false)
         {
             var testTelemetryClient = new MockTelemetryClient();
-            var cts = new CancellationTokenSource();
 
             var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                 theoryData.MetadataAddress,
@@ -122,7 +116,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 TelemetryClient = testTelemetryClient
             };
 
-            configurationManager.BackgroundRefreshTaskCancellationToken = cts.Token;
             AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
 
             var timeProvider = new FakeTimeProvider();
@@ -150,7 +143,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
             finally
             {
-                cts.Cancel();
+                configurationManager.ShutdownBackgroundTask();
             }
 
             await ConfigurationManagerTests.PollForConditionAsync(

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 TelemetryClient = testTelemetryClient
             };
 
-            configurationManager.BackgroundTaskCancellationToken = cts.Token;
+            configurationManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             var cancel = new CancellationToken();
             AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
@@ -122,7 +122,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 TelemetryClient = testTelemetryClient
             };
 
-            configurationManager.BackgroundTaskCancellationToken = cts.Token;
+            configurationManager.BackgroundRefreshTaskCancellationToken = cts.Token;
             AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager, blocking);
 
             var timeProvider = new FakeTimeProvider();

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
@@ -13,13 +13,27 @@ using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Telemetry;
 using Microsoft.IdentityModel.Telemetry.Tests;
 using Xunit;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 {
+    [ResetAppContextSwitches]
     public class ConfigurationManagerTelemetryTests
     {
         [Fact]
         public async Task RequestRefresh_ExpectedTagsExist()
+        {
+            await RequestRefresh_ExpectedTagsBody();
+        }
+
+        [Fact]
+        public async Task RequestRefresh_ExpectedTagsExist_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await RequestRefresh_ExpectedTagsBody(true);
+        }
+
+        private static async Task RequestRefresh_ExpectedTagsBody(bool blocking = false)
         {
             // arrange
             var testTelemetryClient = new MockTelemetryClient();
@@ -42,6 +56,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             configurationManager.RequestRefresh();
             await configurationManager.GetConfigurationAsync(cancel);
 
+            if (!blocking)
+                Thread.Sleep(250);
+
             // assert
             var expectedCounterTagList = new Dictionary<string, object>
             {
@@ -62,6 +79,20 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
         [Theory, MemberData(nameof(GetConfiguration_ExpectedTagList_TheoryData), DisableDiscoveryEnumeration = true)]
         public async Task GetConfigurationAsync_ExpectedTagsExist(ConfigurationManagerTelemetryTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            await GetConfigurationAsync_ExpectedTagList_Body(theoryData);
+        }
+
+        [Theory, MemberData(nameof(GetConfiguration_ExpectedTagList_TheoryData), DisableDiscoveryEnumeration = true)]
+        public async Task GetConfigurationAsync_ExpectedTagsExist_Blocking(ConfigurationManagerTelemetryTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await GetConfigurationAsync_ExpectedTagList_Body(theoryData, true);
+        }
+
+        private static async Task GetConfigurationAsync_ExpectedTagList_Body(
+            ConfigurationManagerTelemetryTheoryData<OpenIdConnectConfiguration> theoryData,
+            bool blocking = false)
         {
             var testTelemetryClient = new MockTelemetryClient();
 
@@ -84,6 +115,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     await configurationManager.GetConfigurationAsync();
                 }
 
+                if (!blocking)
+                    Thread.Sleep(250);
             }
             catch (Exception)
             {

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     theoryData.DocumentRetriever,
                     theoryData.ConfigurationValidator);
 
-                configurationManager.BackgroundTaskCancellationToken = cts.Token;
+                configurationManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
                 var configuration = await configurationManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -203,7 +203,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             var documentRetriever = new HttpDocumentRetriever(HttpResponseMessageUtils.SetupHttpClientThatReturns("OpenIdConnectMetadata.json", HttpStatusCode.NotFound));
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), documentRetriever);
-            configManager.BackgroundTaskCancellationToken = cts.Token;
+            configManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             // First time to fetch metadata
             try
@@ -252,7 +252,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     new OpenIdConnectConfigurationRetriever(),
                     inMemoryDocumentRetriever);
 
-            configurationManager.BackgroundTaskCancellationToken = cts.Token;
+            configurationManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             OpenIdConnectConfiguration configuration = await configurationManager.GetConfigurationAsync();
 
@@ -305,7 +305,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 documentRetriever)
             { RefreshInterval = TimeSpan.FromSeconds(2) };
 
-            configManager.BackgroundTaskCancellationToken = cts.Token;
+            configManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             // ConfigurationManager._syncAfter is set to DateTimeOffset.MinValue on startup
             // If obtaining the metadata fails due to error, the value should not change
@@ -512,7 +512,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever)
                     {
-                        BackgroundTaskCancellationToken = cts.Token
+                        BackgroundRefreshTaskCancellationToken = cts.Token
                     },
                     CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
@@ -531,7 +531,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                        new OpenIdConnectConfigurationRetriever(),
                        InMemoryDocumentRetriever)
                     {
-                        BackgroundTaskCancellationToken = cts.Token
+                        BackgroundRefreshTaskCancellationToken = cts.Token
                     },
                     CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
@@ -550,7 +550,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever)
                     {
-                        BackgroundTaskCancellationToken = cts.Token
+                        BackgroundRefreshTaskCancellationToken = cts.Token
                     },
                     CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
@@ -632,7 +632,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever)
                     {
-                        BackgroundTaskCancellationToken = cts.Token
+                        BackgroundRefreshTaskCancellationToken = cts.Token
                     },
                     CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
@@ -651,7 +651,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever)
                     {
-                        BackgroundTaskCancellationToken = cts.Token
+                        BackgroundRefreshTaskCancellationToken = cts.Token
                     },
                     CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
@@ -670,7 +670,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever)
                     {
-                        BackgroundTaskCancellationToken = cts.Token
+                        BackgroundRefreshTaskCancellationToken = cts.Token
                     },
                     CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
@@ -773,7 +773,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 new OpenIdConnectConfigurationRetriever(),
                 docRetriever);
 
-            configManager.BackgroundTaskCancellationToken = cts.Token;
+            configManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             AutoResetEvent resetEvent = SetupResetEvent(configManager, blocking);
 
@@ -855,7 +855,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 new OpenIdConnectConfigurationRetriever(),
                 docRetriever);
 
-            configManager.BackgroundTaskCancellationToken = cts.Token;
+            configManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             var configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -996,7 +996,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 docRetriever);
 
             TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
-            configManager.BackgroundTaskCancellationToken = cts.Token;
+            configManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             var resetEvent = SetupResetEvent(configManager, blocking);
 
@@ -1093,7 +1093,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 docRetriever);
 
             TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
-            configManager.BackgroundTaskCancellationToken = cts.Token;
+            configManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             TimeSpan advanceInterval = BaseConfigurationManager.DefaultAutomaticRefreshInterval.Add(TimeSpan.FromSeconds(configManager.AutomaticRefreshInterval.TotalSeconds));
 
@@ -1162,7 +1162,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 theoryData.DocumentRetriever,
                 theoryData.ConfigurationValidator)
             {
-                BackgroundTaskCancellationToken = theoryData.CancellationTokenSource.Token
+                BackgroundRefreshTaskCancellationToken = theoryData.CancellationTokenSource.Token
             };
 
             var resetEvent = SetupResetEvent(configurationManager, blocking);

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         [Theory, MemberData(nameof(GetPublicMetadataTheoryData), DisableDiscoveryEnumeration = true)]
         public async Task GetPublicMetadata(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
         {
+            var cts = new CancellationTokenSource();
             CompareContext context = TestUtilities.WriteHeader($"{this}.GetPublicMetadata", theoryData);
             try
             {
@@ -42,6 +43,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     theoryData.DocumentRetriever,
                     theoryData.ConfigurationValidator);
 
+                TestUtilities.SetField(configurationManager, "_cancellationToken", cts.Token);
+
                 var configuration = await configurationManager.GetConfigurationAsync(CancellationToken.None);
 
                 Assert.NotNull(configuration);
@@ -50,6 +53,10 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             catch (Exception ex)
             {
                 theoryData.ExpectedException.ProcessException(ex, context);
+            }
+            finally
+            {
+                cts.Cancel();
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -191,8 +198,11 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         {
             var context = new CompareContext($"{this}.FetchMetadataFailureTest");
 
+            var cts = new CancellationTokenSource();
+
             var documentRetriever = new HttpDocumentRetriever(HttpResponseMessageUtils.SetupHttpClientThatReturns("OpenIdConnectMetadata.json", HttpStatusCode.NotFound));
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), documentRetriever);
+            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
 
             // First time to fetch metadata
             try
@@ -217,6 +227,10 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     IdentityComparer.AreEqual(firstFetchMetadataFailure, secondFetchMetadataFailure, context);
                 }
             }
+            finally
+            {
+                cts.Cancel();
+            }
 
             TestUtilities.AssertFailIfErrors(context);
         }
@@ -230,10 +244,14 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             InMemoryDocumentRetriever inMemoryDocumentRetriever = InMemoryDocumentRetrieverWithEvents(waitEvent, signalEvent);
             waitEvent.Set();
 
+            var cts = new CancellationTokenSource();
+
             var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                     "AADCommonV1Json",
                     new OpenIdConnectConfigurationRetriever(),
                     inMemoryDocumentRetriever);
+
+            TestUtilities.SetField(configurationManager, "_cancellationToken", cts.Token);
 
             OpenIdConnectConfiguration configuration = await configurationManager.GetConfigurationAsync();
 
@@ -262,6 +280,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             // Configuration should be AADCommonV1Config
             configuration = await configurationManager.GetConfigurationAsync();
+
+            cts.Cancel();
+
             Assert.True(configuration.Issuer.Equals(OpenIdConfigData.AADCommonV1Config.Issuer),
                     $"configuration.Issuer from configurationManager was not as expected," +
                     $" configuration.Issuer: '{configuration.Issuer}' != expected: '{OpenIdConfigData.AADCommonV1Config.Issuer}'.");
@@ -275,11 +296,15 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             var documentRetriever = new HttpDocumentRetriever(
                 HttpResponseMessageUtils.SetupHttpClientThatReturns("OpenIdConnectMetadata.json", HttpStatusCode.NotFound));
 
+            var cts = new CancellationTokenSource();
+
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                 "OpenIdConnectMetadata.json",
                 new OpenIdConnectConfigurationRetriever(),
                 documentRetriever)
             { RefreshInterval = TimeSpan.FromSeconds(2) };
+
+            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
 
             // ConfigurationManager._syncAfter is set to DateTimeOffset.MinValue on startup
             // If obtaining the metadata fails due to error, the value should not change
@@ -315,6 +340,10 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                     IdentityComparer.AreEqual(firstFetchMetadataFailure, secondFetchMetadataFailure, context);
                 }
+            }
+            finally
+            {
+                cts.Cancel();
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -372,6 +401,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         [Fact]
         public void GetSets()
         {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+
             TestUtilities.WriteHeader($"{this}.GetSets", "GetSets", true);
 
             int ExpectedPropertyCount = 7;
@@ -428,6 +459,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.ConfigurationManager.MetadataAddress = theoryData.UpdatedMetadataAddress;
                 TestUtilities.SetField(theoryData.ConfigurationManager, "_syncAfter", theoryData.SyncAfter.UtcDateTime);
+                TestUtilities.SetField(theoryData.ConfigurationManager, "_cancellationToken", theoryData.CancellationTokenSource.Token);
                 var updatedConfiguration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
 
                 if (!blocking && theoryData.SyncAfter < DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(1)))
@@ -442,6 +474,10 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             catch (Exception ex)
             {
                 theoryData.ExpectedException.ProcessException(ex, context);
+            }
+            finally
+            {
+                theoryData.CancellationTokenSource.Cancel();
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -473,6 +509,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         "AADCommonV1Json",
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever),
+                    CancellationTokenSource = new(),
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     SyncAfter = DateTime.UtcNow - TimeSpan.FromDays(2),
@@ -486,6 +523,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                        "AADCommonV1Json",
                        new OpenIdConnectConfigurationRetriever(),
                        InMemoryDocumentRetriever),
+                    CancellationTokenSource = new(),
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     SyncAfter = DateTime.UtcNow + TimeSpan.FromDays(2),
@@ -499,6 +537,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         "AADCommonV1Json",
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever),
+                    CancellationTokenSource = new(),
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV2Config,
                     SyncAfter = DateTime.UtcNow,
@@ -533,6 +572,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             var timeProvider = new FakeTimeProvider();
             TestUtilities.SetField(theoryData.ConfigurationManager, "_timeProvider", timeProvider);
+            TestUtilities.SetField(theoryData.ConfigurationManager, "_cancellationToken", theoryData.CancellationTokenSource.Token);
 
             // the first call to RequestRefresh will trigger a refresh with ConfigurationManager.RefreshInterval being ignored.
             // Testing RefreshInterval requires a two calls, the second call will trigger a refresh with ConfigurationManager.RefreshInterval being used.
@@ -557,6 +597,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             var updatedConfiguration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
 
+            theoryData.CancellationTokenSource.Cancel();
+
             IdentityComparer.AreEqual(updatedConfiguration, theoryData.ExpectedUpdatedConfiguration, context);
 
             TestUtilities.AssertFailIfErrors(context);
@@ -575,6 +617,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         "AADCommonV1Json",
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever),
+                    CancellationTokenSource = new(),
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV2Config,
                     RefreshInterval = TimeSpan.FromSeconds(1),
@@ -590,6 +633,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         "AADCommonV1Json",
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever),
+                    CancellationTokenSource = new(),
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     RefreshInterval = TimeSpan.MaxValue,
@@ -605,6 +649,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         "AADCommonV1Json",
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever),
+                    CancellationTokenSource = new(),
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV2Config,
                     SleepTimeInMs = 1000,
@@ -623,11 +668,17 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             try
             {
                 _ = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
+                TestUtilities.SetField(theoryData.ConfigurationManager, "_cancellationToken", theoryData.CancellationTokenSource.Token);
+
                 theoryData.ExpectedException.ProcessNoException(context);
             }
             catch (Exception ex)
             {
                 theoryData.ExpectedException.ProcessException(ex, context);
+            }
+            finally
+            {
+                theoryData.CancellationTokenSource.Cancel();
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -645,6 +696,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         "https://httpstat.us/429",
                         new OpenIdConnectConfigurationRetriever(),
                         new HttpDocumentRetriever()),
+                    CancellationTokenSource = new(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX20803:", typeof(IOException)),
                 });
 
@@ -654,6 +706,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         "https://127.0.0.1",
                         new OpenIdConnectConfigurationRetriever(),
                         new HttpDocumentRetriever()),
+                    CancellationTokenSource = new(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX20803:", typeof(IOException)),
                 });
 
@@ -663,6 +716,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         "http://127.0.0.1",
                         new OpenIdConnectConfigurationRetriever(),
                         new HttpDocumentRetriever()),
+                    CancellationTokenSource = new(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX20803:", typeof(ArgumentException)),
                 });
 
@@ -688,8 +742,15 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             // This test checks that the _syncAfter field is set correctly after a refresh.
             var context = new CompareContext($"{this}.CheckSyncAfterAndRefreshRequested");
 
+            var cts = new CancellationTokenSource();
+
             var docRetriever = new FileDocumentRetriever();
-            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
+            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                "OpenIdConnectMetadata.json",
+                new OpenIdConnectConfigurationRetriever(),
+                docRetriever);
+
+            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
 
             AutoResetEvent resetEvent = SetupResetEvent(configManager, blocking);
 
@@ -742,6 +803,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             if (syncAfter < minimumRefreshInterval)
                 context.Diffs.Add($"(RequestRefresh) syncAfter '{syncAfter}' < DateTimeOffset.UtcNow + configManager.AutomaticRefreshInterval: '{minimumRefreshInterval}'.");
 
+            cts.Cancel();
+
             TestUtilities.AssertFailIfErrors(context);
         }
 
@@ -760,21 +823,30 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
         private async Task GetConfigurationBody()
         {
-            var docRetriever = new FileDocumentRetriever();
-            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
             var context = new CompareContext($"{this}.GetConfiguration");
+            var cts = new CancellationTokenSource();
 
-            // Unable to obtain a new configuration, but _currentConfiguration is not null so it should be returned.
-            configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
+            var docRetriever = new FileDocumentRetriever();
+            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                "OpenIdConnectMetadata.json",
+                new OpenIdConnectConfigurationRetriever(),
+                docRetriever);
+
+            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
+
             var configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
 
             TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
             configManager.MetadataAddress = "http://127.0.0.1";
             configManager.RequestRefresh();
+
+            // Unable to obtain a new configuration, but _currentConfiguration is not null so it should be returned.
             var configuration2 = await configManager.GetConfigurationAsync(CancellationToken.None);
             IdentityComparer.AreEqual(configuration, configuration2, context);
             if (!object.ReferenceEquals(configuration, configuration2))
                 context.Diffs.Add("!object.ReferenceEquals(configuration, configuration2)");
+
+            cts.Cancel();
 
             // get configuration from http address, should throw
             // get configuration with unsuccessful HTTP response status code
@@ -891,11 +963,17 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             // This test checks that the _syncAfter field is set correctly after a refresh.
             var context = new CompareContext($"{this}.RequestRefresh_RespectsRefreshInterval");
 
+            var cts = new CancellationTokenSource();
             var timeProvider = new FakeTimeProvider();
 
             var docRetriever = new FileDocumentRetriever();
-            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
+            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                "OpenIdConnectMetadata.json",
+                new OpenIdConnectConfigurationRetriever(),
+                docRetriever);
+
             TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
+            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
 
             var resetEvent = SetupResetEvent(configManager, blocking);
 
@@ -960,6 +1038,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             if (object.ReferenceEquals(configAfterLessThanRefreshInterval, configAfterOneYear))
                 context.Diffs.Add("object.ReferenceEquals(configAfterLessThanRefreshInterval, configAfterOneYear)");
 
+            cts.Cancel();
+
             TestUtilities.AssertFailIfErrors(context);
         }
 
@@ -983,10 +1063,17 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             var timeProvider = new FakeTimeProvider();
 
             var docRetriever = new FileDocumentRetriever();
-            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
-            TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
 
-            TimeSpan advanceInterval = BaseConfigurationManager.DefaultAutomaticRefreshInterval.Add(TimeSpan.FromSeconds(configManager.AutomaticRefreshInterval.TotalSeconds / 10));
+            var cts = new CancellationTokenSource();
+            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                "OpenIdConnectMetadata.json",
+                new OpenIdConnectConfigurationRetriever(),
+                docRetriever);
+
+            TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
+            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
+
+            TimeSpan advanceInterval = BaseConfigurationManager.DefaultAutomaticRefreshInterval.Add(TimeSpan.FromSeconds(configManager.AutomaticRefreshInterval.TotalSeconds));
 
             TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
 
@@ -1026,6 +1113,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     context.Diffs.Add("object.ReferenceEquals(configAfterTimeIsAdvanced, configuration)");
             }
 
+            cts.Cancel();
+
             TestUtilities.AssertFailIfErrors(context);
         }
 
@@ -1047,7 +1136,13 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             TestUtilities.WriteHeader($"{this}.ValidateOpenIdConnectConfigurationTests");
             var context = new CompareContext();
             OpenIdConnectConfiguration configuration;
-            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(theoryData.MetadataAddress, theoryData.ConfigurationRetriever, theoryData.DocumentRetriever, theoryData.ConfigurationValidator);
+            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                theoryData.MetadataAddress,
+                theoryData.ConfigurationRetriever,
+                theoryData.DocumentRetriever,
+                theoryData.ConfigurationValidator);
+
+            TestUtilities.SetField(configurationManager, "_cancellationToken", theoryData.CancellationTokenSource.Token);
 
             var resetEvent = SetupResetEvent(configurationManager, blocking);
 
@@ -1067,7 +1162,11 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 // Need to wait for the events on the listener to be processed.
                 if (!string.IsNullOrEmpty(theoryData.ExpectedErrorMessage))
                 {
-                    var success = await PollForConditionAsync(() => listener.WriteCount >= 1, TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(10));
+                    var success = await PollForConditionAsync(
+                        () => listener.TraceBuffer.Contains(theoryData.ExpectedErrorMessage),
+                        TimeSpan.FromMilliseconds(100),
+                        TimeSpan.FromSeconds(10));
+
                     if (!success)
                         context.AddDiff($"Expected 1 or more logs to be written, but only {listener.WriteCount} were written.");
                 }
@@ -1085,11 +1184,15 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.ExpectedException.ProcessException(ex, context);
             }
+            finally
+            {
+                theoryData.CancellationTokenSource.Cancel();
+            }
 
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        private static async Task<bool> PollForConditionAsync(Func<bool> condition, TimeSpan interval, TimeSpan timeout)
+        internal static async Task<bool> PollForConditionAsync(Func<bool> condition, TimeSpan interval, TimeSpan timeout)
         {
             var startTime = DateTime.UtcNow;
 
@@ -1126,7 +1229,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     DocumentRetriever = new FileDocumentRetriever(),
                     First = true,
                     MetadataAddress = "OpenIdConnectMetadata.json",
-                    TestId = "ValidConfiguration"
+                    TestId = "ValidConfiguration",
+                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1136,7 +1240,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     DocumentRetriever = new FileDocumentRetriever(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX21818:", typeof(InvalidConfigurationException)),
                     MetadataAddress = "OpenIdConnectMetadata.json",
-                    TestId = "ValidConfiguration_NotEnoughKey"
+                    TestId = "ValidConfiguration_NotEnoughKey",
+                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1147,7 +1252,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     PresetCurrentConfiguration = true,
                     ExpectedErrorMessage = "IDX21818: ",
                     MetadataAddress = "OpenIdConnectMetadata.json",
-                    TestId = "ValidConfiguration_NotEnoughKey_PresetCurrentConfiguration"
+                    TestId = "ValidConfiguration_NotEnoughKey_PresetCurrentConfiguration",
+                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1157,7 +1263,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     DocumentRetriever = new FileDocumentRetriever(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX10810:", typeof(InvalidConfigurationException)),
                     MetadataAddress = "OpenIdConnectMetadataUnrecognizedKty.json",
-                    TestId = "InvalidConfiguration_UnrecognizedKty"
+                    TestId = "InvalidConfiguration_UnrecognizedKty",
+                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1168,7 +1275,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     PresetCurrentConfiguration = true,
                     ExpectedErrorMessage = "IDX10810: ",
                     MetadataAddress = "OpenIdConnectMetadataUnrecognizedKty.json",
-                    TestId = "InvalidConfiguration_UnrecognizedKty_PresetCurrentConfiguration"
+                    TestId = "InvalidConfiguration_UnrecognizedKty_PresetCurrentConfiguration",
+                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1178,7 +1286,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     DocumentRetriever = new FileDocumentRetriever(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX21817:", typeof(InvalidConfigurationException)),
                     MetadataAddress = "JsonWebKeySetUnrecognizedKty.json",
-                    TestId = "InvalidConfiguration_EmptyJsonWenKeySet"
+                    TestId = "InvalidConfiguration_EmptyJsonWenKeySet",
+                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1189,7 +1298,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     PresetCurrentConfiguration = true,
                     ExpectedErrorMessage = "IDX21817: ",
                     MetadataAddress = "JsonWebKeySetUnrecognizedKty.json",
-                    TestId = "InvalidConfiguration_EmptyJsonWenKeySet_PresetCurrentConfiguration"
+                    TestId = "InvalidConfiguration_EmptyJsonWenKeySet_PresetCurrentConfiguration",
+                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1199,7 +1309,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     DocumentRetriever = new FileDocumentRetriever(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX10814:", typeof(InvalidConfigurationException)),
                     MetadataAddress = "OpenIdConnectMetadataBadRsaDataMissingComponent.json",
-                    TestId = "InvalidConfiguration_RsaKeyMissingComponent"
+                    TestId = "InvalidConfiguration_RsaKeyMissingComponent",
+                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1210,7 +1321,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     PresetCurrentConfiguration = true,
                     ExpectedErrorMessage = "IDX10814: ",
                     MetadataAddress = "OpenIdConnectMetadataBadRsaDataMissingComponent.json",
-                    TestId = "InvalidConfiguration_RsaKeyMissingComponent_PresetCurrentConfiguration"
+                    TestId = "InvalidConfiguration_RsaKeyMissingComponent_PresetCurrentConfiguration",
+                    CancellationTokenSource = new(),
                 });
 
                 return theoryData;
@@ -1290,6 +1402,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
 
             public string UpdatedMetadataAddress { get; set; }
+
+            public CancellationTokenSource CancellationTokenSource { get; set; }
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     theoryData.DocumentRetriever,
                     theoryData.ConfigurationValidator);
 
-                TestUtilities.SetField(configurationManager, "_cancellationToken", cts.Token);
+                TestUtilities.SetField(configurationManager, "_BackgroundTaskCancellationToken", cts.Token);
 
                 var configuration = await configurationManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -202,7 +202,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             var documentRetriever = new HttpDocumentRetriever(HttpResponseMessageUtils.SetupHttpClientThatReturns("OpenIdConnectMetadata.json", HttpStatusCode.NotFound));
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), documentRetriever);
-            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
+            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
 
             // First time to fetch metadata
             try
@@ -251,7 +251,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     new OpenIdConnectConfigurationRetriever(),
                     inMemoryDocumentRetriever);
 
-            TestUtilities.SetField(configurationManager, "_cancellationToken", cts.Token);
+            TestUtilities.SetField(configurationManager, "_BackgroundTaskCancellationToken", cts.Token);
 
             OpenIdConnectConfiguration configuration = await configurationManager.GetConfigurationAsync();
 
@@ -304,7 +304,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 documentRetriever)
             { RefreshInterval = TimeSpan.FromSeconds(2) };
 
-            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
+            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
 
             // ConfigurationManager._syncAfter is set to DateTimeOffset.MinValue on startup
             // If obtaining the metadata fails due to error, the value should not change
@@ -459,7 +459,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.ConfigurationManager.MetadataAddress = theoryData.UpdatedMetadataAddress;
                 TestUtilities.SetField(theoryData.ConfigurationManager, "_syncAfter", theoryData.SyncAfter.UtcDateTime);
-                TestUtilities.SetField(theoryData.ConfigurationManager, "_cancellationToken", theoryData.CancellationTokenSource.Token);
+                TestUtilities.SetField(theoryData.ConfigurationManager, "_BackgroundTaskCancellationToken", theoryData.CancellationTokenSource.Token);
                 var updatedConfiguration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
 
                 if (!blocking && theoryData.SyncAfter < DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(1)))
@@ -572,7 +572,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             var timeProvider = new FakeTimeProvider();
             TestUtilities.SetField(theoryData.ConfigurationManager, "_timeProvider", timeProvider);
-            TestUtilities.SetField(theoryData.ConfigurationManager, "_cancellationToken", theoryData.CancellationTokenSource.Token);
+            TestUtilities.SetField(theoryData.ConfigurationManager, "_BackgroundTaskCancellationToken", theoryData.CancellationTokenSource.Token);
 
             // the first call to RequestRefresh will trigger a refresh with ConfigurationManager.RefreshInterval being ignored.
             // Testing RefreshInterval requires a two calls, the second call will trigger a refresh with ConfigurationManager.RefreshInterval being used.
@@ -668,7 +668,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             try
             {
                 _ = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
-                TestUtilities.SetField(theoryData.ConfigurationManager, "_cancellationToken", theoryData.CancellationTokenSource.Token);
+                TestUtilities.SetField(theoryData.ConfigurationManager, "_BackgroundTaskCancellationToken", theoryData.CancellationTokenSource.Token);
 
                 theoryData.ExpectedException.ProcessNoException(context);
             }
@@ -750,7 +750,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 new OpenIdConnectConfigurationRetriever(),
                 docRetriever);
 
-            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
+            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
 
             AutoResetEvent resetEvent = SetupResetEvent(configManager, blocking);
 
@@ -832,7 +832,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 new OpenIdConnectConfigurationRetriever(),
                 docRetriever);
 
-            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
+            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
 
             var configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -973,7 +973,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 docRetriever);
 
             TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
-            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
+            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
 
             var resetEvent = SetupResetEvent(configManager, blocking);
 
@@ -1071,7 +1071,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 docRetriever);
 
             TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
-            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
+            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
 
             TimeSpan advanceInterval = BaseConfigurationManager.DefaultAutomaticRefreshInterval.Add(TimeSpan.FromSeconds(configManager.AutomaticRefreshInterval.TotalSeconds));
 
@@ -1142,7 +1142,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 theoryData.DocumentRetriever,
                 theoryData.ConfigurationValidator);
 
-            TestUtilities.SetField(configurationManager, "_cancellationToken", theoryData.CancellationTokenSource.Token);
+            TestUtilities.SetField(configurationManager, "_BackgroundTaskCancellationToken", theoryData.CancellationTokenSource.Token);
 
             var resetEvent = SetupResetEvent(configurationManager, blocking);
 

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -20,6 +20,7 @@ using Xunit;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 {
+    [ResetAppContextSwitches]
     public class ConfigurationManagerTests
     {
         /// <summary>
@@ -175,6 +176,19 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         [Fact]
         public async Task FetchMetadataFailureTest()
         {
+            await FetchMetadataFailureTestBody();
+        }
+
+        [Fact]
+        public async Task FetchMetadataFailureTest_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+
+            await FetchMetadataFailureTestBody();
+        }
+
+        private async Task FetchMetadataFailureTestBody()
+        {
             var context = new CompareContext($"{this}.FetchMetadataFailureTest");
 
             var documentRetriever = new HttpDocumentRetriever(HttpResponseMessageUtils.SetupHttpClientThatReturns("OpenIdConnectMetadata.json", HttpStatusCode.NotFound));
@@ -276,14 +290,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             catch (Exception firstFetchMetadataFailure)
             {
                 // _syncAfter should not have been changed, because the fetch failed.
-                DateTime syncAfter = (DateTime)TestUtilities.GetField(configManager, "_syncAfter");
-                if (syncAfter != DateTime.MinValue)
-                    context.AddDiff($"ConfigurationManager._syncAfter: '{syncAfter}' should equal '{DateTimeOffset.MinValue}'.");
+                var syncAfter = TestUtilities.GetField(configManager, "_syncAfter");
+                if ((DateTime)syncAfter != DateTime.MinValue)
+                    context.AddDiff($"ConfigurationManager._syncAfter: '{syncAfter}' should equal '{DateTime.MinValue}'.");
 
                 if (firstFetchMetadataFailure.InnerException == null)
                     context.AddDiff($"Expected exception to contain inner exception for fetch metadata failure.");
-
-                DateTime requestTime = DateTime.UtcNow;
 
                 // Fetch metadata again during refresh interval, the exception should be same from above.
                 try
@@ -297,10 +309,58 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         context.AddDiff($"Expected exception to contain inner exception for fetch metadata failure.");
 
                     // _syncAfter should not have been changed, because the fetch failed.
-                    syncAfter = (DateTime)TestUtilities.GetField(configManager, "_syncAfter");
+                    syncAfter = TestUtilities.GetField(configManager, "_syncAfter");
+                    if ((DateTime)syncAfter != DateTime.MinValue)
+                        context.AddDiff($"ConfigurationManager._syncAfter: '{syncAfter}' should equal '{DateTime.MinValue}'.");
 
-                    if (!IdentityComparer.AreDatesEqualWithEpsilon(requestTime, syncAfter, 1))
-                        context.AddDiff($"ConfigurationManager._syncAfter: '{syncAfter}' should equal be within 1 second of '{requestTime}'.");
+                    IdentityComparer.AreEqual(firstFetchMetadataFailure, secondFetchMetadataFailure, context);
+                }
+            }
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Fact]
+        public async Task BootstrapRefreshIntervalTest_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+
+            var context = new CompareContext($"{this}.BootstrapRefreshIntervalTest_Blocking");
+
+            var documentRetriever = new HttpDocumentRetriever(HttpResponseMessageUtils.SetupHttpClientThatReturns("OpenIdConnectMetadata.json", HttpStatusCode.NotFound));
+            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), documentRetriever) { RefreshInterval = TimeSpan.FromSeconds(2) };
+
+            // First time to fetch metadata.
+            try
+            {
+                var configuration = await configManager.GetConfigurationAsync();
+            }
+            catch (Exception firstFetchMetadataFailure)
+            {
+                // Refresh interval is BootstrapRefreshInterval
+                var syncAfter = configManager.GetType().GetField("_syncAfter", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(configManager);
+                if ((DateTime)syncAfter > DateTime.UtcNow + TimeSpan.FromSeconds(2))
+                    context.AddDiff($"Expected the refresh interval is longer than 2 seconds.");
+
+                if (firstFetchMetadataFailure.InnerException == null)
+                    context.AddDiff($"Expected exception to contain inner exception for fetch metadata failure.");
+
+                // Fetch metadata again during refresh interval, the exception should be same from above.
+                try
+                {
+                    configManager.RequestRefresh();
+                    var configuration = await configManager.GetConfigurationAsync();
+                }
+                catch (Exception secondFetchMetadataFailure)
+                {
+                    if (secondFetchMetadataFailure.InnerException == null)
+                        context.AddDiff($"Expected exception to contain inner exception for fetch metadata failure.");
+
+                    syncAfter = configManager.GetType().GetField("_syncAfter", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(configManager);
+
+                    // Refresh interval is RefreshInterval
+                    if ((DateTime)syncAfter > DateTime.UtcNow + configManager.RefreshInterval)
+                        context.AddDiff($"Expected the refresh interval is longer than 2 seconds.");
 
                     IdentityComparer.AreEqual(firstFetchMetadataFailure, secondFetchMetadataFailure, context);
                 }
@@ -346,20 +406,37 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         [Theory, MemberData(nameof(AutomaticIntervalTestCases), DisableDiscoveryEnumeration = true)]
         public async Task AutomaticRefreshInterval(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
         {
+            await AutomaticRefreshIntervalBody(theoryData);
+        }
+
+        [Theory, MemberData(nameof(AutomaticIntervalTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task AutomaticRefreshInterval_Blocking(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await AutomaticRefreshIntervalBody(theoryData, true);
+        }
+
+        private async Task AutomaticRefreshIntervalBody(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData, bool blocking = false)
+        {
             var context = new CompareContext($"{this}.AutomaticRefreshInterval");
 
             try
             {
-
                 var configuration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
                 IdentityComparer.AreEqual(configuration, theoryData.ExpectedConfiguration, context);
 
                 theoryData.ConfigurationManager.MetadataAddress = theoryData.UpdatedMetadataAddress;
                 TestUtilities.SetField(theoryData.ConfigurationManager, "_syncAfter", theoryData.SyncAfter.UtcDateTime);
                 var updatedConfiguration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
-                // we wait 100 ms here to make the task is finished.
-                Thread.Sleep(100);
+
+                if (!blocking)
+                {
+                    // we wait here to make the task is finished.
+                    Thread.Sleep(1000);
+                }
+
                 updatedConfiguration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
+
                 IdentityComparer.AreEqual(updatedConfiguration, theoryData.ExpectedUpdatedConfiguration, context);
 
                 theoryData.ExpectedException.ProcessNoException(context);
@@ -424,8 +501,20 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         [Theory, MemberData(nameof(RequestRefreshTestCases), DisableDiscoveryEnumeration = true)]
         public async Task RequestRefresh(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
         {
-            var context = new CompareContext($"{this}.RequestRefresh");
+            await RequestRefreshBody(theoryData);
+        }
 
+
+        [Theory, MemberData(nameof(RequestRefreshTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task RequestRefresh_Blocking(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await RequestRefreshBody(theoryData);
+        }
+
+        private async Task RequestRefreshBody(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            var context = new CompareContext($"{this}.RequestRefresh");
             var configuration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
             IdentityComparer.AreEqual(configuration, theoryData.ExpectedConfiguration, context);
 
@@ -434,6 +523,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             if (theoryData.RequestRefresh)
             {
                 theoryData.ConfigurationManager.RequestRefresh();
+                if (theoryData.SleepTimeInMs > 0)
+                    Thread.Sleep(theoryData.SleepTimeInMs);
                 configuration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
             }
 
@@ -500,7 +591,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         InMemoryDocumentRetriever),
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV2Config,
-                    SleepTimeInMs = 100,
+                    SleepTimeInMs = 1000,
                     UpdatedMetadataAddress = "AADCommonV2Json"
                 });
 
@@ -564,7 +655,19 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         }
 
         [Fact]
-        public async Task CheckSyncAfterAndRefreshRequested()
+        public async Task CheckSyncAfter_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await CheckSyncAfterBody(true);
+        }
+
+        [Fact]
+        public async Task CheckSyncAfter()
+        {
+            await CheckSyncAfterBody();
+        }
+
+        private async Task CheckSyncAfterBody(bool blocking = false)
         {
             // This test checks that the _syncAfter field is set correctly after a refresh.
             var context = new CompareContext($"{this}.CheckSyncAfterAndRefreshRequested");
@@ -582,8 +685,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             // force a refresh by setting internal field
             TestUtilities.SetField(configManager, "_syncAfter", DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
             configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
-            // wait 1000ms here because update of config is run as a new task.
-            Thread.Sleep(1000);
+
+            if (!blocking)
+                Thread.Sleep(500);
 
             // check that _syncAfter is greater than DateTimeOffset.UtcNow + AutomaticRefreshInterval
             DateTime syncAfter = (DateTime)TestUtilities.GetField(configManager, "_syncAfter");
@@ -596,15 +700,25 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             configManager.RequestRefresh();
 
-            bool refreshRequested = (bool)TestUtilities.GetField(configManager, "_refreshRequested");
-            if (!refreshRequested)
-                context.Diffs.Add("Refresh is expected to be requested after RequestRefresh is called");
+            if (blocking)
+            {
+                bool refreshRequested = (bool)TestUtilities.GetField(configManager, "_refreshRequested");
+                if (!refreshRequested)
+                    context.Diffs.Add("Refresh is expected to be requested after RequestRefresh is called");
+            }
 
             await configManager.GetConfigurationAsync();
 
-            refreshRequested = (bool)TestUtilities.GetField(configManager, "_refreshRequested");
-            if (refreshRequested)
-                context.Diffs.Add("Refresh is not expected to be requested after GetConfigurationAsync is called");
+            if (blocking)
+            {
+                bool refreshRequested = (bool)TestUtilities.GetField(configManager, "_refreshRequested");
+                if (refreshRequested)
+                    context.Diffs.Add("Refresh is expected to be requested after RequestRefresh is called");
+            }
+
+            // wait 1000ms here because update of config is run as a new task.
+            if (!blocking)
+                Thread.Sleep(1000);
 
             // check that _syncAfter is greater than DateTimeOffset.UtcNow + AutomaticRefreshInterval
             syncAfter = (DateTime)TestUtilities.GetField(configManager, "_syncAfter");
@@ -616,6 +730,18 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
         [Fact]
         public async Task GetConfigurationAsync()
+        {
+            await GetConfigurationBody();
+        }
+
+        [Fact]
+        public async Task GetConfigurationAsync_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await GetConfigurationBody();
+        }
+
+        private async Task GetConfigurationBody()
         {
             var docRetriever = new FileDocumentRetriever();
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
@@ -642,6 +768,18 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         // a new LKG is set.
         [Fact]
         public void ResetLastKnownGoodLifetime()
+        {
+            ResetLastKnownGoodLifetimeBody();
+        }
+
+        [Fact]
+        public void ResetLastKnownGoodLifetime_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            ResetLastKnownGoodLifetimeBody();
+        }
+
+        private void ResetLastKnownGoodLifetimeBody()
         {
             TestUtilities.WriteHeader($"{this}.ResetLastKnownGoodLifetime");
             var context = new CompareContext();
@@ -721,6 +859,18 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         [Fact]
         public async Task RequestRefresh_RespectsRefreshInterval()
         {
+            await RequestRefresh_RespectsRefreshInterval_Body();
+        }
+
+        [Fact]
+        public async Task RequestRefresh_RespectsRefreshInterval_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await RequestRefresh_RespectsRefreshInterval_Body(true);
+        }
+
+        private async Task RequestRefresh_RespectsRefreshInterval_Body(bool blocking = false)
+        {
             // This test checks that the _syncAfter field is set correctly after a refresh.
             var context = new CompareContext($"{this}.RequestRefresh_RespectsRefreshInterval");
 
@@ -735,6 +885,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             configManager.RequestRefresh();
 
+            if (!blocking)
+                Thread.Sleep(250);
+
             var configAfterFirstRefresh = await configManager.GetConfigurationAsync(CancellationToken.None);
 
             // First RequestRefresh triggers a refresh.
@@ -742,6 +895,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 context.Diffs.Add("object.ReferenceEquals(configuration, configAfterFirstRefresh)");
 
             configManager.RequestRefresh();
+
+            if (!blocking)
+                Thread.Sleep(250);
 
             var configAfterNoTimePassed = await configManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -754,6 +910,9 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             configManager.RequestRefresh();
 
+            if (!blocking)
+                Thread.Sleep(250);
+
             var configAfterRefreshInterval = await configManager.GetConfigurationAsync(CancellationToken.None);
 
             // Third RequestRefresh should trigger a refresh because the refresh interval has passed.
@@ -763,7 +922,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             // Advance time just prior to a refresh.
             timeProvider.Advance(configManager.RefreshInterval.Subtract(TimeSpan.FromSeconds(1)));
 
+            configManager.RequestRefresh();
+
             var configAfterLessThanRefreshInterval = await configManager.GetConfigurationAsync(CancellationToken.None);
+
+            if (!blocking)
+                Thread.Sleep(250);
 
             // Fourth RequestRefresh should not trigger a refresh because the refresh interval has not passed.
             if (!object.ReferenceEquals(configAfterRefreshInterval, configAfterLessThanRefreshInterval))
@@ -772,10 +936,15 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             // Advance time 365 days.
             timeProvider.Advance(TimeSpan.FromDays(365));
 
+            configManager.RequestRefresh();
+
+            if (!blocking)
+                Thread.Sleep(250);
+
             var configAfterOneYear = await configManager.GetConfigurationAsync(CancellationToken.None);
 
             // Fifth RequestRefresh should trigger a refresh because the refresh interval has passed.
-            if (!object.ReferenceEquals(configAfterLessThanRefreshInterval, configAfterOneYear))
+            if (object.ReferenceEquals(configAfterLessThanRefreshInterval, configAfterOneYear))
                 context.Diffs.Add("object.ReferenceEquals(configAfterLessThanRefreshInterval, configAfterOneYear)");
 
             TestUtilities.AssertFailIfErrors(context);
@@ -783,6 +952,18 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
         [Fact]
         public async Task GetConfigurationAsync_RespectsRefreshInterval()
+        {
+            await GetConfigurationAsync_RespectsRefreshIntervalBody();
+        }
+
+        [Fact]
+        public async Task GetConfigurationAsync_RespectsRefreshInterval_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await GetConfigurationAsync_RespectsRefreshIntervalBody(true);
+        }
+
+        private async Task GetConfigurationAsync_RespectsRefreshIntervalBody(bool blocking = false)
         {
             var context = new CompareContext($"{this}.GetConfigurationAsync_RespectsRefreshInterval");
 
@@ -810,24 +991,44 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             var configAfterTimeIsAdvanced = await configManager.GetConfigurationAsync(CancellationToken.None);
 
-            // Same config, but a task is queued to update the configuration.
-            if (!object.ReferenceEquals(configNoAdvanceInTime, configAfterTimeIsAdvanced))
-                context.Diffs.Add("!object.ReferenceEquals(configuration, configAfterTimeIsAdvanced)");
+            if (!blocking)
+            {
+                // Same config, but a task is queued to update the configuration.
+                if (!object.ReferenceEquals(configNoAdvanceInTime, configAfterTimeIsAdvanced))
+                    context.Diffs.Add("!object.ReferenceEquals(configuration, configAfterTimeIsAdvanced)");
 
-            // Need to wait for background task to finish.
-            Thread.Sleep(250);
+                // Need to wait for background task to finish.
+                Thread.Sleep(500);
 
-            var configAfterBackgroundTask = await configManager.GetConfigurationAsync(CancellationToken.None);
+                var configAfterBackgroundTask = await configManager.GetConfigurationAsync(CancellationToken.None);
 
-            // Configuration should be updated after the background task finishes.
-            if (object.ReferenceEquals(configAfterTimeIsAdvanced, configAfterBackgroundTask))
-                context.Diffs.Add("object.ReferenceEquals(configuration, configAfterBackgroundTask)");
+                // Configuration should be updated after the background task finishes.
+                if (object.ReferenceEquals(configAfterTimeIsAdvanced, configAfterBackgroundTask))
+                    context.Diffs.Add("object.ReferenceEquals(configuration, configAfterBackgroundTask)");
+            }
+            else
+            {
+                if (object.ReferenceEquals(configAfterTimeIsAdvanced, configuration))
+                    context.Diffs.Add("object.ReferenceEquals(configAfterTimeIsAdvanced, configuration)");
+            }
 
             TestUtilities.AssertFailIfErrors(context);
         }
 
         [Theory, MemberData(nameof(ValidateOpenIdConnectConfigurationTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task ValidateOpenIdConnectConfigurationTests_Blocking(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await ValidateOIDCConfigurationBody(theoryData);
+        }
+
+        [Theory, MemberData(nameof(ValidateOpenIdConnectConfigurationTestCases), DisableDiscoveryEnumeration = true)]
         public async Task ValidateOpenIdConnectConfigurationTests(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            await ValidateOIDCConfigurationBody(theoryData);
+        }
+
+        private async Task ValidateOIDCConfigurationBody(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
         {
             TestUtilities.WriteHeader($"{this}.ValidateOpenIdConnectConfigurationTests");
             var context = new CompareContext();
@@ -843,8 +1044,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 var listener = TestUtils.SampleListener.CreateLoggerListener(EventLevel.Warning);
                 configuration = await configurationManager.GetConfigurationAsync();
 
-                // we need to sleep here to make sure the task that updates configuration has finished.
-                Thread.Sleep(250);
+                Thread.Sleep(1000);
 
                 if (!string.IsNullOrEmpty(theoryData.ExpectedErrorMessage) && !listener.TraceBuffer.Contains(theoryData.ExpectedErrorMessage))
                     context.AddDiff($"Expected exception to contain: '{theoryData.ExpectedErrorMessage}'.{Environment.NewLine}Log is:{Environment.NewLine}'{listener.TraceBuffer}'");

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -21,6 +21,7 @@ using Xunit;
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 {
     [ResetAppContextSwitches]
+    [Collection(nameof(AppContextSwitches.UpdateConfigAsBlocking))]
     public class ConfigurationManagerTests
     {
         /// <summary>
@@ -1061,7 +1062,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             var context = new CompareContext($"{this}.GetConfigurationAsync_RespectsRefreshInterval");
 
             var timeProvider = new FakeTimeProvider();
-
             var docRetriever = new FileDocumentRetriever();
 
             var cts = new CancellationTokenSource();
@@ -1074,8 +1074,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
 
             TimeSpan advanceInterval = BaseConfigurationManager.DefaultAutomaticRefreshInterval.Add(TimeSpan.FromSeconds(configManager.AutomaticRefreshInterval.TotalSeconds));
-
-            TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
 
             // Get the first configuration.
             var configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
@@ -1166,15 +1164,11 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         () => listener.TraceBuffer.Contains(theoryData.ExpectedErrorMessage),
                         TimeSpan.FromMilliseconds(100),
                         TimeSpan.FromSeconds(10));
-
-                    if (!success)
-                        context.AddDiff($"Expected 1 or more logs to be written, but only {listener.WriteCount} were written.");
                 }
 
                 if (!string.IsNullOrEmpty(theoryData.ExpectedErrorMessage) && !listener.TraceBuffer.Contains(theoryData.ExpectedErrorMessage))
                     context.AddDiff($"Expected exception to contain: '{theoryData.ExpectedErrorMessage}'.{Environment.NewLine}Log is:{Environment.NewLine}'{listener.TraceBuffer}'");
 
-                Console.WriteLine(listener.WriteCount);
                 theoryData.ExpectedException.ProcessNoException(context);
             }
             catch (Exception ex)

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -36,16 +36,15 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         {
             var cts = new CancellationTokenSource();
             CompareContext context = TestUtilities.WriteHeader($"{this}.GetPublicMetadata", theoryData);
+
+            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                theoryData.MetadataAddress,
+                theoryData.ConfigurationRetriever,
+                theoryData.DocumentRetriever,
+                theoryData.ConfigurationValidator);
+
             try
             {
-                var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
-                    theoryData.MetadataAddress,
-                    theoryData.ConfigurationRetriever,
-                    theoryData.DocumentRetriever,
-                    theoryData.ConfigurationValidator);
-
-                configurationManager.BackgroundRefreshTaskCancellationToken = cts.Token;
-
                 var configuration = await configurationManager.GetConfigurationAsync(CancellationToken.None);
 
                 Assert.NotNull(configuration);
@@ -57,7 +56,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
             finally
             {
-                cts.Cancel();
+                configurationManager.ShutdownBackgroundTask();
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -203,7 +202,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             var documentRetriever = new HttpDocumentRetriever(HttpResponseMessageUtils.SetupHttpClientThatReturns("OpenIdConnectMetadata.json", HttpStatusCode.NotFound));
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), documentRetriever);
-            configManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             // First time to fetch metadata
             try
@@ -230,7 +228,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
             finally
             {
-                cts.Cancel();
+                configManager.ShutdownBackgroundTask();
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -252,7 +250,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     new OpenIdConnectConfigurationRetriever(),
                     inMemoryDocumentRetriever);
 
-            configurationManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             OpenIdConnectConfiguration configuration = await configurationManager.GetConfigurationAsync();
 
@@ -282,7 +279,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             // Configuration should be AADCommonV1Config
             configuration = await configurationManager.GetConfigurationAsync();
 
-            cts.Cancel();
+            configurationManager.ShutdownBackgroundTask();
 
             Assert.True(configuration.Issuer.Equals(OpenIdConfigData.AADCommonV1Config.Issuer),
                     $"configuration.Issuer from configurationManager was not as expected," +
@@ -305,7 +302,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 documentRetriever)
             { RefreshInterval = TimeSpan.FromSeconds(2) };
 
-            configManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             // ConfigurationManager._syncAfter is set to DateTimeOffset.MinValue on startup
             // If obtaining the metadata fails due to error, the value should not change
@@ -344,7 +340,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
             finally
             {
-                cts.Cancel();
+                configManager.ShutdownBackgroundTask();
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -406,7 +402,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             TestUtilities.WriteHeader($"{this}.GetSets", "GetSets", true);
 
-            int ExpectedPropertyCount = 8;
+            int ExpectedPropertyCount = 7;
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), new FileDocumentRetriever());
             Type type = typeof(ConfigurationManager<OpenIdConnectConfiguration>);
             PropertyInfo[] properties = type.GetProperties();
@@ -477,7 +473,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
             finally
             {
-                theoryData.CancellationTokenSource.Cancel();
+                theoryData.ConfigurationManager.ShutdownBackgroundTask();
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -512,16 +508,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever)
                     {
-                        BackgroundRefreshTaskCancellationToken = cts.Token
                     },
-                    CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     SyncAfter = DateTime.UtcNow - TimeSpan.FromDays(2),
                     UpdatedMetadataAddress = "https://httpstat.us/429"
                 });
-
-                cts = new();
 
                 // AutomaticRefreshInterval interval should return same config.
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AutomaticRefreshIntervalNotHit")
@@ -531,16 +523,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                        new OpenIdConnectConfigurationRetriever(),
                        InMemoryDocumentRetriever)
                     {
-                        BackgroundRefreshTaskCancellationToken = cts.Token
                     },
-                    CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     SyncAfter = DateTime.UtcNow + TimeSpan.FromDays(2),
                     UpdatedMetadataAddress = "AADCommonV2Json"
                 });
-
-                cts = new();
 
                 // AutomaticRefreshInterval should pick up new bits.
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AutomaticRefreshIntervalHit")
@@ -550,9 +538,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever)
                     {
-                        BackgroundRefreshTaskCancellationToken = cts.Token
                     },
-                    CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV2Config,
                     SyncAfter = DateTime.UtcNow,
@@ -611,7 +597,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             var updatedConfiguration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
 
-            theoryData.CancellationTokenSource.Cancel();
+            theoryData.ConfigurationManager.ShutdownBackgroundTask();
 
             IdentityComparer.AreEqual(updatedConfiguration, theoryData.ExpectedUpdatedConfiguration, context);
 
@@ -632,9 +618,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever)
                     {
-                        BackgroundRefreshTaskCancellationToken = cts.Token
                     },
-                    CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV2Config,
                     RefreshInterval = TimeSpan.FromSeconds(1),
@@ -651,9 +635,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever)
                     {
-                        BackgroundRefreshTaskCancellationToken = cts.Token
                     },
-                    CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     RefreshInterval = TimeSpan.MaxValue,
@@ -670,9 +652,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         new OpenIdConnectConfigurationRetriever(),
                         InMemoryDocumentRetriever)
                     {
-                        BackgroundRefreshTaskCancellationToken = cts.Token
                     },
-                    CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV2Config,
                     SleepTimeInMs = 1000,
@@ -691,7 +671,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             try
             {
                 _ = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
-                TestUtilities.SetField(theoryData.ConfigurationManager, "_BackgroundTaskCancellationToken", theoryData.CancellationTokenSource.Token);
+                TestUtilities.SetField(theoryData.ConfigurationManager, "_BackgroundTaskCancellationToken", CancellationToken.None);
 
                 theoryData.ExpectedException.ProcessNoException(context);
             }
@@ -701,7 +681,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
             finally
             {
-                theoryData.CancellationTokenSource.Cancel();
+                theoryData.ConfigurationManager.ShutdownBackgroundTask();
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -719,7 +699,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         "https://httpstat.us/429",
                         new OpenIdConnectConfigurationRetriever(),
                         new HttpDocumentRetriever()),
-                    CancellationTokenSource = new(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX20803:", typeof(IOException)),
                 });
 
@@ -729,7 +708,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         "https://127.0.0.1",
                         new OpenIdConnectConfigurationRetriever(),
                         new HttpDocumentRetriever()),
-                    CancellationTokenSource = new(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX20803:", typeof(IOException)),
                 });
 
@@ -739,7 +717,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                         "http://127.0.0.1",
                         new OpenIdConnectConfigurationRetriever(),
                         new HttpDocumentRetriever()),
-                    CancellationTokenSource = new(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX20803:", typeof(ArgumentException)),
                 });
 
@@ -773,7 +750,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 new OpenIdConnectConfigurationRetriever(),
                 docRetriever);
 
-            configManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             AutoResetEvent resetEvent = SetupResetEvent(configManager, blocking);
 
@@ -826,7 +802,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             if (syncAfter < minimumRefreshInterval)
                 context.Diffs.Add($"(RequestRefresh) syncAfter '{syncAfter}' < DateTimeOffset.UtcNow + configManager.AutomaticRefreshInterval: '{minimumRefreshInterval}'.");
 
-            cts.Cancel();
+            configManager.ShutdownBackgroundTask();
 
             TestUtilities.AssertFailIfErrors(context);
         }
@@ -855,7 +831,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 new OpenIdConnectConfigurationRetriever(),
                 docRetriever);
 
-            configManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             var configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -869,7 +844,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             if (!object.ReferenceEquals(configuration, configuration2))
                 context.Diffs.Add("!object.ReferenceEquals(configuration, configuration2)");
 
-            cts.Cancel();
+            configManager.ShutdownBackgroundTask();
 
             // get configuration from http address, should throw
             // get configuration with unsuccessful HTTP response status code
@@ -996,7 +971,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 docRetriever);
 
             TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
-            configManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             var resetEvent = SetupResetEvent(configManager, blocking);
 
@@ -1061,7 +1035,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             if (object.ReferenceEquals(configAfterLessThanRefreshInterval, configAfterOneYear))
                 context.Diffs.Add("object.ReferenceEquals(configAfterLessThanRefreshInterval, configAfterOneYear)");
 
-            cts.Cancel();
+            configManager.ShutdownBackgroundTask();
 
             TestUtilities.AssertFailIfErrors(context);
         }
@@ -1093,7 +1067,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 docRetriever);
 
             TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
-            configManager.BackgroundRefreshTaskCancellationToken = cts.Token;
 
             TimeSpan advanceInterval = BaseConfigurationManager.DefaultAutomaticRefreshInterval.Add(TimeSpan.FromSeconds(configManager.AutomaticRefreshInterval.TotalSeconds));
 
@@ -1133,7 +1106,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     context.Diffs.Add("object.ReferenceEquals(configAfterTimeIsAdvanced, configuration)");
             }
 
-            cts.Cancel();
+            configManager.ShutdownBackgroundTask();
 
             TestUtilities.AssertFailIfErrors(context);
         }
@@ -1160,10 +1133,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 theoryData.MetadataAddress,
                 theoryData.ConfigurationRetriever,
                 theoryData.DocumentRetriever,
-                theoryData.ConfigurationValidator)
-            {
-                BackgroundRefreshTaskCancellationToken = theoryData.CancellationTokenSource.Token
-            };
+                theoryData.ConfigurationValidator);
 
             var resetEvent = SetupResetEvent(configurationManager, blocking);
 
@@ -1203,7 +1173,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
             finally
             {
-                theoryData.CancellationTokenSource.Cancel();
+                configurationManager.ShutdownBackgroundTask();
             }
 
             TestUtilities.AssertFailIfErrors(context);
@@ -1247,7 +1217,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     First = true,
                     MetadataAddress = "OpenIdConnectMetadata.json",
                     TestId = "ValidConfiguration",
-                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1258,7 +1227,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX21818:", typeof(InvalidConfigurationException)),
                     MetadataAddress = "OpenIdConnectMetadata.json",
                     TestId = "ValidConfiguration_NotEnoughKey",
-                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1270,7 +1238,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     ExpectedErrorMessage = "IDX21818: ",
                     MetadataAddress = "OpenIdConnectMetadata.json",
                     TestId = "ValidConfiguration_NotEnoughKey_PresetCurrentConfiguration",
-                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1281,7 +1248,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX10810:", typeof(InvalidConfigurationException)),
                     MetadataAddress = "OpenIdConnectMetadataUnrecognizedKty.json",
                     TestId = "InvalidConfiguration_UnrecognizedKty",
-                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1293,7 +1259,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     ExpectedErrorMessage = "IDX10810: ",
                     MetadataAddress = "OpenIdConnectMetadataUnrecognizedKty.json",
                     TestId = "InvalidConfiguration_UnrecognizedKty_PresetCurrentConfiguration",
-                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1304,7 +1269,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX21817:", typeof(InvalidConfigurationException)),
                     MetadataAddress = "JsonWebKeySetUnrecognizedKty.json",
                     TestId = "InvalidConfiguration_EmptyJsonWenKeySet",
-                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1316,7 +1280,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     ExpectedErrorMessage = "IDX21817: ",
                     MetadataAddress = "JsonWebKeySetUnrecognizedKty.json",
                     TestId = "InvalidConfiguration_EmptyJsonWenKeySet_PresetCurrentConfiguration",
-                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1327,7 +1290,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX10814:", typeof(InvalidConfigurationException)),
                     MetadataAddress = "OpenIdConnectMetadataBadRsaDataMissingComponent.json",
                     TestId = "InvalidConfiguration_RsaKeyMissingComponent",
-                    CancellationTokenSource = new(),
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
@@ -1339,7 +1301,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     ExpectedErrorMessage = "IDX10814: ",
                     MetadataAddress = "OpenIdConnectMetadataBadRsaDataMissingComponent.json",
                     TestId = "InvalidConfiguration_RsaKeyMissingComponent_PresetCurrentConfiguration",
-                    CancellationTokenSource = new(),
                 });
 
                 return theoryData;
@@ -1419,8 +1380,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
 
             public string UpdatedMetadataAddress { get; set; }
-
-            public CancellationTokenSource CancellationTokenSource { get; set; }
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -447,7 +447,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        private static AutoResetEvent SetupResetEvent(ConfigurationManager<OpenIdConnectConfiguration> configurationManager, bool blocking)
+        internal static AutoResetEvent SetupResetEvent(ConfigurationManager<OpenIdConnectConfiguration> configurationManager, bool blocking)
         {
             var resetEvent = new AutoResetEvent(false);
 
@@ -1240,7 +1240,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 signalEvent);
         }
 
-        private static void WaitOrFail(AutoResetEvent are)
+        internal static void WaitOrFail(AutoResetEvent are)
         {
             if (!are.WaitOne(30000))
                 Assert.Fail("Failed to receive a signal in 30s, failing test");

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     DocumentRetriever = new HttpDocumentRetriever(),
                     ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
                     MetadataAddress = "OpenIdConnectMetadata.json",
-                    TestId = "ConfigurationRetreiver: NULL"
+                    TestId = "ConfigurationRetriever: NULL"
                 });
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -419,6 +419,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         private async Task AutomaticRefreshIntervalBody(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData, bool blocking = false)
         {
             var context = new CompareContext($"{this}.AutomaticRefreshInterval");
+            AutoResetEvent resetEvent = SetupResetEvent(theoryData.ConfigurationManager, blocking);
 
             try
             {
@@ -429,11 +430,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 TestUtilities.SetField(theoryData.ConfigurationManager, "_syncAfter", theoryData.SyncAfter.UtcDateTime);
                 var updatedConfiguration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
 
-                if (!blocking)
-                {
-                    // we wait here to make the task is finished.
-                    Thread.Sleep(1000);
-                }
+                if (!blocking && theoryData.SyncAfter < DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(1)))
+                    WaitOrFail(resetEvent);
 
                 updatedConfiguration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -447,6 +445,19 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
 
             TestUtilities.AssertFailIfErrors(context);
+        }
+
+        private static AutoResetEvent SetupResetEvent(ConfigurationManager<OpenIdConnectConfiguration> configurationManager, bool blocking)
+        {
+            var resetEvent = new AutoResetEvent(false);
+
+            if (!blocking)
+            {
+                Action _waitAction = () => resetEvent.Set();
+                TestUtilities.SetField(configurationManager, "_onBackgroundTaskFinish", _waitAction);
+            }
+
+            return resetEvent;
         }
 
         public static TheoryData<ConfigurationManagerTheoryData<OpenIdConnectConfiguration>> AutomaticIntervalTestCases
@@ -509,35 +520,40 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         public async Task RequestRefresh_Blocking(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
         {
             AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
-            await RequestRefreshBody(theoryData);
+            await RequestRefreshBody(theoryData, true);
         }
 
-        private async Task RequestRefreshBody(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
+        private async Task RequestRefreshBody(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData, bool blocking = false)
         {
             var context = new CompareContext($"{this}.RequestRefresh");
             var configuration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
             IdentityComparer.AreEqual(configuration, theoryData.ExpectedConfiguration, context);
+
+            AutoResetEvent resetEvent = SetupResetEvent(theoryData.ConfigurationManager, blocking);
+
+            var timeProvider = new FakeTimeProvider();
+            TestUtilities.SetField(theoryData.ConfigurationManager, "_timeProvider", timeProvider);
 
             // the first call to RequestRefresh will trigger a refresh with ConfigurationManager.RefreshInterval being ignored.
             // Testing RefreshInterval requires a two calls, the second call will trigger a refresh with ConfigurationManager.RefreshInterval being used.
             if (theoryData.RequestRefresh)
             {
                 theoryData.ConfigurationManager.RequestRefresh();
-                if (theoryData.SleepTimeInMs > 0)
-                    Thread.Sleep(theoryData.SleepTimeInMs);
+                if (!blocking)
+                    WaitOrFail(resetEvent);
+
                 configuration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
             }
-
-            if (theoryData.SleepTimeInMs > 0)
-                Thread.Sleep(theoryData.SleepTimeInMs);
 
             theoryData.ConfigurationManager.RefreshInterval = theoryData.RefreshInterval;
             theoryData.ConfigurationManager.MetadataAddress = theoryData.UpdatedMetadataAddress;
 
+            timeProvider.Advance(TimeSpan.FromMilliseconds(theoryData.SleepTimeInMs));
+
             theoryData.ConfigurationManager.RequestRefresh();
 
-            if (theoryData.SleepTimeInMs > 0)
-                Thread.Sleep(theoryData.SleepTimeInMs);
+            if (!blocking && theoryData.RefreshInterval != TimeSpan.MaxValue)
+                WaitOrFail(resetEvent);
 
             var updatedConfiguration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -675,6 +691,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             var docRetriever = new FileDocumentRetriever();
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
 
+            AutoResetEvent resetEvent = SetupResetEvent(configManager, blocking);
+
             // This is the minimum time that should pass before an automatic refresh occurs
             // stored in advance to avoid any time drift issues.
             DateTimeOffset minimumRefreshInterval = DateTimeOffset.UtcNow + configManager.AutomaticRefreshInterval;
@@ -687,7 +705,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
 
             if (!blocking)
-                Thread.Sleep(500);
+                WaitOrFail(resetEvent);
 
             // check that _syncAfter is greater than DateTimeOffset.UtcNow + AutomaticRefreshInterval
             DateTime syncAfter = (DateTime)TestUtilities.GetField(configManager, "_syncAfter");
@@ -716,9 +734,8 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     context.Diffs.Add("Refresh is expected to be requested after RequestRefresh is called");
             }
 
-            // wait 1000ms here because update of config is run as a new task.
             if (!blocking)
-                Thread.Sleep(1000);
+                WaitOrFail(resetEvent);
 
             // check that _syncAfter is greater than DateTimeOffset.UtcNow + AutomaticRefreshInterval
             syncAfter = (DateTime)TestUtilities.GetField(configManager, "_syncAfter");
@@ -880,13 +897,15 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
             TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
 
+            var resetEvent = SetupResetEvent(configManager, blocking);
+
             // Get the first configuration.
             var configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
 
             configManager.RequestRefresh();
 
             if (!blocking)
-                Thread.Sleep(250);
+                WaitOrFail(resetEvent);
 
             var configAfterFirstRefresh = await configManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -895,9 +914,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 context.Diffs.Add("object.ReferenceEquals(configuration, configAfterFirstRefresh)");
 
             configManager.RequestRefresh();
-
-            if (!blocking)
-                Thread.Sleep(250);
 
             var configAfterNoTimePassed = await configManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -911,7 +927,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             configManager.RequestRefresh();
 
             if (!blocking)
-                Thread.Sleep(250);
+                WaitOrFail(resetEvent);
 
             var configAfterRefreshInterval = await configManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -926,9 +942,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             var configAfterLessThanRefreshInterval = await configManager.GetConfigurationAsync(CancellationToken.None);
 
-            if (!blocking)
-                Thread.Sleep(250);
-
             // Fourth RequestRefresh should not trigger a refresh because the refresh interval has not passed.
             if (!object.ReferenceEquals(configAfterRefreshInterval, configAfterLessThanRefreshInterval))
                 context.Diffs.Add("object.ReferenceEquals(configAfterRefreshInterval, configAfterLessThanRefreshInterval)");
@@ -939,7 +952,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             configManager.RequestRefresh();
 
             if (!blocking)
-                Thread.Sleep(250);
+                WaitOrFail(resetEvent);
 
             var configAfterOneYear = await configManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -973,7 +986,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
             TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
 
-            TimeSpan advanceInterval = BaseConfigurationManager.DefaultAutomaticRefreshInterval.Add(TimeSpan.FromSeconds(configManager.AutomaticRefreshInterval.TotalSeconds / 20));
+            TimeSpan advanceInterval = BaseConfigurationManager.DefaultAutomaticRefreshInterval.Add(TimeSpan.FromSeconds(configManager.AutomaticRefreshInterval.TotalSeconds / 10));
 
             TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
 
@@ -993,12 +1006,13 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             if (!blocking)
             {
+                var resetEvent = SetupResetEvent(configManager, blocking);
                 // Same config, but a task is queued to update the configuration.
                 if (!object.ReferenceEquals(configNoAdvanceInTime, configAfterTimeIsAdvanced))
                     context.Diffs.Add("!object.ReferenceEquals(configuration, configAfterTimeIsAdvanced)");
 
                 // Need to wait for background task to finish.
-                Thread.Sleep(500);
+                WaitOrFail(resetEvent);
 
                 var configAfterBackgroundTask = await configManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -1019,7 +1033,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         public async Task ValidateOpenIdConnectConfigurationTests_Blocking(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
         {
             AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
-            await ValidateOIDCConfigurationBody(theoryData);
+            await ValidateOIDCConfigurationBody(theoryData, true);
         }
 
         [Theory, MemberData(nameof(ValidateOpenIdConnectConfigurationTestCases), DisableDiscoveryEnumeration = true)]
@@ -1028,12 +1042,14 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             await ValidateOIDCConfigurationBody(theoryData);
         }
 
-        private async Task ValidateOIDCConfigurationBody(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
+        private async Task ValidateOIDCConfigurationBody(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData, bool blocking = false)
         {
             TestUtilities.WriteHeader($"{this}.ValidateOpenIdConnectConfigurationTests");
             var context = new CompareContext();
             OpenIdConnectConfiguration configuration;
             var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(theoryData.MetadataAddress, theoryData.ConfigurationRetriever, theoryData.DocumentRetriever, theoryData.ConfigurationValidator);
+
+            var resetEvent = SetupResetEvent(configurationManager, blocking);
 
             if (theoryData.PresetCurrentConfiguration)
                 TestUtilities.SetField(configurationManager, "_currentConfiguration", new OpenIdConnectConfiguration() { Issuer = Default.Issuer });
@@ -1041,14 +1057,25 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             try
             {
                 //create a listener and enable it for logs
-                var listener = TestUtils.SampleListener.CreateLoggerListener(EventLevel.Warning);
+                using var listener = TestUtils.SampleListener.CreateLoggerListener(EventLevel.Warning);
+
                 configuration = await configurationManager.GetConfigurationAsync();
 
-                Thread.Sleep(1000);
+                if (!blocking && theoryData.ExpectedException is null && string.IsNullOrEmpty(theoryData.ExpectedErrorMessage))
+                    WaitOrFail(resetEvent);
+
+                // Need to wait for the events on the listener to be processed.
+                if (!string.IsNullOrEmpty(theoryData.ExpectedErrorMessage))
+                {
+                    var success = await PollForConditionAsync(() => listener.WriteCount >= 1, TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(10));
+                    if (!success)
+                        context.AddDiff($"Expected 1 or more logs to be written, but only {listener.WriteCount} were written.");
+                }
 
                 if (!string.IsNullOrEmpty(theoryData.ExpectedErrorMessage) && !listener.TraceBuffer.Contains(theoryData.ExpectedErrorMessage))
                     context.AddDiff($"Expected exception to contain: '{theoryData.ExpectedErrorMessage}'.{Environment.NewLine}Log is:{Environment.NewLine}'{listener.TraceBuffer}'");
 
+                Console.WriteLine(listener.WriteCount);
                 theoryData.ExpectedException.ProcessNoException(context);
             }
             catch (Exception ex)
@@ -1060,6 +1087,28 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
 
             TestUtilities.AssertFailIfErrors(context);
+        }
+
+        private static async Task<bool> PollForConditionAsync(Func<bool> condition, TimeSpan interval, TimeSpan timeout)
+        {
+            var startTime = DateTime.UtcNow;
+
+            while (DateTime.UtcNow - startTime < timeout)
+            {
+                if (condition())
+                    return true;
+
+                try
+                {
+                    await Task.Delay(interval);
+                }
+                catch (TaskCanceledException)
+                {
+                    return false;
+                }
+            }
+
+            return false;
         }
 
         public static TheoryData<ConfigurationManagerTheoryData<OpenIdConnectConfiguration>> ValidateOpenIdConnectConfigurationTestCases
@@ -1189,6 +1238,12 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 },
                 waitEvent,
                 signalEvent);
+        }
+
+        private static void WaitOrFail(AutoResetEvent are)
+        {
+            if (!are.WaitOne(30000))
+                Assert.Fail("Failed to receive a signal in 30s, failing test");
         }
 
         public class ConfigurationManagerTheoryData<T> : TheoryDataBase where T : class

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     theoryData.DocumentRetriever,
                     theoryData.ConfigurationValidator);
 
-                TestUtilities.SetField(configurationManager, "_BackgroundTaskCancellationToken", cts.Token);
+                configurationManager.BackgroundTaskCancellationToken = cts.Token;
 
                 var configuration = await configurationManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -203,7 +203,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             var documentRetriever = new HttpDocumentRetriever(HttpResponseMessageUtils.SetupHttpClientThatReturns("OpenIdConnectMetadata.json", HttpStatusCode.NotFound));
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), documentRetriever);
-            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
+            configManager.BackgroundTaskCancellationToken = cts.Token;
 
             // First time to fetch metadata
             try
@@ -252,7 +252,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     new OpenIdConnectConfigurationRetriever(),
                     inMemoryDocumentRetriever);
 
-            TestUtilities.SetField(configurationManager, "_BackgroundTaskCancellationToken", cts.Token);
+            configurationManager.BackgroundTaskCancellationToken = cts.Token;
 
             OpenIdConnectConfiguration configuration = await configurationManager.GetConfigurationAsync();
 
@@ -305,7 +305,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 documentRetriever)
             { RefreshInterval = TimeSpan.FromSeconds(2) };
 
-            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
+            configManager.BackgroundTaskCancellationToken = cts.Token;
 
             // ConfigurationManager._syncAfter is set to DateTimeOffset.MinValue on startup
             // If obtaining the metadata fails due to error, the value should not change
@@ -406,7 +406,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             TestUtilities.WriteHeader($"{this}.GetSets", "GetSets", true);
 
-            int ExpectedPropertyCount = 7;
+            int ExpectedPropertyCount = 8;
             var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), new FileDocumentRetriever());
             Type type = typeof(ConfigurationManager<OpenIdConnectConfiguration>);
             PropertyInfo[] properties = type.GetProperties();
@@ -460,7 +460,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.ConfigurationManager.MetadataAddress = theoryData.UpdatedMetadataAddress;
                 TestUtilities.SetField(theoryData.ConfigurationManager, "_syncAfter", theoryData.SyncAfter.UtcDateTime);
-                TestUtilities.SetField(theoryData.ConfigurationManager, "_BackgroundTaskCancellationToken", theoryData.CancellationTokenSource.Token);
                 var updatedConfiguration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
 
                 if (!blocking && theoryData.SyncAfter < DateTimeOffset.UtcNow.Add(TimeSpan.FromMinutes(1)))
@@ -503,19 +502,26 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             {
                 var theoryData = new TheoryData<ConfigurationManagerTheoryData<OpenIdConnectConfiguration>>();
 
+                var cts = new CancellationTokenSource();
+
                 // Failing to get metadata returns existing.
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("HttpFault_ReturnExisting")
                 {
                     ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                         "AADCommonV1Json",
                         new OpenIdConnectConfigurationRetriever(),
-                        InMemoryDocumentRetriever),
-                    CancellationTokenSource = new(),
+                        InMemoryDocumentRetriever)
+                    {
+                        BackgroundTaskCancellationToken = cts.Token
+                    },
+                    CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     SyncAfter = DateTime.UtcNow - TimeSpan.FromDays(2),
                     UpdatedMetadataAddress = "https://httpstat.us/429"
                 });
+
+                cts = new();
 
                 // AutomaticRefreshInterval interval should return same config.
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AutomaticRefreshIntervalNotHit")
@@ -523,13 +529,18 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                        "AADCommonV1Json",
                        new OpenIdConnectConfigurationRetriever(),
-                       InMemoryDocumentRetriever),
-                    CancellationTokenSource = new(),
+                       InMemoryDocumentRetriever)
+                    {
+                        BackgroundTaskCancellationToken = cts.Token
+                    },
+                    CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     SyncAfter = DateTime.UtcNow + TimeSpan.FromDays(2),
                     UpdatedMetadataAddress = "AADCommonV2Json"
                 });
+
+                cts = new();
 
                 // AutomaticRefreshInterval should pick up new bits.
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AutomaticRefreshIntervalHit")
@@ -537,8 +548,11 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                         "AADCommonV1Json",
                         new OpenIdConnectConfigurationRetriever(),
-                        InMemoryDocumentRetriever),
-                    CancellationTokenSource = new(),
+                        InMemoryDocumentRetriever)
+                    {
+                        BackgroundTaskCancellationToken = cts.Token
+                    },
+                    CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV2Config,
                     SyncAfter = DateTime.UtcNow,
@@ -573,7 +587,6 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             var timeProvider = new FakeTimeProvider();
             TestUtilities.SetField(theoryData.ConfigurationManager, "_timeProvider", timeProvider);
-            TestUtilities.SetField(theoryData.ConfigurationManager, "_BackgroundTaskCancellationToken", theoryData.CancellationTokenSource.Token);
 
             // the first call to RequestRefresh will trigger a refresh with ConfigurationManager.RefreshInterval being ignored.
             // Testing RefreshInterval requires a two calls, the second call will trigger a refresh with ConfigurationManager.RefreshInterval being used.
@@ -611,14 +624,17 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             {
                 var theoryData = new TheoryData<ConfigurationManagerTheoryData<OpenIdConnectConfiguration>>();
 
-                // RefreshInterval set to 1 sec should return new config.
+                var cts = new CancellationTokenSource();
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("RequestRefresh_TimeSpan_1000ms")
                 {
                     ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                         "AADCommonV1Json",
                         new OpenIdConnectConfigurationRetriever(),
-                        InMemoryDocumentRetriever),
-                    CancellationTokenSource = new(),
+                        InMemoryDocumentRetriever)
+                    {
+                        BackgroundTaskCancellationToken = cts.Token
+                    },
+                    CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV2Config,
                     RefreshInterval = TimeSpan.FromSeconds(1),
@@ -627,14 +643,17 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     UpdatedMetadataAddress = "AADCommonV2Json"
                 });
 
-                // RefreshInterval set to TimeSpan.MaxValue should return same config.
+                cts = new CancellationTokenSource();
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("RequestRefresh_TimeSpan_MaxValue")
                 {
                     ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                         "AADCommonV1Json",
                         new OpenIdConnectConfigurationRetriever(),
-                        InMemoryDocumentRetriever),
-                    CancellationTokenSource = new(),
+                        InMemoryDocumentRetriever)
+                    {
+                        BackgroundTaskCancellationToken = cts.Token
+                    },
+                    CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     RefreshInterval = TimeSpan.MaxValue,
@@ -643,14 +662,17 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                     UpdatedMetadataAddress = "AADCommonV2Json"
                 });
 
-                // First RequestRefresh should pickup new config
+                cts = new CancellationTokenSource();
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("RequestRefresh_FirstRefresh")
                 {
                     ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                         "AADCommonV1Json",
                         new OpenIdConnectConfigurationRetriever(),
-                        InMemoryDocumentRetriever),
-                    CancellationTokenSource = new(),
+                        InMemoryDocumentRetriever)
+                    {
+                        BackgroundTaskCancellationToken = cts.Token
+                    },
+                    CancellationTokenSource = cts,
                     ExpectedConfiguration = OpenIdConfigData.AADCommonV1Config,
                     ExpectedUpdatedConfiguration = OpenIdConfigData.AADCommonV2Config,
                     SleepTimeInMs = 1000,
@@ -751,7 +773,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 new OpenIdConnectConfigurationRetriever(),
                 docRetriever);
 
-            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
+            configManager.BackgroundTaskCancellationToken = cts.Token;
 
             AutoResetEvent resetEvent = SetupResetEvent(configManager, blocking);
 
@@ -833,7 +855,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 new OpenIdConnectConfigurationRetriever(),
                 docRetriever);
 
-            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
+            configManager.BackgroundTaskCancellationToken = cts.Token;
 
             var configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
 
@@ -974,7 +996,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 docRetriever);
 
             TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
-            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
+            configManager.BackgroundTaskCancellationToken = cts.Token;
 
             var resetEvent = SetupResetEvent(configManager, blocking);
 
@@ -1071,7 +1093,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 docRetriever);
 
             TestUtilities.SetField(configManager, "_timeProvider", timeProvider);
-            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
+            configManager.BackgroundTaskCancellationToken = cts.Token;
 
             TimeSpan advanceInterval = BaseConfigurationManager.DefaultAutomaticRefreshInterval.Add(TimeSpan.FromSeconds(configManager.AutomaticRefreshInterval.TotalSeconds));
 
@@ -1138,9 +1160,10 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 theoryData.MetadataAddress,
                 theoryData.ConfigurationRetriever,
                 theoryData.DocumentRetriever,
-                theoryData.ConfigurationValidator);
-
-            TestUtilities.SetField(configurationManager, "_BackgroundTaskCancellationToken", theoryData.CancellationTokenSource.Token);
+                theoryData.ConfigurationValidator)
+            {
+                BackgroundTaskCancellationToken = theoryData.CancellationTokenSource.Token
+            };
 
             var resetEvent = SetupResetEvent(configurationManager, blocking);
 

--- a/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
@@ -67,9 +67,12 @@ namespace Microsoft.IdentityModel.Protocols.Tests
         [Fact]
         public async Task ConfigurationManagerUsingCustomClass()
         {
+            var cts = new CancellationTokenSource();
             var docRetriever = new FileDocumentRetriever();
             var configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever);
             var context = new CompareContext($"{this}.ConfigurationManagerUsingCustomClass");
+
+            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
 
             var configuration = await configManager.GetConfigurationAsync();
             configManager.MetadataAddress = "IssuerMetadata.json";
@@ -82,6 +85,8 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             configManager.RequestRefresh();
             configuration = await configManager.GetConfigurationAsync();
             TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
+            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
+
             configManager.MetadataAddress = "IssuerMetadata2.json";
 
             // Wait for the refresh to complete.
@@ -100,6 +105,8 @@ namespace Microsoft.IdentityModel.Protocols.Tests
 
             if (IdentityComparer.AreEqual(configuration.Issuer, configuration2.Issuer))
                 context.Diffs.Add($"Expected: {configuration.Issuer}, to be different from: {configuration2.Issuer}");
+
+            cts.Cancel();
 
             TestUtilities.AssertFailIfErrors(context);
         }

--- a/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
@@ -67,12 +67,8 @@ namespace Microsoft.IdentityModel.Protocols.Tests
         [Fact]
         public async Task ConfigurationManagerUsingCustomClass()
         {
-            var cts = new CancellationTokenSource();
             var docRetriever = new FileDocumentRetriever();
-            var configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever)
-            {
-                BackgroundRefreshTaskCancellationToken = cts.Token
-            };
+            var configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever);
             var context = new CompareContext($"{this}.ConfigurationManagerUsingCustomClass");
 
             var configuration = await configManager.GetConfigurationAsync();
@@ -81,11 +77,10 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             if (!IdentityComparer.AreEqual(configuration.Issuer, configuration2.Issuer, context))
                 context.Diffs.Add("!IdentityComparer.AreEqual(configuration, configuration2)");
 
+            configManager.ShutdownBackgroundTask();
+
             // AutomaticRefreshInterval should pick up new bits.
-            configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever)
-            {
-                BackgroundRefreshTaskCancellationToken = cts.Token
-            };
+            configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever);
             configManager.RequestRefresh();
             configuration = await configManager.GetConfigurationAsync();
             TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
@@ -109,7 +104,7 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             if (IdentityComparer.AreEqual(configuration.Issuer, configuration2.Issuer))
                 context.Diffs.Add($"Expected: {configuration.Issuer}, to be different from: {configuration2.Issuer}");
 
-            cts.Cancel();
+            configManager.ShutdownBackgroundTask();
 
             TestUtilities.AssertFailIfErrors(context);
         }

--- a/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             var configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever);
             var context = new CompareContext($"{this}.ConfigurationManagerUsingCustomClass");
 
-            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
+            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
 
             var configuration = await configManager.GetConfigurationAsync();
             configManager.MetadataAddress = "IssuerMetadata.json";
@@ -85,7 +85,7 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             configManager.RequestRefresh();
             configuration = await configManager.GetConfigurationAsync();
             TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
-            TestUtilities.SetField(configManager, "_cancellationToken", cts.Token);
+            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
 
             configManager.MetadataAddress = "IssuerMetadata2.json";
 

--- a/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             var docRetriever = new FileDocumentRetriever();
             var configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever)
             {
-                BackgroundTaskCancellationToken = cts.Token
+                BackgroundRefreshTaskCancellationToken = cts.Token
             };
             var context = new CompareContext($"{this}.ConfigurationManagerUsingCustomClass");
 
@@ -84,7 +84,7 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             // AutomaticRefreshInterval should pick up new bits.
             configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever)
             {
-                BackgroundTaskCancellationToken = cts.Token
+                BackgroundRefreshTaskCancellationToken = cts.Token
             };
             configManager.RequestRefresh();
             configuration = await configManager.GetConfigurationAsync();

--- a/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/ExtensibilityTests.cs
@@ -69,10 +69,11 @@ namespace Microsoft.IdentityModel.Protocols.Tests
         {
             var cts = new CancellationTokenSource();
             var docRetriever = new FileDocumentRetriever();
-            var configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever);
+            var configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever)
+            {
+                BackgroundTaskCancellationToken = cts.Token
+            };
             var context = new CompareContext($"{this}.ConfigurationManagerUsingCustomClass");
-
-            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
 
             var configuration = await configManager.GetConfigurationAsync();
             configManager.MetadataAddress = "IssuerMetadata.json";
@@ -81,11 +82,13 @@ namespace Microsoft.IdentityModel.Protocols.Tests
                 context.Diffs.Add("!IdentityComparer.AreEqual(configuration, configuration2)");
 
             // AutomaticRefreshInterval should pick up new bits.
-            configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever);
+            configManager = new ConfigurationManager<IssuerMetadata>("IssuerMetadata.json", new IssuerConfigurationRetriever(), docRetriever)
+            {
+                BackgroundTaskCancellationToken = cts.Token
+            };
             configManager.RequestRefresh();
             configuration = await configManager.GetConfigurationAsync();
             TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
-            TestUtilities.SetField(configManager, "_BackgroundTaskCancellationToken", cts.Token);
 
             configManager.MetadataAddress = "IssuerMetadata2.json";
 

--- a/test/Microsoft.IdentityModel.TestUtils/ResetAppContextSwitchesAttribute.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ResetAppContextSwitchesAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit.Sdk;
+
+namespace Microsoft.IdentityModel.TestUtils
+{
+    /// <inheritdoc/>
+    public class ResetAppContextSwitchesAttribute : BeforeAfterTestAttribute
+    {
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            AppContextSwitches.ResetAllSwitches();
+        }
+
+        public override void After(MethodInfo methodUnderTest)
+        {
+            AppContextSwitches.ResetAllSwitches();
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.TestUtils/SampleListener.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/SampleListener.cs
@@ -10,14 +10,11 @@ namespace Microsoft.IdentityModel.TestUtils
     {
         public string TraceBuffer { get; set; } = string.Empty;
 
-        public int WriteCount { get; set; }
-
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
             if (eventData != null && eventData.Payload.Count > 0)
             {
                 TraceBuffer += eventData.Payload[0] + "\n";
-                WriteCount += 1;
             }
         }
 

--- a/test/Microsoft.IdentityModel.TestUtils/SampleListener.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/SampleListener.cs
@@ -10,11 +10,14 @@ namespace Microsoft.IdentityModel.TestUtils
     {
         public string TraceBuffer { get; set; } = string.Empty;
 
+        public int WriteCount { get; set; }
+
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
             if (eventData != null && eventData.Payload.Count > 0)
             {
                 TraceBuffer += eventData.Payload[0] + "\n";
+                WriteCount += 1;
             }
         }
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Telemetry/MockTelemetryClient.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Telemetry/MockTelemetryClient.cs
@@ -15,6 +15,7 @@ namespace Microsoft.IdentityModel.Telemetry.Tests
         public void ClearExportedItems()
         {
             ExportedItems.Clear();
+            ExportedHistogramItems.Clear();
         }
 
         public void IncrementConfigurationRefreshRequestCounter(string metadataAddress, string operationStatus)

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Telemetry/MockTelemetryClient.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Telemetry/MockTelemetryClient.cs
@@ -45,5 +45,12 @@ namespace Microsoft.IdentityModel.Telemetry.Tests
             ExportedHistogramItems.Add(TelemetryConstants.MetadataAddressTag, metadataAddress);
             ExportedHistogramItems.Add(TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString());
         }
+
+        void ITelemetryClient.LogBackgroundRefreshFailure(string metadataAddress, Exception exception)
+        {
+            ExportedItems.Add(TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer);
+            ExportedItems.Add(TelemetryConstants.MetadataAddressTag, metadataAddress);
+            ExportedItems.Add(TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString());
+        }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Telemetry/MockTelemetryClient.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Telemetry/MockTelemetryClient.cs
@@ -46,7 +46,7 @@ namespace Microsoft.IdentityModel.Telemetry.Tests
             ExportedHistogramItems.Add(TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString());
         }
 
-        void ITelemetryClient.LogBackgroundRefreshFailure(string metadataAddress, Exception exception)
+        void ITelemetryClient.LogBackgroundConfigurationRefreshFailure(string metadataAddress, Exception exception)
         {
             ExportedItems.Add(TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer);
             ExportedItems.Add(TelemetryConstants.MetadataAddressTag, metadataAddress);


### PR DESCRIPTION
# App context switch to allow blocking or non-blocking GetConfiguration

Stress testing showed that the current non-blocking implementation wasn't always triggered as expected, moving to an AutoResetEvent fixed this.

How Configuration is Updated Now:
Asynchronous Updates: The configuration can be updated asynchronously using background tasks. The method. The method to trigger the background task was updated to a AutoResetEvent.

Blocking vs Non-Blocking: The AppContextSwitches.UpdateConfigAsBlocking switch determines whether the configuration update should block other requests. If this switch is enabled, the method RequestRefreshBlocking is called; otherwise, RequestRefreshBackgroundThread is used.

Telemetry: The method TelemetryForUpdate handles logging the mode of update (manual or automatic) to a telemetry client.
These changes aim to improve the efficiency and responsiveness of the configuration update process by leveraging background tasks and signals.

Adds ShutdownBackgroundTask() method to ConfigurationManager to stop the background task.

Introduce ResetAppContextSwitches to have deterministic reset per test that uses an app context, this also serializes tests.

Adds 

Fixes #3082