### PR TITLE
Don't lose TimeZone kind when creating sync after

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -348,7 +348,7 @@ namespace Microsoft.IdentityModel.Protocols
         private void UpdateConfiguration(T configuration)
         {
             _currentConfiguration = configuration;
-            _syncAfter = DateTimeUtil.Add(TimeProvider.GetUtcNow().DateTime, AutomaticRefreshInterval +
+            _syncAfter = DateTimeUtil.Add(TimeProvider.GetUtcNow().UtcDateTime, AutomaticRefreshInterval +
                 TimeSpan.FromSeconds(new Random().Next((int)AutomaticRefreshInterval.TotalSeconds / 20)));
         }
 


### PR DESCRIPTION
# Don't lose Time Zone kind when creating sync after

Summary of the changes (Less than 80 chars)

## Description

Don't convert from UTC DateTimeOffset to DateTime, need to specify the kind as UTC, this is done through UtcDateTime from DateTimeOffset

Fixes #3212 
