### PR TITLE
Lozensky/gotta change the locks

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Json/JsonClaimSet.cs
@@ -12,6 +12,10 @@ using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.IdentityModel.Tokens.Json;
 
+#if NET9_0_OR_GREATER
+using System.Threading;
+#endif
+
 namespace Microsoft.IdentityModel.JsonWebTokens
 {
     /// <summary>
@@ -21,8 +25,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens
     internal class JsonClaimSet
     {
         internal const string ClassName = "Microsoft.IdentityModel.JsonWebTokens.JsonClaimSet";
-
+#if NET9_0_OR_GREATER
+        internal Lock _claimsLock = new();
+#else
         internal object _claimsLock = new();
+#endif
         internal readonly Dictionary<string, object> _jsonClaims;
         private List<Claim> _claims;
 

--- a/src/Microsoft.IdentityModel.JsonWebTokens/PublicAPI/net9.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/PublicAPI/net9.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.IdentityModel.JsonWebTokens.JsonClaimSet._claimsLock -> System.Threading.Lock

--- a/src/Microsoft.IdentityModel.Tokens/Encryption/SymmetricKeyWrapProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Encryption/SymmetricKeyWrapProvider.cs
@@ -5,6 +5,10 @@ using System;
 using System.Security.Cryptography;
 using Microsoft.IdentityModel.Logging;
 
+#if NET9_0_OR_GREATER
+using System.Threading;
+#endif
+
 namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
@@ -15,9 +19,13 @@ namespace Microsoft.IdentityModel.Tokens
         private static readonly byte[] _defaultIV = new byte[] { 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6 };
         private const int _blockSizeInBits = 64;
         private const int _blockSizeInBytes = _blockSizeInBits >> 3;
-        private static readonly object _encryptorLock = new object();
-        private static readonly object _decryptorLock = new object();
-
+#if NET9_0_OR_GREATER
+        private static readonly Lock s_encryptorLock = new();
+        private static readonly Lock s_decryptorLock = new();
+#else
+        private static readonly object s_encryptorLock = new();
+        private static readonly object s_decryptorLock = new();
+#endif
         private Lazy<SymmetricAlgorithm> _symmetricAlgorithm;
         private ICryptoTransform _symmetricAlgorithmEncryptor;
         private ICryptoTransform _symmetricAlgorithmDecryptor;
@@ -259,7 +267,7 @@ namespace Microsoft.IdentityModel.Tokens
 
             if (_symmetricAlgorithmDecryptor == null)
             {
-                lock (_decryptorLock)
+                lock (s_decryptorLock)
                 {
                     if (_symmetricAlgorithmDecryptor == null)
                         _symmetricAlgorithmDecryptor = _symmetricAlgorithm.Value.CreateDecryptor();
@@ -409,7 +417,7 @@ namespace Microsoft.IdentityModel.Tokens
 
             if (_symmetricAlgorithmEncryptor == null)
             {
-                lock (_encryptorLock)
+                lock (s_encryptorLock)
                 {
                     if (_symmetricAlgorithmEncryptor == null)
                         _symmetricAlgorithmEncryptor = _symmetricAlgorithm.Value.CreateEncryptor();

--- a/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityKey.cs
@@ -5,6 +5,10 @@ using System;
 using System.Text.Json.Serialization;
 using Microsoft.IdentityModel.Logging;
 
+#if NET9_0_OR_GREATER
+using System.Threading;
+#endif
+
 namespace Microsoft.IdentityModel.Tokens
 {
     /// <summary>
@@ -13,9 +17,13 @@ namespace Microsoft.IdentityModel.Tokens
     public abstract class SecurityKey
     {
         private CryptoProviderFactory _cryptoProviderFactory;
-        private object _internalIdLock = new object();
-        private string _internalId;
 
+#if NET9_0_OR_GREATER
+        private readonly Lock _internalIdLock = new();
+#else
+        private readonly object _internalIdLock = new();
+#endif
+        private string _internalId;
         internal SecurityKey(SecurityKey key)
         {
             _cryptoProviderFactory = key._cryptoProviderFactory;

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/TokenValidationResult.cs
@@ -30,7 +30,11 @@ namespace Microsoft.IdentityModel.Tokens
         // reordered relative to the other operations. The rest of the objects are not because the .NET memory model
         // guarantees object writes are store releases and that reads won't be introduced.
         private volatile bool _claimsIdentityInitialized;
+#if NET9_0_OR_GREATER
+        private Lock _claimsIdentitySyncObj = new();
+#else
         private object _claimsIdentitySyncObj;
+#endif
         private ClaimsIdentity _claimsIdentity;
         private Dictionary<string, object> _claims;
         private Dictionary<string, object> _propertyBag;
@@ -196,6 +200,23 @@ namespace Microsoft.IdentityModel.Tokens
             }
         }
 
+#if NET9_0_OR_GREATER
+        /// <summary>Gets the object to use in <see cref="ClaimsIdentity"/> for double-checked locking.</summary>
+        private Lock ClaimsIdentitySyncObj
+        {
+            get
+            {
+                Lock syncObj = _claimsIdentitySyncObj;
+                if (syncObj is null)
+                {
+                    Interlocked.CompareExchange(ref _claimsIdentitySyncObj, new Lock(), null);
+                    syncObj = _claimsIdentitySyncObj;
+                }
+
+                return syncObj;
+            }
+        }
+#else
         /// <summary>Gets the object to use in <see cref="ClaimsIdentity"/> for double-checked locking.</summary>
         private object ClaimsIdentitySyncObj
         {
@@ -211,7 +232,7 @@ namespace Microsoft.IdentityModel.Tokens
                 return syncObj;
             }
         }
-
+#endif
         /// <summary>
         /// Gets or sets the <see cref="Exception"/> that occurred during validation.
         /// </summary>

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/TokenValidationResult.cs
@@ -31,7 +31,7 @@ namespace Microsoft.IdentityModel.Tokens
         // guarantees object writes are store releases and that reads won't be introduced.
         private volatile bool _claimsIdentityInitialized;
 #if NET9_0_OR_GREATER
-        private Lock _claimsIdentitySyncObj = new();
+        private Lock _claimsIdentitySyncObj;
 #else
         private object _claimsIdentitySyncObj;
 #endif

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/ValidatedToken.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/ValidatedToken.cs
@@ -114,9 +114,13 @@ namespace Microsoft.IdentityModel.Tokens
         // reordered relative to the other operations. The rest of the objects are not because the .NET memory model
         // guarantees object writes are store releases and that reads won't be introduced.
         private volatile bool _claimsIdentityInitialized;
-        private object? _claimsIdentitySyncObj;
         private ClaimsIdentity? _claimsIdentity;
         private Dictionary<string, object>? _claims;
+#if NET9_0_OR_GREATER
+        private Lock? _claimsIdentitySyncObj;
+#else
+        private object? _claimsIdentitySyncObj;
+#endif
 
         /// <summary>
         /// The <see cref="Dictionary{String, Object}"/> created from the validated security token.
@@ -190,6 +194,23 @@ namespace Microsoft.IdentityModel.Tokens
             }
         }
 
+#if NET9_0_OR_GREATER
+        /// <summary>Gets the Lock to use in <see cref="ClaimsIdentity"/> for double-checked locking.</summary>
+        private Lock ClaimsIdentitySyncObj
+        {
+            get
+            {
+                Lock? syncObj = _claimsIdentitySyncObj;
+                if (syncObj is null)
+                {
+                    Interlocked.CompareExchange(ref _claimsIdentitySyncObj, new Lock(), null);
+                    syncObj = _claimsIdentitySyncObj;
+                }
+
+                return syncObj;
+            }
+        }
+#else
         /// <summary>Gets the object to use in <see cref="ClaimsIdentity"/> for double-checked locking.</summary>
         private object ClaimsIdentitySyncObj
         {
@@ -205,6 +226,7 @@ namespace Microsoft.IdentityModel.Tokens
                 return syncObj;
             }
         }
+#endif
         #endregion
 
         #region Logging

--- a/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
@@ -117,10 +117,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
         }
 #if NET9_0_OR_GREATER
-        Lock ThisLock
-        {
-            get { return _thisLock; }
-        }
+        Lock ThisLock => _thisLock;
 #else
         object ThisLock
         {

--- a/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/X509SecurityKey.cs
@@ -5,6 +5,9 @@ using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.IdentityModel.Logging;
+#if NET9_0_OR_GREATER
+using System.Threading;
+#endif
 
 namespace Microsoft.IdentityModel.Tokens
 {
@@ -16,8 +19,11 @@ namespace Microsoft.IdentityModel.Tokens
         AsymmetricAlgorithm _privateKey;
         bool _privateKeyAvailabilityDetermined;
         AsymmetricAlgorithm _publicKey;
-        object _thisLock = new Object();
-
+#if NET9_0_OR_GREATER
+        Lock _thisLock = new();
+#else
+        object _thisLock = new();
+#endif
         internal X509SecurityKey(JsonWebKey webKey)
             : base(webKey)
         {
@@ -110,12 +116,17 @@ namespace Microsoft.IdentityModel.Tokens
                 return _publicKey;
             }
         }
-
+#if NET9_0_OR_GREATER
+        Lock ThisLock
+        {
+            get { return _thisLock; }
+        }
+#else
         object ThisLock
         {
             get { return _thisLock; }
         }
-
+#endif
         /// <summary>
         /// Gets a bool indicating if a private key exists.
         /// </summary>

--- a/src/Microsoft.IdentityModel.Xml/EnvelopedSignatureWriter.cs
+++ b/src/Microsoft.IdentityModel.Xml/EnvelopedSignatureWriter.cs
@@ -8,6 +8,10 @@ using System.Xml;
 using Microsoft.IdentityModel.Tokens;
 using static Microsoft.IdentityModel.Logging.LogHelper;
 
+#if NET9_0_OR_GREATER
+using System.Threading;
+#endif
+
 namespace Microsoft.IdentityModel.Xml
 {
     /// <summary>
@@ -39,7 +43,12 @@ namespace Microsoft.IdentityModel.Xml
         private bool _signaturePlaceholderWritten;
         private SigningCredentials _signingCredentials;
         private MemoryStream _internalStream;
-        private object _signatureLock = new object();
+
+#if NET9_0_OR_GREATER
+        private Lock _signatureLock = new();
+#else
+        private object _signatureLock = new();
+#endif
 
         /// <summary>
         /// Initializes an instance of <see cref="EnvelopedSignatureWriter"/>. The returned writer can be directly used

--- a/test/Microsoft.IdentityModel.Abstractions.Tests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.IdentityModel.Abstractions.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-// Copyright(c) Microsoft Corporation.All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;


### PR DESCRIPTION
This PR was already approved once, it had to be reverted due to errors caused in another library's tests that were blocking a release. These errors stemmed from the other library's test infra implementation, not any issues with the lock functionality. The other library's tests have been fixed so it is safe to merge this again.

Testing for the changes in this PR is in [another PR here](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3185). I'm not combining the two as this one was already approved once while that one is still under review.

[Here is the originally approved PR](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3171)
