### PR TITLE
New validation model: Fixed stack frames being created when already cached

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/ValidationError.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/ValidationError.cs
@@ -288,16 +288,9 @@ namespace Microsoft.IdentityModel.Tokens
             // String is allocated, but it goes out of scope immediately after the call
             string key = filePath + lineNumber;
 
-            // Try to get the stack frame from the cache,
-            // otherwise create a new one and add it to the cache
-            if (!CachedStackFrames.TryGetValue(key, out StackFrame? frame))
-            {
-                frame = new StackFrame(skipFrames, true);
-                CachedStackFrames.TryAdd(key, frame);
-            }
-
-            // By this point the frame cannot be null, but the compiler doesn't know that
-            return frame!;
+            return CachedStackFrames.GetOrAdd(
+                key,
+                _ => new StackFrame(skipFrames, true));
         }
 
         // ConcurrentDictionary is thread-safe and only locks when adding a new item.

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/ValidationError.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/ValidationError.cs
@@ -287,8 +287,17 @@ namespace Microsoft.IdentityModel.Tokens
         {
             // String is allocated, but it goes out of scope immediately after the call
             string key = filePath + lineNumber;
-            StackFrame frame = CachedStackFrames.GetOrAdd(key, new StackFrame(skipFrames, true));
-            return frame;
+
+            // Try to get the stack frame from the cache,
+            // otherwise create a new one and add it to the cache
+            if (!CachedStackFrames.TryGetValue(key, out StackFrame? frame))
+            {
+                frame = new StackFrame(skipFrames, true);
+                CachedStackFrames.TryAdd(key, frame);
+            }
+
+            // By this point the frame cannot be null, but the compiler doesn't know that
+            return frame!;
         }
 
         // ConcurrentDictionary is thread-safe and only locks when adding a new item.

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/ValidationError.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/Details/ValidationError.cs
@@ -290,7 +290,8 @@ namespace Microsoft.IdentityModel.Tokens
 
             return CachedStackFrames.GetOrAdd(
                 key,
-                _ => new StackFrame(skipFrames, true));
+                // Need to skip the call to the delegate + GetOrAdd when creating the frame
+                _ => new StackFrame(skipFrames + 2, true));
         }
 
         // ConcurrentDictionary is thread-safe and only locks when adding a new item.


### PR DESCRIPTION
# New validation model: Fixed stack frames being created when already cached
Addressed a bug in the `GetCurrentStackFrame` method in the `ValidationError.cs` file that caused stack frames to be created even when they were already cached.