### PR TITLE
Add LegacyBaseUrlEncoder

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Base64UrlEncoder.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Base64UrlEncoder.cs
@@ -196,6 +196,13 @@ namespace Microsoft.IdentityModel.Tokens
 #endif
 
 #if NET9_0_OR_GREATER
+        /// <summary>
+        /// Decodes a base64url encoded string into bytes for .NET 9 or greater platforms.
+        /// </summary>
+        /// <param name="strSpan">The base64url encoded string to decode.</param>
+        /// <param name="output">The span to write the decoded bytes to.</param>
+        /// <param name="decodedLength">The expected length of the decoded string after padding.</param>
+        /// <returns>The number of bytes written to the output span.</returns>
         [SkipLocalsInit]
         private static int Decode(ReadOnlySpan<char> strSpan, Span<byte> output, int decodedLength)
         {
@@ -254,6 +261,14 @@ namespace Microsoft.IdentityModel.Tokens
             }
         }
 
+        /// <summary>
+        /// Adds padding characters to a base64url encoded string to prepare it for standard base64 decoding.
+        /// This method copies the source data to the destination span and appends the appropriate number
+        /// of padding ('=') characters to ensure the string length is a multiple of 4.
+        /// </summary>
+        /// <param name="source">The original base64url encoded string without padding.</param>
+        /// <param name="charsSpan">The destination span where the padded string will be stored.</param>
+        /// <returns>A read-only span containing the padded string ready for standard base64 decoding.</returns>
         private static ReadOnlySpan<char> HandlePadding(ReadOnlySpan<char> source, Span<char> charsSpan)
         {
             source.CopyTo(charsSpan);

--- a/src/Microsoft.IdentityModel.Tokens/Base64UrlEncoder.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Base64UrlEncoder.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Buffers;
 #if NET9_0_OR_GREATER
+using System.Buffers;
 using System.Buffers.Text;
 #endif
 using System.Text;
@@ -20,11 +20,9 @@ namespace Microsoft.IdentityModel.Tokens
     /// </summary>
     public static class Base64UrlEncoder
     {
+#if NET9_0_OR_GREATER
         private const char Base64PadCharacter = '=';
-        private const char Base64Character62 = '+';
-        private const char Base64Character63 = '/';
-        private const char Base64UrlCharacter62 = '-';
-        private const char Base64UrlCharacter63 = '_';
+#endif
 
         /// <summary>
         /// Performs base64url encoding, which differs from regular base64 encoding as follows:
@@ -112,15 +110,6 @@ namespace Microsoft.IdentityModel.Tokens
 #endif
         }
 
-#if NET9_0_OR_GREATER
-        /// <summary>
-        /// Populates a <see cref="Span{T}"/> with the base64url encoded representation of a <see cref="ReadOnlySpan{T}"/> of bytes.
-        /// </summary>
-        /// <param name="inArray">A read-only span of bytes to encode.</param>
-        /// <param name="output">The span of characters to write the encoded output.</param>
-        /// <returns>The number of characters written to the output span.</returns>
-        public static int Encode(ReadOnlySpan<byte> inArray, Span<char> output) => Base64Url.EncodeToChars(inArray, output);
-#else
         /// <summary>
         /// Populates a <see cref="Span{T}"/> with the base64url encoded representation of a <see cref="ReadOnlySpan{T}"/> of bytes.
         /// </summary>
@@ -129,59 +118,13 @@ namespace Microsoft.IdentityModel.Tokens
         /// <returns>The number of characters written to the output span.</returns>
         public static int Encode(ReadOnlySpan<byte> inArray, Span<char> output)
         {
-            int lengthmod3 = inArray.Length % 3;
-            int limit = (inArray.Length - lengthmod3);
-            ReadOnlySpan<byte> table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"u8;
-
-            int i, j = 0;
-
-            // takes 3 bytes from inArray and insert 4 bytes into output
-            for (i = 0; i < limit; i += 3)
-            {
-                byte d0 = inArray[i];
-                byte d1 = inArray[i + 1];
-                byte d2 = inArray[i + 2];
-
-                output[j + 0] = (char)table[d0 >> 2];
-                output[j + 1] = (char)table[((d0 & 0x03) << 4) | (d1 >> 4)];
-                output[j + 2] = (char)table[((d1 & 0x0f) << 2) | (d2 >> 6)];
-                output[j + 3] = (char)table[d2 & 0x3f];
-                j += 4;
-            }
-
-            //Where we left off before
-            i = limit;
-
-            switch (lengthmod3)
-            {
-                case 2:
-                    {
-                        byte d0 = inArray[i];
-                        byte d1 = inArray[i + 1];
-
-                        output[j + 0] = (char)table[d0 >> 2];
-                        output[j + 1] = (char)table[((d0 & 0x03) << 4) | (d1 >> 4)];
-                        output[j + 2] = (char)table[(d1 & 0x0f) << 2];
-                        j += 3;
-                    }
-                    break;
-                case 1:
-                    {
-                        byte d0 = inArray[i];
-
-                        output[j + 0] = (char)table[d0 >> 2];
-                        output[j + 1] = (char)table[(d0 & 0x03) << 4];
-                        j += 2;
-                    }
-                    break;
-
-                    //default or case 0: no further operations are needed.
-            }
-
-            return j;
+#if NET9_0_OR_GREATER
+            return Base64Url.EncodeToChars(inArray, output);
+#else
+            return LegacyBase64UrlEncoder.Encode(inArray, output);
+#endif
         }
 
-#endif
         /// <summary>
         /// Converts the specified base64url encoded string to UTF-8 bytes.
         /// </summary>
@@ -197,9 +140,9 @@ namespace Microsoft.IdentityModel.Tokens
         [SkipLocalsInit]
 #endif
 
-#if NET9_0_OR_GREATER
         internal static byte[] Decode(ReadOnlySpan<char> strSpan)
         {
+#if NET9_0_OR_GREATER
             int upperBound = Base64Url.GetMaxDecodedLength(strSpan.Length);
             byte[] rented = null;
 
@@ -218,25 +161,10 @@ namespace Microsoft.IdentityModel.Tokens
                 if (rented is not null)
                     ArrayPool<byte>.Shared.Return(rented, true);
             }
-        }
 #else
-        internal static byte[] Decode(ReadOnlySpan<char> strSpan)
-        {
-            int mod = strSpan.Length % 4;
-            if (mod == 1)
-                throw LogHelper.LogExceptionMessage(new FormatException(LogHelper.FormatInvariant(LogMessages.IDX10400, strSpan.ToString())));
-
-            bool needReplace = strSpan.IndexOfAny(Base64UrlCharacter62, Base64UrlCharacter63) >= 0;
-            int decodedLength = strSpan.Length + (4 - mod) % 4;
-#if NET6_0_OR_GREATER
-            Span<byte> output = new byte[decodedLength];
-            int length = Decode(strSpan, output, needReplace, decodedLength);
-            return output.Slice(0, length).ToArray();
-#else
-            return UnsafeDecode(strSpan, needReplace, decodedLength);
+            return LegacyBase64UrlEncoder.Decode(strSpan);
 #endif
         }
-#endif
 
 #if NETCOREAPP
         [SkipLocalsInit]
@@ -262,16 +190,7 @@ namespace Microsoft.IdentityModel.Tokens
 #else
         internal static void Decode(ReadOnlySpan<char> strSpan, Span<byte> output)
         {
-            int mod = strSpan.Length % 4;
-            if (mod == 1)
-                throw LogHelper.LogExceptionMessage(new FormatException(LogHelper.FormatInvariant(LogMessages.IDX10400, strSpan.ToString())));
-            bool needReplace = strSpan.IndexOfAny(Base64UrlCharacter62, Base64UrlCharacter63) >= 0;
-            int decodedLength = strSpan.Length + (4 - mod) % 4;
-#if NET6_0_OR_GREATER
-            Decode(strSpan, output, needReplace, decodedLength);
-#else
-            Decode(strSpan, output, needReplace, decodedLength);
-#endif
+            LegacyBase64UrlEncoder.Decode(strSpan, output);
         }
 
 #endif
@@ -350,143 +269,14 @@ namespace Microsoft.IdentityModel.Tokens
             return charsSpan;
         }
 #elif NET6_0_OR_GREATER
-        [SkipLocalsInit]
         private static int Decode(ReadOnlySpan<char> strSpan, Span<byte> output, bool needReplace, int decodedLength)
         {
-            // If the incoming chars don't contain any of the base64url characters that need to be replaced,
-            // and if the incoming chars are of the exact right length, then we'll be able to just pass the
-            // incoming chars directly to DecodeFromUtf8InPlace. Otherwise, rent an array, copy all the
-            // data into it, and do whatever fixups are necessary on that copy, then pass that copy into
-            // DecodeFromUtf8InPlace.
-
-            const int StackAllocThreshold = 512;
-            char[] arrayPoolChars = null;
-            scoped Span<char> charsSpan = default;
-            scoped ReadOnlySpan<char> source = strSpan;
-
-            if (needReplace || decodedLength != source.Length)
-            {
-                charsSpan = decodedLength <= StackAllocThreshold ?
-                    stackalloc char[StackAllocThreshold] :
-                    arrayPoolChars = ArrayPool<char>.Shared.Rent(decodedLength);
-                charsSpan = charsSpan.Slice(0, decodedLength);
-
-                source = HandlePaddingAndReplace(source, charsSpan, needReplace);
-            }
-
-            byte[] arrayPoolBytes = null;
-            Span<byte> bytesSpan = decodedLength <= StackAllocThreshold ?
-                stackalloc byte[StackAllocThreshold] :
-                arrayPoolBytes = ArrayPool<byte>.Shared.Rent(decodedLength);
-
-            int length = Encoding.UTF8.GetBytes(source, bytesSpan);
-            Span<byte> utf8Span = bytesSpan.Slice(0, length);
-            try
-            {
-                OperationStatus status = System.Buffers.Text.Base64.DecodeFromUtf8InPlace(utf8Span, out int bytesWritten);
-                if (status != OperationStatus.Done)
-                    throw LogHelper.LogExceptionMessage(new FormatException(LogHelper.FormatInvariant(LogMessages.IDX10400, strSpan.ToString())));
-
-                utf8Span.Slice(0, bytesWritten).CopyTo(output);
-
-                return bytesWritten;
-            }
-            finally
-            {
-                if (arrayPoolBytes is not null)
-                {
-                    bytesSpan.Clear();
-                    ArrayPool<byte>.Shared.Return(arrayPoolBytes);
-                }
-
-                if (arrayPoolChars is not null)
-                {
-                    charsSpan.Clear();
-                    ArrayPool<char>.Shared.Return(arrayPoolChars);
-                }
-            }
+            return LegacyBase64UrlEncoder.Decode(strSpan, output, needReplace, decodedLength);
         }
-
-        private static ReadOnlySpan<char> HandlePaddingAndReplace(ReadOnlySpan<char> source, Span<char> charsSpan, bool needReplace)
-        {
-            source.CopyTo(charsSpan);
-            if (source.Length < charsSpan.Length)
-            {
-                charsSpan[source.Length] = Base64PadCharacter;
-                if (source.Length + 1 < charsSpan.Length)
-                {
-                    charsSpan[source.Length + 1] = Base64PadCharacter;
-                }
-            }
-
-            if (needReplace)
-            {
-                Span<char> remaining = charsSpan;
-                int pos;
-                while ((pos = remaining.IndexOfAny(Base64UrlCharacter62, Base64UrlCharacter63)) >= 0)
-                {
-                    remaining[pos] = (remaining[pos] == Base64UrlCharacter62) ? Base64Character62 : Base64Character63;
-                    remaining = remaining.Slice(pos + 1);
-                }
-            }
-
-            return charsSpan;
-        }
-
 #else
         private static unsafe byte[] UnsafeDecode(ReadOnlySpan<char> strSpan, bool needReplace, int decodedLength)
         {
-            if (needReplace)
-            {
-                string decodedString = new(char.MinValue, decodedLength);
-                fixed (char* dest = decodedString)
-                {
-                    int i = 0;
-                    for (; i < strSpan.Length; i++)
-                    {
-                        if (strSpan[i] == Base64UrlCharacter62)
-                            dest[i] = Base64Character62;
-                        else if (strSpan[i] == Base64UrlCharacter63)
-                            dest[i] = Base64Character63;
-                        else
-                            dest[i] = strSpan[i];
-                    }
-
-                    for (; i < decodedLength; i++)
-                        dest[i] = Base64PadCharacter;
-                }
-
-                return Convert.FromBase64String(decodedString);
-            }
-            else
-            {
-                if (decodedLength == strSpan.Length)
-                {
-                    return Convert.FromBase64CharArray(strSpan.ToArray(), 0, strSpan.Length);
-                }
-                else
-                {
-                    string decodedString = new(char.MinValue, decodedLength);
-                    fixed (char* src = strSpan)
-                    fixed (char* dest = decodedString)
-                    {
-                        Buffer.MemoryCopy(src, dest, strSpan.Length * 2, strSpan.Length * 2);
-
-                        dest[strSpan.Length] = Base64PadCharacter;
-                        if (strSpan.Length + 2 == decodedLength)
-                            dest[strSpan.Length + 1] = Base64PadCharacter;
-                    }
-
-                    return Convert.FromBase64String(decodedString);
-                }
-            }
-        }
-
-        private static void Decode(ReadOnlySpan<char> strSpan, Span<byte> output, bool needReplace, int decodedLength)
-        {
-            byte[] result = UnsafeDecode(strSpan, needReplace, decodedLength);
-            result.CopyTo(output);
-
+            return LegacyBase64UrlEncoder.UnsafeDecode(strSpan, needReplace, decodedLength);
         }
 #endif
 

--- a/src/Microsoft.IdentityModel.Tokens/LegacyBaseUrlEncoder.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LegacyBaseUrlEncoder.cs
@@ -1,0 +1,258 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Buffers;
+using System.Text;
+using Microsoft.IdentityModel.Logging;
+
+#if NETCOREAPP
+using System.Runtime.CompilerServices;
+#endif
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Encodes and Decodes strings as base64url encoding.
+    /// </summary>
+    public static class LegacyBase64UrlEncoder
+    {
+        private const char Base64PadCharacter = '=';
+        private const char Base64Character62 = '+';
+        private const char Base64Character63 = '/';
+        private const char Base64UrlCharacter62 = '-';
+        private const char Base64UrlCharacter63 = '_';
+
+
+        /// <summary>
+        /// Populates a <see cref="Span{T}"/> with the base64url encoded representation of a <see cref="ReadOnlySpan{T}"/> of bytes.
+        /// </summary>
+        /// <param name="inArray">A read-only span of bytes to encode.</param>
+        /// <param name="output">The span of characters to write the encoded output.</param>
+        /// <returns>The number of characters written to the output span.</returns>
+        public static int Encode(ReadOnlySpan<byte> inArray, Span<char> output)
+        {
+            int lengthmod3 = inArray.Length % 3;
+            int limit = (inArray.Length - lengthmod3);
+            ReadOnlySpan<byte> table = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"u8;
+
+            int i, j = 0;
+
+            // takes 3 bytes from inArray and insert 4 bytes into output
+            for (i = 0; i < limit; i += 3)
+            {
+                byte d0 = inArray[i];
+                byte d1 = inArray[i + 1];
+                byte d2 = inArray[i + 2];
+
+                output[j + 0] = (char)table[d0 >> 2];
+                output[j + 1] = (char)table[((d0 & 0x03) << 4) | (d1 >> 4)];
+                output[j + 2] = (char)table[((d1 & 0x0f) << 2) | (d2 >> 6)];
+                output[j + 3] = (char)table[d2 & 0x3f];
+                j += 4;
+            }
+
+            //Where we left off before
+            i = limit;
+
+            switch (lengthmod3)
+            {
+                case 2:
+                    {
+                        byte d0 = inArray[i];
+                        byte d1 = inArray[i + 1];
+
+                        output[j + 0] = (char)table[d0 >> 2];
+                        output[j + 1] = (char)table[((d0 & 0x03) << 4) | (d1 >> 4)];
+                        output[j + 2] = (char)table[(d1 & 0x0f) << 2];
+                        j += 3;
+                    }
+                    break;
+                case 1:
+                    {
+                        byte d0 = inArray[i];
+
+                        output[j + 0] = (char)table[d0 >> 2];
+                        output[j + 1] = (char)table[(d0 & 0x03) << 4];
+                        j += 2;
+                    }
+                    break;
+
+                    //default or case 0: no further operations are needed.
+            }
+
+            return j;
+        }
+
+        //for net6 or greater
+        internal static byte[] Decode(ReadOnlySpan<char> strSpan)
+        {
+            int mod = strSpan.Length % 4;
+            if (mod == 1)
+                throw LogHelper.LogExceptionMessage(new FormatException(LogHelper.FormatInvariant(LogMessages.IDX10400, strSpan.ToString())));
+
+            bool needReplace = strSpan.IndexOfAny(Base64UrlCharacter62, Base64UrlCharacter63) >= 0;
+            int decodedLength = strSpan.Length + (4 - mod) % 4;
+#if NET6_0_OR_GREATER
+            Span<byte> output = new byte[decodedLength];
+            int length = Decode(strSpan, output, needReplace, decodedLength);
+            return output.Slice(0, length).ToArray();
+#else
+            return UnsafeDecode(strSpan, needReplace, decodedLength);
+#endif
+        }
+
+        internal static void Decode(ReadOnlySpan<char> strSpan, Span<byte> output)
+        {
+            int mod = strSpan.Length % 4;
+            if (mod == 1)
+                throw LogHelper.LogExceptionMessage(new FormatException(LogHelper.FormatInvariant(LogMessages.IDX10400, strSpan.ToString())));
+            bool needReplace = strSpan.IndexOfAny(Base64UrlCharacter62, Base64UrlCharacter63) >= 0;
+            int decodedLength = strSpan.Length + (4 - mod) % 4;
+#if NET6_0_OR_GREATER
+            Decode(strSpan, output, needReplace, decodedLength);
+#else
+            Decode(strSpan, output, needReplace, decodedLength);
+#endif
+        }
+
+#if NET6_0_OR_GREATER
+        internal static int Decode(ReadOnlySpan<char> strSpan, Span<byte> output, bool needReplace, int decodedLength)
+        {
+            // If the incoming chars don't contain any of the base64url characters that need to be replaced,
+            // and if the incoming chars are of the exact right length, then we'll be able to just pass the
+            // incoming chars directly to DecodeFromUtf8InPlace. Otherwise, rent an array, copy all the
+            // data into it, and do whatever fixups are necessary on that copy, then pass that copy into
+            // DecodeFromUtf8InPlace.
+
+            const int StackAllocThreshold = 512;
+            char[] arrayPoolChars = null;
+            scoped Span<char> charsSpan = default;
+            scoped ReadOnlySpan<char> source = strSpan;
+
+            if (needReplace || decodedLength != source.Length)
+            {
+                charsSpan = decodedLength <= StackAllocThreshold ?
+                    stackalloc char[StackAllocThreshold] :
+                    arrayPoolChars = ArrayPool<char>.Shared.Rent(decodedLength);
+                charsSpan = charsSpan.Slice(0, decodedLength);
+
+                source = HandlePaddingAndReplace(source, charsSpan, needReplace);
+            }
+
+            byte[] arrayPoolBytes = null;
+            Span<byte> bytesSpan = decodedLength <= StackAllocThreshold ?
+                stackalloc byte[StackAllocThreshold] :
+                arrayPoolBytes = ArrayPool<byte>.Shared.Rent(decodedLength);
+
+            int length = Encoding.UTF8.GetBytes(source, bytesSpan);
+            Span<byte> utf8Span = bytesSpan.Slice(0, length);
+            try
+            {
+                OperationStatus status = System.Buffers.Text.Base64.DecodeFromUtf8InPlace(utf8Span, out int bytesWritten);
+                if (status != OperationStatus.Done)
+                    throw LogHelper.LogExceptionMessage(new FormatException(LogHelper.FormatInvariant(LogMessages.IDX10400, strSpan.ToString())));
+
+                utf8Span.Slice(0, bytesWritten).CopyTo(output);
+
+                return bytesWritten;
+            }
+            finally
+            {
+                if (arrayPoolBytes is not null)
+                {
+                    bytesSpan.Clear();
+                    ArrayPool<byte>.Shared.Return(arrayPoolBytes);
+                }
+
+                if (arrayPoolChars is not null)
+                {
+                    charsSpan.Clear();
+                    ArrayPool<char>.Shared.Return(arrayPoolChars);
+                }
+            }
+        }
+#else
+        private static void Decode(ReadOnlySpan<char> strSpan, Span<byte> output, bool needReplace, int decodedLength)
+        {
+            byte[] result = UnsafeDecode(strSpan, needReplace, decodedLength);
+            result.CopyTo(output);
+
+        }
+#endif
+
+        private static ReadOnlySpan<char> HandlePaddingAndReplace(ReadOnlySpan<char> source, Span<char> charsSpan, bool needReplace)
+        {
+            source.CopyTo(charsSpan);
+            if (source.Length < charsSpan.Length)
+            {
+                charsSpan[source.Length] = Base64PadCharacter;
+                if (source.Length + 1 < charsSpan.Length)
+                {
+                    charsSpan[source.Length + 1] = Base64PadCharacter;
+                }
+            }
+
+            if (needReplace)
+            {
+                Span<char> remaining = charsSpan;
+                int pos;
+                while ((pos = remaining.IndexOfAny(Base64UrlCharacter62, Base64UrlCharacter63)) >= 0)
+                {
+                    remaining[pos] = (remaining[pos] == Base64UrlCharacter62) ? Base64Character62 : Base64Character63;
+                    remaining = remaining.Slice(pos + 1);
+                }
+            }
+
+            return charsSpan;
+        }
+
+        internal static unsafe byte[] UnsafeDecode(ReadOnlySpan<char> strSpan, bool needReplace, int decodedLength)
+        {
+            if (needReplace)
+            {
+                string decodedString = new(char.MinValue, decodedLength);
+                fixed (char* dest = decodedString)
+                {
+                    int i = 0;
+                    for (; i < strSpan.Length; i++)
+                    {
+                        if (strSpan[i] == Base64UrlCharacter62)
+                            dest[i] = Base64Character62;
+                        else if (strSpan[i] == Base64UrlCharacter63)
+                            dest[i] = Base64Character63;
+                        else
+                            dest[i] = strSpan[i];
+                    }
+
+                    for (; i < decodedLength; i++)
+                        dest[i] = Base64PadCharacter;
+                }
+
+                return Convert.FromBase64String(decodedString);
+            }
+            else
+            {
+                if (decodedLength == strSpan.Length)
+                {
+                    return Convert.FromBase64CharArray(strSpan.ToArray(), 0, strSpan.Length);
+                }
+                else
+                {
+                    string decodedString = new(char.MinValue, decodedLength);
+                    fixed (char* src = strSpan)
+                    fixed (char* dest = decodedString)
+                    {
+                        Buffer.MemoryCopy(src, dest, strSpan.Length * 2, strSpan.Length * 2);
+
+                        dest[strSpan.Length] = Base64PadCharacter;
+                        if (strSpan.Length + 2 == decodedLength)
+                            dest[strSpan.Length + 1] = Base64PadCharacter;
+                    }
+
+                    return Convert.FromBase64String(decodedString);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/LegacyBaseUrlEncoder.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LegacyBaseUrlEncoder.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Buffers;
+#if NET6_0_OR_GREATER
 using System.Text;
-using Microsoft.IdentityModel.Logging;
-
-#if NETCOREAPP
-using System.Runtime.CompilerServices;
 #endif
+using Microsoft.IdentityModel.Logging;
 
 namespace Microsoft.IdentityModel.Tokens
 {

--- a/src/Microsoft.IdentityModel.Tokens/LegacyBaseUrlEncoder.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LegacyBaseUrlEncoder.cs
@@ -125,6 +125,14 @@ namespace Microsoft.IdentityModel.Tokens
         }
 
 #if NET6_0_OR_GREATER
+        /// <summary>
+        /// Decodes a base64url encoded string into bytes, handling padding and character replacement.
+        /// </summary>
+        /// <param name="strSpan">The base64url encoded string to decode.</param>
+        /// <param name="output">The span to write the decoded bytes to.</param>
+        /// <param name="needReplace">Indicates whether the input contains base64url-specific characters that need replacement.</param>
+        /// <param name="decodedLength">The expected length of the decoded string after padding.</param>
+        /// <returns>The number of bytes written to the output span.</returns>
         internal static int Decode(ReadOnlySpan<char> strSpan, Span<byte> output, bool needReplace, int decodedLength)
         {
             // If the incoming chars don't contain any of the base64url characters that need to be replaced,
@@ -181,6 +189,14 @@ namespace Microsoft.IdentityModel.Tokens
             }
         }
 #else
+        /// <summary>
+        /// Wrapper method for unsafeDecode.
+        /// </summary>
+        /// <param name="strSpan">The base64url encoded string to decode.</param>
+        /// <param name="output">The span to write the decoded bytes to.</param>
+        /// <param name="needReplace">Indicates whether the input contains base64url-specific characters that need replacement.</param>
+        /// <param name="decodedLength">The expected length of the decoded string after padding.</param>
+        /// <returns>The number of bytes written to the output span.</returns>
         private static void Decode(ReadOnlySpan<char> strSpan, Span<byte> output, bool needReplace, int decodedLength)
         {
             byte[] result = UnsafeDecode(strSpan, needReplace, decodedLength);
@@ -189,6 +205,15 @@ namespace Microsoft.IdentityModel.Tokens
         }
 #endif
 
+        /// <summary>
+        /// Prepares a base64url encoded string for standard base64 decoding by adding any missing padding
+        /// characters and replacing base64url-specific characters ('-' and '_') with standard base64 
+        /// characters ('+' and '/').
+        /// </summary>
+        /// <param name="source">The original base64url encoded string.</param>
+        /// <param name="charsSpan">The destination span where the prepared string will be stored.</param>
+        /// <param name="needReplace">Indicates whether the input contains base64url-specific characters that need replacement.</param>
+        /// <returns>A read-only span containing the prepared string ready for standard base64 decoding.</returns>
         private static ReadOnlySpan<char> HandlePaddingAndReplace(ReadOnlySpan<char> source, Span<char> charsSpan, bool needReplace)
         {
             source.CopyTo(charsSpan);
@@ -215,6 +240,14 @@ namespace Microsoft.IdentityModel.Tokens
             return charsSpan;
         }
 
+
+        /// <summary>
+        /// Decodes a base64url encoded string into a byte array using unsafe code for pre-.NET 6 platforms.
+        /// </summary>
+        /// <param name="strSpan">The base64url encoded string to decode.</param>
+        /// <param name="needReplace">Indicates whether the input contains base64url-specific characters that need replacement.</param>
+        /// <param name="decodedLength">The expected length of the string after padding is applied.</param>
+        /// <returns>The decoded byte array.</returns>
         internal static unsafe byte[] UnsafeDecode(ReadOnlySpan<char> strSpan, bool needReplace, int decodedLength)
         {
             if (needReplace)

--- a/src/Microsoft.IdentityModel.Tokens/LegacyBaseUrlEncoder.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LegacyBaseUrlEncoder.cs
@@ -82,7 +82,11 @@ namespace Microsoft.IdentityModel.Tokens
             return j;
         }
 
-        //for net6 or greater
+        /// <summary>
+        /// Decodes a base64url encoded string into a byte array.
+        /// </summary>
+        /// <param name="strSpan">The base64url encoded string.</param>
+        /// <returns>The UTF-8 byte array.</returns>
         internal static byte[] Decode(ReadOnlySpan<char> strSpan)
         {
             int mod = strSpan.Length % 4;
@@ -100,6 +104,12 @@ namespace Microsoft.IdentityModel.Tokens
 #endif
         }
 
+        /// <summary>
+        /// Entry point for base64url decoding.
+        /// </summary>
+        /// <param name="strSpan">The base64url encoded string.</param>
+        /// <param name="output">The preallocated buffer for the decoded bytes</param>
+        /// <returns>The UTF-8 byte array.</returns>
         internal static void Decode(ReadOnlySpan<char> strSpan, Span<byte> output)
         {
             int mod = strSpan.Length % 4;

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net462/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net462/InternalAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan) -> byte[]
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan, System.Span<byte> output) -> void
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan, System.Span<byte> output, bool needReplace, int decodedLength) -> int
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.UnsafeDecode(System.ReadOnlySpan<char> strSpan, bool needReplace, int decodedLength) -> byte[]

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Encode(System.ReadOnlySpan<byte> inArray, System.Span<char> output) -> int

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net472/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net472/InternalAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan) -> byte[]
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan, System.Span<byte> output) -> void
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan, System.Span<byte> output, bool needReplace, int decodedLength) -> int
+static unsafe Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.UnsafeDecode(System.ReadOnlySpan<char> strSpan, bool needReplace, int decodedLength) -> byte[]

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Encode(System.ReadOnlySpan<byte> inArray, System.Span<char> output) -> int

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net6.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net6.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan) -> byte[]
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan, System.Span<byte> output) -> void
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan, System.Span<byte> output, bool needReplace, int decodedLength) -> int
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.UnsafeDecode(System.ReadOnlySpan<char> strSpan, bool needReplace, int decodedLength) -> byte[]

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Encode(System.ReadOnlySpan<byte> inArray, System.Span<char> output) -> int

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net8.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net8.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan) -> byte[]
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan, System.Span<byte> output) -> void
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan, System.Span<byte> output, bool needReplace, int decodedLength) -> int
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.UnsafeDecode(System.ReadOnlySpan<char> strSpan, bool needReplace, int decodedLength) -> byte[]

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Encode(System.ReadOnlySpan<byte> inArray, System.Span<char> output) -> int

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net9.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net9.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan) -> byte[]
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan, System.Span<byte> output) -> void
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan, System.Span<byte> output, bool needReplace, int decodedLength) -> int
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.UnsafeDecode(System.ReadOnlySpan<char> strSpan, bool needReplace, int decodedLength) -> byte[]

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Encode(System.ReadOnlySpan<byte> inArray, System.Span<char> output) -> int

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/netstandard2.0/InternalAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan) -> byte[]
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan, System.Span<byte> output) -> void
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Decode(System.ReadOnlySpan<char> strSpan, System.Span<byte> output, bool needReplace, int decodedLength) -> int
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.UnsafeDecode(System.ReadOnlySpan<char> strSpan, bool needReplace, int decodedLength) -> byte[]

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder
+static Microsoft.IdentityModel.Tokens.LegacyBase64UrlEncoder.Encode(System.ReadOnlySpan<byte> inArray, System.Span<char> output) -> int


### PR DESCRIPTION
# Add LegacyBaseUrlEncoder
<!-- Thank you for submitting a pull request to our repo. -->



<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [X] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [X] You've included unit or integration tests for your change, where applicable.
- [X] You've included inline docs for your change, where applicable.
- [X] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [X] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

This PR is a follow up to: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3220
It was created in response to this comment: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3220#issuecomment-2877837625

This PR does two things:
1. refactors the BaseUrlEncoder into two files: BaseUrlEncoder for .NET 9 implementation and LegacyBaseUrlEncoder for lower TFMs
2. updates Public API files

Fixes #3240  (in this specific format)
