### PR TITLE
Revert "Need to change the locks"

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
@@ -12,10 +12,6 @@ using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.IdentityModel.Tokens.Json;
 
-#if NET9_0_OR_GREATER
-using System.Threading;
-#endif
-
 namespace Microsoft.IdentityModel.JsonWebTokens
 {
     /// <summary>
@@ -25,11 +21,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens
     internal class JsonClaimSet
     {
         internal const string ClassName = "Microsoft.IdentityModel.JsonWebTokens.JsonClaimSet";
-#if NET9_0_OR_GREATER
-        internal Lock _claimsLock = new();
-#else
+
         internal object _claimsLock = new();
-#endif
         internal readonly Dictionary<string, object> _jsonClaims;
         private List<Claim> _claims;
 

--- a/src/Microsoft.IdentityModel.JsonWebTokens/PublicAPI/net9.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/PublicAPI/net9.0/InternalAPI.Unshipped.txt
@@ -1,1 +1,0 @@
-Microsoft.IdentityModel.JsonWebTokens.JsonClaimSet._claimsLock -> System.Threading.Lock

--- a/src/Microsoft.IdentityModel.Tokens/Encryption/SymmetricKeyWrapProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/SymmetricKeyWrapProvider.cs
@@ -5,10 +5,6 @@ using System;
 using System.Security.Cryptography;
 using Microsoft.IdentityModel.Logging;
 
-#if NET9_0_OR_GREATER
-using System.Threading;
-#endif
-
 namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
@@ -19,13 +15,9 @@ namespace Microsoft.IdentityModel.Tokens
         private static readonly byte[] _defaultIV = new byte[] { 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6 };
         private const int _blockSizeInBits = 64;
         private const int _blockSizeInBytes = _blockSizeInBits >> 3;
-#if NET9_0_OR_GREATER
-        private static readonly Lock s_encryptorLock = new();
-        private static readonly Lock s_decryptorLock = new();
-#else
-        private static readonly object s_encryptorLock = new();
-        private static readonly object s_decryptorLock = new();
-#endif
+        private static readonly object _encryptorLock = new object();
+        private static readonly object _decryptorLock = new object();
+
         private Lazy<SymmetricAlgorithm> _symmetricAlgorithm;
         private ICryptoTransform _symmetricAlgorithmEncryptor;
         private ICryptoTransform _symmetricAlgorithmDecryptor;
@@ -267,7 +259,7 @@ namespace Microsoft.IdentityModel.Tokens
 
             if (_symmetricAlgorithmDecryptor == null)
             {
-                lock (s_decryptorLock)
+                lock (_decryptorLock)
                 {
                     if (_symmetricAlgorithmDecryptor == null)
                         _symmetricAlgorithmDecryptor = _symmetricAlgorithm.Value.CreateDecryptor();
@@ -417,7 +409,7 @@ namespace Microsoft.IdentityModel.Tokens
 
             if (_symmetricAlgorithmEncryptor == null)
             {
-                lock (s_encryptorLock)
+                lock (_encryptorLock)
                 {
                     if (_symmetricAlgorithmEncryptor == null)
                         _symmetricAlgorithmEncryptor = _symmetricAlgorithm.Value.CreateEncryptor();

--- a/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
@@ -5,10 +5,6 @@ using System;
 using System.Text.Json.Serialization;
 using Microsoft.IdentityModel.Logging;
 
-#if NET9_0_OR_GREATER
-using System.Threading;
-#endif
-
 namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
@@ -17,13 +13,9 @@ namespace Microsoft.IdentityModel.Tokens
     public abstract class SecurityKey
     {
         private CryptoProviderFactory _cryptoProviderFactory;
-
-#if NET9_0_OR_GREATER
-        private readonly Lock _internalIdLock = new();
-#else
-        private readonly object _internalIdLock = new();
-#endif
+        private object _internalIdLock = new object();
         private string _internalId;
+
         internal SecurityKey(SecurityKey key)
         {
             _cryptoProviderFactory = key._cryptoProviderFactory;

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/TokenValidationResult.cs
@@ -30,11 +30,7 @@ namespace Microsoft.IdentityModel.Tokens
         // reordered relative to the other operations. The rest of the objects are not because the .NET memory model
         // guarantees object writes are store releases and that reads won't be introduced.
         private volatile bool _claimsIdentityInitialized;
-#if NET9_0_OR_GREATER
-        private Lock _claimsIdentitySyncObj;
-#else
         private object _claimsIdentitySyncObj;
-#endif
         private ClaimsIdentity _claimsIdentity;
         private Dictionary<string, object> _claims;
         private Dictionary<string, object> _propertyBag;
@@ -200,23 +196,6 @@ namespace Microsoft.IdentityModel.Tokens
             }
         }
 
-#if NET9_0_OR_GREATER
-        /// <summary>Gets the object to use in <see cref="ClaimsIdentity"/> for double-checked locking.</summary>
-        private Lock ClaimsIdentitySyncObj
-        {
-            get
-            {
-                Lock syncObj = _claimsIdentitySyncObj;
-                if (syncObj is null)
-                {
-                    Interlocked.CompareExchange(ref _claimsIdentitySyncObj, new Lock(), null);
-                    syncObj = _claimsIdentitySyncObj;
-                }
-
-                return syncObj;
-            }
-        }
-#else
         /// <summary>Gets the object to use in <see cref="ClaimsIdentity"/> for double-checked locking.</summary>
         private object ClaimsIdentitySyncObj
         {
@@ -232,7 +211,7 @@ namespace Microsoft.IdentityModel.Tokens
                 return syncObj;
             }
         }
-#endif
+
         /// <summary>
         /// Gets or sets the <see cref="Exception"/> that occurred during validation.
         /// </summary>

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/ValidatedToken.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/ValidatedToken.cs
@@ -114,13 +114,9 @@ namespace Microsoft.IdentityModel.Tokens
         // reordered relative to the other operations. The rest of the objects are not because the .NET memory model
         // guarantees object writes are store releases and that reads won't be introduced.
         private volatile bool _claimsIdentityInitialized;
+        private object? _claimsIdentitySyncObj;
         private ClaimsIdentity? _claimsIdentity;
         private Dictionary<string, object>? _claims;
-#if NET9_0_OR_GREATER
-        private Lock? _claimsIdentitySyncObj;
-#else
-        private object? _claimsIdentitySyncObj;
-#endif
 
         /// <summary>
         /// The <see cref="Dictionary{String, Object}"/> created from the validated security token.
@@ -194,23 +190,6 @@ namespace Microsoft.IdentityModel.Tokens
             }
         }
 
-#if NET9_0_OR_GREATER
-        /// <summary>Gets the Lock to use in <see cref="ClaimsIdentity"/> for double-checked locking.</summary>
-        private Lock ClaimsIdentitySyncObj
-        {
-            get
-            {
-                Lock? syncObj = _claimsIdentitySyncObj;
-                if (syncObj is null)
-                {
-                    Interlocked.CompareExchange(ref _claimsIdentitySyncObj, new Lock(), null);
-                    syncObj = _claimsIdentitySyncObj;
-                }
-
-                return syncObj;
-            }
-        }
-#else
         /// <summary>Gets the object to use in <see cref="ClaimsIdentity"/> for double-checked locking.</summary>
         private object ClaimsIdentitySyncObj
         {
@@ -226,7 +205,6 @@ namespace Microsoft.IdentityModel.Tokens
                 return syncObj;
             }
         }
-#endif
         #endregion
 
         #region Logging

--- a/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
@@ -5,9 +5,6 @@ using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.IdentityModel.Logging;
-#if NET9_0_OR_GREATER
-using System.Threading;
-#endif
 
 namespace Microsoft.IdentityModel.Tokens
 {
@@ -19,11 +16,8 @@ namespace Microsoft.IdentityModel.Tokens
         AsymmetricAlgorithm _privateKey;
         bool _privateKeyAvailabilityDetermined;
         AsymmetricAlgorithm _publicKey;
-#if NET9_0_OR_GREATER
-        Lock _thisLock = new();
-#else
-        object _thisLock = new();
-#endif
+        object _thisLock = new Object();
+
         internal X509SecurityKey(JsonWebKey webKey)
             : base(webKey)
         {
@@ -116,14 +110,12 @@ namespace Microsoft.IdentityModel.Tokens
                 return _publicKey;
             }
         }
-#if NET9_0_OR_GREATER
-        Lock ThisLock => _thisLock;
-#else
+
         object ThisLock
         {
             get { return _thisLock; }
         }
-#endif
+
         /// <summary>
         /// Gets a bool indicating if a private key exists.
         /// </summary>

--- a/src/Microsoft.IdentityModel.Xml/EnvelopedSignatureWriter.cs
+++ b/src/Microsoft.IdentityModel.Xml/EnvelopedSignatureWriter.cs
@@ -8,10 +8,6 @@ using System.Xml;
 using Microsoft.IdentityModel.Tokens;
 using static Microsoft.IdentityModel.Logging.LogHelper;
 
-#if NET9_0_OR_GREATER
-using System.Threading;
-#endif
-
 namespace Microsoft.IdentityModel.Xml
 {
     /// <summary>
@@ -43,12 +39,7 @@ namespace Microsoft.IdentityModel.Xml
         private bool _signaturePlaceholderWritten;
         private SigningCredentials _signingCredentials;
         private MemoryStream _internalStream;
-
-#if NET9_0_OR_GREATER
-        private Lock _signatureLock = new();
-#else
-        private object _signatureLock = new();
-#endif
+        private object _signatureLock = new object();
 
         /// <summary>
         /// Initializes an instance of <see cref="EnvelopedSignatureWriter"/>. The returned writer can be directly used

--- a/test/Microsoft.IdentityModel.Abstractions.Tests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.IdentityModel.Abstractions.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright(c) Microsoft Corporation.All rights reserved.
 // Licensed under the MIT License.
 
 using System;


### PR DESCRIPTION
Reverts AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet#3171

There were some tests failing in the pipeline, but not locally. Will add back after the 8.7.0 release.