### PR TITLE
Do not set JsonWebToken.SigningKey until signature succeeds

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateSignature.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateSignature.cs
@@ -104,8 +104,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
             if (key is not null)
             {
-                jwtToken.SigningKey = key;
-
                 // If the key is found, validate the signature.
                 return ValidateSignatureWithKey(jwtToken, key, validationParameters, callContext);
             }
@@ -314,7 +312,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     ValidateSignature);
 
                 if (valid)
+                {
+                    jsonWebToken.SigningKey = key;
+
                     return key;
+                }
                 else
                     return new SignatureValidationError(
                         new MessageDetail(

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateSignatureTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateSignatureTests.cs
@@ -66,6 +66,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
                 Exception exception = validationError.GetException();
                 theoryData.ExpectedException.ProcessException(exception, context);
+
+                if (jsonWebToken is not null)
+                    Assert.Null(jsonWebToken.SigningKey);
             }
 
             TestUtilities.AssertFailIfErrors(context);


### PR DESCRIPTION
# Do not set JsonWebToken.SigningKey until signature succeeds
- Set the SigningKey in JsonWebToken only after the signature has been validated.
- Added test to prevent regressions

Fixes #3109 