### PR TITLE
Add in lazy client certificate obtaining action functionality

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/HttpRequestData.cs
+++ b/src/Microsoft.IdentityModel.Protocols/HttpRequestData.cs
@@ -17,6 +17,8 @@ namespace Microsoft.IdentityModel.Protocols
     {
         private IDictionary<string, IEnumerable<string>> _headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
         private X509Certificate2Collection _clientCertificates;
+        private Action<X509Certificate2Collection> _lazyClientCertificates;
+        private readonly object _lazyClientCertificatesLock = new object();
 
         /// <summary>
         /// Gets or sets the http request URI. 
@@ -51,9 +53,29 @@ namespace Microsoft.IdentityModel.Protocols
         /// <summary>
         /// Gets the certificate collection involved in authenticating the client against the server.
         /// </summary>
-        public X509Certificate2Collection ClientCertificates => _clientCertificates ??
-            Interlocked.CompareExchange(ref _clientCertificates, [], null) ??
-            _clientCertificates;
+        public X509Certificate2Collection ClientCertificates
+        {
+            get
+            {
+                _clientCertificates ??=
+                    Interlocked.CompareExchange(ref _clientCertificates, [], null) ??
+                    _clientCertificates;
+
+                if (_lazyClientCertificates != null)
+                {
+                    lock (_lazyClientCertificatesLock)
+                    {
+                        if (_lazyClientCertificates != null)
+                        {
+                            _lazyClientCertificates(_clientCertificates);
+                            _lazyClientCertificates = null;
+                        }
+                    }
+                }
+
+                return _clientCertificates;
+            }
+        }
 
         /// <summary>
         /// Gets or sets an <see cref="IDictionary{String, Object}"/> that enables custom extensibility scenarios.
@@ -76,6 +98,18 @@ namespace Microsoft.IdentityModel.Protocols
                 else
                     Headers.Add(header.Key, header.Value);
             }
+        }
+
+        /// <summary>
+        /// Sets an action to lazily populate the <see cref="ClientCertificates"/> property.
+        /// </summary>
+        /// <param name="lazyClientCertificates">The action to lazily populate the property.</param>
+        public void SetLazyClientCertificates(Action<X509Certificate2Collection> lazyClientCertificates)
+        {
+            if (lazyClientCertificates == null)
+                return;
+
+            _lazyClientCertificates = lazyClientCertificates;
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Protocols/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Protocols/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.IdentityModel.Protocols.HttpRequestData.SetLazyClientCertificates(System.Action<System.Security.Cryptography.X509Certificates.X509Certificate2Collection> lazyClientCertificates) -> void

--- a/test/Microsoft.IdentityModel.Protocols.Tests/HttpRequestDataTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/HttpRequestDataTests.cs
@@ -22,5 +22,33 @@ namespace Microsoft.IdentityModel.Protocols.Tests
             Assert.Single(httpRequestData.ClientCertificates);
             Assert.Equal(cert, httpRequestData.ClientCertificates[0]);
         }
+
+        [Fact]
+        public void LazyClientCertificates()
+        {
+            var httpRequestData = new HttpRequestData();
+            Assert.NotNull(httpRequestData.ClientCertificates);
+            Assert.Empty(httpRequestData.ClientCertificates);
+
+            X509Certificate2 cert = TestUtils.CertificateHelper.LoadX509Certificate(KeyingMaterial.AADCertData);
+
+            int numberCertsPopulatedCalled = 0;
+            httpRequestData.SetLazyClientCertificates((c) =>
+            {
+                numberCertsPopulatedCalled++;
+                c.Add(cert);
+            });
+
+            Assert.Equal(0, numberCertsPopulatedCalled);
+
+            Assert.Single(httpRequestData.ClientCertificates);
+            Assert.Equal(cert, httpRequestData.ClientCertificates[0]);
+            Assert.Equal(1, numberCertsPopulatedCalled);
+
+            // Invoke again, should not call the delegate again
+            _ = httpRequestData.ClientCertificates;
+
+            Assert.Equal(1, numberCertsPopulatedCalled);
+        }
     }
 }


### PR DESCRIPTION
# Add in lazy client certificate obtaining action functionality

- [X] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Adds the ability to populate the ClientCertificates property when first obtained, instead of immediately. This is important as obtaining the client certificates may trigger a renegotiation, which is not desirable if the client certificates are not to be inspected.


Fixes #{bug number} (in this specific format)
