### PR TITLE
Use IList to avoid enumerator allocation

### DIFF
--- a/benchmark/Microsoft.IdentityModel.Benchmarks/ValidatorBenchmarks.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/ValidatorBenchmarks.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.IdentityModel.Tokens;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.IdentityModel.Benchmarks
+{
+    /// <summary>
+    /// Benchmarks for validator methods to measure performance of different implementations
+    /// </summary>
+    public class ValidatorBenchmarks
+    {
+        private List<string> _audiences;
+        private TokenValidationParameters _parametersWithList;
+        private TokenValidationParameters _parametersWithEnumerable;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _audiences = ["audience1"];
+            var validAudiences = new List<string> { "invalid1", "invalid2", "audience1" }; // Make sure audience is last to maximize iteration
+
+            _parametersWithList = new TokenValidationParameters
+            {
+                ValidAudiences = validAudiences
+            };
+
+            _parametersWithEnumerable = new TokenValidationParameters
+            {
+                ValidAudiences = validAudiences.Select(x => x) // Force enumerable by using LINQ
+            };
+        }
+
+        [Benchmark(Baseline = true)]
+        public void ValidateAudience_WithList()
+        {
+            Validators.ValidateAudience(_audiences, null, _parametersWithList);
+        }
+
+        [Benchmark]
+        public void ValidateAudience_WithEnumerable()
+        {
+            Validators.ValidateAudience(_audiences, null, _parametersWithEnumerable);
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/Validators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validators.cs
@@ -143,37 +143,36 @@ namespace Microsoft.IdentityModel.Tokens
                 if (string.IsNullOrWhiteSpace(tokenAudience))
                     continue;
 
+                bool TryMatchAudience(string validAudience)
+                {
+                    if (string.IsNullOrWhiteSpace(validAudience))
+                        return false;
+
+                    if (AudiencesMatch(validationParameters, tokenAudience, validAudience))
+                    {
+                        if (LogHelper.IsEnabled(EventLogLevel.Informational))
+                            LogHelper.LogInformation(LogMessages.IDX10234, LogHelper.MarkAsNonPII(tokenAudience));
+
+                        return true;
+                    }
+
+                    return false;
+                }
+
                 if (validationParametersAudiences is IList<string> audienceList)
                 {
                     for (int i = 0; i < audienceList.Count; i++)
                     {
-                        string validAudience = audienceList[i];
-                        if (string.IsNullOrWhiteSpace(validAudience))
-                            continue;
-
-                        if (AudiencesMatch(validationParameters, tokenAudience, validAudience))
-                        {
-                            if (LogHelper.IsEnabled(EventLogLevel.Informational))
-                                LogHelper.LogInformation(LogMessages.IDX10234, LogHelper.MarkAsNonPII(tokenAudience));
-
+                        if (TryMatchAudience(audienceList[i]))
                             return true;
-                        }
                     }
                 }
                 else
                 {
                     foreach (string validAudience in validationParametersAudiences)
                     {
-                        if (string.IsNullOrWhiteSpace(validAudience))
-                            continue;
-
-                        if (AudiencesMatch(validationParameters, tokenAudience, validAudience))
-                        {
-                            if (LogHelper.IsEnabled(EventLogLevel.Informational))
-                                LogHelper.LogInformation(LogMessages.IDX10234, LogHelper.MarkAsNonPII(tokenAudience));
-
+                        if (TryMatchAudience(validAudience))
                             return true;
-                        }
                     }
                 }
             }

--- a/src/Microsoft.IdentityModel.Tokens/Validators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validators.cs
@@ -143,17 +143,37 @@ namespace Microsoft.IdentityModel.Tokens
                 if (string.IsNullOrWhiteSpace(tokenAudience))
                     continue;
 
-                foreach (string validAudience in validationParametersAudiences)
+                if (validationParametersAudiences is IList<string> audienceList)
                 {
-                    if (string.IsNullOrWhiteSpace(validAudience))
-                        continue;
-
-                    if (AudiencesMatch(validationParameters, tokenAudience, validAudience))
+                    for (int i = 0; i < audienceList.Count; i++)
                     {
-                        if (LogHelper.IsEnabled(EventLogLevel.Informational))
-                            LogHelper.LogInformation(LogMessages.IDX10234, LogHelper.MarkAsNonPII(tokenAudience));
+                        string validAudience = audienceList[i];
+                        if (string.IsNullOrWhiteSpace(validAudience))
+                            continue;
 
-                        return true;
+                        if (AudiencesMatch(validationParameters, tokenAudience, validAudience))
+                        {
+                            if (LogHelper.IsEnabled(EventLogLevel.Informational))
+                                LogHelper.LogInformation(LogMessages.IDX10234, LogHelper.MarkAsNonPII(tokenAudience));
+
+                            return true;
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (string validAudience in validationParametersAudiences)
+                    {
+                        if (string.IsNullOrWhiteSpace(validAudience))
+                            continue;
+
+                        if (AudiencesMatch(validationParameters, tokenAudience, validAudience))
+                        {
+                            if (LogHelper.IsEnabled(EventLogLevel.Informational))
+                                LogHelper.LogInformation(LogMessages.IDX10234, LogHelper.MarkAsNonPII(tokenAudience));
+
+                            return true;
+                        }
                     }
                 }
             }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Microsoft.IdentityModel.Tokens.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Microsoft.IdentityModel.Tokens.Tests.csproj
@@ -21,8 +21,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault.Cryptography" Version="$(MicrosoftAzureKeyVaultCryptographyVersion)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressions)"/>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntimeVersion)"/>
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressions)" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntimeVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Microsoft.IdentityModel.Tokens.Tests.csproj
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Microsoft.IdentityModel.Tokens.Tests.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault.Cryptography" Version="$(MicrosoftAzureKeyVaultCryptographyVersion)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressions)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="$(SystemTextRegularExpressions)"/>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntimeVersion)" />
   </ItemGroup>
 

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidatorsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidatorsTests.cs
@@ -270,6 +270,23 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         Audiences = audiences1WithTwoSlashes,
                         ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
                         TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience1 }
+                    },
+                    new AudienceValidationTheoryData("ValidAudiencesList_OptimizedPath")
+                    {
+                        Audiences = new List<string> { "audience1" },
+                        TokenValidationParameters = new TokenValidationParameters
+                        {
+                            ValidAudiences = new List<string> { "invalidAudience", "audience1" }  // Using List<string> to test IList optimization
+                        }
+                    },
+                    new AudienceValidationTheoryData("ValidAudiencesList_EmptyList_OptimizedPath")
+                    {
+                        Audiences = new List<string> { "audience1" },
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TokenValidationParameters = new TokenValidationParameters
+                        {
+                            ValidAudiences = new List<string>()  // Empty list should still return false through optimized path
+                        }
                     }
                 };
             }


### PR DESCRIPTION
fixes #3174 

done w/cline in VS code.
<img width="938" alt="image" src="https://github.com/user-attachments/assets/721f4007-2af7-48f2-8f14-f57424be3771" />

<img width="771" alt="image" src="https://github.com/user-attachments/assets/5693fe0f-3597-4ab1-9ddc-36cd247d52bc" />

Benchmark results (not done on dev box):
<img width="1229" alt="image" src="https://github.com/user-attachments/assets/af0d1d76-6d8f-4404-99be-0082ffc0bba2" />