### PR TITLE
Move CNF from SHR to M.IM.Tokens

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/Cnf.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/Cnf.cs
@@ -1,88 +1,19 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-using Microsoft.IdentityModel.Logging;
-using Microsoft.IdentityModel.Tokens;
-using Microsoft.IdentityModel.Tokens.Json;
-
 namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
 {
     /// <summary>
     /// Represents the Cnf Claim
     /// </summary>
-    internal class Cnf
+    internal class Cnf : Tokens.Cnf
     {
-        internal const string ClassName = "Microsoft.IdentityModel.Protocols.SignedHttpRequest.Cnf";
-
-        public Cnf() { }
-
-        public Cnf(string json)
+        public Cnf() : base()
         {
-            if (string.IsNullOrEmpty(json))
-                throw LogHelper.LogArgumentNullException(nameof(json));
-
-            Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(json).AsSpan());
-            if (!JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartObject, true))
-                throw LogHelper.LogExceptionMessage(
-                    new JsonException(
-                        LogHelper.FormatInvariant(
-                        Tokens.LogMessages.IDX11023,
-                        LogHelper.MarkAsNonPII("JsonTokenType.StartObject"),
-                        LogHelper.MarkAsNonPII(reader.TokenType),
-                        LogHelper.MarkAsNonPII(ClassName),
-                        LogHelper.MarkAsNonPII(reader.TokenStartIndex),
-                        LogHelper.MarkAsNonPII(reader.CurrentDepth),
-                        LogHelper.MarkAsNonPII(reader.BytesConsumed))));
-
-            while (true)
-            {
-                if (reader.TokenType == JsonTokenType.PropertyName)
-                {
-                    if (reader.ValueTextEquals(ConfirmationClaimTypesUtf8Bytes.Jwk))
-                    {
-                        reader.Read();
-                        JsonWebKey = JsonWebKeySerializer.Read(ref reader, new JsonWebKey());
-                    }
-                    else if (reader.ValueTextEquals(ConfirmationClaimTypesUtf8Bytes.Kid))
-                    {
-                        Kid = JsonSerializerPrimitives.ReadString(ref reader, ConfirmationClaimTypes.Kid, ClassName, true);
-                    }
-                    else if (reader.ValueTextEquals(ConfirmationClaimTypesUtf8Bytes.Jku))
-                    {
-                        Jku = JsonSerializerPrimitives.ReadString(ref reader, ConfirmationClaimTypes.Kid, ClassName, true);
-                    }
-                    else if (reader.ValueTextEquals(ConfirmationClaimTypesUtf8Bytes.Jwe))
-                    {
-                        Jwe = JsonSerializerPrimitives.ReadString(ref reader, ConfirmationClaimTypes.Jwe, ClassName, true);
-                    }
-                    else
-                    {
-                        // this is not a property we recognize, skip it.
-                        reader.Skip();
-                    }
-                }
-                // We read a JsonTokenType.StartObject above, exiting and positioning reader at next token.
-                else if (JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.EndObject, true))
-                    break;
-                else if (!reader.Read())
-                    break;
-            }
         }
 
-        [JsonPropertyName("kid")]
-        public string Kid { get; set; }
-
-        [JsonPropertyName("jwe")]
-        public string Jwe { get; set; }
-
-        [JsonPropertyName("jku")]
-        public string Jku { get; set; }
-
-        [JsonPropertyName("jwk")]
-        public JsonWebKey JsonWebKey { get; set; }
+        public Cnf(string json) : base(json)
+        {
+        }
     }
 }

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/Cnf.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/Cnf.cs
@@ -8,16 +8,16 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
     /// </summary>
     internal class Cnf : Tokens.Cnf
     {
-        private readonly string _shrClassName = "Microsoft.IdentityModel.Protocols.SignedHttpRequest.Cnf";
+        private const string ShrClassName = "Microsoft.IdentityModel.Protocols.SignedHttpRequest.Cnf";
 
         public Cnf() : base()
         {
-            ClassName = _shrClassName;
+            ClassName = ShrClassName;
         }
 
         public Cnf(string json) : base(json)
         {
-            ClassName = _shrClassName;
+            ClassName = ShrClassName;
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/Cnf.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/Cnf.cs
@@ -8,16 +8,12 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
     /// </summary>
     internal class Cnf : Tokens.Cnf
     {
-        private const string ShrClassName = "Microsoft.IdentityModel.Protocols.SignedHttpRequest.Cnf";
-
         public Cnf() : base()
         {
-            ClassName = ShrClassName;
         }
 
         public Cnf(string json) : base(json)
         {
-            ClassName = ShrClassName;
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/Cnf.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/Cnf.cs
@@ -8,12 +8,16 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
     /// </summary>
     internal class Cnf : Tokens.Cnf
     {
+        private readonly string _shrClassName = "Microsoft.IdentityModel.Protocols.SignedHttpRequest.Cnf";
+
         public Cnf() : base()
         {
+            ClassName = _shrClassName;
         }
 
         public Cnf(string json) : base(json)
         {
+            ClassName = _shrClassName;
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Cnf.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Cnf.cs
@@ -15,18 +15,19 @@ namespace Microsoft.IdentityModel.Tokens
     /// </summary>
     public class Cnf
     {
-        private const string DefaultClassName = "Microsoft.IdentityModel.Tokens.Cnf";
-
         /// <summary>
         /// The class name used for logging and exception messages.
         /// </summary>
-        protected internal string ClassName { get; set; } = DefaultClassName;
+        internal string ClassName { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Cnf"/> class.
         /// </summary>
         public Cnf()
         {
+            // GetType returns the runtime type, e.g. if derived,
+            // it will return the derived type.
+            ClassName = GetType().FullName;
         }
 
         /// <summary>
@@ -35,7 +36,7 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="json">
         /// JSON representation of the Cnf Claim.
         /// </param>
-        public Cnf(string json)
+        public Cnf(string json) : this()
         {
             if (string.IsNullOrEmpty(json))
                 throw LogHelper.LogArgumentNullException(nameof(json));

--- a/src/Microsoft.IdentityModel.Tokens/Cnf.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Cnf.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.Tokens.Json;
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Represents the Cnf Claim
+    /// </summary>
+    public class Cnf
+    {
+        private const string ClassName = "Microsoft.IdentityModel.Protocols.SignedHttpRequest.Cnf";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Cnf"/> class.
+        /// </summary>
+        public Cnf() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Cnf"/> class.
+        /// </summary>
+        /// <param name="json">
+        /// JSON representation of the Cnf Claim.
+        /// </param>
+        public Cnf(string json)
+        {
+            if (string.IsNullOrEmpty(json))
+                throw LogHelper.LogArgumentNullException(nameof(json));
+
+            Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(json).AsSpan());
+            if (!JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.StartObject, true))
+                throw LogHelper.LogExceptionMessage(
+                    new JsonException(
+                        LogHelper.FormatInvariant(
+                        LogMessages.IDX11023,
+                        LogHelper.MarkAsNonPII("JsonTokenType.StartObject"),
+                        LogHelper.MarkAsNonPII(reader.TokenType),
+                        LogHelper.MarkAsNonPII(ClassName),
+                        LogHelper.MarkAsNonPII(reader.TokenStartIndex),
+                        LogHelper.MarkAsNonPII(reader.CurrentDepth),
+                        LogHelper.MarkAsNonPII(reader.BytesConsumed))));
+
+            while (true)
+            {
+                if (reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (reader.ValueTextEquals(ConfirmationClaimTypesUtf8Bytes.Jwk))
+                    {
+                        reader.Read();
+                        JsonWebKey = JsonWebKeySerializer.Read(ref reader, new JsonWebKey());
+                    }
+                    else if (reader.ValueTextEquals(ConfirmationClaimTypesUtf8Bytes.Kid))
+                    {
+                        Kid = JsonSerializerPrimitives.ReadString(ref reader, ConfirmationClaimTypes.Kid, ClassName, true);
+                    }
+                    else if (reader.ValueTextEquals(ConfirmationClaimTypesUtf8Bytes.Jku))
+                    {
+                        Jku = JsonSerializerPrimitives.ReadString(ref reader, ConfirmationClaimTypes.Kid, ClassName, true);
+                    }
+                    else if (reader.ValueTextEquals(ConfirmationClaimTypesUtf8Bytes.Jwe))
+                    {
+                        Jwe = JsonSerializerPrimitives.ReadString(ref reader, ConfirmationClaimTypes.Jwe, ClassName, true);
+                    }
+                    else
+                    {
+                        // this is not a property we recognize, skip it.
+                        reader.Skip();
+                    }
+                }
+                // We read a JsonTokenType.StartObject above, exiting and positioning reader at next token.
+                else if (JsonSerializerPrimitives.IsReaderAtTokenType(ref reader, JsonTokenType.EndObject, true))
+                    break;
+                else if (!reader.Read())
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// The Kid property is used to specify the key ID of the public key used to verify the signature of the JWT.
+        /// </summary>
+        [JsonPropertyName("kid")]
+        public string Kid { get; internal set; }
+
+        /// <summary>
+        /// The Jwe property is used to specify an encrypted JSON web key.
+        /// </summary>
+        [JsonPropertyName("jwe")]
+        public string Jwe { get; internal set; }
+
+        /// <summary>
+        /// The Jku property is used to specify the location of the public key used to verify the signature of the JWT.
+        /// </summary>
+        [JsonPropertyName("jku")]
+        public string Jku { get; internal set; }
+
+        /// <summary>
+        /// The Jwk property is used to specify the public key used to verify the signature of the JWT.
+        /// </summary>
+        [JsonPropertyName("jwk")]
+        public JsonWebKey JsonWebKey { get; internal set; }
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/Cnf.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Cnf.cs
@@ -15,12 +15,19 @@ namespace Microsoft.IdentityModel.Tokens
     /// </summary>
     public class Cnf
     {
-        private const string ClassName = "Microsoft.IdentityModel.Protocols.SignedHttpRequest.Cnf";
+        private const string DefaultClassName = "Microsoft.IdentityModel.Tokens.Cnf";
+
+        /// <summary>
+        /// The class name used for logging and exception messages.
+        /// </summary>
+        protected internal string ClassName { get; set; } = DefaultClassName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Cnf"/> class.
         /// </summary>
-        public Cnf() { }
+        public Cnf()
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Cnf"/> class.

--- a/src/Microsoft.IdentityModel.Tokens/ConfirmationClaimTypes.cs
+++ b/src/Microsoft.IdentityModel.Tokens/ConfirmationClaimTypes.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
+namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
     /// Confirmation Claim ("cnf") related constants
@@ -14,27 +14,27 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// <summary>
         /// https://datatracker.ietf.org/doc/html/rfc7800#section-6.1.1
         /// </summary>
-        public const string Cnf = Tokens.ConfirmationClaimTypes.Cnf;
+        public const string Cnf = "cnf";
 
         /// <summary>
         /// https://datatracker.ietf.org/doc/html/rfc7800#section-6.2.2
         /// </summary>
-        public const string Jwk = Tokens.ConfirmationClaimTypes.Jwk;
+        public const string Jwk = "jwk";
 
         /// <summary>
         /// https://datatracker.ietf.org/doc/html/rfc7800#section-6.2.2
         /// </summary>
-        public const string Jwe = Tokens.ConfirmationClaimTypes.Jwe;
+        public const string Jwe = "jwe";
 
         /// <summary>
         /// https://datatracker.ietf.org/doc/html/rfc7800#section-6.2.2
         /// </summary>
-        public const string Jku = Tokens.ConfirmationClaimTypes.Jku;
+        public const string Jku = "jku";
 
         /// <summary>
         /// https://datatracker.ietf.org/doc/html/rfc7800#section-6.2.2
         /// </summary>
-        public const string Kid = Tokens.ConfirmationClaimTypes.Kid;
+        public const string Kid = "kid";
     }
 
     internal static class ConfirmationClaimTypesUtf8Bytes
@@ -45,5 +45,4 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         public static ReadOnlySpan<byte> Jku => "jku"u8;
         public static ReadOnlySpan<byte> Kid => "kid"u8;
     }
-
 }

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -1,0 +1,9 @@
+Microsoft.IdentityModel.Tokens.Cnf.Jku.set -> void
+Microsoft.IdentityModel.Tokens.Cnf.JsonWebKey.set -> void
+Microsoft.IdentityModel.Tokens.Cnf.Jwe.set -> void
+Microsoft.IdentityModel.Tokens.Cnf.Kid.set -> void
+Microsoft.IdentityModel.Protocols.SignedHttpRequest.ConfirmationClaimTypesUtf8Bytes
+Microsoft.IdentityModel.Tokens.Cnf.Jku.set -> void
+Microsoft.IdentityModel.Tokens.Cnf.JsonWebKey.set -> void
+Microsoft.IdentityModel.Tokens.Cnf.Jwe.set -> void
+Microsoft.IdentityModel.Tokens.Cnf.Kid.set -> void

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
@@ -1,0 +1,13 @@
+Microsoft.IdentityModel.Tokens.Cnf
+Microsoft.IdentityModel.Tokens.Cnf.Cnf() -> void
+Microsoft.IdentityModel.Tokens.Cnf.Cnf(string json) -> void
+Microsoft.IdentityModel.Tokens.Cnf.Jku.get -> string
+Microsoft.IdentityModel.Tokens.Cnf.JsonWebKey.get -> Microsoft.IdentityModel.Tokens.JsonWebKey
+Microsoft.IdentityModel.Tokens.Cnf.Jwe.get -> string
+Microsoft.IdentityModel.Tokens.Cnf.Kid.get -> string
+const Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes.Cnf = "cnf" -> string
+const Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes.Jku = "jku" -> string
+const Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes.Jwe = "jwe" -> string
+const Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes.Jwk = "jwk" -> string
+const Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes.Kid = "kid" -> string
+Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
@@ -11,5 +11,3 @@ const Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes.Jwe = "jwe" -> strin
 const Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes.Jwk = "jwk" -> string
 const Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes.Kid = "kid" -> string
 Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes
-Microsoft.IdentityModel.Tokens.Cnf.ClassName.get -> string
-Microsoft.IdentityModel.Tokens.Cnf.ClassName.set -> void

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
@@ -11,3 +11,5 @@ const Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes.Jwe = "jwe" -> strin
 const Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes.Jwk = "jwk" -> string
 const Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes.Kid = "kid" -> string
 Microsoft.IdentityModel.Tokens.ConfirmationClaimTypes
+Microsoft.IdentityModel.Tokens.Cnf.ClassName.get -> string
+Microsoft.IdentityModel.Tokens.Cnf.ClassName.set -> void

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/CnfTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/CnfTests.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
+{
+    public class CnfTests
+    {
+        [Fact]
+        public void CtorWithJson_ExpectedClassName()
+        {
+            var json = "{\"jwk\":{\"kty\":\"oct\",\"k\":\"AQIDBAUGBwgJCgsMDQ4PEC==\"}}";
+            var cnf = new Cnf(json);
+            Assert.Equal("Microsoft.IdentityModel.Protocols.SignedHttpRequest.Cnf", cnf.ClassName);
+        }
+
+        [Fact]
+        public void Ctor_ExpectedClassName()
+        {
+            var cnf = new Cnf();
+            Assert.Equal("Microsoft.IdentityModel.Protocols.SignedHttpRequest.Cnf", cnf.ClassName);
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CnfTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CnfTests.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Microsoft.IdentityModel.Tokens.Tests
+{
+    public class CnfTests
+    {
+        [Fact]
+        public void CtorWithJson_ExpectedClassName()
+        {
+            var json = "{\"jwk\":{\"kty\":\"oct\",\"k\":\"AQIDBAUGBwgJCgsMDQ4PEC==\"}}";
+            var cnf = new Cnf(json);
+            Assert.Equal("Microsoft.IdentityModel.Tokens.Cnf", cnf.ClassName);
+        }
+
+        [Fact]
+        public void Ctor_ExpectedClassName()
+        {
+            var cnf = new Cnf();
+            Assert.Equal("Microsoft.IdentityModel.Tokens.Cnf", cnf.ClassName);
+        }
+    }
+}


### PR DESCRIPTION
# Make CNF type public

## Description

Makes the Cnf type public and moves it to M.IM.Tokens. Don't remove any types from SHR, instead make it inherit from the new type

Fixes #3165
