### PR TITLE
Add concurrency tests for locks

### DIFF
--- a/src/Microsoft.IdentityModel.LoggingExtensions/Microsoft.IdentityModel.LoggingExtensions.csproj
+++ b/src/Microsoft.IdentityModel.LoggingExtensions/Microsoft.IdentityModel.LoggingExtensions.csproj
@@ -8,7 +8,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Microsoft.IdentityModel.LoggingExtensions</PackageId>
     <PackageTags>.NET;Windows;Authentication;Identity;Extensions;Logging</PackageTags>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
@@ -105,7 +104,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
         // Tests a JsonClaimSet, to ensure the same List object is returned for concurrent calls to the Claims member.
         [Fact]
-        public void ValidJsonClaimSet_ConcurrencyTest()
+        public async Task ValidJsonClaimSet_ConcurrencyTest()
         {
             // Arrange
             var numThreads = 10;
@@ -116,27 +115,28 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 { "claim2", "value2" }
             };
             var jsonClaimSet = new JsonClaimSet(jsonClaims);
-            ConcurrentBag<List<Claim>> allClaims = new();
-            List<Action> actions = new List<Action>();
+            List<Claim>[] allClaims = new List<Claim>[numThreads];
+            Task[] tasks = new Task[numThreads];
 
-            for (int i = 0; i < numThreads; i++)
+            for (var i = 0; i < numThreads; i++)
             {
-                actions.Add(() =>
+                var index = i;
+                tasks[i] = (Task.Run(() =>
                 {
                     barrier.SignalAndWait();
-                    allClaims.Add(jsonClaimSet.Claims("claim1"));
-                });
+                    allClaims[index] = jsonClaimSet.Claims("claim1");
+                }));
             }
 
             // Act
-            Parallel.Invoke(actions.ToArray());
+            await Task.WhenAll(tasks);
 
             // Assert
-            Assert.Equal(numThreads, allClaims.Count);
-            Assert.True(allClaims.TryTake(out List<Claim> controlClaims));
-            foreach (var claims in allClaims)
+            Assert.All(allClaims, claims => Assert.NotNull(claims));
+            var firstClaims = allClaims[0];
+            for (var i = 1; i < numThreads; i++)
             {
-                Assert.Same(controlClaims, claims);
+                Assert.Same(firstClaims, allClaims[i]);
             }
         }
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
@@ -12,6 +12,8 @@ using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens.Json.Tests;
 using Microsoft.IdentityModel.Tokens;
 using Xunit;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 {
@@ -98,6 +100,26 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
 
             TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Fact]
+        public void ValidJsonClaimSet_ConcurrencyTest()
+        {
+            var jsonClaims = new Dictionary<string, object>
+        {
+            { "claim1", "value1" },
+            { "claim2", "value2" }
+        };
+            var jsonClaimSet = new JsonClaimSet(jsonClaims);
+            List<Claim> firstClaims = null;
+
+            Parallel.For(0, 1000, i =>
+            {
+                var claims = jsonClaimSet.Claims("issuer");
+                Assert.NotNull(claims);
+                Interlocked.CompareExchange(ref firstClaims, claims, null);
+                Assert.Same(firstClaims, claims);
+            });
         }
 
         public static TheoryData<JsonClaimSetTheoryData> GetClaimAsTypeTheoryData()

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonClaimSetTests.cs
@@ -2,18 +2,19 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
-using Microsoft.IdentityModel.TestUtils;
-using Microsoft.IdentityModel.Tokens.Json.Tests;
-using Microsoft.IdentityModel.Tokens;
-using Xunit;
-using System.Threading.Tasks;
 using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Json.Tests;
+using Xunit;
 
 namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 {
@@ -102,24 +103,41 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
+        // Tests a JsonClaimSet, to ensure the same List object is returned for concurrent calls to the Claims member.
         [Fact]
         public void ValidJsonClaimSet_ConcurrencyTest()
         {
+            // Arrange
+            var numThreads = 10;
+            var barrier = new Barrier(numThreads);
             var jsonClaims = new Dictionary<string, object>
-        {
-            { "claim1", "value1" },
-            { "claim2", "value2" }
-        };
-            var jsonClaimSet = new JsonClaimSet(jsonClaims);
-            List<Claim> firstClaims = null;
-
-            Parallel.For(0, 1000, i =>
             {
-                var claims = jsonClaimSet.Claims("issuer");
-                Assert.NotNull(claims);
-                Interlocked.CompareExchange(ref firstClaims, claims, null);
-                Assert.Same(firstClaims, claims);
-            });
+                { "claim1", "value1" },
+                { "claim2", "value2" }
+            };
+            var jsonClaimSet = new JsonClaimSet(jsonClaims);
+            ConcurrentBag<List<Claim>> allClaims = new();
+            List<Action> actions = new List<Action>();
+
+            for (int i = 0; i < numThreads; i++)
+            {
+                actions.Add(() =>
+                {
+                    barrier.SignalAndWait();
+                    allClaims.Add(jsonClaimSet.Claims("claim1"));
+                });
+            }
+
+            // Act
+            Parallel.Invoke(actions.ToArray());
+
+            // Assert
+            Assert.Equal(numThreads, allClaims.Count);
+            Assert.True(allClaims.TryTake(out List<Claim> controlClaims));
+            foreach (var claims in allClaims)
+            {
+                Assert.Same(controlClaims, claims);
+            }
         }
 
         public static TheoryData<JsonClaimSetTheoryData> GetClaimAsTypeTheoryData()

--- a/test/Microsoft.IdentityModel.Tokens.Tests/KeyWrapProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/KeyWrapProviderTests.cs
@@ -283,31 +283,37 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
-        // Tests that concurrent calls to WrapKey and UnwrapKey do not run into encrypt/decrypt lock contention issues or race conditions.
+        // Tests that concurrent calls to WrapKey and UnwrapKey do not run into encrypt/decrypt lock contention issues or other race conditions.
         [Fact]
         public void WrapAndUnwrapKey_ConcurrencyTest()
         {
             // Arrange
             var numThreads = 10;
-            var barrier = new Barrier(numThreads);
+            var wrapBarrier = new Barrier(numThreads);
+            var unwrapBarrier = new Barrier(numThreads);
             var barrierTimeoutInMs = 5000;
             var key = new SymmetricSecurityKey(new byte[32]);
             var provider = new SymmetricKeyWrapProvider(key, SecurityAlgorithms.Aes256KW);
-            var actions = new List<Action>();
+            var tasks = new List<Task>(numThreads);
 
             // Act and Assert
             for (int i = 0; i < numThreads; i++)
             {
-                actions.Add(() =>
+                tasks.Add(Task.Run(() =>
                 {
-                    barrier.SignalAndWait(barrierTimeoutInMs);
-                    var wrappedKey = provider.WrapKey(new byte[32]);
+                    // Wait for all threads to be ready before checking the WrapKey locks
+                    var keyBytes = new byte[32];
+                    wrapBarrier.SignalAndWait(barrierTimeoutInMs);
+                    var wrappedKey = provider.WrapKey(keyBytes);
                     Assert.NotNull(wrappedKey);
+
+                    // Wait for all threads to be ready before checking the UnwrapKey locks
+                    unwrapBarrier.SignalAndWait(barrierTimeoutInMs);
                     var unwrappedKey = provider.UnwrapKey(wrappedKey);
                     Assert.NotNull(unwrappedKey);
-                });
+                }));
             }
-            Parallel.Invoke(actions.ToArray());
+            Task.WhenAll(tasks);
         }
 
         public static TheoryData<KeyWrapTheoryData> UnwrapTheoryData()

--- a/test/Microsoft.IdentityModel.Tokens.Tests/KeyWrapProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/KeyWrapProviderTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
@@ -281,19 +283,31 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
+        // Tests that concurrent calls to WrapKey and UnwrapKey do not run into encrypt/decrypt lock contention issues or race conditions.
         [Fact]
         public void WrapAndUnwrapKey_ConcurrencyTest()
         {
+            // Arrange
+            var numThreads = 10;
+            var barrier = new Barrier(numThreads);
+            var barrierTimeoutInMs = 5000;
             var key = new SymmetricSecurityKey(new byte[32]);
             var provider = new SymmetricKeyWrapProvider(key, SecurityAlgorithms.Aes256KW);
+            var actions = new List<Action>();
 
-            Parallel.For(0, 1000, i =>
+            // Act and Assert
+            for (int i = 0; i < numThreads; i++)
             {
-                var wrappedKey = provider.WrapKey(new byte[32]);
-                Assert.NotNull(wrappedKey);
-                var unwrappedKey = provider.UnwrapKey(wrappedKey);
-                Assert.NotNull(unwrappedKey);
-            });
+                actions.Add(() =>
+                {
+                    barrier.SignalAndWait(barrierTimeoutInMs);
+                    var wrappedKey = provider.WrapKey(new byte[32]);
+                    Assert.NotNull(wrappedKey);
+                    var unwrappedKey = provider.UnwrapKey(wrappedKey);
+                    Assert.NotNull(unwrappedKey);
+                });
+            }
+            Parallel.Invoke(actions.ToArray());
         }
 
         public static TheoryData<KeyWrapTheoryData> UnwrapTheoryData()

--- a/test/Microsoft.IdentityModel.Tokens.Tests/KeyWrapProviderTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/KeyWrapProviderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -278,6 +279,21 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             }
 
             TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Fact]
+        public void WrapAndUnwrapKey_ConcurrencyTest()
+        {
+            var key = new SymmetricSecurityKey(new byte[32]);
+            var provider = new SymmetricKeyWrapProvider(key, SecurityAlgorithms.Aes256KW);
+
+            Parallel.For(0, 1000, i =>
+            {
+                var wrappedKey = provider.WrapKey(new byte[32]);
+                Assert.NotNull(wrappedKey);
+                var unwrappedKey = provider.UnwrapKey(wrappedKey);
+                Assert.NotNull(unwrappedKey);
+            });
         }
 
         public static TheoryData<KeyWrapTheoryData> UnwrapTheoryData()

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -214,20 +214,36 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             Assert.False(new CustomSecurityKey().CanComputeJwkThumbprint(), "CustomSecurityKey shouldn't be able to compute JWK thumbprint if CanComputeJwkThumbprint() is not overriden.");
         }
 
+        // Tests a SecurityKey object, to ensure the InternalId is set exactly once when faced with concurrent calls.
         [Fact]
         public void InternalId_ConcurrencyTest()
         {
+            // Arrange
+            var numThreads = 10;
+            var barrier = new Barrier(numThreads);
             var key = new CustomSecurityKey();
-            string firstInternalId = null;
+            ConcurrentBag<string> internalIds = new();
+            List<Action> actions = [];
 
-            Parallel.For(0, 1000, i =>
+            for (int i = 0; i < numThreads; i++)
             {
-                var internalId = key.InternalId;
-                Assert.NotNull(internalId);
-                Interlocked.CompareExchange(ref firstInternalId, internalId, null);
-                Assert.Same(firstInternalId, internalId);
+                actions.Add(() =>
+                {
+                    barrier.SignalAndWait();
+                    internalIds.Add(key.InternalId);
+                });
+            }
 
-            });
+            // Act
+            Parallel.Invoke(actions.ToArray());
+
+            // Assert
+            Assert.Equal(numThreads, internalIds.Count);
+            Assert.True(internalIds.TryTake(out var internalId));
+            foreach (var id in internalIds)
+            {
+                Assert.Same(internalId, id);
+            }
         }
 
         public class SecurityKeyTheoryData : TheoryDataBase

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -208,6 +212,22 @@ namespace Microsoft.IdentityModel.Tokens.Tests
         public void CanComputeJwkThumbprint()
         {
             Assert.False(new CustomSecurityKey().CanComputeJwkThumbprint(), "CustomSecurityKey shouldn't be able to compute JWK thumbprint if CanComputeJwkThumbprint() is not overriden.");
+        }
+
+        [Fact]
+        public void InternalId_ConcurrencyTest()
+        {
+            var key = new CustomSecurityKey();
+            string firstInternalId = null;
+
+            Parallel.For(0, 1000, i =>
+            {
+                var internalId = key.InternalId;
+                Assert.NotNull(internalId);
+                Interlocked.CompareExchange(ref firstInternalId, internalId, null);
+                Assert.Same(firstInternalId, internalId);
+
+            });
         }
 
         public class SecurityKeyTheoryData : TheoryDataBase

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SecurityKeyTests.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.TestUtils;
@@ -216,33 +214,34 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
         // Tests a SecurityKey object, to ensure the InternalId is set exactly once when faced with concurrent calls.
         [Fact]
-        public void InternalId_ConcurrencyTest()
+        public async Task InternalId_ConcurrencyTest()
         {
             // Arrange
-            var numThreads = 10;
-            var barrier = new Barrier(numThreads);
+            var numTasks = 10;
+            var barrier = new Barrier(numTasks);
             var key = new CustomSecurityKey();
-            ConcurrentBag<string> internalIds = new();
-            List<Action> actions = [];
+            string[] internalIds = new string[numTasks];
+            Task[] tasks = new Task[numTasks];
 
-            for (int i = 0; i < numThreads; i++)
+            for (int i = 0; i < numTasks; i++)
             {
-                actions.Add(() =>
+                var index = i;
+                tasks[i] = Task.Run(() =>
                 {
                     barrier.SignalAndWait();
-                    internalIds.Add(key.InternalId);
+                    internalIds[index] = key.InternalId;
                 });
             }
 
             // Act
-            Parallel.Invoke(actions.ToArray());
+            await Task.WhenAll(tasks);
 
             // Assert
-            Assert.Equal(numThreads, internalIds.Count);
-            Assert.True(internalIds.TryTake(out var internalId));
-            foreach (var id in internalIds)
+            Assert.All(internalIds, id => Assert.NotNull(id));
+            var firstId = internalIds[0];
+            for (int i = 1; i < numTasks; i++)
             {
-                Assert.Same(internalId, id);
+                Assert.Same(firstId, internalIds[i]);
             }
         }
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationResultTests.cs
@@ -4,12 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.TestUtils;
-using Microsoft.IdentityModel.Tokens;
 using Xunit;
 
 namespace Microsoft.IdentityModel.Tokens.Tests
@@ -71,25 +69,6 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
             // Act and implicit Assert as any exception will cause the test to fail
             await Task.WhenAll(tasks);
-        }
-
-        private static async Task<TokenValidationResult> GetTestValidationResultAsync()
-        {
-            var tokenHandler = new JsonWebTokenHandler();
-            var tokenDescriptor = new SecurityTokenDescriptor
-            {
-                Subject = new CaseSensitiveClaimsIdentity(Default.PayloadClaims),
-                SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
-            };
-            var accessToken = tokenHandler.CreateToken(tokenDescriptor);
-            var tokenValidationParameters = new TokenValidationParameters()
-            {
-                ValidAudience = "http://Default.Audience.com",
-                ValidateLifetime = false,
-                ValidIssuer = "http://Default.Issuer.com",
-                IssuerSigningKey = KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key,
-            };
-            return await tokenHandler.ValidateTokenAsync(accessToken, tokenValidationParameters);
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationResultTests.cs
@@ -4,6 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
@@ -43,6 +46,21 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.GetSet(context);
 
             TestUtilities.AssertFailIfErrors("TokenValidationResultTests.GetSets", context.Errors);
+        }
+
+        [Fact]
+        public void ClaimsIdentity_ConcurrencyTest()
+        {
+            var result = new TokenValidationResult();
+            ClaimsIdentity firstClaimsIdentity = null;
+
+            Parallel.For(0, 1000, i =>
+            {
+                var claimsIdentity = result.ClaimsIdentity;
+                Assert.NotNull(claimsIdentity);
+                Interlocked.CompareExchange(ref firstClaimsIdentity, claimsIdentity, null);
+                Assert.Same(firstClaimsIdentity, claimsIdentity);
+            });
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationResultTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Security.Claims;
@@ -48,19 +49,36 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors("TokenValidationResultTests.GetSets", context.Errors);
         }
 
+        // Ensure the same ClaimsIdentity object is returned when concurrent calls made to TokenValidationResult.
         [Fact]
         public void ClaimsIdentity_ConcurrencyTest()
         {
+            // Arrange
+            var numThreads = 10;
+            var barrier = new Barrier(numThreads);
             var result = new TokenValidationResult();
-            ClaimsIdentity firstClaimsIdentity = null;
+            ConcurrentBag<ClaimsIdentity> allClaimsIdentity = new();
+            List<Action> actions = [];
 
-            Parallel.For(0, 1000, i =>
+            for (int i = 0; i < numThreads; i++)
             {
-                var claimsIdentity = result.ClaimsIdentity;
-                Assert.NotNull(claimsIdentity);
-                Interlocked.CompareExchange(ref firstClaimsIdentity, claimsIdentity, null);
-                Assert.Same(firstClaimsIdentity, claimsIdentity);
-            });
+                actions.Add(() =>
+                {
+                    barrier.SignalAndWait();
+                    allClaimsIdentity.Add(result.ClaimsIdentity);
+                });
+            }
+
+            // Act
+            Parallel.Invoke(actions.ToArray());
+
+            // Assert
+            Assert.Equal(numThreads, allClaimsIdentity.Count);
+            Assert.True(allClaimsIdentity.TryTake(out var controlClaimsIdentity));
+            foreach (var claimsIdentity in allClaimsIdentity)
+            {
+                Assert.Same(controlClaimsIdentity, claimsIdentity);
+            }
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationResultTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Security.Claims;
@@ -10,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
 using Xunit;
 
 namespace Microsoft.IdentityModel.Tokens.Tests
@@ -49,36 +49,47 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors("TokenValidationResultTests.GetSets", context.Errors);
         }
 
-        // Ensure the same ClaimsIdentity object is returned when concurrent calls made to TokenValidationResult.
+        // Ensure setting the ClaimsIdentity object simultaneously doesn't cause lock contention or other concurrency issues.
         [Fact]
-        public void ClaimsIdentity_ConcurrencyTest()
+        public async Task ClaimsIdentity_ConcurrencyTest()
         {
             // Arrange
             var numThreads = 10;
             var barrier = new Barrier(numThreads);
             var result = new TokenValidationResult();
-            ConcurrentBag<ClaimsIdentity> allClaimsIdentity = new();
-            List<Action> actions = [];
+            var claimsIdentity = new CaseSensitiveClaimsIdentity(Default.PayloadClaims);
+            Task[] tasks = new Task[numThreads];
 
             for (int i = 0; i < numThreads; i++)
             {
-                actions.Add(() =>
+                tasks[i] = Task.Run(() =>
                 {
                     barrier.SignalAndWait();
-                    allClaimsIdentity.Add(result.ClaimsIdentity);
+                    result.ClaimsIdentity = claimsIdentity;
                 });
             }
 
-            // Act
-            Parallel.Invoke(actions.ToArray());
+            // Act and implicit Assert as any exception will cause the test to fail
+            await Task.WhenAll(tasks);
+        }
 
-            // Assert
-            Assert.Equal(numThreads, allClaimsIdentity.Count);
-            Assert.True(allClaimsIdentity.TryTake(out var controlClaimsIdentity));
-            foreach (var claimsIdentity in allClaimsIdentity)
+        private static async Task<TokenValidationResult> GetTestValidationResultAsync()
+        {
+            var tokenHandler = new JsonWebTokenHandler();
+            var tokenDescriptor = new SecurityTokenDescriptor
             {
-                Assert.Same(controlClaimsIdentity, claimsIdentity);
-            }
+                Subject = new CaseSensitiveClaimsIdentity(Default.PayloadClaims),
+                SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
+            };
+            var accessToken = tokenHandler.CreateToken(tokenDescriptor);
+            var tokenValidationParameters = new TokenValidationParameters()
+            {
+                ValidAudience = "http://Default.Audience.com",
+                ValidateLifetime = false,
+                ValidIssuer = "http://Default.Issuer.com",
+                IssuerSigningKey = KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key,
+            };
+            return await tokenHandler.ValidateTokenAsync(accessToken, tokenValidationParameters);
         }
     }
 }


### PR DESCRIPTION
There were not thread-safety tests for the places we have locks, this adds some. Addresses #3178 
