### PR TITLE
Ssathe/fix casting for xml attr type

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -120,6 +120,9 @@ namespace Microsoft.IdentityModel.Tokens
 
             _doNotScrubExceptions = null;
             AppContext.SetSwitch(DoNotScrubExceptionsSwitch, false);
+
+            _useCapitalizedXMLTypeAttr = null;
+            AppContext.SetSwitch(UseCapitalizedXMLTypeAttrSwitch, false);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -92,6 +92,13 @@ namespace Microsoft.IdentityModel.Tokens
         internal static bool DoNotScrubExceptions => _doNotScrubExceptions ??= (AppContext.TryGetSwitch(DoNotScrubExceptionsSwitch, out bool doNotScrubExceptions) && doNotScrubExceptions);
 
         /// <summary>
+        /// When enabled, the XML type attribute will be capitalized (XML) for saml configurations.
+        /// </summary>
+        internal const string UseCapitalizedXMLTypeAttrSwitch = "Switch.Microsoft.IdentityModel.UseCapitalizedXMLTypeAttr";
+        private static bool? _useCapitalizedXMLTypeAttr;
+        internal static bool UseCapitalizedXMLTypeAttr => _useCapitalizedXMLTypeAttr ??= (AppContext.TryGetSwitch(UseCapitalizedXMLTypeAttrSwitch, out bool useCapitalizedXMLTypeAttr) && useCapitalizedXMLTypeAttr);
+
+        /// <summary>
         /// Used for testing to reset all switches to its default value.
         /// </summary>
         internal static void ResetAllSwitches()

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+const Microsoft.IdentityModel.Tokens.AppContextSwitches.UseCapitalizedXMLTypeAttrSwitch = "Switch.Microsoft.IdentityModel.UseCapitalizedXMLTypeAttr" -> string
+static Microsoft.IdentityModel.Tokens.AppContextSwitches.UseCapitalizedXMLTypeAttr.get -> bool

--- a/src/Microsoft.IdentityModel.Xml/PublicAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Xml/PublicAPI.Shipped.txt
@@ -8,7 +8,6 @@ const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.Id = "Id" -> 
 const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.NcName = "NCName" -> string
 const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.Nil = "nil" -> string
 const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.PrefixList = "PrefixList" -> string
-const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.Type = "type" -> string
 const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.URI = "URI" -> string
 const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Elements.CanonicalizationMethod = "CanonicalizationMethod" -> string
 const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Elements.DigestMethod = "DigestMethod" -> string

--- a/src/Microsoft.IdentityModel.Xml/PublicAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Xml/PublicAPI.Shipped.txt
@@ -8,6 +8,7 @@ const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.Id = "Id" -> 
 const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.NcName = "NCName" -> string
 const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.Nil = "nil" -> string
 const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.PrefixList = "PrefixList" -> string
+const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.Type = "type" -> string
 const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.URI = "URI" -> string
 const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Elements.CanonicalizationMethod = "CanonicalizationMethod" -> string
 const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Elements.DigestMethod = "DigestMethod" -> string

--- a/src/Microsoft.IdentityModel.Xml/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Xml/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+static Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.Type.get -> string

--- a/src/Microsoft.IdentityModel.Xml/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Xml/PublicAPI.Unshipped.txt
@@ -1,1 +1,0 @@
-const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.Type = "Type" -> string

--- a/src/Microsoft.IdentityModel.Xml/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Xml/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.IdentityModel.Xml.XmlSignatureConstants.Attributes.Type = "Type" -> string

--- a/src/Microsoft.IdentityModel.Xml/XmlSignatureConstants.cs
+++ b/src/Microsoft.IdentityModel.Xml/XmlSignatureConstants.cs
@@ -31,7 +31,7 @@ namespace Microsoft.IdentityModel.Xml
             public const string NcName = "NCName";
             public const string Nil = "nil";
             public const string PrefixList = "PrefixList";
-            public const string Type = "Type";
+            public const string Type = "type";
             public const string URI = "URI";
         }
 

--- a/src/Microsoft.IdentityModel.Xml/XmlSignatureConstants.cs
+++ b/src/Microsoft.IdentityModel.Xml/XmlSignatureConstants.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.IdentityModel.Tokens;
+
 namespace Microsoft.IdentityModel.Xml
 {
     /// <summary>
@@ -31,7 +33,11 @@ namespace Microsoft.IdentityModel.Xml
             public const string NcName = "NCName";
             public const string Nil = "nil";
             public const string PrefixList = "PrefixList";
-            public const string Type = "type";
+            // Change the non-constant field `Type` to a property to resolve CA2211 diagnostic.
+            public static string Type
+            {
+                get => AppContextSwitches.UseCapitalizedXMLTypeAttr ? "Type" : "type";
+            }
             public const string URI = "URI";
         }
 

--- a/src/Microsoft.IdentityModel.Xml/XmlSignatureConstants.cs
+++ b/src/Microsoft.IdentityModel.Xml/XmlSignatureConstants.cs
@@ -31,7 +31,7 @@ namespace Microsoft.IdentityModel.Xml
             public const string NcName = "NCName";
             public const string Nil = "nil";
             public const string PrefixList = "PrefixList";
-            public const string Type = "type";
+            public const string Type = "Type";
             public const string URI = "URI";
         }
 

--- a/test/Microsoft.IdentityModel.TestUtils/Default.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/Default.cs
@@ -1035,7 +1035,7 @@ namespace Microsoft.IdentityModel.TestUtils
                 {
                     KeyInfo = KeyInfo,
                     SignedInfo = SignedInfoReferenceWithoutPrefix,
-                    SignatureValue = "OaTq3jGqbPLUVROvhiqV+PneMwdu6iZgVv7vbW++wEk4tSXoqEUkY+b/M2ZzHFy0M/k33migp3s0w+Ff1vNHRI0uT8Zs1D+EdI/Oz4Pu3FwPA/UK+8qe+JTRAOhdN5H7Wv4c0p1nrWJlVlT5WWCUe2uRSpojS2+D+KC1gG/DiDqK5gWgQt/7Z0HV8ml6C0PTqXWvZcYc1u49Y3tNEPOUuSXGzSZOAfhEAMdQ6+qC+126wcbSFK5ww1aOI2K6Nk3u8sxJUXHdUXs92DKvLemcaHXw0yDNUNi/izVldy3yu6VEDEflCJkj1+yvB52U+EpvG/7IGwY66QceVbu/1FFLFA=="
+                    SignatureValue = AppContextSwitches.UseCapitalizedXMLTypeAttr ? "OaTq3jGqbPLUVROvhiqV+PneMwdu6iZgVv7vbW++wEk4tSXoqEUkY+b/M2ZzHFy0M/k33migp3s0w+Ff1vNHRI0uT8Zs1D+EdI/Oz4Pu3FwPA/UK+8qe+JTRAOhdN5H7Wv4c0p1nrWJlVlT5WWCUe2uRSpojS2+D+KC1gG/DiDqK5gWgQt/7Z0HV8ml6C0PTqXWvZcYc1u49Y3tNEPOUuSXGzSZOAfhEAMdQ6+qC+126wcbSFK5ww1aOI2K6Nk3u8sxJUXHdUXs92DKvLemcaHXw0yDNUNi/izVldy3yu6VEDEflCJkj1+yvB52U+EpvG/7IGwY66QceVbu/1FFLFA==" : "kzGIa0ZwE1Y7CYZ3hZHdFLGEQ6LvTdoKYSr+jClEdoL8l0bRf0Mkp7zsp0uCPyoZHKVBatU7otEmbciu9FWNMSXmpiDj9eSL/eNqpJ0sRkaNPyM3AqR2zy7TG2481K4SWZfo5EahrSat0glEUC6i3sxojjLb8DRq8ETYO1JsNhLOHQjKWlBEBZ04rAcz/kWXt0N1CQne4+GozQtiaMDvN/PXeqwiEYHbS1Gr5G16wHdiFZNYylH2pW14+t5t/eIZX8c/VJNT5uM09KHeBSMEn7Uksp2qx1brKP1K9SULzke0Pgx+lIJZgVndGbviGd5UP4ufovexs4F5TkhI7Pel6A=="
                 };
                 return signature;
             }
@@ -1049,7 +1049,7 @@ namespace Microsoft.IdentityModel.TestUtils
                 {
                     KeyInfo = KeyInfo,
                     SignedInfo = SignedInfoReferenceWithId,
-                    SignatureValue = "fqbb3WVUTLu/ihWXHUYgPWO5rgnm9AuwAT8YeiWiood/z+ObWpTwxs42be4HIDac9U94hR05rfLOR+0WxmlzhJp7/fye50VHMKex5kAAp9aCMAzCvDkfNzhMUN3WOHGEFOs4tmxrR0TBV6j+KNnjyDs3AUtdzZnZB+QmOJAlZubdOzWk/D0CGSXSgMmqYgmvH/GZGQWxQtbGMFuB29VCR7moegGN/9VAo/K7Z22xmfUWNKWVHB0OUC8FI36sadVnnUvcKnUo3M3pnQwbEWYz/+rMSYYrboM4dOKEqxZCgFXKou08Pz0MtNe2VwketLbJrKSmuEJOgVnXrzPTwlVSpw=="
+                    SignatureValue = AppContextSwitches.UseCapitalizedXMLTypeAttr ? "fqbb3WVUTLu/ihWXHUYgPWO5rgnm9AuwAT8YeiWiood/z+ObWpTwxs42be4HIDac9U94hR05rfLOR+0WxmlzhJp7/fye50VHMKex5kAAp9aCMAzCvDkfNzhMUN3WOHGEFOs4tmxrR0TBV6j+KNnjyDs3AUtdzZnZB+QmOJAlZubdOzWk/D0CGSXSgMmqYgmvH/GZGQWxQtbGMFuB29VCR7moegGN/9VAo/K7Z22xmfUWNKWVHB0OUC8FI36sadVnnUvcKnUo3M3pnQwbEWYz/+rMSYYrboM4dOKEqxZCgFXKou08Pz0MtNe2VwketLbJrKSmuEJOgVnXrzPTwlVSpw==" : "BOMo5aCr+YIjOq+lmPj8be8/6u8iXJFXuJskeWaYk1iNadUhhUPcSHeFv8XmOBIXV7Yrvk2WiVoBKawJh79iqRrVpJmdpHTxuukUua6iijxEEhwjYGLneleVgBzDTnk2os21WThYSEXmhi52z4Or0eq29vObOlRN3c2VlqDba8avu8jMNqZuKWsptxLDS1q0JfE8zu7Srs9y2GD7SULbWYpsl2VIO3ZCV+0/YWnBHQ09Ee1QKP18HMNr3jgrmpNj165olYKnn+Vr2YDEBSuNX1mxdw2bqAbpEeWITmmIkW2KDivxOtL2lOZEC6QnEVidWr1oyFUb+srKAlmksiy3wA=="
                 };
                 return signature;
             }

--- a/test/Microsoft.IdentityModel.TestUtils/Default.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/Default.cs
@@ -1021,7 +1021,7 @@ namespace Microsoft.IdentityModel.TestUtils
                 {
                     KeyInfo = KeyInfo,
                     SignedInfo = SignedInfo,
-                    SignatureValue = "kzGIa0ZwE1Y7CYZ3hZHdFLGEQ6LvTdoKYSr+jClEdoL8l0bRf0Mkp7zsp0uCPyoZHKVBatU7otEmbciu9FWNMSXmpiDj9eSL/eNqpJ0sRkaNPyM3AqR2zy7TG2481K4SWZfo5EahrSat0glEUC6i3sxojjLb8DRq8ETYO1JsNhLOHQjKWlBEBZ04rAcz/kWXt0N1CQne4+GozQtiaMDvN/PXeqwiEYHbS1Gr5G16wHdiFZNYylH2pW14+t5t/eIZX8c/VJNT5uM09KHeBSMEn7Uksp2qx1brKP1K9SULzke0Pgx+lIJZgVndGbviGd5UP4ufovexs4F5TkhI7Pel6A=="
+                    SignatureValue = "OaTq3jGqbPLUVROvhiqV+PneMwdu6iZgVv7vbW++wEk4tSXoqEUkY+b/M2ZzHFy0M/k33migp3s0w+Ff1vNHRI0uT8Zs1D+EdI/Oz4Pu3FwPA/UK+8qe+JTRAOhdN5H7Wv4c0p1nrWJlVlT5WWCUe2uRSpojS2+D+KC1gG/DiDqK5gWgQt/7Z0HV8ml6C0PTqXWvZcYc1u49Y3tNEPOUuSXGzSZOAfhEAMdQ6+qC+126wcbSFK5ww1aOI2K6Nk3u8sxJUXHdUXs92DKvLemcaHXw0yDNUNi/izVldy3yu6VEDEflCJkj1+yvB52U+EpvG/7IGwY66QceVbu/1FFLFA=="
                 };
                 return signature;
             }
@@ -1049,7 +1049,7 @@ namespace Microsoft.IdentityModel.TestUtils
                 {
                     KeyInfo = KeyInfo,
                     SignedInfo = SignedInfoReferenceWithId,
-                    SignatureValue = "BOMo5aCr+YIjOq+lmPj8be8/6u8iXJFXuJskeWaYk1iNadUhhUPcSHeFv8XmOBIXV7Yrvk2WiVoBKawJh79iqRrVpJmdpHTxuukUua6iijxEEhwjYGLneleVgBzDTnk2os21WThYSEXmhi52z4Or0eq29vObOlRN3c2VlqDba8avu8jMNqZuKWsptxLDS1q0JfE8zu7Srs9y2GD7SULbWYpsl2VIO3ZCV+0/YWnBHQ09Ee1QKP18HMNr3jgrmpNj165olYKnn+Vr2YDEBSuNX1mxdw2bqAbpEeWITmmIkW2KDivxOtL2lOZEC6QnEVidWr1oyFUb+srKAlmksiy3wA=="
+                    SignatureValue = "fqbb3WVUTLu/ihWXHUYgPWO5rgnm9AuwAT8YeiWiood/z+ObWpTwxs42be4HIDac9U94hR05rfLOR+0WxmlzhJp7/fye50VHMKex5kAAp9aCMAzCvDkfNzhMUN3WOHGEFOs4tmxrR0TBV6j+KNnjyDs3AUtdzZnZB+QmOJAlZubdOzWk/D0CGSXSgMmqYgmvH/GZGQWxQtbGMFuB29VCR7moegGN/9VAo/K7Z22xmfUWNKWVHB0OUC8FI36sadVnnUvcKnUo3M3pnQwbEWYz/+rMSYYrboM4dOKEqxZCgFXKou08Pz0MtNe2VwketLbJrKSmuEJOgVnXrzPTwlVSpw=="
                 };
                 return signature;
             }

--- a/test/Microsoft.IdentityModel.TestUtils/Default.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/Default.cs
@@ -1021,7 +1021,7 @@ namespace Microsoft.IdentityModel.TestUtils
                 {
                     KeyInfo = KeyInfo,
                     SignedInfo = SignedInfo,
-                    SignatureValue = "OaTq3jGqbPLUVROvhiqV+PneMwdu6iZgVv7vbW++wEk4tSXoqEUkY+b/M2ZzHFy0M/k33migp3s0w+Ff1vNHRI0uT8Zs1D+EdI/Oz4Pu3FwPA/UK+8qe+JTRAOhdN5H7Wv4c0p1nrWJlVlT5WWCUe2uRSpojS2+D+KC1gG/DiDqK5gWgQt/7Z0HV8ml6C0PTqXWvZcYc1u49Y3tNEPOUuSXGzSZOAfhEAMdQ6+qC+126wcbSFK5ww1aOI2K6Nk3u8sxJUXHdUXs92DKvLemcaHXw0yDNUNi/izVldy3yu6VEDEflCJkj1+yvB52U+EpvG/7IGwY66QceVbu/1FFLFA=="
+                    SignatureValue = AppContextSwitches.UseCapitalizedXMLTypeAttr ? "OaTq3jGqbPLUVROvhiqV+PneMwdu6iZgVv7vbW++wEk4tSXoqEUkY+b/M2ZzHFy0M/k33migp3s0w+Ff1vNHRI0uT8Zs1D+EdI/Oz4Pu3FwPA/UK+8qe+JTRAOhdN5H7Wv4c0p1nrWJlVlT5WWCUe2uRSpojS2+D+KC1gG/DiDqK5gWgQt/7Z0HV8ml6C0PTqXWvZcYc1u49Y3tNEPOUuSXGzSZOAfhEAMdQ6+qC+126wcbSFK5ww1aOI2K6Nk3u8sxJUXHdUXs92DKvLemcaHXw0yDNUNi/izVldy3yu6VEDEflCJkj1+yvB52U+EpvG/7IGwY66QceVbu/1FFLFA==" : "kzGIa0ZwE1Y7CYZ3hZHdFLGEQ6LvTdoKYSr+jClEdoL8l0bRf0Mkp7zsp0uCPyoZHKVBatU7otEmbciu9FWNMSXmpiDj9eSL/eNqpJ0sRkaNPyM3AqR2zy7TG2481K4SWZfo5EahrSat0glEUC6i3sxojjLb8DRq8ETYO1JsNhLOHQjKWlBEBZ04rAcz/kWXt0N1CQne4+GozQtiaMDvN/PXeqwiEYHbS1Gr5G16wHdiFZNYylH2pW14+t5t/eIZX8c/VJNT5uM09KHeBSMEn7Uksp2qx1brKP1K9SULzke0Pgx+lIJZgVndGbviGd5UP4ufovexs4F5TkhI7Pel6A=="
                 };
                 return signature;
             }

--- a/test/Microsoft.IdentityModel.TestUtils/TestSets.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/TestSets.cs
@@ -884,7 +884,8 @@ namespace Microsoft.IdentityModel.TestUtils
                                 SecurityAlgorithms.EnvelopedSignature,
                                 SecurityAlgorithms.ExclusiveC14n,
                                 Default.ReferenceDigestMethod,
-                                digestValue, typeAttr))
+                                digestValue,
+                                typeAttr))
                 };
             }
         }
@@ -992,7 +993,8 @@ namespace Microsoft.IdentityModel.TestUtils
                                 unknownTransform,
                                 SecurityAlgorithms.ExclusiveC14n,
                                 SecurityAlgorithms.Sha256Digest,
-                                Default.ReferenceDigestValue, typeAttr))
+                                Default.ReferenceDigestValue,
+                                typeAttr))
 
                 };
             }

--- a/test/Microsoft.IdentityModel.TestUtils/TestSets.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/TestSets.cs
@@ -862,6 +862,7 @@ namespace Microsoft.IdentityModel.TestUtils
             {
                 var digestValue = Guid.NewGuid().ToString();
                 var reference = Default.ReferenceWithNullTokenStreamNS;
+                string typeAttr = AppContextSwitches.UseCapitalizedXMLTypeAttr ? "Type" : "type";
                 reference.DigestValue = digestValue;
                 var signedInfo = Default.SignedInfoNS;
                 signedInfo.References.Clear();
@@ -883,7 +884,7 @@ namespace Microsoft.IdentityModel.TestUtils
                                 SecurityAlgorithms.EnvelopedSignature,
                                 SecurityAlgorithms.ExclusiveC14n,
                                 Default.ReferenceDigestMethod,
-                                digestValue))
+                                digestValue, typeAttr))
                 };
             }
         }
@@ -974,6 +975,7 @@ namespace Microsoft.IdentityModel.TestUtils
                 reference.CanonicalizingTransfrom = new ExclusiveCanonicalizationTransform();
                 signedInfo.References.Clear();
                 signedInfo.References.Add(reference);
+                string typeAttr = AppContextSwitches.UseCapitalizedXMLTypeAttr ? "Type" : "type";
                 return new SignedInfoTestSet
                 {
                     SignedInfo = signedInfo,
@@ -990,7 +992,7 @@ namespace Microsoft.IdentityModel.TestUtils
                                 unknownTransform,
                                 SecurityAlgorithms.ExclusiveC14n,
                                 SecurityAlgorithms.Sha256Digest,
-                                Default.ReferenceDigestValue))
+                                Default.ReferenceDigestValue, typeAttr))
 
                 };
             }

--- a/test/Microsoft.IdentityModel.TestUtils/XmlGenerator.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/XmlGenerator.cs
@@ -354,12 +354,12 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static string ReferenceTemplate
         {
-            get => "<{0}Reference Id=\"{1}\" {8}=\"{2}\" URI=\"{3}\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><Transforms><Transform Algorithm=\"{4}\" /><Transform Algorithm=\"{5}\" /></Transforms><DigestMethod Algorithm=\"{6}\" /><DigestValue>{7}</DigestValue></{0}Reference>";
+            get => "<{0}Reference Id=\"{1}\" {2}=\"{3}\" URI=\"{4}\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><Transforms><Transform Algorithm=\"{5}\" /><Transform Algorithm=\"{6}\" /></Transforms><DigestMethod Algorithm=\"{7}\" /><DigestValue>{8}</DigestValue></{0}Reference>";
         }
 
         public static string ReferenceXml(string prefix, string id, string type, string referenceUri, string envelopingAlgorithm, string c14nAlgorithm, string digestAlgorithm, string digestValue, string typeAttr = "type")
         {
-            return string.Format(ReferenceTemplate, prefix, id, type, referenceUri, envelopingAlgorithm, c14nAlgorithm, digestAlgorithm, digestValue, typeAttr);
+            return string.Format(ReferenceTemplate, prefix, id, typeAttr, type, referenceUri, envelopingAlgorithm, c14nAlgorithm, digestAlgorithm, digestValue);
         }
 
         // Always assumes two transforms

--- a/test/Microsoft.IdentityModel.TestUtils/XmlGenerator.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/XmlGenerator.cs
@@ -377,7 +377,7 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static string RoleDescriptorTemplate
         {
-            get => "<RoleDescriptor xsi:Type=\"{0}\" protocolSupportEnumeration=\"{1}\" xmlns:xsi=\"{2}\" xmlns:fed=\"{3}\">{4}{5}{6}{7}{8}{9}{10}</RoleDescriptor>";
+            get => "<RoleDescriptor xsi:type=\"{0}\" protocolSupportEnumeration=\"{1}\" xmlns:xsi=\"{2}\" xmlns:fed=\"{3}\">{4}{5}{6}{7}{8}{9}{10}</RoleDescriptor>";
         }
 
         public static string SignatureTemplate

--- a/test/Microsoft.IdentityModel.TestUtils/XmlGenerator.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/XmlGenerator.cs
@@ -354,12 +354,12 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static string ReferenceTemplate
         {
-            get => "<{0}Reference Id=\"{1}\" Type=\"{2}\" URI=\"{3}\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><Transforms><Transform Algorithm=\"{4}\" /><Transform Algorithm=\"{5}\" /></Transforms><DigestMethod Algorithm=\"{6}\" /><DigestValue>{7}</DigestValue></{0}Reference>";
+            get => "<{0}Reference Id=\"{1}\" {8}=\"{2}\" URI=\"{3}\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><Transforms><Transform Algorithm=\"{4}\" /><Transform Algorithm=\"{5}\" /></Transforms><DigestMethod Algorithm=\"{6}\" /><DigestValue>{7}</DigestValue></{0}Reference>";
         }
 
-        public static string ReferenceXml(string prefix, string id, string type, string referenceUri, string envelopingAlgorithm, string c14nAlgorithm, string digestAlgorithm, string digestValue)
+        public static string ReferenceXml(string prefix, string id, string type, string referenceUri, string envelopingAlgorithm, string c14nAlgorithm, string digestAlgorithm, string digestValue, string typeAttr = "type")
         {
-            return string.Format(ReferenceTemplate, prefix, id, type, referenceUri, envelopingAlgorithm, c14nAlgorithm, digestAlgorithm, digestValue);
+            return string.Format(ReferenceTemplate, prefix, id, type, referenceUri, envelopingAlgorithm, c14nAlgorithm, digestAlgorithm, digestValue, typeAttr);
         }
 
         // Always assumes two transforms

--- a/test/Microsoft.IdentityModel.TestUtils/XmlGenerator.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/XmlGenerator.cs
@@ -354,7 +354,7 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static string ReferenceTemplate
         {
-            get => "<{0}Reference Id=\"{1}\" type=\"{2}\" URI=\"{3}\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><Transforms><Transform Algorithm=\"{4}\" /><Transform Algorithm=\"{5}\" /></Transforms><DigestMethod Algorithm=\"{6}\" /><DigestValue>{7}</DigestValue></{0}Reference>";
+            get => "<{0}Reference Id=\"{1}\" Type=\"{2}\" URI=\"{3}\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><Transforms><Transform Algorithm=\"{4}\" /><Transform Algorithm=\"{5}\" /></Transforms><DigestMethod Algorithm=\"{6}\" /><DigestValue>{7}</DigestValue></{0}Reference>";
         }
 
         public static string ReferenceXml(string prefix, string id, string type, string referenceUri, string envelopingAlgorithm, string c14nAlgorithm, string digestAlgorithm, string digestValue)
@@ -377,7 +377,7 @@ namespace Microsoft.IdentityModel.TestUtils
 
         public static string RoleDescriptorTemplate
         {
-            get => "<RoleDescriptor xsi:type=\"{0}\" protocolSupportEnumeration=\"{1}\" xmlns:xsi=\"{2}\" xmlns:fed=\"{3}\">{4}{5}{6}{7}{8}{9}{10}</RoleDescriptor>";
+            get => "<RoleDescriptor xsi:Type=\"{0}\" protocolSupportEnumeration=\"{1}\" xmlns:xsi=\"{2}\" xmlns:fed=\"{3}\">{4}{5}{6}{7}{8}{9}{10}</RoleDescriptor>";
         }
 
         public static string SignatureTemplate

--- a/test/Microsoft.IdentityModel.Xml.Tests/DSigSerializerTests.cs
+++ b/test/Microsoft.IdentityModel.Xml.Tests/DSigSerializerTests.cs
@@ -9,7 +9,6 @@ using System.Text;
 using System.Xml;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.IdentityModel.Xml;
 using Xunit;
 
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
@@ -166,6 +165,27 @@ namespace Microsoft.IdentityModel.Xml.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
+        [Theory, MemberData(nameof(ReadSignatureTheoryDataTypeCapitalized), DisableDiscoveryEnumeration = true)]
+        public void ReadSignatureTypeCapitalized(DSigSerializerTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.ReadSignature", theoryData);
+            bool switchValue;
+            AppContext.TryGetSwitch("Switch.Microsoft.IdentityModel.UseCapitalizedXMLTypeAttr", out switchValue);
+            AppContext.SetSwitch("Switch.Microsoft.IdentityModel.UseCapitalizedXMLTypeAttr", true);
+            try
+            {
+                var signature = theoryData.Serializer.ReadSignature(XmlUtilities.CreateDictionaryReader(theoryData.Xml));
+                theoryData.ExpectedException.ProcessNoException(context);
+                IdentityComparer.AreEqual(signature, theoryData.Signature, context);
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex, context);
+            }
+            AppContext.SetSwitch("Switch.Microsoft.IdentityModel.UseCapitalizedXMLTypeAttr", switchValue);
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
         public static TheoryData<DSigSerializerTheoryData> ReadSignatureTheoryData
         {
             get
@@ -232,6 +252,79 @@ namespace Microsoft.IdentityModel.Xml.Tests
                     Xml = "<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\"></Signature>"
                 });
 
+                return theoryData;
+            }
+        }
+
+        public static TheoryData<DSigSerializerTheoryData> ReadSignatureTheoryDataTypeCapitalized
+        {
+            get
+            {
+                bool switchValue;
+                AppContext.TryGetSwitch("Switch.Microsoft.IdentityModel.UseCapitalizedXMLTypeAttr", out switchValue);
+                AppContext.SetSwitch("Switch.Microsoft.IdentityModel.UseCapitalizedXMLTypeAttr", true);
+                var signature = Default.Signature;
+                signature.SignedInfo.References[0] = Default.ReferenceWithNullTokenStream;
+
+                // uncomment to view exception displayed to user
+                // ExpectedException.DefaultVerbose = true;
+                var theoryData = new TheoryData<DSigSerializerTheoryData>
+                {
+                    new DSigSerializerTheoryData
+                    {
+                        First = true,
+                        Signature = signature,
+                        TestId = nameof(Default.Signature),
+                        Xml =  XmlGenerator.Generate(Default.Signature),
+                    }
+                };
+
+                signature = Default.SignatureReferenceWithId;
+                signature.SignedInfo.References[0] = Default.ReferenceWithNullTokenStreamAndId;
+                theoryData.Add(new DSigSerializerTheoryData
+                {
+                    Signature = signature,
+                    TestId = nameof(Default.SignatureReferenceWithId),
+                    Xml = XmlGenerator.Generate(Default.SignatureReferenceWithId),
+                });
+
+                signature = Default.Signature;
+                signature.SignedInfo.References[0] = Default.ReferenceWithNullTokenStream;
+                theoryData.Add(new DSigSerializerTheoryData
+                {
+                    Signature = signature,
+                    TestId = nameof(Default.Signature) + "ReferenceWithoutPrefix",
+                    Xml = XmlGenerator.Generate(Default.SignatureReferenceWithoutPrefix),
+                });
+
+                signature = Default.Signature;
+                signature.SignedInfo.References[0] = Default.ReferenceWithNullTokenStream;
+                signature.SignedInfo.References[0].DigestMethod = $"_{SecurityAlgorithms.Sha256Digest}";
+                theoryData.Add(new DSigSerializerTheoryData
+                {
+                    Signature = signature,
+                    TestId = "UnknownDigestAlgorithm",
+                    Xml = XmlGenerator.Generate(Default.Signature).Replace(SecurityAlgorithms.Sha256Digest, $"_{SecurityAlgorithms.Sha256Digest}")
+                });
+
+                signature = Default.Signature;
+                signature.SignedInfo.References[0] = Default.ReferenceWithNullTokenStream;
+                signature.SignedInfo.SignatureMethod = $"_{SecurityAlgorithms.RsaSha256Signature}";
+                theoryData.Add(new DSigSerializerTheoryData
+                {
+                    Signature = signature,
+                    TestId = "UnknownSignatureAlgorithm",
+                    Xml = XmlGenerator.Generate(Default.Signature).Replace(SecurityAlgorithms.RsaSha256Signature, $"_{SecurityAlgorithms.RsaSha256Signature}")
+                });
+
+                theoryData.Add(new DSigSerializerTheoryData
+                {
+                    ExpectedException = new ExpectedException(typeof(XmlReadException), "IDX30022:"),
+                    Signature = new Signature(),
+                    TestId = "EmptySignature",
+                    Xml = "<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\"></Signature>"
+                });
+                AppContext.SetSwitch("Switch.Microsoft.IdentityModel.UseCapitalizedXMLTypeAttr", switchValue);
                 return theoryData;
             }
         }


### PR DESCRIPTION
# Provide option to use capitalized type ("Type") for xml type attribute
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description
In this PR I have introduced an AppContextSwitch so that customers can use Type or type as per their requirements in their SAML signatures and XMLs. 
Default value is type as per the specs here: https://docs.oasis-open.org/dita/dita/v1.3/cos02/part2-tech-content/langRef/attributes/thetypeattribute.html 
One more unit test has been added with theorydata having type attribute as Type to test the extended behavior
Fixes #3206 
