### PR TITLE
Switch for metadata refresh to be blocking

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -151,13 +151,24 @@ namespace Microsoft.IdentityModel.Protocols
         /// <param name="cancel">CancellationToken</param>
         /// <returns>Configuration of type <typeparamref name="T"/>.</returns>
         /// <remarks>
+        /// <para>
         /// If the time since the last call is less than <see cref="BaseConfigurationManager.AutomaticRefreshInterval"/>
         /// then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.
-        /// By default, this method blocks until the configuration is retrieved the first time. After the configuration is retrieved,
+        /// By default, this method blocks until the configuration is retrieved the first time. After the configuration was retrieved once,
         /// updates will happen in the background. Failures to retrieve the configuration on the background thread will be logged.
+        /// </para>
+        /// <para>
         /// If this operation is configured to be blocking through the switch 'Switch.Microsoft.IdentityModel.UpdateConfigAsBlocking'
-        /// then this method will block when the configuration needs to be updated or hasn't been retrieved. If the configuration
-        /// is unable to be retrieved, an exception will be thrown.
+        /// then this method will block each time the configuration needs to be updated or hasn't been retrieved. If the configuration
+        /// cannot be initially retrieved an exception will be thrown. If the configuration has been retrieved, but cannot be updated,
+        /// then the exception will be logged and the current configuration will be returned.
+        /// </para>
+        /// <para>
+        /// By using the app context switch you choose what works best for you when there is a signing key update:
+        /// either block requests from being validated until the new key is retrieved, or allow requests to be validated
+        /// with the current key until the new key is retrieved. If blocking, a service receiving high concurrent request
+        /// may experience thread starvation.
+        /// </para>
         /// </remarks>
         public virtual async Task<T> GetConfigurationAsync(CancellationToken cancel)
         {

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.IdentityModel.Protocols
     /// </summary>
     /// <typeparam name="T">The type of <see cref="IDocumentRetriever"/>.</typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable")]
-    public class ConfigurationManager<T> : BaseConfigurationManager, IConfigurationManager<T> where T : class
+    public partial class ConfigurationManager<T> : BaseConfigurationManager, IConfigurationManager<T> where T : class
     {
         internal Action _onBackgroundTaskFinish;
 
@@ -138,7 +138,7 @@ namespace Microsoft.IdentityModel.Protocols
         /// <summary>
         /// Obtains an updated version of Configuration.
         /// </summary>
-        /// <returns>Configuration of type T.</returns>
+        /// <returns>Configuration of type <typeparamref name="T"/>.</returns>
         /// <remarks>If the time since the last call is less than <see cref="BaseConfigurationManager.AutomaticRefreshInterval"/> then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.</remarks>
         public async Task<T> GetConfigurationAsync()
         {
@@ -149,13 +149,29 @@ namespace Microsoft.IdentityModel.Protocols
         /// Obtains an updated version of Configuration.
         /// </summary>
         /// <param name="cancel">CancellationToken</param>
-        /// <returns>Configuration of type T.</returns>
-        /// <remarks>If the time since the last call is less than <see cref="BaseConfigurationManager.AutomaticRefreshInterval"/> then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.</remarks>
+        /// <returns>Configuration of type <typeparamref name="T"/>.</returns>
+        /// <remarks>
+        /// If the time since the last call is less than <see cref="BaseConfigurationManager.AutomaticRefreshInterval"/>
+        /// then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.
+        /// By default, this method blocks until the configuration is retrieved the first time. After the configuration is retrieved,
+        /// updates will happen in the background. Failures to retrieve the configuration on the background thread will be logged.
+        /// If this operation is configured to be blocking through the switch 'Switch.Microsoft.IdentityModel.UpdateConfigAsBlocking'
+        /// then this method will block when the configuration needs to be updated or hasn't been retrieved. If the configuration
+        /// is unable to be retrieved, an exception will be thrown.
+        /// </remarks>
         public virtual async Task<T> GetConfigurationAsync(CancellationToken cancel)
         {
             if (_currentConfiguration != null && _syncAfter > TimeProvider.GetUtcNow())
                 return _currentConfiguration;
 
+            if (AppContextSwitches.UpdateConfigAsBlocking)
+                return await GetConfigurationWithBlockingAsync(cancel).ConfigureAwait(false);
+            else
+                return await GetConfigurationNonBlockingAsync(cancel).ConfigureAwait(false);
+        }
+
+        private async Task<T> GetConfigurationNonBlockingAsync(CancellationToken cancel)
+        {
             Exception fetchMetadataFailure = null;
 
             // LOGIC
@@ -174,7 +190,6 @@ namespace Microsoft.IdentityModel.Protocols
                     return _currentConfiguration;
                 }
 
-#pragma warning disable CA1031 // Do not catch general exception types
                 try
                 {
                     // Don't use the individual CT here, this is a shared operation that shouldn't be affected by an individual's cancellation.
@@ -205,6 +220,7 @@ namespace Microsoft.IdentityModel.Protocols
 
                     UpdateConfiguration(configuration);
                 }
+#pragma warning disable CA1031 // Do not catch general exception types
                 catch (Exception ex)
                 {
                     fetchMetadataFailure = ex;
@@ -221,11 +237,11 @@ namespace Microsoft.IdentityModel.Protocols
                                 LogHelper.MarkAsNonPII(ex)),
                             ex));
                 }
+#pragma warning restore CA1031 // Do not catch general exception types
                 finally
                 {
                     _configurationNullLock.Release();
                 }
-#pragma warning restore CA1031 // Do not catch general exception types
             }
             else
             {
@@ -260,7 +276,6 @@ namespace Microsoft.IdentityModel.Protocols
         /// </summary>
         private void UpdateCurrentConfiguration()
         {
-#pragma warning disable CA1031 // Do not catch general exception types
             long startTimestamp = TimeProvider.GetTimestamp();
 
             try
@@ -293,6 +308,7 @@ namespace Microsoft.IdentityModel.Protocols
                         UpdateConfiguration(configuration);
                 }
             }
+#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
             {
                 var elapsedTime = TimeProvider.GetElapsedTime(startTimestamp);
@@ -309,13 +325,13 @@ namespace Microsoft.IdentityModel.Protocols
                             ex),
                         ex));
             }
+#pragma warning restore CA1031 // Do not catch general exception types
             finally
             {
                 Interlocked.Exchange(ref _configurationRetrieverState, ConfigurationRetrieverIdle);
             }
 
             _onBackgroundTaskFinish?.Invoke();
-#pragma warning restore CA1031 // Do not catch general exception types
         }
 
         private void UpdateConfiguration(T configuration)
@@ -343,7 +359,20 @@ namespace Microsoft.IdentityModel.Protocols
         /// <para>2. The time between when this method was called and DateTimeOffset.Now is greater than <see cref="BaseConfigurationManager.RefreshInterval"/>.</para>
         /// <para>If <see cref="BaseConfigurationManager.RefreshInterval"/> == <see cref="TimeSpan.MaxValue"/> then this method does nothing.</para>
         /// </summary>
+        /// <remarks>
+        /// If the strategy is configured to be blocking through the switch 'Switch.Microsoft.IdentityModel.UpdateConfigAsBlocking',
+        /// then this method will not update the configuration, instead it will request the next call to <see cref="GetConfigurationAsync()"/>
+        /// should request new configuration.
+        /// </remarks>
         public override void RequestRefresh()
+        {
+            if (AppContextSwitches.UpdateConfigAsBlocking)
+                RequestRefreshBlocking();
+            else
+                RequestRefreshBackgroundThread();
+        }
+
+        private void RequestRefreshBackgroundThread()
         {
             DateTimeOffset now = TimeProvider.GetUtcNow();
 

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager_Blocking.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager_Blocking.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.Protocols.Configuration;
+using Microsoft.IdentityModel.Telemetry;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.IdentityModel.Protocols
+{
+    partial class ConfigurationManager<T> where T : class
+    {
+        private readonly SemaphoreSlim _refreshLock = new(1, 1);
+        private TimeSpan _bootstrapRefreshInterval = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        /// Only used to track the type of request for telemetry.
+        /// </summary>
+        private bool _refreshRequested;
+
+        private async Task<T> GetConfigurationWithBlockingAsync(CancellationToken cancel)
+        {
+            Exception _fetchMetadataFailure = null;
+            await _refreshLock.WaitAsync(cancel).ConfigureAwait(false);
+
+            long startTimestamp = TimeProvider.GetTimestamp();
+
+            try
+            {
+                if (_syncAfter <= TimeProvider.GetUtcNow())
+                {
+                    try
+                    {
+                        // Don't use the individual CT here, this is a shared operation that shouldn't be affected by an individual's cancellation.
+                        // The transport should have it's own timeouts, etc..
+                        var configuration = await _configRetriever.GetConfigurationAsync(MetadataAddress, _docRetriever, CancellationToken.None).ConfigureAwait(false);
+
+                        var elapsedTime = TimeProvider.GetElapsedTime(startTimestamp);
+                        TelemetryClient.LogConfigurationRetrievalDuration(
+                            MetadataAddress,
+                            elapsedTime);
+
+                        if (_configValidator != null)
+                        {
+                            ConfigurationValidationResult result = _configValidator.Validate(configuration);
+                            if (!result.Succeeded)
+                                throw LogHelper.LogExceptionMessage(new InvalidConfigurationException(LogHelper.FormatInvariant(LogMessages.IDX20810, result.ErrorMessage)));
+                        }
+
+                        _lastRequestRefresh = TimeProvider.GetUtcNow().UtcDateTime;
+
+                        TelemetryForUpdateBlocking();
+
+                        if (_refreshRequested)
+                            _refreshRequested = false;
+
+                        UpdateConfiguration(configuration);
+                    }
+                    catch (Exception ex)
+                    {
+                        _fetchMetadataFailure = ex;
+
+                        if (_currentConfiguration == null)
+                        {
+                            if (_bootstrapRefreshInterval < RefreshInterval)
+                            {
+                                // Adopt exponential backoff for bootstrap refresh interval with a decorrelated jitter if it is not longer than the refresh interval.
+                                TimeSpan _bootstrapRefreshIntervalWithJitter = TimeSpan.FromSeconds(new Random().Next((int)_bootstrapRefreshInterval.TotalSeconds));
+                                _bootstrapRefreshInterval += _bootstrapRefreshInterval;
+                                _syncAfter = DateTimeUtil.Add(DateTime.UtcNow, _bootstrapRefreshIntervalWithJitter);
+                            }
+                            else
+                            {
+                                _syncAfter = DateTimeUtil.Add(
+                                    TimeProvider.GetUtcNow().UtcDateTime,
+                                    AutomaticRefreshInterval < RefreshInterval ? AutomaticRefreshInterval : RefreshInterval);
+                            }
+
+                            TelemetryClient.IncrementConfigurationRefreshRequestCounter(
+                                MetadataAddress,
+                                TelemetryConstants.Protocols.FirstRefresh,
+                                ex);
+
+                            throw LogHelper.LogExceptionMessage(
+                                new InvalidOperationException(
+                                    LogHelper.FormatInvariant(LogMessages.IDX20803, LogHelper.MarkAsNonPII(MetadataAddress ?? "null"), LogHelper.MarkAsNonPII(_syncAfter), LogHelper.MarkAsNonPII(ex)), ex));
+                        }
+                        else
+                        {
+                            _syncAfter = DateTimeUtil.Add(
+                                TimeProvider.GetUtcNow().UtcDateTime,
+                                AutomaticRefreshInterval < RefreshInterval ? AutomaticRefreshInterval : RefreshInterval);
+
+                            var elapsedTime = TimeProvider.GetElapsedTime(startTimestamp);
+
+                            TelemetryClient.LogConfigurationRetrievalDuration(
+                                MetadataAddress,
+                                elapsedTime,
+                                ex);
+
+                            LogHelper.LogExceptionMessage(
+                                new InvalidOperationException(
+                                    LogHelper.FormatInvariant(LogMessages.IDX20806, LogHelper.MarkAsNonPII(MetadataAddress ?? "null"), LogHelper.MarkAsNonPII(ex)), ex));
+                        }
+                    }
+                }
+
+                // Stale metadata is better than no metadata
+                if (_currentConfiguration != null)
+                    return _currentConfiguration;
+                else
+                    throw LogHelper.LogExceptionMessage(
+                        new InvalidOperationException(
+                            LogHelper.FormatInvariant(
+                                LogMessages.IDX20803,
+                                LogHelper.MarkAsNonPII(MetadataAddress ?? "null"),
+                                LogHelper.MarkAsNonPII(_syncAfter),
+                                LogHelper.MarkAsNonPII(_fetchMetadataFailure)),
+                            _fetchMetadataFailure));
+            }
+            finally
+            {
+                _refreshLock.Release();
+            }
+        }
+
+        private void RequestRefreshBlocking()
+        {
+            DateTime now = TimeProvider.GetUtcNow().UtcDateTime;
+
+            if (now >= DateTimeUtil.Add(_lastRequestRefresh.UtcDateTime, RefreshInterval) || _isFirstRefreshRequest)
+            {
+                _refreshRequested = true;
+                _syncAfter = now;
+                _isFirstRefreshRequest = false;
+            }
+        }
+
+        private void TelemetryForUpdateBlocking()
+        {
+            string updateMode;
+
+            if (_currentConfiguration is null)
+                updateMode = TelemetryConstants.Protocols.FirstRefresh;
+            else
+                updateMode = _refreshRequested ? TelemetryConstants.Protocols.Manual : TelemetryConstants.Protocols.Automatic;
+
+            try
+            {
+                TelemetryClient.IncrementConfigurationRefreshRequestCounter(
+                    MetadataAddress,
+                    updateMode);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch
+            { }
+#pragma warning restore CA1031 // Do not catch general exception types
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -70,7 +70,11 @@ namespace Microsoft.IdentityModel.Tokens
 
         internal static bool UseRfcDefinitionOfEpkAndKid => _useRfcDefinitionOfEpkAndKid ??= (AppContext.TryGetSwitch(UseRfcDefinitionOfEpkAndKidSwitch, out bool isEnabled) && isEnabled);
 
-
+        /// <summary>
+        /// Enabling this switch will cause the configuration manager to block other requests to GetConfigurationAsync if a request is already in progress.
+        /// The default configuration refresh behavior is if a request is already in progress, the current configuration will be returned until the ongoing request is completed on
+        /// a background thread.
+        /// </summary>
         internal const string UpdateConfigAsBlockingSwitch = "Switch.Microsoft.IdentityModel.UpdateConfigAsBlocking";
 
         private static bool? _updateConfigAsBlockingCall;
@@ -96,6 +100,9 @@ namespace Microsoft.IdentityModel.Tokens
 
             _useRfcDefinitionOfEpkAndKid = null;
             AppContext.SetSwitch(UseRfcDefinitionOfEpkAndKidSwitch, false);
+
+            _updateConfigAsBlockingCall = null;
+            AppContext.SetSwitch(UpdateConfigAsBlockingSwitch, false);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/Telemetry/ITelemetryClient.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Telemetry/ITelemetryClient.cs
@@ -25,8 +25,6 @@ namespace Microsoft.IdentityModel.Telemetry
             string operationStatus,
             Exception exception);
 
-        // Unused, this was part of a previous release, since it is a friend,
-        // it cannot be removed.
         internal void LogBackgroundConfigurationRefreshFailure(
             string metadataAddress,
             Exception exception);

--- a/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryClient.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryClient.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
@@ -15,13 +16,19 @@ namespace Microsoft.IdentityModel.Telemetry
     {
         public string ClientVer = IdentityModelTelemetryUtil.ClientVer;
 
+        private KeyValuePair<string, object> _blockingTagValue = new(
+            TelemetryConstants.BlockingTypeTag,
+            AppContextSwitches.UpdateConfigAsBlocking.ToString()
+        );
+
         public void IncrementConfigurationRefreshRequestCounter(string metadataAddress, string operationStatus)
         {
             var tagList = new TagList()
             {
                 { TelemetryConstants.IdentityModelVersionTag, ClientVer },
                 { TelemetryConstants.MetadataAddressTag, metadataAddress },
-                { TelemetryConstants.OperationStatusTag, operationStatus }
+                { TelemetryConstants.OperationStatusTag, operationStatus },
+                _blockingTagValue
             };
 
             TelemetryDataRecorder.IncrementConfigurationRefreshRequestCounter(tagList);
@@ -34,7 +41,8 @@ namespace Microsoft.IdentityModel.Telemetry
                 { TelemetryConstants.IdentityModelVersionTag, ClientVer },
                 { TelemetryConstants.MetadataAddressTag, metadataAddress },
                 { TelemetryConstants.OperationStatusTag, operationStatus },
-                { TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString() }
+                { TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString() },
+                _blockingTagValue
             };
 
             TelemetryDataRecorder.IncrementConfigurationRefreshRequestCounter(tagList);
@@ -58,7 +66,8 @@ namespace Microsoft.IdentityModel.Telemetry
             {
                 { TelemetryConstants.IdentityModelVersionTag, ClientVer },
                 { TelemetryConstants.MetadataAddressTag, metadataAddress },
-                { TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString() }
+                { TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString() },
+                _blockingTagValue
             };
 
             long durationInMilliseconds = (long)operationDuration.TotalMilliseconds;
@@ -74,7 +83,7 @@ namespace Microsoft.IdentityModel.Telemetry
                 { TelemetryConstants.IdentityModelVersionTag, ClientVer },
                 { TelemetryConstants.MetadataAddressTag, metadataAddress },
                 { TelemetryConstants.ExceptionTypeTag, exception.GetType().ToString() },
-                { TelemetryConstants.BlockingTypeTag, AppContextSwitches.UpdateConfigAsBlocking.ToString() }
+                _blockingTagValue
             };
 
             TelemetryDataRecorder.IncrementBackgroundConfigurationRefreshFailureCounter(tagList);

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
@@ -104,6 +104,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             bool blocking = false)
         {
             var testTelemetryClient = new MockTelemetryClient();
+            var timeProvider = new FakeTimeProvider();
 
             var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                 theoryData.MetadataAddress,
@@ -111,13 +112,11 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 theoryData.DocumentRetriever,
                 theoryData.ConfigurationValidator)
             {
-                TelemetryClient = testTelemetryClient
+                TelemetryClient = testTelemetryClient,
+                TimeProvider = timeProvider,
             };
 
             AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager);
-
-            var timeProvider = new FakeTimeProvider();
-            TestUtilities.SetField(configurationManager, "_timeProvider", timeProvider);
 
             OpenIdConnectConfiguration firstConfig = null;
             OpenIdConnectConfiguration secondConfig = null;

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTelemetryTests.cs
@@ -13,54 +13,29 @@ using Microsoft.IdentityModel.Protocols.OpenIdConnect.Configuration;
 using Microsoft.IdentityModel.Telemetry;
 using Microsoft.IdentityModel.Telemetry.Tests;
 using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
 using Xunit;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 {
+    [ResetAppContextSwitches]
+    [Collection(nameof(AppContextSwitches.UpdateConfigAsBlocking))]
     public class ConfigurationManagerTelemetryTests
     {
         [Fact]
-        public async Task RequestRefresh_IntervalHasNotPassed_ExpectedCount()
+        public async Task RequestRefresh_ExpectedTagsExist()
         {
-            // arrange
-            var testTelemetryClient = new MockTelemetryClient();
-            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
-                OpenIdConfigData.AccountsGoogle,
-                new OpenIdConnectConfigurationRetriever(),
-                new HttpDocumentRetriever(),
-                new OpenIdConnectConfigurationValidator())
-            {
-                TelemetryClient = testTelemetryClient
-            };
-            var cancel = new CancellationToken();
-
-            AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager);
-
-            var timeProvider = new FakeTimeProvider();
-            configurationManager.TimeProvider = timeProvider;
-
-            // act
-            // Retrieve the configuration for the first time
-            await configurationManager.GetConfigurationAsync(cancel);
-            testTelemetryClient.ClearExportedItems();
-
-            // Manually request a config refresh
-            configurationManager.RequestRefresh();
-            await configurationManager.GetConfigurationAsync(cancel);
-
-            ConfigurationManagerTests.WaitOrFail(resetEvent);
-
-            // Request a second refresh, but don't wait for the interval to pass
-            configurationManager.RequestRefresh();
-            await configurationManager.GetConfigurationAsync(cancel);
-
-            // assert: There should be two calls here, first from the call to GetConfigurationAsync
-            // the second from RequestRefresh, first request refresh always goes through
-            Assert.Equal(2, testTelemetryClient.RequestRefreshCounter);
+            await RequestRefresh_ExpectedTagsBody();
         }
 
         [Fact]
-        public async Task RequestRefresh_ExpectedTagsExist()
+        public async Task RequestRefresh_ExpectedTagsExist_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await RequestRefresh_ExpectedTagsBody(true);
+        }
+
+        private static async Task RequestRefresh_ExpectedTagsBody(bool blocking = false)
         {
             // arrange
             var testTelemetryClient = new MockTelemetryClient();
@@ -72,23 +47,20 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             {
                 TelemetryClient = testTelemetryClient
             };
-            var cancel = new CancellationToken();
 
             AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager);
 
-            var timeProvider = new FakeTimeProvider();
-            configurationManager.TimeProvider = timeProvider;
-
             // act
             // Retrieve the configuration for the first time
-            await configurationManager.GetConfigurationAsync(cancel);
+            await configurationManager.GetConfigurationAsync();
             testTelemetryClient.ClearExportedItems();
 
             // Manually request a config refresh
             configurationManager.RequestRefresh();
-            await configurationManager.GetConfigurationAsync(cancel);
+            await configurationManager.GetConfigurationAsync();
 
-            ConfigurationManagerTests.WaitOrFail(resetEvent);
+            if (!blocking)
+                ConfigurationManagerTests.WaitOrFail(resetEvent);
 
             // assert
             var expectedCounterTagList = new Dictionary<string, object>
@@ -104,12 +76,32 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer }
             };
 
+            await ConfigurationManagerTests.PollForConditionAsync(
+                () => expectedCounterTagList.Count == testTelemetryClient.ExportedItems.Count &&
+                    expectedHistogramTagList.Count == testTelemetryClient.ExportedHistogramItems.Count,
+                TimeSpan.FromMilliseconds(250),
+                TimeSpan.FromSeconds(20));
+
             Assert.Equal(expectedCounterTagList, testTelemetryClient.ExportedItems);
             Assert.Equal(expectedHistogramTagList, testTelemetryClient.ExportedHistogramItems);
         }
 
         [Theory, MemberData(nameof(GetConfiguration_ExpectedTagList_TheoryData), DisableDiscoveryEnumeration = true)]
         public async Task GetConfigurationAsync_ExpectedTagsExist(ConfigurationManagerTelemetryTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            await GetConfigurationAsync_ExpectedTagList_Body(theoryData);
+        }
+
+        [Theory, MemberData(nameof(GetConfiguration_ExpectedTagList_TheoryData), DisableDiscoveryEnumeration = true)]
+        public async Task GetConfigurationAsync_ExpectedTagsExist_Blocking(ConfigurationManagerTelemetryTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await GetConfigurationAsync_ExpectedTagList_Body(theoryData, true);
+        }
+
+        private static async Task GetConfigurationAsync_ExpectedTagList_Body(
+            ConfigurationManagerTelemetryTheoryData<OpenIdConnectConfiguration> theoryData,
+            bool blocking = false)
         {
             var testTelemetryClient = new MockTelemetryClient();
 
@@ -125,24 +117,35 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             AutoResetEvent resetEvent = ConfigurationManagerTests.SetupResetEvent(configurationManager);
 
             var timeProvider = new FakeTimeProvider();
-            configurationManager.TimeProvider = timeProvider;
+            TestUtilities.SetField(configurationManager, "_timeProvider", timeProvider);
+
+            OpenIdConnectConfiguration firstConfig = null;
+            OpenIdConnectConfiguration secondConfig = null;
 
             try
             {
-                await configurationManager.GetConfigurationAsync();
-                if (theoryData.SyncAfter != null)
+                firstConfig = await configurationManager.GetConfigurationAsync();
+                if (theoryData.AdjustTime.HasValue)
                 {
                     testTelemetryClient.ClearExportedItems();
-                    timeProvider.Advance((theoryData.SyncAfter - DateTimeOffset.UtcNow).Value);
-                    await configurationManager.GetConfigurationAsync();
+                    timeProvider.Advance(theoryData.AdjustTime.Value);
+                    secondConfig = await configurationManager.GetConfigurationAsync();
 
-                    ConfigurationManagerTests.WaitOrFail(resetEvent);
+                    if (!blocking)
+                        ConfigurationManagerTests.WaitOrFail(resetEvent);
                 }
             }
             catch (Exception)
             {
                 // Ignore exceptions
             }
+
+            await ConfigurationManagerTests.PollForConditionAsync(
+                () => theoryData.ExpectedTagList.Count == testTelemetryClient.ExportedItems.Count,
+                TimeSpan.FromMilliseconds(250),
+                TimeSpan.FromSeconds(20));
+
+            DateTimeOffset syncAfter = (DateTimeOffset)TestUtilities.GetField(configurationManager, "_syncAfter");
 
             Assert.Equal(theoryData.ExpectedTagList, testTelemetryClient.ExportedItems);
         }
@@ -192,7 +195,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 {
                     MetadataAddress = OpenIdConfigData.AADCommonUrl,
                     ConfigurationValidator = new OpenIdConnectConfigurationValidator(),
-                    SyncAfter = DateTime.UtcNow + TimeSpan.FromDays(2),
+                    AdjustTime = TimeSpan.FromDays(1),
                     ExpectedTagList = new Dictionary<string, object>
                     {
                         { TelemetryConstants.MetadataAddressTag, OpenIdConfigData.AADCommonUrl },
@@ -214,7 +217,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
         public IConfigurationValidator<T> ConfigurationValidator { get; set; }
 
-        public DateTimeOffset? SyncAfter { get; set; } = null;
+        public TimeSpan? AdjustTime { get; set; }
 
         public Dictionary<string, object> ExpectedTagList { get; set; }
     }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -738,20 +738,20 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             var configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
 
             // force a refresh by setting internal field
-            TestUtilities.SetField(configManager, "_syncAfter", DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
+            TestUtilities.SetField(configManager, "_syncAfter", DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(1)));
             configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
 
             if (!blocking)
                 WaitOrFail(resetEvent);
 
             // check that _syncAfter is greater than DateTimeOffset.UtcNow + AutomaticRefreshInterval
-            DateTime syncAfter = (DateTime)TestUtilities.GetField(configManager, "_syncAfter");
+            DateTimeOffset syncAfter = (DateTimeOffset)TestUtilities.GetField(configManager, "_syncAfter");
             if (syncAfter < minimumRefreshInterval)
                 context.Diffs.Add($"(AutomaticRefreshInterval) syncAfter '{syncAfter}' < DateTimeOffset.UtcNow + configManager.AutomaticRefreshInterval: '{minimumRefreshInterval}'.");
 
             // make same check for RequestRefresh
             // force a refresh by setting internal field
-            TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
+            TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(1)));
 
             configManager.RequestRefresh();
 
@@ -775,7 +775,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 WaitOrFail(resetEvent);
 
             // check that _syncAfter is greater than DateTimeOffset.UtcNow + AutomaticRefreshInterval
-            syncAfter = (DateTime)TestUtilities.GetField(configManager, "_syncAfter");
+            syncAfter = (DateTimeOffset)TestUtilities.GetField(configManager, "_syncAfter");
             if (syncAfter < minimumRefreshInterval)
                 context.Diffs.Add($"(RequestRefresh) syncAfter '{syncAfter}' < DateTimeOffset.UtcNow + configManager.AutomaticRefreshInterval: '{minimumRefreshInterval}'.");
 
@@ -807,7 +807,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             var configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
 
-            TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
+            TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(1)));
             configManager.MetadataAddress = "http://127.0.0.1";
             configManager.RequestRefresh();
 

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -20,9 +20,8 @@ using Xunit;
 
 namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 {
-    /// <summary>
-    /// 
-    /// </summary>
+    [ResetAppContextSwitches]
+    [Collection(nameof(AppContextSwitches.UpdateConfigAsBlocking))]
     public class ConfigurationManagerTests
     {
         /// <summary>
@@ -40,7 +39,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             {
                 var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
                     theoryData.MetadataAddress,
-                    theoryData.ConfigurationRetreiver,
+                    theoryData.ConfigurationRetriever,
                     theoryData.DocumentRetriever,
                     theoryData.ConfigurationValidator);
 
@@ -63,7 +62,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AccountsGoogleCom")
             {
-                ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                 ConfigurationValidator = new OpenIdConnectConfigurationValidator(),
                 DocumentRetriever = new HttpDocumentRetriever(),
                 MetadataAddress = OpenIdConfigData.AccountsGoogle
@@ -71,7 +70,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AADCommonUrl")
             {
-                ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                 ConfigurationValidator = new OpenIdConnectConfigurationValidator(),
                 DocumentRetriever = new HttpDocumentRetriever(),
                 MetadataAddress = OpenIdConfigData.AADCommonUrl
@@ -79,7 +78,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AADCommonUrlV1")
             {
-                ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                 ConfigurationValidator = new OpenIdConnectConfigurationValidator(),
                 DocumentRetriever = new HttpDocumentRetriever(),
                 MetadataAddress = OpenIdConfigData.AADCommonUrlV1
@@ -87,7 +86,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>("AADCommonUrlV2")
             {
-                ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                 ConfigurationValidator = new OpenIdConnectConfigurationValidator(),
                 DocumentRetriever = new HttpDocumentRetriever(),
                 MetadataAddress = OpenIdConfigData.AADCommonUrlV2
@@ -102,7 +101,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             var context = TestUtilities.WriteHeader($"{this}.OpenIdConnectConstructor", theoryData);
             try
             {
-                var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(theoryData.MetadataAddress, theoryData.ConfigurationRetreiver, theoryData.DocumentRetriever, theoryData.ConfigurationValidator);
+                var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(theoryData.MetadataAddress, theoryData.ConfigurationRetriever, theoryData.DocumentRetriever, theoryData.ConfigurationValidator);
                 theoryData.ExpectedException.ProcessNoException();
             }
             catch (Exception ex)
@@ -121,7 +120,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
                 {
-                    ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                    ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                     ConfigurationValidator = new OpenIdConnectConfigurationValidator(),
                     DocumentRetriever = new HttpDocumentRetriever(),
                     ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
@@ -132,7 +131,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
                 {
-                    ConfigurationRetreiver = null,
+                    ConfigurationRetriever = null,
                     ConfigurationValidator = new OpenIdConnectConfigurationValidator(),
                     DocumentRetriever = new HttpDocumentRetriever(),
                     ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
@@ -142,7 +141,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
                 {
-                    ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                    ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                     ConfigurationValidator = new OpenIdConnectConfigurationValidator(),
                     DocumentRetriever = null,
                     ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
@@ -152,7 +151,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
                 {
-                    ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                    ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                     ConfigurationValidator = null,
                     DocumentRetriever = new HttpDocumentRetriever(),
                     ExpectedException = ExpectedException.ArgumentNullException("IDX10000:"),
@@ -177,6 +176,18 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
         [Fact]
         public async Task FetchMetadataFailureTest()
+        {
+            await FetchMetadataFailureTestBody();
+        }
+
+        [Fact]
+        public async Task FetchMetadataFailureTest_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await FetchMetadataFailureTestBody();
+        }
+
+        private async ValueTask FetchMetadataFailureTestBody()
         {
             var context = new CompareContext($"{this}.FetchMetadataFailureTest");
 
@@ -352,6 +363,54 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         }
 
         [Fact]
+        public async Task BootstrapRefreshIntervalTest_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+
+            var context = new CompareContext($"{this}.BootstrapRefreshIntervalTest_Blocking");
+
+            var documentRetriever = new HttpDocumentRetriever(HttpResponseMessageUtils.SetupHttpClientThatReturns("OpenIdConnectMetadata.json", HttpStatusCode.NotFound));
+            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), documentRetriever) { RefreshInterval = TimeSpan.FromSeconds(2) };
+
+            // First time to fetch metadata.
+            try
+            {
+                var configuration = await configManager.GetConfigurationAsync();
+            }
+            catch (Exception firstFetchMetadataFailure)
+            {
+                // Refresh interval is BootstrapRefreshInterval
+                var syncAfter = (DateTimeOffset)configManager.GetType().GetField("_syncAfter", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(configManager);
+                if (syncAfter > DateTime.UtcNow + TimeSpan.FromSeconds(2))
+                    context.AddDiff($"Expected the refresh interval is longer than 2 seconds.");
+
+                if (firstFetchMetadataFailure.InnerException == null)
+                    context.AddDiff($"Expected exception to contain inner exception for fetch metadata failure.");
+
+                // Fetch metadata again during refresh interval, the exception should be same from above.
+                try
+                {
+                    configManager.RequestRefresh();
+                    var configuration = await configManager.GetConfigurationAsync();
+                }
+                catch (Exception secondFetchMetadataFailure)
+                {
+                    if (secondFetchMetadataFailure.InnerException == null)
+                        context.AddDiff($"Expected exception to contain inner exception for fetch metadata failure.");
+
+                    syncAfter = (DateTimeOffset)configManager.GetType().GetField("_syncAfter", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(configManager);
+
+                    // Refresh interval is RefreshInterval
+                    if (syncAfter > DateTime.UtcNow + configManager.RefreshInterval)
+                        context.AddDiff($"Expected the refresh interval is longer than 2 seconds.");
+
+                    IdentityComparer.AreEqual(firstFetchMetadataFailure, secondFetchMetadataFailure, context);
+                }
+            }
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Fact]
         public void GetSets()
         {
             TestUtilities.WriteHeader($"{this}.GetSets", "GetSets", true);
@@ -388,6 +447,18 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         [Theory, MemberData(nameof(AutomaticIntervalTestCases), DisableDiscoveryEnumeration = true)]
         public async Task AutomaticRefreshInterval(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
         {
+            await AutomaticRefreshIntervalBody(theoryData, false);
+        }
+
+        [Theory, MemberData(nameof(AutomaticIntervalTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task AutomaticRefreshInterval_Blocking(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await AutomaticRefreshIntervalBody(theoryData, true);
+        }
+
+        private async Task AutomaticRefreshIntervalBody(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData, bool blocking)
+        {
             var context = new CompareContext($"{this}.AutomaticRefreshInterval");
 
             AutoResetEvent resetEvent = SetupResetEvent(theoryData.ConfigurationManager);
@@ -401,7 +472,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
                 TestUtilities.SetField(theoryData.ConfigurationManager, "_syncAfter", theoryData.SyncAfter);
                 var updatedConfiguration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
 
-                if (theoryData.WaitForEvent)
+                if (theoryData.WaitForEvent && !blocking)
                     WaitOrFail(resetEvent);
 
                 updatedConfiguration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
@@ -470,6 +541,18 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         [Theory, MemberData(nameof(RequestRefreshTestCases), DisableDiscoveryEnumeration = true)]
         public async Task RequestRefresh(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
         {
+            await RequestRefreshBody(theoryData, false);
+        }
+
+        [Theory, MemberData(nameof(RequestRefreshTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task RequestRefresh_Blocking(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await RequestRefreshBody(theoryData, true);
+        }
+
+        private async Task RequestRefreshBody(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData, bool blocking)
+        {
             var context = new CompareContext($"{this}.RequestRefresh");
 
             AutoResetEvent resetEvent = SetupResetEvent(theoryData.ConfigurationManager);
@@ -486,7 +569,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             {
                 theoryData.ConfigurationManager.RequestRefresh();
 
-                if (theoryData.WaitForEvent)
+                if (theoryData.WaitForEvent && !blocking)
                     WaitOrFail(resetEvent);
 
                 configuration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
@@ -499,7 +582,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             theoryData.ConfigurationManager.RequestRefresh();
 
-            if (theoryData.WaitForEvent)
+            if (theoryData.WaitForEvent && !blocking)
                 WaitOrFail(resetEvent);
 
             var updatedConfiguration = await theoryData.ConfigurationManager.GetConfigurationAsync(CancellationToken.None);
@@ -620,48 +703,79 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         }
 
         [Fact]
+        public async Task CheckSyncAfter_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await CheckSyncAfterBody(true);
+        }
+
+        [Fact]
         public async Task CheckSyncAfter()
         {
+            await CheckSyncAfterBody();
+        }
+
+        private async Task CheckSyncAfterBody(bool blocking = false)
+        {
             // This test checks that the _syncAfter field is set correctly after a refresh.
-            var context = new CompareContext($"{this}.CheckSyncAfter");
+            var context = new CompareContext($"{this}.CheckSyncAfterAndRefreshRequested");
+
+            var cts = new CancellationTokenSource();
 
             var docRetriever = new FileDocumentRetriever();
-            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
+            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                "OpenIdConnectMetadata.json",
+                new OpenIdConnectConfigurationRetriever(),
+                docRetriever);
 
             AutoResetEvent resetEvent = SetupResetEvent(configManager);
 
-            var timeProvider = new FakeTimeProvider();
-            configManager.TimeProvider = timeProvider;
-
             // This is the minimum time that should pass before an automatic refresh occurs
             // stored in advance to avoid any time drift issues.
-            DateTimeOffset minimumRefreshInterval = timeProvider.GetUtcNow() + configManager.AutomaticRefreshInterval;
+            DateTimeOffset minimumRefreshInterval = DateTimeOffset.UtcNow + configManager.AutomaticRefreshInterval;
 
             // get the first configuration, internal _syncAfter should be set to a time greater than UtcNow + AutomaticRefreshInterval.
             var configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
 
             // force a refresh by setting internal field
-            timeProvider.Advance(TimeSpan.FromDays(1));
+            TestUtilities.SetField(configManager, "_syncAfter", DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
             configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
 
-            // wait 1000ms here because update of config is run as a new task.
-            WaitOrFail(resetEvent);
+            if (!blocking)
+                WaitOrFail(resetEvent);
 
             // check that _syncAfter is greater than DateTimeOffset.UtcNow + AutomaticRefreshInterval
-            DateTimeOffset syncAfter = (DateTimeOffset)TestUtilities.GetField(configManager, "_syncAfter");
+            DateTime syncAfter = (DateTime)TestUtilities.GetField(configManager, "_syncAfter");
             if (syncAfter < minimumRefreshInterval)
                 context.Diffs.Add($"(AutomaticRefreshInterval) syncAfter '{syncAfter}' < DateTimeOffset.UtcNow + configManager.AutomaticRefreshInterval: '{minimumRefreshInterval}'.");
 
             // make same check for RequestRefresh
             // force a refresh by setting internal field
-            TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTimeOffset.UtcNow - TimeSpan.FromHours(1));
+            TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
+
             configManager.RequestRefresh();
 
-            // wait 1000ms here because update of config is run as a new task.
-            WaitOrFail(resetEvent);
+            if (blocking)
+            {
+                bool refreshRequested = (bool)TestUtilities.GetField(configManager, "_refreshRequested");
+                if (!refreshRequested)
+                    context.Diffs.Add("Refresh is expected to be requested after RequestRefresh is called");
+            }
+
+            await configManager.GetConfigurationAsync();
+
+            if (blocking)
+            {
+                bool refreshRequested = (bool)TestUtilities.GetField(configManager, "_refreshRequested");
+                if (refreshRequested)
+                    context.Diffs.Add("Refresh is expected to be requested after RequestRefresh is called");
+            }
+
+            if (!blocking)
+                WaitOrFail(resetEvent);
 
             // check that _syncAfter is greater than DateTimeOffset.UtcNow + AutomaticRefreshInterval
-            syncAfter = (DateTimeOffset)TestUtilities.GetField(configManager, "_syncAfter");
+            syncAfter = (DateTime)TestUtilities.GetField(configManager, "_syncAfter");
             if (syncAfter < minimumRefreshInterval)
                 context.Diffs.Add($"(RequestRefresh) syncAfter '{syncAfter}' < DateTimeOffset.UtcNow + configManager.AutomaticRefreshInterval: '{minimumRefreshInterval}'.");
 
@@ -671,22 +785,37 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         [Fact]
         public async Task GetConfigurationAsync()
         {
-            var docRetriever = new FileDocumentRetriever();
-            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
+            await GetConfigurationBody();
+        }
+
+        [Fact]
+        public async Task GetConfigurationAsync_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await GetConfigurationBody();
+        }
+
+        private async Task GetConfigurationBody()
+        {
             var context = new CompareContext($"{this}.GetConfiguration");
 
-            // Unable to obtain a new configuration, but _currentConfiguration is not null so it should be returned.
-            configManager = new ConfigurationManager<OpenIdConnectConfiguration>("OpenIdConnectMetadata.json", new OpenIdConnectConfigurationRetriever(), docRetriever);
+            var docRetriever = new FileDocumentRetriever();
+            var configManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                "OpenIdConnectMetadata.json",
+                new OpenIdConnectConfigurationRetriever(),
+                docRetriever);
+
             var configuration = await configManager.GetConfigurationAsync(CancellationToken.None);
 
-            TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTimeOffset.UtcNow - TimeSpan.FromHours(1));
-            configManager.RequestRefresh();
+            TestUtilities.SetField(configManager, "_lastRequestRefresh", DateTime.UtcNow.Subtract(TimeSpan.FromHours(1)));
             configManager.MetadataAddress = "http://127.0.0.1";
+            configManager.RequestRefresh();
+
+            // Unable to obtain a new configuration, but _currentConfiguration is not null so it should be returned.
             var configuration2 = await configManager.GetConfigurationAsync(CancellationToken.None);
             IdentityComparer.AreEqual(configuration, configuration2, context);
             if (!object.ReferenceEquals(configuration, configuration2))
                 context.Diffs.Add("!object.ReferenceEquals(configuration, configuration2)");
-
 
             // get configuration from http address, should throw
             // get configuration with unsuccessful HTTP response status code
@@ -697,6 +826,18 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         // a new LKG is set.
         [Fact]
         public void ResetLastKnownGoodLifetime()
+        {
+            ResetLastKnownGoodLifetimeBody();
+        }
+
+        [Fact]
+        public void ResetLastKnownGoodLifetime_Blocking()
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            ResetLastKnownGoodLifetimeBody();
+        }
+
+        private void ResetLastKnownGoodLifetimeBody()
         {
             TestUtilities.WriteHeader($"{this}.ResetLastKnownGoodLifetime");
             var context = new CompareContext();
@@ -774,26 +915,52 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
         }
 
         [Theory, MemberData(nameof(ValidateOpenIdConnectConfigurationTestCases), DisableDiscoveryEnumeration = true)]
+        public async Task ValidateOpenIdConnectConfigurationTests_Blocking(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+            await ValidateOIDCConfigurationBody(theoryData, true);
+        }
+
+        [Theory, MemberData(nameof(ValidateOpenIdConnectConfigurationTestCases), DisableDiscoveryEnumeration = true)]
         public async Task ValidateOpenIdConnectConfigurationTests(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData)
+        {
+            await ValidateOIDCConfigurationBody(theoryData);
+        }
+
+        private async Task ValidateOIDCConfigurationBody(ConfigurationManagerTheoryData<OpenIdConnectConfiguration> theoryData, bool blocking = false)
         {
             TestUtilities.WriteHeader($"{this}.ValidateOpenIdConnectConfigurationTests");
             var context = new CompareContext();
             OpenIdConnectConfiguration configuration;
-            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(theoryData.MetadataAddress, theoryData.ConfigurationRetreiver, theoryData.DocumentRetriever, theoryData.ConfigurationValidator);
+            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                theoryData.MetadataAddress,
+                theoryData.ConfigurationRetriever,
+                theoryData.DocumentRetriever,
+                theoryData.ConfigurationValidator);
+
+            var resetEvent = SetupResetEvent(configurationManager);
 
             if (theoryData.PresetCurrentConfiguration)
                 TestUtilities.SetField(configurationManager, "_currentConfiguration", new OpenIdConnectConfiguration() { Issuer = Default.Issuer });
 
-            AutoResetEvent resetEvent = SetupResetEvent(configurationManager);
-
             try
             {
                 //create a listener and enable it for logs
-                var listener = TestUtils.SampleListener.CreateLoggerListener(EventLevel.Warning);
+                using var listener = TestUtils.SampleListener.CreateLoggerListener(EventLevel.Warning);
+
                 configuration = await configurationManager.GetConfigurationAsync();
 
-                if (theoryData.WaitForEvent)
+                if (!blocking && theoryData.ExpectedException is null && string.IsNullOrEmpty(theoryData.ExpectedErrorMessage))
                     WaitOrFail(resetEvent);
+
+                // Need to wait for the events on the listener to be processed.
+                if (!string.IsNullOrEmpty(theoryData.ExpectedErrorMessage))
+                {
+                    var success = await PollForConditionAsync(
+                        () => listener.TraceBuffer.Contains(theoryData.ExpectedErrorMessage),
+                        TimeSpan.FromMilliseconds(100),
+                        TimeSpan.FromSeconds(10));
+                }
 
                 if (!string.IsNullOrEmpty(theoryData.ExpectedErrorMessage) && !listener.TraceBuffer.Contains(theoryData.ExpectedErrorMessage))
                     context.AddDiff($"Expected exception to contain: '{theoryData.ExpectedErrorMessage}'.{Environment.NewLine}Log is:{Environment.NewLine}'{listener.TraceBuffer}'");
@@ -811,6 +978,28 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
+        internal static async Task<bool> PollForConditionAsync(Func<bool> condition, TimeSpan interval, TimeSpan timeout)
+        {
+            var startTime = DateTime.UtcNow;
+
+            while (DateTime.UtcNow - startTime < timeout)
+            {
+                if (condition())
+                    return true;
+
+                try
+                {
+                    await Task.Delay(interval);
+                }
+                catch (TaskCanceledException)
+                {
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
         public static TheoryData<ConfigurationManagerTheoryData<OpenIdConnectConfiguration>> ValidateOpenIdConnectConfigurationTestCases
         {
             get
@@ -821,7 +1010,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
                 {
-                    ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                    ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                     ConfigurationValidator = openIdConnectConfigurationValidator,
                     DocumentRetriever = new FileDocumentRetriever(),
                     First = true,
@@ -831,7 +1020,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
                 {
-                    ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                    ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                     ConfigurationValidator = openIdConnectConfigurationValidator2,
                     DocumentRetriever = new FileDocumentRetriever(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX21818:", typeof(InvalidConfigurationException)),
@@ -842,7 +1031,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
                 {
-                    ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                    ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                     ConfigurationValidator = openIdConnectConfigurationValidator2,
                     DocumentRetriever = new FileDocumentRetriever(),
                     PresetCurrentConfiguration = true,
@@ -854,7 +1043,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
                 {
-                    ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                    ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                     ConfigurationValidator = openIdConnectConfigurationValidator2,
                     DocumentRetriever = new FileDocumentRetriever(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX10810:", typeof(InvalidConfigurationException)),
@@ -865,7 +1054,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
                 {
-                    ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                    ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                     ConfigurationValidator = openIdConnectConfigurationValidator2,
                     DocumentRetriever = new FileDocumentRetriever(),
                     PresetCurrentConfiguration = true,
@@ -877,7 +1066,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
                 {
-                    ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                    ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                     ConfigurationValidator = openIdConnectConfigurationValidator2,
                     DocumentRetriever = new FileDocumentRetriever(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX21817:", typeof(InvalidConfigurationException)),
@@ -888,7 +1077,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
                 {
-                    ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                    ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                     ConfigurationValidator = openIdConnectConfigurationValidator2,
                     DocumentRetriever = new FileDocumentRetriever(),
                     PresetCurrentConfiguration = true,
@@ -900,7 +1089,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
                 {
-                    ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                    ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                     ConfigurationValidator = openIdConnectConfigurationValidator2,
                     DocumentRetriever = new FileDocumentRetriever(),
                     ExpectedException = new ExpectedException(typeof(InvalidOperationException), "IDX10814:", typeof(InvalidConfigurationException)),
@@ -911,7 +1100,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
                 theoryData.Add(new ConfigurationManagerTheoryData<OpenIdConnectConfiguration>
                 {
-                    ConfigurationRetreiver = new OpenIdConnectConfigurationRetriever(),
+                    ConfigurationRetriever = new OpenIdConnectConfigurationRetriever(),
                     ConfigurationValidator = openIdConnectConfigurationValidator2,
                     DocumentRetriever = new FileDocumentRetriever(),
                     PresetCurrentConfiguration = true,
@@ -974,7 +1163,7 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
 
             public TimeSpan AutomaticRefreshInterval { get; set; }
 
-            public IConfigurationRetriever<T> ConfigurationRetreiver { get; set; }
+            public IConfigurationRetriever<T> ConfigurationRetriever { get; set; }
 
             public IConfigurationValidator<T> ConfigurationValidator { get; set; }
 

--- a/test/Microsoft.IdentityModel.TestUtils/ResetAppContextSwitchesAttribute.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/ResetAppContextSwitchesAttribute.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit.Sdk;
+
+namespace Microsoft.IdentityModel.TestUtils
+{
+    /// <inheritdoc/>
+    public class ResetAppContextSwitchesAttribute : BeforeAfterTestAttribute
+    {
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            AppContextSwitches.ResetAllSwitches();
+        }
+
+        public override void After(MethodInfo methodUnderTest)
+        {
+            AppContextSwitches.ResetAllSwitches();
+        }
+    }
+}


### PR DESCRIPTION
# Switch for metadata refresh to be blocking
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Adds the ability for the metadata refresh to be done as a blocking call, as per 8.0.1 behavior.

This is done through the 'Switch.Microsoft.IdentityModel.UpdateConfigAsBlocking'.

If set, configuration calls will be blocking on update, and exceptions when requesting new metadata will be returned to the caller

Fixes #3192
