### PR TITLE
Add TryAllDecryptionKeys flag to whether decrypt if no key IDs match

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
@@ -1320,7 +1320,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             // 2. ResolveTokenDecryptionKey returned null
             // 3. ResolveTokenDecryptionKeyFromConfig returned null
             // Try all the keys. This is the degenerate case, not concerned about perf.
-            if (keys == null)
+            if (validationParameters.TryAllDecryptionKeys && keys.IsNullOrEmpty())
             {
                 keys = JwtTokenUtilities.GetAllDecryptionKeys(validationParameters);
                 if (configuration != null)
@@ -1335,60 +1335,62 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             // keep track of exceptions thrown, keys that were tried
             StringBuilder exceptionStrings = null;
             StringBuilder keysAttempted = null;
-            foreach (var key in keys)
+            if (keys != null)
             {
-                try
+                foreach (var key in keys)
                 {
-#if NET472 || NET6_0_OR_GREATER
-                    if (SupportedAlgorithms.EcdsaWrapAlgorithms.Contains(jwtToken.Alg))
+                    try
                     {
-                        ECDsaSecurityKey publicKey;
-
-                        // Since developers may have already worked around this issue, implicitly taking a dependency on the
-                        // old behavior, we guard the new behavior behind an AppContext switch. The new/RFC-conforming behavior
-                        // is treated as opt-in. When the library is at the point where it is able to make breaking changes
-                        // (such as the next major version update) we should consider whether or not this app-compat switch
-                        // needs to be maintained.
-                        if (AppContextSwitches.UseRfcDefinitionOfEpkAndKid)
+#if NET472 || NET6_0_OR_GREATER
+                        if (SupportedAlgorithms.EcdsaWrapAlgorithms.Contains(jwtToken.Alg))
                         {
-                            // on decryption we get the public key from the EPK value see: https://datatracker.ietf.org/doc/html/rfc7518#appendix-C
-                            jwtToken.TryGetHeaderValue(JwtHeaderParameterNames.Epk, out string epk);
-                            publicKey = new ECDsaSecurityKey(new JsonWebKey(epk), false);
+                            ECDsaSecurityKey publicKey;
+
+                            // Since developers may have already worked around this issue, implicitly taking a dependency on the
+                            // old behavior, we guard the new behavior behind an AppContext switch. The new/RFC-conforming behavior
+                            // is treated as opt-in. When the library is at the point where it is able to make breaking changes
+                            // (such as the next major version update) we should consider whether or not this app-compat switch
+                            // needs to be maintained.
+                            if (AppContextSwitches.UseRfcDefinitionOfEpkAndKid)
+                            {
+                                // on decryption we get the public key from the EPK value see: https://datatracker.ietf.org/doc/html/rfc7518#appendix-C
+                                jwtToken.TryGetHeaderValue(JwtHeaderParameterNames.Epk, out string epk);
+                                publicKey = new ECDsaSecurityKey(new JsonWebKey(epk), false);
+                            }
+                            else
+                            {
+                                publicKey = validationParameters.TokenDecryptionKey as ECDsaSecurityKey;
+                            }
+
+                            var ecdhKeyExchangeProvider = new EcdhKeyExchangeProvider(
+                                key as ECDsaSecurityKey,
+                                publicKey,
+                                jwtToken.Alg,
+                                jwtToken.Enc);
+                            jwtToken.TryGetHeaderValue(JwtHeaderParameterNames.Apu, out string apu);
+                            jwtToken.TryGetHeaderValue(JwtHeaderParameterNames.Apv, out string apv);
+                            SecurityKey kdf = ecdhKeyExchangeProvider.GenerateKdf(apu, apv);
+                            var kwp = key.CryptoProviderFactory.CreateKeyWrapProviderForUnwrap(kdf, ecdhKeyExchangeProvider.GetEncryptionAlgorithm());
+                            var unwrappedKey = kwp.UnwrapKey(Base64UrlEncoder.DecodeBytes(jwtToken.EncryptedKey));
+                            unwrappedKeys.Add(new SymmetricSecurityKey(unwrappedKey));
                         }
                         else
-                        {
-                            publicKey = validationParameters.TokenDecryptionKey as ECDsaSecurityKey;
-                        }
-
-                        var ecdhKeyExchangeProvider = new EcdhKeyExchangeProvider(
-                            key as ECDsaSecurityKey,
-                            publicKey,
-                            jwtToken.Alg,
-                            jwtToken.Enc);
-                        jwtToken.TryGetHeaderValue(JwtHeaderParameterNames.Apu, out string apu);
-                        jwtToken.TryGetHeaderValue(JwtHeaderParameterNames.Apv, out string apv);
-                        SecurityKey kdf = ecdhKeyExchangeProvider.GenerateKdf(apu, apv);
-                        var kwp = key.CryptoProviderFactory.CreateKeyWrapProviderForUnwrap(kdf, ecdhKeyExchangeProvider.GetEncryptionAlgorithm());
-                        var unwrappedKey = kwp.UnwrapKey(Base64UrlEncoder.DecodeBytes(jwtToken.EncryptedKey));
-                        unwrappedKeys.Add(new SymmetricSecurityKey(unwrappedKey));
-                    }
-                    else
 #endif
-                    if (key.CryptoProviderFactory.IsSupportedAlgorithm(jwtToken.Alg, key))
-                    {
-                        var kwp = key.CryptoProviderFactory.CreateKeyWrapProviderForUnwrap(key, jwtToken.Alg);
-                        var unwrappedKey = kwp.UnwrapKey(jwtToken.EncryptedKeyBytes);
-                        unwrappedKeys.Add(new SymmetricSecurityKey(unwrappedKey));
+                        if (key.CryptoProviderFactory.IsSupportedAlgorithm(jwtToken.Alg, key))
+                        {
+                            var kwp = key.CryptoProviderFactory.CreateKeyWrapProviderForUnwrap(key, jwtToken.Alg);
+                            var unwrappedKey = kwp.UnwrapKey(jwtToken.EncryptedKeyBytes);
+                            unwrappedKeys.Add(new SymmetricSecurityKey(unwrappedKey));
+                        }
                     }
-                }
-                catch (Exception ex)
-                {
-                    (exceptionStrings ??= new StringBuilder()).AppendLine(ex.ToString());
-                }
+                    catch (Exception ex)
+                    {
+                        (exceptionStrings ??= new StringBuilder()).AppendLine(ex.ToString());
+                    }
 
-                (keysAttempted ??= new StringBuilder()).AppendLine(key.KeyId);
+                    (keysAttempted ??= new StringBuilder()).AppendLine(key.KeyId);
+                }
             }
-
             if (unwrappedKeys.Count > 0 || exceptionStrings is null)
                 return unwrappedKeys;
             else

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.DecryptToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.DecryptToken.cs
@@ -121,7 +121,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             // 2. ResolveTokenDecryptionKey returned null
             // 3. ResolveTokenDecryptionKeyFromConfig returned null
             // Try all the keys. This is the degenerate case, not concerned about perf.
-            if (keys == null)
+            if (validationParameters.TryAllDecryptionKeys && keys.IsNullOrEmpty())
             {
                 keys = validationParameters.TokenDecryptionKeys;
                 if (configuration != null)

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -142,7 +142,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10617 = "IDX10617: Encryption failed. Keywrap is only supported for: '{0}', '{1}' and '{2}'. The content encryption specified is: '{3}'.";
         public const string IDX10618 = "IDX10618: Key unwrap failed using decryption Keys: '{0}'.\nExceptions caught:\n '{1}'.\ntoken: '{2}'.";
         public const string IDX10619 = "IDX10619: Decryption failed. Algorithm: '{0}'. Either the Encryption Algorithm: '{1}' or none of the Security Keys are supported by the CryptoProviderFactory.";
-        public const string IDX10620 = "IDX10620: Unable to obtain a CryptoProviderFactory, both EncryptingCredentials.CryptoProviderFactory and EncryptingCredentials.Key.CrypoProviderFactory are null.";
+        public const string IDX10620 = "IDX10620: Unable to obtain a CryptoProviderFactory, both EncryptingCredentials.CryptoProviderFactory and EncryptingCredentials.Key.CryptoProviderFactory are null.";
         //public const string IDX10903 = "IDX10903: Token decryption succeeded. With thumbprint: '{0}'.";
         public const string IDX10904 = "IDX10904: Token decryption key : '{0}' found in TokenValidationParameters.";
         public const string IDX10905 = "IDX10905: Token decryption key : '{0}' found in Configuration/Metadata.";

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor.IncludeKeyIdInHeader.get -> bool
 Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor.IncludeKeyIdInHeader.set -> void
 static Microsoft.IdentityModel.Tokens.JsonWebKeyConverter.TryConvertToSecurityKey(Microsoft.IdentityModel.Tokens.JsonWebKey webKey, out Microsoft.IdentityModel.Tokens.SecurityKey key) -> bool
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.TryAllDecryptionKeys.get -> bool
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.TryAllDecryptionKeys.set -> void

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -89,6 +89,7 @@ namespace Microsoft.IdentityModel.Tokens
             TokenReplayCache = other.TokenReplayCache;
             TokenReplayValidator = other.TokenReplayValidator;
             TransformBeforeSignatureValidation = other.TransformBeforeSignatureValidation;
+            TryAllDecryptionKeys = other.TryAllDecryptionKeys;
             TryAllIssuerSigningKeys = other.TryAllIssuerSigningKeys;
             TypeValidator = other.TypeValidator;
             ValidateActor = other.ValidateActor;
@@ -118,6 +119,7 @@ namespace Microsoft.IdentityModel.Tokens
             RequireSignedTokens = true;
             RequireAudience = true;
             SaveSigninToken = false;
+            TryAllDecryptionKeys = true;
             TryAllIssuerSigningKeys = true;
             ValidateActor = false;
             ValidateAudience = true;
@@ -552,10 +554,13 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Gets or sets the <see cref="SecurityKey"/> that is to be used for decryption.
         /// </summary>
+        /// <remarks>
+        /// This <see cref="TokenDecryptionKey"/> will only be used if its <see cref="SecurityKey.KeyId"/> matches the 'kid' parameter in the token.
+        /// </remarks>
         public SecurityKey TokenDecryptionKey { get; set; }
 
         /// <summary>
-        /// Gets or sets a delegate that will be called to retreive a <see cref="SecurityKey"/> used for decryption.
+        /// Gets or sets a delegate that will be called to retrieve a <see cref="SecurityKey"/> used for decryption.
         /// </summary>
         /// <remarks>
         /// This <see cref="SecurityKey"/> will be used to decrypt the token. This can be helpful when the <see cref="SecurityToken"/> does not contain a key identifier.
@@ -565,6 +570,9 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Gets or sets the <see cref="IEnumerable{SecurityKey}"/> that is to be used for decrypting inbound tokens.
         /// </summary>
+        /// <remarks>
+        /// The decryption keys in this <see cref="TokenDecryptionKeys"/> collection will only be used if their <see cref="SecurityKey.KeyId"/> matches the 'kid' parameter in the token.
+        /// </remarks>
         public IEnumerable<SecurityKey> TokenDecryptionKeys { get; set; }
 
         /// <summary>
@@ -592,7 +600,14 @@ namespace Microsoft.IdentityModel.Tokens
         public TokenReplayValidator TokenReplayValidator { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether all <see cref="IssuerSigningKeys"/> should be tried during signature validation when a key is not matched to token kid or if token kid is empty.
+        /// Gets or sets a value indicating whether all <see cref="TokenDecryptionKeys"/> should be tried during token decryption when a key is not matched to token 'kid' or if token 'kid' is empty.
+        /// The default is <c>true</c>.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool TryAllDecryptionKeys { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether all <see cref="IssuerSigningKeys"/> should be tried during signature validation when a key is not matched to token 'kid' or if token 'kid' is empty.
         /// The default is <c>true</c>.
         /// </summary>
         [DefaultValue(true)]

--- a/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/ValidationParameters.cs
@@ -92,6 +92,7 @@ namespace Microsoft.IdentityModel.Tokens
             SaveSigninToken = other.SaveSigninToken;
             _signatureValidator = other.SignatureValidator;
             TimeProvider = other.TimeProvider;
+            TryAllDecryptionKeys = other.TryAllDecryptionKeys;
             TokenDecryptionKeyResolver = other.TokenDecryptionKeyResolver;
             _tokenDecryptionKeys = other.TokenDecryptionKeys;
             TokenReplayCache = other.TokenReplayCache;
@@ -112,6 +113,7 @@ namespace Microsoft.IdentityModel.Tokens
         {
             LogTokenId = true;
             SaveSigninToken = false;
+            TryAllDecryptionKeys = true;
             ValidateActor = false;
         }
 
@@ -478,6 +480,9 @@ namespace Microsoft.IdentityModel.Tokens
         /// <summary>
         /// Gets the <see cref="IList{T}"/> that is to be used for decrypting inbound tokens.
         /// </summary>
+        /// <remarks>
+        /// The decryption keys in this <see cref="TokenDecryptionKeys"/> collection will only be used if their <see cref="SecurityKey.KeyId"/> matches the 'kid' parameter in the token.
+        /// </remarks>
         public IList<SecurityKey> TokenDecryptionKeys
         {
             get
@@ -512,6 +517,13 @@ namespace Microsoft.IdentityModel.Tokens
             get { return _tokenReplayValidator; }
             set { _tokenReplayValidator = value ?? throw new ArgumentNullException(nameof(value), "TokenReplayValidator cannot be set as null."); }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether all <see cref="TokenDecryptionKeys"/> should be tried during token decryption when a key is not matched to token 'kid' or if token 'kid' is empty.
+        /// The default is <c>true</c>.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool TryAllDecryptionKeys { get; set; }
 
         /// <summary>
         /// If the IssuerSigningKeyResolver is unable to resolve the key when validating the signature of the SecurityToken,

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -672,7 +672,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 var jwtTokenFromJsonHandlerWithKid = new JsonWebToken(jweFromJsonHandlerWithKid);
                 var encryptionKeysFromJsonHandlerWithKid = theoryData.JsonWebTokenHandler.GetContentEncryptionKeys(jwtTokenFromJsonHandlerWithKid, theoryData.ValidationParameters, theoryData.Configuration);
 
-                IdentityComparer.AreEqual(encryptionKeysFromJsonHandlerWithKid, theoryData.ExpectedDecryptionKeys);
+                Assert.True(IdentityComparer.AreEqual(encryptionKeysFromJsonHandlerWithKid, theoryData.ExpectedDecryptionKeys));
                 theoryData.ExpectedException.ProcessNoException(context);
             }
             catch (Exception ex)
@@ -696,15 +696,19 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 configurationWithDecryptionKeys.TokenDecryptionKeys.Add(KeyingMaterial.DefaultSymmetricSecurityKey_256);
                 configurationWithDecryptionKeys.TokenDecryptionKeys.Add(KeyingMaterial.DefaultSymmetricSecurityKey_512);
 
-                var configurationThatThrows = CreateCustomConfigurationThatThrows();
+                var rsaKey = new RsaSecurityKey(KeyingMaterial.RsaParameters_2048) { KeyId = "CustomRsaSecurityKey_2048" };
+                var configurationThatThrows = CreateCustomConfigurationThatThrows(rsaKey);
+
+                var configurationWithMismatchedKeys = new OpenIdConnectConfiguration();
+                configurationWithMismatchedKeys.TokenDecryptionKeys.Add(rsaKey);
 
                 tokenHandler.InboundClaimTypeMap.Clear();
                 return new TheoryData<CreateTokenTheoryData>
                 {
-                   new CreateTokenTheoryData
-                   {
+                    new CreateTokenTheoryData
+                    {
                         First = true,
-                        TestId = "EncryptionKeyInConfig",
+                        TestId = "ValidKeyInConfig_KeysSetInConfig",
                         Payload = Default.PayloadString,
                         TokenDescriptor =  new SecurityTokenDescriptor
                         {
@@ -720,10 +724,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         },
                         Configuration = configurationWithDecryptionKeys,
                         ExpectedDecryptionKeys =  new List<SecurityKey>(){ KeyingMaterial.DefaultSymmetricSecurityKey_256 },
-                   },
-                   new CreateTokenTheoryData
-                   {
-                        TestId = "ValidEncryptionKeyInConfig",
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "ValidKeyInConfig_KeysSetInConfigAndTvp",
                         Payload = Default.PayloadString,
                         TokenDescriptor =  new SecurityTokenDescriptor
                         {
@@ -740,10 +744,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         },
                         Configuration = configurationWithDecryptionKeys,
                         ExpectedDecryptionKeys =  new List<SecurityKey>(){ KeyingMaterial.DefaultSymmetricSecurityKey_256 },
-                   },
-                   new CreateTokenTheoryData
-                   {
-                        TestId = "Valid",
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "ValidKeyInTvp_KeysSetInTvp",
                         Payload = Default.PayloadString,
                         TokenDescriptor =  new SecurityTokenDescriptor
                         {
@@ -759,10 +763,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             ValidIssuer = Default.Issuer
                         },
                         ExpectedDecryptionKeys =  new List<SecurityKey>(){ KeyingMaterial.DefaultSymmetricSecurityKey_256 },
-                   },
-                   new CreateTokenTheoryData
-                   {
-                        TestId = "AlgorithmMismatch",
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "AlgorithmMismatch_ReturnsNoKeys",
                         Payload = Default.PayloadString,
                         // There is no error, just no decryption keys are returned.
                         ExpectedException = ExpectedException.NoExceptionExpected,
@@ -780,10 +784,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             ValidAudience = Default.Audience,
                             ValidIssuer = Default.Issuer
                         },
-                   },
-                   new CreateTokenTheoryData
-                   {
-                        TestId = "EncryptionKeyInConfig_OneKeysThrows_SuccessfulKeyReturned",
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "ValidKeyInConfig_OneKeyThrows_SuccessfulKeyReturned",
                         Payload = Default.PayloadString,
                         TokenDescriptor =  new SecurityTokenDescriptor
                         {
@@ -798,13 +802,53 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                             ValidIssuer = Default.Issuer
                         },
                         Configuration = configurationThatThrows,
-                        ExpectedDecryptionKeys =  new List<SecurityKey>(){ KeyingMaterial.DefaultSymmetricSecurityKey_256 },
-                   }
+                        ExpectedDecryptionKeys =  new List<SecurityKey>(){ rsaKey },
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "KeyIdMismatch_TryAllDecryptionKeysTrue_ReturnsKey",
+                        Payload = Default.PayloadString,
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
+                            EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256),
+                            Claims = Default.PayloadDictionary
+                        },
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key,
+                            TryAllDecryptionKeys = true,
+                            ValidAudience = Default.Audience,
+                            ValidIssuer = Default.Issuer
+                        },
+                        Configuration = configurationWithMismatchedKeys,
+                        ExpectedDecryptionKeys =  new List<SecurityKey>(){ rsaKey },
+                    },
+                    new CreateTokenTheoryData
+                    {
+                        TestId = "KeyIdMismatch_TryAllDecryptionKeysFalse_ReturnsNoKeys",
+                        Payload = Default.PayloadString,
+                        TokenDescriptor =  new SecurityTokenDescriptor
+                        {
+                            SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
+                            EncryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256),
+                            Claims = Default.PayloadDictionary
+                        },
+                        ValidationParameters = new TokenValidationParameters
+                        {
+                            IssuerSigningKey = KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key,
+                            TryAllDecryptionKeys = false,
+                            ValidAudience = Default.Audience,
+                            ValidIssuer = Default.Issuer
+                        },
+                        Configuration = configurationWithMismatchedKeys,
+                        ExpectedDecryptionKeys =  new List<SecurityKey>(),
+                    }
                 };
             }
         }
 
-        private static OpenIdConnectConfiguration CreateCustomConfigurationThatThrows()
+        private static OpenIdConnectConfiguration CreateCustomConfigurationThatThrows(SecurityKey rsaKey)
         {
             var customCryptoProviderFactory = new DerivedCryptoProviderFactory
             {
@@ -814,8 +858,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
             var sym512Hey = new SymmetricSecurityKey(KeyingMaterial.DefaultSymmetricKeyBytes_512) { KeyId = "CustomSymmetricSecurityKey_512" };
             sym512Hey.CryptoProviderFactory = customCryptoProviderFactory;
-
-            var rsaKey = new RsaSecurityKey(KeyingMaterial.RsaParameters_2048) { KeyId = "CustomRsaSecurityKey_2048" };
 
             var configurationWithCustomCryptoProviderFactory = new OpenIdConnectConfiguration();
             configurationWithCustomCryptoProviderFactory.TokenDecryptionKeys.Add(rsaKey);

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class TokenValidationParametersTests
     {
-        int ExpectedPropertyCount = 60;
+        int ExpectedPropertyCount = 61;
 
         // GetSets() compares the total property count which includes internal properties, against a list of public properties, minus delegates.
         // This allows us to keep track of any properties we are including in the total that are not public nor delegates.
@@ -135,7 +135,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             var compareContext = new CompareContext();
             IdentityComparer.AreEqual(validationParametersInline, validationParametersSets, compareContext);
 
-            // only exlude 'IsClone' when comparing Clone vs. Original.
+            // only exclude 'IsClone' when comparing Clone vs. Original.
             var instanceContext = new CompareContext();
             instanceContext.PropertiesToIgnoreWhenComparing.Add(typeof(TokenValidationParameters), new List<string> { "IsClone" });
             TokenValidationParameters validationParametersInLineClone = validationParametersInline.Clone();
@@ -221,6 +221,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     new KeyValuePair<string, List<object>>("TokenDecryptionKey", new List<object>{(SecurityKey)null, KeyingMaterial.DefaultX509Key_2048, KeyingMaterial.RsaSecurityKey_2048}),
                     new KeyValuePair<string, List<object>>("TokenDecryptionKeys", new List<object>{(IEnumerable<SecurityKey>)null, new List<SecurityKey>{KeyingMaterial.DefaultX509Key_2048, KeyingMaterial.RsaSecurityKey_1024}, new List<SecurityKey>()}),
                     new KeyValuePair<string, List<object>>("TokenReplayCache", new List<object>{(ITokenReplayCache)null, new TokenReplayCache(), new TokenReplayCache()}),
+                    new KeyValuePair<string, List<object>>("TryAllDecryptionKeys", new List<object>{true, false, true}),
                     new KeyValuePair<string, List<object>>("TryAllIssuerSigningKeys", new List<object>{true, false, true}),
                     new KeyValuePair<string, List<object>>("ValidateActor", new List<object>{false, true, false}),
                     new KeyValuePair<string, List<object>>("ValidAlgorithms", new List<object>{(IEnumerable<string>)null, new List<string>{Guid.NewGuid().ToString()}, new List<string>{Guid.NewGuid().ToString()}}),
@@ -240,7 +241,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                 Object = validationParameters,
             };
 
-            // check that we have checked all properties, subract the number of delegates.
+            // check that we have checked all properties, subtract the number of delegates.
             if (context.PropertyNamesAndSetGetValue.Count != ExpectedPropertyCount - delegates.Count - internalNonDelegateProperties.Count)
                 compareContext.AddDiff($"Number of properties being set is: {context.PropertyNamesAndSetGetValue.Count}, number of properties is: {properties.Length - delegates.Count} (#Properties - #Delegates), adjust tests");
 


### PR DESCRIPTION
Fixes #3129

* Added a new property `TryAllDecryptionKeys` to `TokenValidationParameters` to indicate whether all decryption keys should be tried during token decryption when a key is not matched to the token 'kid' or if the token 'kid' is empty. This property defaults to `true`. [[1]](diffhunk://#diff-fd6fb46108ab0d6b00c019e12ed417bd02e026042ddaa215ec2b2301fc1304faL595-R608) [[2]](diffhunk://#diff-3c7d43b6d12b5f2a95d17637606de002d7b7fcff07f51a247f2c642de3f794c2R519-R525)
* Updated the `GetContentEncryptionKeys` and `DecryptToken` methods to use the new `TryAllDecryptionKeys` property for determining when to try all decryption keys. [[1]](diffhunk://#diff-2e592db8e9e75f43c6efe0487d18431538706d98ec79c930924eb92e2a47d753L1323-R1323) [[2]](diffhunk://#diff-3f800ae7e51ac75b2620fa577baef4714bd8435b92b8ba271947e8da321407c5L124-R124)
* Also updates the new validation code path.

The precedence of decryption methods:
- `TokenValidationParameters.TokenDecryptionKeyResolver`, if set.
- `TokenValidationParameters.TokenDecryptionKey`, if set and key ID matches.
- `TokenValidationParameters.TokenDecryptionKeys`, if set and contains any keys where key ID matches.
- If `TokenValidationParameters.TryAllDecryptionKeys` is set to 'true', `TokenValidationParameters.TokenDecryptionKey`, `TokenValidationParameters.TokenDecryptionKeys`, and `TokenDecryptionKeys` from configuration.

**Note: I will add more tests if this approach is agreed on.**