### PR TITLE
Populate error messages correctly from JwtTokenUtilities.DecryptJwtToken

### DIFF
--- a/build/commonTest.props
+++ b/build/commonTest.props
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.console" Version="$(XunitRunnerConsoleVersion)" />

--- a/build/dependenciesTest.props
+++ b/build/dependenciesTest.props
@@ -5,7 +5,12 @@
     <DotNetCoreAppRuntimeVersion>2.1.30</DotNetCoreAppRuntimeVersion>
     <MicrosoftAzureKeyVaultCryptographyVersion>3.0.5</MicrosoftAzureKeyVaultCryptographyVersion>
     <MicrosoftNETTestSdkVersion>17.11.1</MicrosoftNETTestSdkVersion>
-    <MoqVersion>4.16.1</MoqVersion>
+    <!--
+    Locking the Moq version similar to https://github.com/Azure/azure-sdk-for-net/pull/38113/.
+    This version should not be changed without team discussion.
+    See https://github.com/Azure/azure-sdk-for-net/issues/38111.
+    -->
+    <MoqVersion>[4.16.1]</MoqVersion>
     <NetStandardVersion>2.0.3</NetStandardVersion>
     <NewtonsoftVersion>13.0.3</NewtonsoftVersion>
     <OpenTelemetryVersion>1.6.0</OpenTelemetryVersion>

--- a/build/dependenciesTest.props
+++ b/build/dependenciesTest.props
@@ -5,6 +5,7 @@
     <DotNetCoreAppRuntimeVersion>2.1.30</DotNetCoreAppRuntimeVersion>
     <MicrosoftAzureKeyVaultCryptographyVersion>3.0.5</MicrosoftAzureKeyVaultCryptographyVersion>
     <MicrosoftNETTestSdkVersion>17.11.1</MicrosoftNETTestSdkVersion>
+    <MoqVersion>4.16.1</MoqVersion>
     <NetStandardVersion>2.0.3</NetStandardVersion>
     <NewtonsoftVersion>13.0.3</NewtonsoftVersion>
     <OpenTelemetryVersion>1.6.0</OpenTelemetryVersion>

--- a/src/Microsoft.IdentityModel.JsonWebTokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/InternalAPI.Unshipped.txt
@@ -1,1 +1,0 @@
-static Microsoft.IdentityModel.JsonWebTokens.JwtTokenUtilities.s_getCryptoProviderFactory -> System.Func<Microsoft.IdentityModel.Tokens.TokenValidationParameters, Microsoft.IdentityModel.Tokens.SecurityKey, Microsoft.IdentityModel.Tokens.CryptoProviderFactory>

--- a/src/Microsoft.IdentityModel.JsonWebTokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/InternalAPI.Unshipped.txt
@@ -1,2 +1,1 @@
-Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler.CreateJwtTokenDecryptionParameters(Microsoft.IdentityModel.JsonWebTokens.JsonWebToken jwtToken, System.Collections.Generic.IEnumerable<Microsoft.IdentityModel.Tokens.SecurityKey> keys) -> Microsoft.IdentityModel.JsonWebTokens.JwtTokenDecryptionParameters
 static Microsoft.IdentityModel.JsonWebTokens.JwtTokenUtilities.s_getCryptoProviderFactory -> System.Func<Microsoft.IdentityModel.Tokens.TokenValidationParameters, Microsoft.IdentityModel.Tokens.SecurityKey, Microsoft.IdentityModel.Tokens.CryptoProviderFactory>

--- a/src/Microsoft.IdentityModel.JsonWebTokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/InternalAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler.CreateJwtTokenDecryptionParameters(Microsoft.IdentityModel.JsonWebTokens.JsonWebToken jwtToken, System.Collections.Generic.IEnumerable<Microsoft.IdentityModel.Tokens.SecurityKey> keys) -> Microsoft.IdentityModel.JsonWebTokens.JwtTokenDecryptionParameters
+static Microsoft.IdentityModel.JsonWebTokens.JwtTokenUtilities.s_getCryptoProviderFactory -> System.Func<Microsoft.IdentityModel.Tokens.TokenValidationParameters, Microsoft.IdentityModel.Tokens.SecurityKey, Microsoft.IdentityModel.Tokens.CryptoProviderFactory>

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.DecryptToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.DecryptToken.cs
@@ -68,15 +68,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     ValidationError.GetCurrentStackFrame());
             }
 
+            var decryptionParameters = CreateJwtTokenDecryptionParameters(jwtToken, result.contentEncryptionKeys);
+
             return JwtTokenUtilities.DecryptJwtToken(
                 jwtToken,
                 validationParameters,
-                new JwtTokenDecryptionParameters
-                {
-                    DecompressionFunction = JwtTokenUtilities.DecompressToken,
-                    Keys = result.contentEncryptionKeys,
-                    MaximumDeflateSize = MaximumTokenSizeInBytes
-                },
+                decryptionParameters,
                 callContext);
         }
 

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.DecryptToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.DecryptToken.cs
@@ -51,13 +51,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     ValidationError.GetCurrentStackFrame());
             }
 
-            (IList<SecurityKey>? contentEncryptionKeys, ValidationError? validationError) result =
+            (IList<SecurityKey>? ContentEncryptionKeys, ValidationError? ValidationError) result =
                 GetContentEncryptionKeys(jwtToken, validationParameters, configuration, callContext);
 
-            if (result.validationError != null)
-                return result.validationError.AddCurrentStackFrame();
+            if (result.ValidationError != null)
+                return result.ValidationError.AddCurrentStackFrame();
 
-            if (result.contentEncryptionKeys == null || result.contentEncryptionKeys.Count == 0)
+            if (result.ContentEncryptionKeys == null || result.ContentEncryptionKeys.Count == 0)
             {
                 return new ValidationError(
                     new MessageDetail(
@@ -68,7 +68,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     ValidationError.GetCurrentStackFrame());
             }
 
-            var decryptionParameters = CreateJwtTokenDecryptionParameters(jwtToken, result.contentEncryptionKeys);
+            var decryptionParameters = CreateJwtTokenDecryptionParameters(jwtToken, result.ContentEncryptionKeys);
 
             return JwtTokenUtilities.DecryptJwtToken(
                 jwtToken,

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -350,7 +350,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             return JwtTokenUtilities.DecryptJwtToken(jwtToken, validationParameters, decryptionParameters);
         }
 
-        internal JwtTokenDecryptionParameters CreateJwtTokenDecryptionParameters(JsonWebToken jwtToken, IEnumerable<SecurityKey> keys)
+        private JwtTokenDecryptionParameters CreateJwtTokenDecryptionParameters(JsonWebToken jwtToken, IEnumerable<SecurityKey> keys)
         {
             return new JwtTokenDecryptionParameters
             {

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -344,15 +344,28 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 throw LogHelper.LogExceptionMessage(new SecurityTokenException(LogHelper.FormatInvariant(TokenLogMessages.IDX10612)));
 
             var keys = GetContentEncryptionKeys(jwtToken, validationParameters, configuration);
-            return JwtTokenUtilities.DecryptJwtToken(
-                jwtToken,
-                validationParameters,
-                new JwtTokenDecryptionParameters
-                {
-                    DecompressionFunction = JwtTokenUtilities.DecompressToken,
-                    Keys = keys,
-                    MaximumDeflateSize = MaximumTokenSizeInBytes
-                });
+
+            var decryptionParameters = CreateJwtTokenDecryptionParameters(jwtToken, keys);
+
+            return JwtTokenUtilities.DecryptJwtToken(jwtToken, validationParameters, decryptionParameters);
+        }
+
+        internal JwtTokenDecryptionParameters CreateJwtTokenDecryptionParameters(JsonWebToken jwtToken, IEnumerable<SecurityKey> keys)
+        {
+            return new JwtTokenDecryptionParameters
+            {
+                Alg = jwtToken.Alg,
+                AuthenticationTagBytes = jwtToken.AuthenticationTagBytes,
+                CipherTextBytes = jwtToken.CipherTextBytes,
+                DecompressionFunction = JwtTokenUtilities.DecompressToken,
+                Enc = jwtToken.Enc,
+                EncodedToken = jwtToken.EncodedToken,
+                HeaderAsciiBytes = jwtToken.HeaderAsciiBytes,
+                InitializationVectorBytes = jwtToken.InitializationVectorBytes,
+                MaximumDeflateSize = MaximumTokenSizeInBytes,
+                Keys = keys,
+                Zip = jwtToken.Zip,
+            };
         }
 
         private static SecurityKey ResolveTokenDecryptionKeyFromConfig(JsonWebToken jwtToken, BaseConfiguration configuration)

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.DecryptTokenResult.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.DecryptTokenResult.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Text;
 using Microsoft.IdentityModel.Tokens;
-using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
 
 namespace Microsoft.IdentityModel.JsonWebTokens
 {
@@ -120,7 +119,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 #pragma warning restore CA1031 // Do not catch general exception types
             {
                 return new ValidationError(
-                    new MessageDetail(TokenLogMessages.IDX10679, zipAlgorithm),
+                    new MessageDetail(GetIDX10679LogMessage(zipAlgorithm)),
                     ValidationFailureType.TokenDecryptionFailed,
                     typeof(SecurityTokenDecompressionFailedException),
                     ValidationError.GetCurrentStackFrame(),

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -332,6 +332,14 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             }
         }
 
+        /// <summary>
+        /// This is added for testing purpose to allow returning null.
+        /// 
+        /// When this is called outside of test(s),
+        /// <see cref="TokenValidationParameters.CryptoProviderFactory"/> can be null
+        /// but <see cref="SecurityKey.CryptoProviderFactory"/> will never be. Thus, the caller
+        /// will never receive a null <see cref="CryptoProviderFactory"/>.
+        /// </summary>
         internal static Func<TokenValidationParameters, SecurityKey, CryptoProviderFactory>
             s_getCryptoProviderFactory = (validationParameters, key) =>
         {

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -264,7 +264,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             string zipAlgorithm = null;
             foreach (SecurityKey key in decryptionParameters.Keys)
             {
-                var cryptoProviderFactory = s_getCryptoProviderFactory(validationParameters, key);
+                var cryptoProviderFactory = validationParameters.CryptoProviderFactory ?? key.CryptoProviderFactory;
                 if (cryptoProviderFactory == null)
                 {
                     if (LogHelper.IsEnabled(EventLogLevel.Warning))
@@ -331,20 +331,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 throw LogHelper.LogExceptionMessage(new SecurityTokenDecompressionFailedException(LogHelper.FormatInvariant(TokenLogMessages.IDX10679, zipAlgorithm), ex));
             }
         }
-
-        /// <summary>
-        /// This is added for testing purpose to allow returning null.
-        /// 
-        /// When this is called outside of test(s),
-        /// <see cref="TokenValidationParameters.CryptoProviderFactory"/> can be null
-        /// but <see cref="SecurityKey.CryptoProviderFactory"/> will never be. Thus, the caller
-        /// will never receive a null <see cref="CryptoProviderFactory"/>.
-        /// </summary>
-        internal static Func<TokenValidationParameters, SecurityKey, CryptoProviderFactory>
-            s_getCryptoProviderFactory = (validationParameters, key) =>
-        {
-            return validationParameters.CryptoProviderFactory ?? key.CryptoProviderFactory;
-        };
 
         private static ValidationError GetDecryptionError(
             JwtTokenDecryptionParameters decryptionParameters,

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -233,7 +233,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
             var decompressedBytes = compressionProvider.Decompress(tokenBytes);
 
-            return decompressedBytes != null ? Encoding.UTF8.GetString(decompressedBytes) : throw LogHelper.LogExceptionMessage(new SecurityTokenDecompressionFailedException(LogHelper.FormatInvariant(TokenLogMessages.IDX10679, LogHelper.MarkAsNonPII(algorithm))));
+            return decompressedBytes != null ? Encoding.UTF8.GetString(decompressedBytes) : throw LogHelper.LogExceptionMessage(new SecurityTokenDecompressionFailedException(GetIDX10679LogMessage(algorithm)));
+        }
+
+        private static string GetIDX10679LogMessage(string algorithm)
+        {
+            return LogHelper.FormatInvariant(TokenLogMessages.IDX10679, LogHelper.MarkAsNonPII(algorithm));
         }
 
         /// <summary>
@@ -328,7 +333,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             }
             catch (Exception ex)
             {
-                throw LogHelper.LogExceptionMessage(new SecurityTokenDecompressionFailedException(LogHelper.FormatInvariant(TokenLogMessages.IDX10679, zipAlgorithm), ex));
+                throw LogHelper.LogExceptionMessage(new SecurityTokenDecompressionFailedException(GetIDX10679LogMessage(zipAlgorithm), ex));
             }
         }
 

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -264,7 +264,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             string zipAlgorithm = null;
             foreach (SecurityKey key in decryptionParameters.Keys)
             {
-                var cryptoProviderFactory = validationParameters.CryptoProviderFactory ?? key.CryptoProviderFactory;
+                var cryptoProviderFactory = s_getCryptoProviderFactory(validationParameters, key);
                 if (cryptoProviderFactory == null)
                 {
                     if (LogHelper.IsEnabled(EventLogLevel.Warning))
@@ -275,61 +275,28 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
                 try
                 {
-                    // The JsonWebTokenHandler will set the JsonWebToken and those values will be used.
-                    // The JwtSecurityTokenHandler will calculate values and set the values on DecryptionParameters.
-
-                    // JsonWebToken from JsonWebTokenHandler
-                    if (securityToken is JsonWebToken jsonWebToken)
+                    if (!cryptoProviderFactory.IsSupportedAlgorithm(decryptionParameters.Enc, key))
                     {
-                        if (!cryptoProviderFactory.IsSupportedAlgorithm(jsonWebToken.Enc, key))
-                        {
-                            if (LogHelper.IsEnabled(EventLogLevel.Warning))
-                                LogHelper.LogWarning(TokenLogMessages.IDX10611, LogHelper.MarkAsNonPII(decryptionParameters.Enc), LogHelper.MarkAsNonPII(key.KeyId));
+                        if (LogHelper.IsEnabled(EventLogLevel.Warning))
+                            LogHelper.LogWarning(TokenLogMessages.IDX10611, LogHelper.MarkAsNonPII(decryptionParameters.Enc), LogHelper.MarkAsNonPII(key.KeyId));
 
-                            algorithmNotSupportedByCryptoProvider = true;
-                            continue;
-                        }
-
-                        Validators.ValidateAlgorithm(jsonWebToken.Enc, key, securityToken, validationParameters);
-                        decryptedTokenBytes = DecryptToken(
-                            cryptoProviderFactory,
-                            key,
-                            jsonWebToken.Enc,
-                            jsonWebToken.CipherTextBytes,
-                            jsonWebToken.HeaderAsciiBytes,
-                            jsonWebToken.InitializationVectorBytes,
-                            jsonWebToken.AuthenticationTagBytes);
-
-                        zipAlgorithm = jsonWebToken.Zip;
-                        decryptionSucceeded = true;
-                        break;
+                        algorithmNotSupportedByCryptoProvider = true;
+                        continue;
                     }
-                    // JwtSecurityToken from JwtSecurityTokenHandler
-                    else
-                    {
-                        if (!cryptoProviderFactory.IsSupportedAlgorithm(decryptionParameters.Enc, key))
-                        {
-                            if (LogHelper.IsEnabled(EventLogLevel.Warning))
-                                LogHelper.LogWarning(TokenLogMessages.IDX10611, LogHelper.MarkAsNonPII(decryptionParameters.Enc), LogHelper.MarkAsNonPII(key.KeyId));
 
-                            algorithmNotSupportedByCryptoProvider = true;
-                            continue;
-                        }
+                    Validators.ValidateAlgorithm(decryptionParameters.Enc, key, securityToken, validationParameters);
+                    decryptedTokenBytes = DecryptToken(
+                        cryptoProviderFactory,
+                        key,
+                        decryptionParameters.Enc,
+                        decryptionParameters.CipherTextBytes,
+                        decryptionParameters.HeaderAsciiBytes,
+                        decryptionParameters.InitializationVectorBytes,
+                        decryptionParameters.AuthenticationTagBytes);
 
-                        Validators.ValidateAlgorithm(decryptionParameters.Enc, key, securityToken, validationParameters);
-                        decryptedTokenBytes = DecryptToken(
-                            cryptoProviderFactory,
-                            key,
-                            decryptionParameters.Enc,
-                            decryptionParameters.CipherTextBytes,
-                            decryptionParameters.HeaderAsciiBytes,
-                            decryptionParameters.InitializationVectorBytes,
-                            decryptionParameters.AuthenticationTagBytes);
-
-                        zipAlgorithm = decryptionParameters.Zip;
-                        decryptionSucceeded = true;
-                        break;
-                    }
+                    zipAlgorithm = decryptionParameters.Zip;
+                    decryptionSucceeded = true;
+                    break;
                 }
                 catch (Exception ex)
                 {
@@ -364,6 +331,12 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 throw LogHelper.LogExceptionMessage(new SecurityTokenDecompressionFailedException(LogHelper.FormatInvariant(TokenLogMessages.IDX10679, zipAlgorithm), ex));
             }
         }
+
+        internal static Func<TokenValidationParameters, SecurityKey, CryptoProviderFactory>
+            s_getCryptoProviderFactory = (validationParameters, key) =>
+        {
+            return validationParameters.CryptoProviderFactory ?? key.CryptoProviderFactory;
+        };
 
         private static ValidationError GetDecryptionError(
             JwtTokenDecryptionParameters decryptionParameters,

--- a/src/Microsoft.IdentityModel.JsonWebTokens/Microsoft.IdentityModel.JsonWebTokens.csproj
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Microsoft.IdentityModel.JsonWebTokens.csproj
@@ -38,7 +38,6 @@
 
   <ItemGroup>
     <AdditionalFiles Include="InternalAPI.Shipped.txt" />
-    <AdditionalFiles Include="InternalAPI.Unshipped.txt" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">

--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1762,7 +1762,14 @@ namespace System.IdentityModel.Tokens.Jwt
 
             var keys = GetContentEncryptionKeys(jwtToken, validationParameters);
 
-            return JwtTokenUtilities.DecryptJwtToken(jwtToken, validationParameters, new JwtTokenDecryptionParameters
+            var decryptionParameters = CreateJwtTokenDecryptionParameters(jwtToken, keys);
+
+            return JwtTokenUtilities.DecryptJwtToken(jwtToken, validationParameters, decryptionParameters);
+        }
+
+        private JwtTokenDecryptionParameters CreateJwtTokenDecryptionParameters(JwtSecurityToken jwtToken, IEnumerable<SecurityKey> keys)
+        {
+            return new JwtTokenDecryptionParameters
             {
                 Alg = jwtToken.Header.Alg,
                 AuthenticationTagBytes = Base64UrlEncoder.DecodeBytes(jwtToken.RawAuthenticationTag),
@@ -1775,7 +1782,7 @@ namespace System.IdentityModel.Tokens.Jwt
                 MaximumDeflateSize = MaximumTokenSizeInBytes,
                 Keys = keys,
                 Zip = jwtToken.Header.Zip,
-            });
+            };
         }
 
         internal IEnumerable<SecurityKey> GetContentEncryptionKeys(JwtSecurityToken jwtToken, TokenValidationParameters validationParameters)

--- a/test/Microsoft.IdentityModel.Abstractions.Tests/Microsoft.IdentityModel.Abstractions.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Abstractions.Tests/Microsoft.IdentityModel.Abstractions.Tests.csproj
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.16.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.Abstractions\Microsoft.IdentityModel.Abstractions.csproj" />
   </ItemGroup>
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -13,6 +13,7 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.TestUtils;
@@ -2797,6 +2798,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         EncryptingCredentials = Default.SymmetricEncryptingCredentials,
                         ExpectedException = ExpectedException.SecurityTokenDecryptionFailedException("IDX10603:")
                     },
+                    GetTokenTheoryDataWithKeyId(),
                     new CreateTokenTheoryData()
                     {
                         TestId = "EncryptionAlgorithmNotSupported",
@@ -2812,6 +2814,38 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         ExpectedException = ExpectedException.SecurityTokenDecryptionFailedException("IDX10619:")
                     },
                 };
+
+                static CreateTokenTheoryData GetTokenTheoryDataWithKeyId()
+                {
+                    var validationParameters = new TokenValidationParameters
+                    {
+                        IssuerSigningKey = Default.SymmetricSigningKey256,
+                        TokenDecryptionKey = NotDefault.SymmetricSigningKey256,
+                    };
+
+                    var keysAttempted = new StringBuilder().AppendLine(validationParameters.TokenDecryptionKey.KeyId);
+                    var incompleteExceptionMessage = new MessageDetail(
+                                Tokens.LogMessages.IDX10603,
+                                LogHelper.MarkAsNonPII(keysAttempted.ToString()),
+                                string.Empty,   // Using empty since actual exception contains file paths, which are machine specific.
+                                string.Empty)   // Using empty since EncodedToken is not available and the message is getting used partially below.
+                        .Message;
+                    // Get partial messages as the actual exception message contains file paths.
+                    var partialExceptionMessage = incompleteExceptionMessage.Substring(
+                        0,
+                        incompleteExceptionMessage.IndexOf(validationParameters.TokenDecryptionKey.KeyId) + validationParameters.TokenDecryptionKey.KeyId.Length);
+
+                    return new CreateTokenTheoryData()
+                    {
+                        TestId = "EncryptionKey-Not-Found-Returns-KeyId-In-Error-Message",
+                        IsValid = false,
+                        ValidationParameters = validationParameters,
+                        Payload = Default.PayloadString,
+                        SigningCredentials = Default.SymmetricSigningCredentials,
+                        EncryptingCredentials = Default.SymmetricEncryptingCredentials,
+                        ExpectedException = ExpectedException.SecurityTokenDecryptionFailedException("IDX10603:")
+                    };
+                }
             }
         }
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -2843,7 +2843,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                         Payload = Default.PayloadString,
                         SigningCredentials = Default.SymmetricSigningCredentials,
                         EncryptingCredentials = Default.SymmetricEncryptingCredentials,
-                        ExpectedException = ExpectedException.SecurityTokenDecryptionFailedException("IDX10603:")
+                        ExpectedException = ExpectedException.SecurityTokenDecryptionFailedException(partialExceptionMessage)
                     };
                 }
             }

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
@@ -453,7 +453,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             Assert.Contains(partialExceptionMessage, exception.Message);
         }
 
-        [Theory, MemberData(nameof(DecompressionFailTheoryData), DisableDiscoveryEnumeration = false)]
+        [Theory, MemberData(nameof(DecompressionFailTheoryData), DisableDiscoveryEnumeration = true)]
         public void DecryptJwtToken_WhenDecompressionFails_ThrowsException(DecompressionFailureTheoryData theoryData)
         {
             // Arrange

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
@@ -4,11 +4,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
+using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
+using System.Text;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
+using Moq;
 using Xunit;
 
 namespace Microsoft.IdentityModel.JsonWebTokens.Tests
@@ -17,6 +20,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
     {
         // Used for formatting a message for testing with one parameter.
         private const string TestMessageOneParam = "This is the parameter: '{0}'.";
+        private static readonly SymmetricSecurityKey symmetricSecurityKey = new SymmetricSecurityKey(KeyingMaterial.DefaultSymmetricSecurityKey_128.Key)
+        {
+            KeyId = KeyingMaterial.DefaultSymmetricSecurityKey_256.KeyId,
+        };
 
         [Fact]
         public void LogSecurityArtifactTest()
@@ -207,6 +214,281 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             resolvedKey = JwtTokenUtilities.ResolveTokenSigningKey(null, null, tvp, GetConfigurationNoMatchingKeyMock());
             Assert.Null(resolvedKey);
         }
+
+        #region DecryptJwtToken Tests
+
+        [Fact]
+        public void GetCryptoProviderFactory_WhenSetOnTokenValidationParameters_ReturnsFromValidationParameters()
+        {
+            // Arrange
+            // SecurityKey can never have 'null' CryptoProviderFactory.
+            var securityKey = symmetricSecurityKey;
+            var validationParameters = new TokenValidationParameters()
+            {
+                CryptoProviderFactory = new CryptoProviderFactory(),
+            };
+
+            // Act
+            var result = JwtTokenUtilities.s_getCryptoProviderFactory(validationParameters, securityKey);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Same(validationParameters.CryptoProviderFactory, result);
+        }
+
+        [Fact]
+        public void GetCryptoProviderFactory_WhenSetToNullOnTokenValidationParameters_ReturnsFromSecurityKey()
+        {
+            // Arrange
+            // SecurityKey can never have 'null' CryptoProviderFactory.
+            var securityKey = symmetricSecurityKey;
+            var validationParameters = new TokenValidationParameters
+            {
+                CryptoProviderFactory = null,
+            };
+
+            // Act
+            var result = JwtTokenUtilities.s_getCryptoProviderFactory(validationParameters, securityKey);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(securityKey.CryptoProviderFactory, result);
+        }
+
+        [Fact]
+        public void DecryptJwtToken_WhenValidationParametersIsNull_ShouldThrow()
+        {
+            // Arrange
+            TokenValidationParameters validationParameters = null;
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                JwtTokenUtilities.DecryptJwtToken(
+                    securityToken: null,
+                    validationParameters: validationParameters,
+                    decryptionParameters: null));
+
+            Assert.Equal("validationParameters", exception.ParamName);
+        }
+
+        [Fact]
+        public void DecryptJwtToken_WhenJwtTokenDecryptionParametersIsNull_ShouldThrow()
+        {
+            // Arrange
+            var validationParameters = new TokenValidationParameters();
+            JwtTokenDecryptionParameters decryptionParameters = null;
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+                JwtTokenUtilities.DecryptJwtToken(
+                    securityToken: null,
+                    validationParameters: validationParameters,
+                    decryptionParameters: decryptionParameters));
+
+            Assert.Equal("decryptionParameters", exception.ParamName);
+        }
+
+        [Fact(Skip = "Skip due to potential false positives it may cause running tests in parallel as it overrides JwtTokenUtilities.s_getCryptoProviderFactory.")]
+        public void DecryptJwtToken_WhenCryptoProviderFactoryIsNull_FailsWithIDX10609AndLogsIDX10607()
+        {
+            // Save the original delegate to restore.
+            var getCryptoProviderFactory = JwtTokenUtilities.s_getCryptoProviderFactory;
+            try
+            {
+                // Arrange
+                var securityKey = symmetricSecurityKey;
+                using var listener = new SampleListener();
+                IdentityModelEventSource.ShowPII = false;
+                IdentityModelEventSource.Logger.LogLevel = EventLevel.Warning;
+                listener.EnableEvents(IdentityModelEventSource.Logger, EventLevel.Warning);
+
+                var keys = new List<SecurityKey>()
+                {
+                    securityKey,
+                };
+
+                var validationParameters = new TokenValidationParameters();
+                var decryptionParameters = new JwtTokenDecryptionParameters
+                {
+                    Keys = keys,
+                };
+
+                JwtTokenUtilities.s_getCryptoProviderFactory = (validationParameters, decryptionParameters) => null;
+
+                var expectedWarning = LogHelper.FormatInvariant(
+                    Tokens.LogMessages.IDX10607,
+                    LogHelper.MarkAsNonPII(securityKey.KeyId));
+                var expectedExceptionMessage = new MessageDetail(
+                    Tokens.LogMessages.IDX10609,
+                    LogHelper.MarkAsSecurityArtifact(decryptionParameters.EncodedToken,
+                    JwtTokenUtilities.SafeLogJwtToken)).Message;
+
+                // Act & Assert
+                var exception = Assert.Throws<SecurityTokenDecryptionFailedException>(() =>
+                    JwtTokenUtilities.DecryptJwtToken(
+                        securityToken: null,
+                        validationParameters: validationParameters,
+                        decryptionParameters: decryptionParameters));
+
+                Assert.Contains(expectedWarning, listener.TraceBuffer);
+                Assert.Contains(expectedExceptionMessage, listener.TraceBuffer);
+                Assert.Equal(expectedExceptionMessage, exception.Message);
+            }
+            finally
+            {
+                // Restore the original delegate.
+                JwtTokenUtilities.s_getCryptoProviderFactory = getCryptoProviderFactory;
+            }
+        }
+
+        [Fact]
+        public void DecryptJwtToken_WhenEncIsNotSupported_FailsWithIDX10619AndLogsIDX10611()
+        {
+            // Arrange
+            var securityKey = symmetricSecurityKey;
+            using var listener = new SampleListener();
+            IdentityModelEventSource.ShowPII = false;
+            IdentityModelEventSource.Logger.LogLevel = EventLevel.Warning;
+            listener.EnableEvents(IdentityModelEventSource.Logger, EventLevel.Warning);
+
+            var keys = new List<SecurityKey>()
+            {
+                securityKey,
+            };
+            var securityToken = new JwtSecurityToken();
+            var decryptionParameters = new JwtTokenDecryptionParameters
+            {
+                Alg = "an algorithm",
+                Enc = "unsupported-algorithm",
+                Keys = keys,
+            };
+
+            var mockCryptoProviderFactory = new Mock<CryptoProviderFactory>();
+            mockCryptoProviderFactory
+                .Setup(factory => factory.IsSupportedAlgorithm(It.IsAny<string>(), It.IsAny<SecurityKey>()))
+                .Returns(false);
+
+            var validationParameters = new TokenValidationParameters()
+            {
+                CryptoProviderFactory = mockCryptoProviderFactory.Object,
+            };
+
+            var expectedWarning = LogHelper.FormatInvariant(
+                Tokens.LogMessages.IDX10611,
+                LogHelper.MarkAsNonPII(decryptionParameters.Enc),
+                LogHelper.MarkAsNonPII(securityKey.KeyId));
+            var expectedExceptionMessage = new MessageDetail(
+                        Tokens.LogMessages.IDX10619,
+                        LogHelper.MarkAsNonPII(decryptionParameters.Alg),
+                        LogHelper.MarkAsNonPII(decryptionParameters.Enc)).Message;
+
+            // Act & Assert
+            var exception = Assert.Throws<SecurityTokenDecryptionFailedException>(() =>
+                JwtTokenUtilities.DecryptJwtToken(securityToken, validationParameters, decryptionParameters));
+
+            Assert.Contains(expectedWarning, listener.TraceBuffer);
+            Assert.Contains(expectedExceptionMessage, listener.TraceBuffer);
+            Assert.Equal(expectedExceptionMessage, exception.Message);
+        }
+
+        [Fact]
+        public void DecryptJwtToken_WhenNoKeys_FailsWithIDX10609()
+        {
+            // Arrange
+            using var listener = new SampleListener();
+            IdentityModelEventSource.ShowPII = false;
+            IdentityModelEventSource.Logger.LogLevel = EventLevel.Warning;
+            listener.EnableEvents(IdentityModelEventSource.Logger, EventLevel.Warning);
+
+            var securityToken = new JwtSecurityToken();
+            var decryptionParameters = new JwtTokenDecryptionParameters()
+            {
+                Keys = new List<SecurityKey>(),
+            };
+
+            var mockCryptoProviderFactory = new Mock<CryptoProviderFactory>();
+            mockCryptoProviderFactory
+                .Setup(factory => factory.IsSupportedAlgorithm(It.IsAny<string>(), It.IsAny<SecurityKey>()))
+                .Returns(false);
+
+            var validationParameters = new TokenValidationParameters()
+            {
+                CryptoProviderFactory = mockCryptoProviderFactory.Object,
+            };
+
+            var expectedExceptionMessage = new MessageDetail(
+                        Tokens.LogMessages.IDX10609,
+                        LogHelper.MarkAsSecurityArtifact(decryptionParameters.EncodedToken, JwtTokenUtilities.SafeLogJwtToken)).Message;
+
+            // Act & Assert
+            var exception = Assert.Throws<SecurityTokenDecryptionFailedException>(() =>
+                JwtTokenUtilities.DecryptJwtToken(securityToken, validationParameters, decryptionParameters));
+
+            Assert.Contains(expectedExceptionMessage, listener.TraceBuffer);
+            Assert.Equal(expectedExceptionMessage, exception.Message);
+        }
+
+        [Fact]
+        public void DecryptJwtToken_WhenDecryptionFails_FailsWithIDX10603()
+        {
+            // Arrange
+            var securityKey = NotDefault.SymmetricSigningKey256;
+            var jsonWebTokenHandler = new JsonWebTokenHandler();
+            var jweCreatedInMemory = jsonWebTokenHandler.CreateToken(
+                Default.PayloadString,
+                Default.SymmetricSigningCredentials,
+                Default.SymmetricEncryptingCredentials);
+            var securityToken = new JsonWebToken(jweCreatedInMemory);
+
+            using var listener = new SampleListener();
+            IdentityModelEventSource.ShowPII = false;
+            IdentityModelEventSource.Logger.LogLevel = EventLevel.Warning;
+            listener.EnableEvents(IdentityModelEventSource.Logger, EventLevel.Warning);
+
+            var keys = new List<SecurityKey>()
+            {
+                securityKey,
+            };
+            var decryptionParameters = new JwtTokenDecryptionParameters
+            {
+                Alg = securityToken.Alg,
+                AuthenticationTagBytes = securityToken.AuthenticationTagBytes,
+                CipherTextBytes = securityToken.CipherTextBytes,
+                DecompressionFunction = JwtTokenUtilities.DecompressToken,
+                Enc = securityToken.Enc,
+                EncodedToken = securityToken.EncodedToken,
+                HeaderAsciiBytes = securityToken.HeaderAsciiBytes,
+                InitializationVectorBytes = securityToken.InitializationVectorBytes,
+                MaximumDeflateSize = jsonWebTokenHandler.MaximumTokenSizeInBytes,
+                Keys = keys,
+                Zip = securityToken.Zip,
+            };
+
+            var validationParameters = new TokenValidationParameters()
+            {
+                IssuerSigningKey = Default.SymmetricSigningKey256,
+                TokenDecryptionKey = securityKey,
+            };
+
+            var keysAttempted = new StringBuilder().AppendLine(validationParameters.TokenDecryptionKey.KeyId);
+            var incompleteExceptionMessage = new MessageDetail(
+                        Tokens.LogMessages.IDX10603,
+                        LogHelper.MarkAsNonPII(keysAttempted.ToString()),
+                        string.Empty,   // Using empty since actual exception contains file paths, which are machine specific.
+                        LogHelper.MarkAsSecurityArtifact(decryptionParameters.EncodedToken, JwtTokenUtilities.SafeLogJwtToken)).Message;
+            // Get partial messages as the actual exception message contains file paths.
+            var partialExceptionMessage = incompleteExceptionMessage.Substring(
+                0,
+                incompleteExceptionMessage.IndexOf(securityKey.KeyId) + securityKey.KeyId.Length);
+
+            // Act & Assert
+            var exception = Assert.Throws<SecurityTokenDecryptionFailedException>(() =>
+                JwtTokenUtilities.DecryptJwtToken(securityToken, validationParameters, decryptionParameters));
+
+            Assert.Contains(partialExceptionMessage, listener.TraceBuffer);
+            Assert.Contains(partialExceptionMessage, exception.Message);
+        }
+        #endregion
 
         private BaseConfiguration GetConfigurationMock()
         {

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.IdentityModel.Tokens.Jwt;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -450,6 +451,107 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
             Assert.Contains(partialExceptionMessage, listener.TraceBuffer);
             Assert.Contains(partialExceptionMessage, exception.Message);
+        }
+
+        [Theory, MemberData(nameof(DecompressionFailTheoryData), DisableDiscoveryEnumeration = true)]
+        public void DecryptJwtToken_WhenDecompressionFails_ThrowsException(DecompressionFailureTheoryData theoryData)
+        {
+            // Arrange
+            var jsonWebTokenHandler = new JsonWebTokenHandler();
+            CompressionProviderFactory.Default = theoryData.CompressionProviderFactory;
+            var securityToken = new JsonWebToken(theoryData.JwtEncodedString);
+
+            using var listener = new SampleListener();
+            IdentityModelEventSource.ShowPII = false;
+            IdentityModelEventSource.Logger.LogLevel = EventLevel.Warning;
+            listener.EnableEvents(IdentityModelEventSource.Logger, EventLevel.Warning);
+
+            var kwp = Default.JWECompressionTokenValidationParameters.TokenDecryptionKey.CryptoProviderFactory.CreateKeyWrapProviderForUnwrap(Default.JWECompressionTokenValidationParameters.TokenDecryptionKey, securityToken.Alg);
+            var unwrappedKey = kwp.UnwrapKey(securityToken.EncryptedKeyBytes);
+
+            var keys = new List<SecurityKey>()
+            {
+                new SymmetricSecurityKey(unwrappedKey),
+            };
+            var decryptionParameters = new JwtTokenDecryptionParameters
+            {
+                Alg = securityToken.Alg,
+                AuthenticationTagBytes = securityToken.AuthenticationTagBytes,
+                CipherTextBytes = securityToken.CipherTextBytes,
+                DecompressionFunction = JwtTokenUtilities.DecompressToken,
+                Enc = securityToken.Enc,
+                EncodedToken = securityToken.EncodedToken,
+                HeaderAsciiBytes = securityToken.HeaderAsciiBytes,
+                InitializationVectorBytes = securityToken.InitializationVectorBytes,
+                MaximumDeflateSize = jsonWebTokenHandler.MaximumTokenSizeInBytes,
+                Keys = keys,
+                Zip = securityToken.Zip,
+            };
+            var validationParameters = Default.JWECompressionTokenValidationParameters;
+
+            var exceptionMessage = LogHelper.FormatInvariant(Tokens.LogMessages.IDX10679, LogHelper.MarkAsNonPII(decryptionParameters.Zip));
+            string innerExceptionMessage = string.Empty;
+            if (theoryData.ValidateInnerExceptionMessage)
+                innerExceptionMessage = LogHelper.FormatInvariant(theoryData.InnerExceptionMessageId, LogHelper.MarkAsNonPII(decryptionParameters.Zip));
+
+            // Act & Assert
+            var exception = Assert.Throws<SecurityTokenDecompressionFailedException>(() =>
+                JwtTokenUtilities.DecryptJwtToken(securityToken, validationParameters, decryptionParameters));
+
+            Assert.Contains(exceptionMessage, listener.TraceBuffer);
+            Assert.Contains(exceptionMessage, exception.Message);
+            Assert.Equal(theoryData.InnerExceptionType, exception.InnerException.GetType());
+            if (theoryData.ValidateInnerExceptionMessage)
+            {
+                Assert.Contains(innerExceptionMessage, listener.TraceBuffer);
+                Assert.Contains(innerExceptionMessage, exception.InnerException.Message);
+            }
+        }
+
+        public static TheoryData<DecompressionFailureTheoryData> DecompressionFailTheoryData()
+        {
+            var compressionProviderFactoryForCustom2 = new CompressionProviderFactory()
+            {
+                CustomCompressionProvider = new SampleCustomCompressionProviderDecompressAndCompressAlwaysFail("MyAlgorithm")
+            };
+
+            return new TheoryData<DecompressionFailureTheoryData>() {
+                new DecompressionFailureTheoryData
+                {
+                    TestId = "NotSupportedAlgorithm",
+                    JwtEncodedString = ReferenceTokens.JWECompressionTokenWithUnsupportedAlgorithm,
+                    CompressionProviderFactory = CompressionProviderFactory.Default,
+                    InnerExceptionType = typeof(NotSupportedException),
+                    ValidateInnerExceptionMessage = true,
+                    InnerExceptionMessageId = Tokens.LogMessages.IDX10682,
+                },
+                new DecompressionFailureTheoryData
+                {
+                    TestId = "InvalidToken",
+                    JwtEncodedString = ReferenceTokens.JWEInvalidCompressionTokenWithDEF,
+                    CompressionProviderFactory = CompressionProviderFactory.Default,
+                    InnerExceptionType = typeof(InvalidDataException),
+                    ValidateInnerExceptionMessage = false,
+                },
+                new DecompressionFailureTheoryData
+                {
+                    TestId = "NotSupportedAlgorithmFromCustomCompressionProvider",
+                    JwtEncodedString = ReferenceTokens.JWECompressionTokenWithDEF,
+                    CompressionProviderFactory = compressionProviderFactoryForCustom2,
+                    InnerExceptionType = typeof(SecurityTokenDecompressionFailedException),
+                    ValidateInnerExceptionMessage = true,
+                    InnerExceptionMessageId = Tokens.LogMessages.IDX10679,
+                }
+            };
+        }
+
+        public class DecompressionFailureTheoryData : TheoryDataBase
+        {
+            public string JwtEncodedString;
+            public CompressionProviderFactory CompressionProviderFactory;
+            public Type InnerExceptionType;
+            public bool ValidateInnerExceptionMessage;
+            public string InnerExceptionMessageId;
         }
         #endregion
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
@@ -453,7 +453,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             Assert.Contains(partialExceptionMessage, exception.Message);
         }
 
-        [Theory, MemberData(nameof(DecompressionFailTheoryData), DisableDiscoveryEnumeration = true)]
+        [Theory, MemberData(nameof(DecompressionFailTheoryData), DisableDiscoveryEnumeration = false)]
         public void DecryptJwtToken_WhenDecompressionFails_ThrowsException(DecompressionFailureTheoryData theoryData)
         {
             // Arrange

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
@@ -256,9 +256,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Fact]
-        public void DecryptJwtToken_WhenValidationParametersIsNull_ShouldThrow()
+        public void DecryptJwtToken_WhenValidationParametersIsNull_ThrowsException()
         {
             // Arrange
+            var expectedExceptionParamName = "validationParameters";
             TokenValidationParameters validationParameters = null;
 
             // Act & Assert
@@ -268,13 +269,14 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     validationParameters: validationParameters,
                     decryptionParameters: null));
 
-            Assert.Equal("validationParameters", exception.ParamName);
+            Assert.Equal(expectedExceptionParamName, exception.ParamName);
         }
 
         [Fact]
-        public void DecryptJwtToken_WhenJwtTokenDecryptionParametersIsNull_ShouldThrow()
+        public void DecryptJwtToken_WhenJwtTokenDecryptionParametersIsNull_ThrowsException()
         {
             // Arrange
+            var expectedExceptionParamName = "decryptionParameters";
             var validationParameters = new TokenValidationParameters();
             JwtTokenDecryptionParameters decryptionParameters = null;
 
@@ -285,11 +287,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                     validationParameters: validationParameters,
                     decryptionParameters: decryptionParameters));
 
-            Assert.Equal("decryptionParameters", exception.ParamName);
+            Assert.Equal(expectedExceptionParamName, exception.ParamName);
         }
 
-        [Fact(Skip = "Skip due to potential false positives it may cause running tests in parallel as it overrides JwtTokenUtilities.s_getCryptoProviderFactory.")]
-        public void DecryptJwtToken_WhenCryptoProviderFactoryIsNull_FailsWithIDX10609AndLogsIDX10607()
+        [Fact]
+        public void DecryptJwtToken_WhenCryptoProviderFactoryIsNull_ThrowsException()
         {
             // Save the original delegate to restore.
             var getCryptoProviderFactory = JwtTokenUtilities.s_getCryptoProviderFactory;
@@ -342,7 +344,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Fact]
-        public void DecryptJwtToken_WhenEncIsNotSupported_FailsWithIDX10619AndLogsIDX10611()
+        public void DecryptJwtToken_WhenEncIsNotSupported_ThrowsException()
         {
             // Arrange
             var securityKey = symmetricSecurityKey;
@@ -392,7 +394,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Fact]
-        public void DecryptJwtToken_WhenNoKeys_FailsWithIDX10609()
+        public void DecryptJwtToken_WhenNoKeys_ThrowsException()
         {
             // Arrange
             using var listener = new SampleListener();
@@ -429,7 +431,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         [Fact]
-        public void DecryptJwtToken_WhenDecryptionFails_FailsWithIDX10603()
+        public void DecryptJwtToken_WhenDecryptionFails_ThrowsException()
         {
             // Arrange
             var securityKey = NotDefault.SymmetricSigningKey256;

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -216,45 +217,6 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         }
 
         #region DecryptJwtToken Tests
-
-        [Fact]
-        public void GetCryptoProviderFactory_WhenSetOnTokenValidationParameters_ReturnsFromValidationParameters()
-        {
-            // Arrange
-            // SecurityKey can never have 'null' CryptoProviderFactory.
-            var securityKey = symmetricSecurityKey;
-            var validationParameters = new TokenValidationParameters()
-            {
-                CryptoProviderFactory = new CryptoProviderFactory(),
-            };
-
-            // Act
-            var result = JwtTokenUtilities.s_getCryptoProviderFactory(validationParameters, securityKey);
-
-            // Assert
-            Assert.NotNull(result);
-            Assert.Same(validationParameters.CryptoProviderFactory, result);
-        }
-
-        [Fact]
-        public void GetCryptoProviderFactory_WhenSetToNullOnTokenValidationParameters_ReturnsFromSecurityKey()
-        {
-            // Arrange
-            // SecurityKey can never have 'null' CryptoProviderFactory.
-            var securityKey = symmetricSecurityKey;
-            var validationParameters = new TokenValidationParameters
-            {
-                CryptoProviderFactory = null,
-            };
-
-            // Act
-            var result = JwtTokenUtilities.s_getCryptoProviderFactory(validationParameters, securityKey);
-
-            // Assert
-            Assert.NotNull(result);
-            Assert.Equal(securityKey.CryptoProviderFactory, result);
-        }
-
         [Fact]
         public void DecryptJwtToken_WhenValidationParametersIsNull_ThrowsException()
         {
@@ -293,54 +255,53 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         [Fact]
         public void DecryptJwtToken_WhenCryptoProviderFactoryIsNull_ThrowsException()
         {
-            // Save the original delegate to restore.
-            var getCryptoProviderFactory = JwtTokenUtilities.s_getCryptoProviderFactory;
-            try
+            // Arrange
+            var securityKey = new SymmetricSecurityKey(KeyingMaterial.DefaultSymmetricSecurityKey_128.Key)
             {
-                // Arrange
-                var securityKey = symmetricSecurityKey;
-                using var listener = new SampleListener();
-                IdentityModelEventSource.ShowPII = false;
-                IdentityModelEventSource.Logger.LogLevel = EventLevel.Warning;
-                listener.EnableEvents(IdentityModelEventSource.Logger, EventLevel.Warning);
+                KeyId = KeyingMaterial.DefaultSymmetricSecurityKey_256.KeyId,
+            };
 
-                var keys = new List<SecurityKey>()
-                {
-                    securityKey,
-                };
+            // Get the private _cryptoProviderFactory field and set it to null.
+            var fieldInfo = typeof(SecurityKey).GetField("_cryptoProviderFactory", BindingFlags.NonPublic | BindingFlags.Instance);
+            fieldInfo.SetValue(securityKey, null);
 
-                var validationParameters = new TokenValidationParameters();
-                var decryptionParameters = new JwtTokenDecryptionParameters
-                {
-                    Keys = keys,
-                };
+            using var listener = new SampleListener();
+            IdentityModelEventSource.ShowPII = false;
+            IdentityModelEventSource.Logger.LogLevel = EventLevel.Warning;
+            listener.EnableEvents(IdentityModelEventSource.Logger, EventLevel.Warning);
 
-                JwtTokenUtilities.s_getCryptoProviderFactory = (validationParameters, decryptionParameters) => null;
-
-                var expectedWarning = LogHelper.FormatInvariant(
-                    Tokens.LogMessages.IDX10607,
-                    LogHelper.MarkAsNonPII(securityKey.KeyId));
-                var expectedExceptionMessage = new MessageDetail(
-                    Tokens.LogMessages.IDX10609,
-                    LogHelper.MarkAsSecurityArtifact(decryptionParameters.EncodedToken,
-                    JwtTokenUtilities.SafeLogJwtToken)).Message;
-
-                // Act & Assert
-                var exception = Assert.Throws<SecurityTokenDecryptionFailedException>(() =>
-                    JwtTokenUtilities.DecryptJwtToken(
-                        securityToken: null,
-                        validationParameters: validationParameters,
-                        decryptionParameters: decryptionParameters));
-
-                Assert.Contains(expectedWarning, listener.TraceBuffer);
-                Assert.Contains(expectedExceptionMessage, listener.TraceBuffer);
-                Assert.Equal(expectedExceptionMessage, exception.Message);
-            }
-            finally
+            var keys = new List<SecurityKey>()
             {
-                // Restore the original delegate.
-                JwtTokenUtilities.s_getCryptoProviderFactory = getCryptoProviderFactory;
-            }
+                securityKey,
+            };
+
+            var validationParameters = new TokenValidationParameters()
+            {
+                CryptoProviderFactory = null,
+            };
+            var decryptionParameters = new JwtTokenDecryptionParameters
+            {
+                Keys = keys,
+            };
+
+            var expectedWarning = LogHelper.FormatInvariant(
+                Tokens.LogMessages.IDX10607,
+                LogHelper.MarkAsNonPII(securityKey.KeyId));
+            var expectedExceptionMessage = new MessageDetail(
+                Tokens.LogMessages.IDX10609,
+                LogHelper.MarkAsSecurityArtifact(decryptionParameters.EncodedToken,
+                JwtTokenUtilities.SafeLogJwtToken)).Message;
+
+            // Act & Assert
+            var exception = Assert.Throws<SecurityTokenDecryptionFailedException>(() =>
+                JwtTokenUtilities.DecryptJwtToken(
+                    securityToken: null,
+                    validationParameters: validationParameters,
+                    decryptionParameters: decryptionParameters));
+
+            Assert.Contains(expectedWarning, listener.TraceBuffer);
+            Assert.Contains(expectedExceptionMessage, listener.TraceBuffer);
+            Assert.Equal(expectedExceptionMessage, exception.Message);
         }
 
         [Fact]

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/Microsoft.IdentityModel.JsonWebTokens.Tests.csproj
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/Microsoft.IdentityModel.JsonWebTokens.Tests.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Moq" Version="4.16.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.JsonWebTokens\Microsoft.IdentityModel.JsonWebTokens.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.TestExtensions\Microsoft.IdentityModel.TestExtensions.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.Tokens\Microsoft.IdentityModel.Tokens.csproj" />

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/Microsoft.IdentityModel.JsonWebTokens.Tests.csproj
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/Microsoft.IdentityModel.JsonWebTokens.Tests.csproj
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.16.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.JsonWebTokens\Microsoft.IdentityModel.JsonWebTokens.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.TestExtensions\Microsoft.IdentityModel.TestExtensions.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.Tokens\Microsoft.IdentityModel.Tokens.csproj" />


### PR DESCRIPTION
# Populate error messages correctly from JwtTokenUtilities.DecryptJwtToken
This PR fixes populating error messages when JwtTokenUtilities.DecryptJwtToken is called for to decrypt JsonWebToken.


<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Fixes #3003