### PR TITLE
JsonWebToken exposes Header Claims

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -614,6 +614,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         }
 
         /// <summary>
+        /// Gets an <see cref="IReadOnlyList{Claim}"/> where each claim in the JWT header { name, value } is returned as a <see cref="Claim"/>.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="Claim"/> requires each value to be represented as a string. If the value was not a string, then <see cref="Claim.Type"/> contains the json type.
+        /// <see cref="JsonClaimValueTypes"/> and <see cref="ClaimValueTypes"/> to determine the json type.
+        /// </remarks>
+        public IReadOnlyList<Claim> HeaderClaims => Header.Claims(Issuer ?? ClaimsIdentity.DefaultIssuer);
+
+        /// <summary>
         /// Gets a <see cref="Claim"/> representing the { key, 'value' } pair corresponding to the provided <paramref name="key"/>.
         /// </summary>
         /// <remarks>

--- a/src/Microsoft.IdentityModel.JsonWebTokens/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.IdentityModel.JsonWebTokens.JsonWebToken.HeaderClaims.get -> System.Collections.Generic.IReadOnlyList<System.Security.Claims.Claim>

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
@@ -44,6 +44,21 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         };
 
         [Fact]
+        public void JsonWebToken_HeaderClaims_ReturnsExpectedClaims()
+        {
+            var jsonWebTokenHandler = new JsonWebTokenHandler();
+            var jsonWebTokenString = jsonWebTokenHandler.CreateToken(Default.PayloadString, KeyingMaterial.JsonWebKeyRsa256SigningCredentials);
+            var jsonWebToken = new JsonWebToken(jsonWebTokenString);
+            var claims = jsonWebToken.HeaderClaims;
+
+            // Header should have three default claims:
+            Assert.Equal(3, claims.Count);
+            Assert.Contains(claims, c => c.Type == "alg");
+            Assert.Contains(claims, c => c.Type == "typ");
+            Assert.Contains(claims, c => c.Type == "kid");
+        }
+
+        [Fact]
         public void ByteArrayClaimsEncodedAsExpected()
         {
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('a', 128)));


### PR DESCRIPTION
# JsonWebToken exposes Header Claims

The JsonWebToken should provide an API that allows access to the JWT header keys, values, and claim value types, this is done already through the Claim type.

Fixes #3164
