### PR TITLE
Remove experimental code from TokenValidationResult

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
@@ -598,7 +598,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             }
 
             string tokenType = Validators.ValidateTokenType(jsonWebToken.Typ, jsonWebToken, validationParameters);
-            return new TokenValidationResult(jsonWebToken, this, validationParameters.Clone(), issuer, null)
+            return new TokenValidationResult(jsonWebToken, this, validationParameters.Clone(), issuer)
             {
                 IsValid = true,
                 TokenType = tokenType

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.DecryptTokenResult.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.DecryptTokenResult.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Text;
+using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.IdentityModel.Tokens.Experimental;
+using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
 
 namespace Microsoft.IdentityModel.JsonWebTokens
 {
@@ -127,5 +129,44 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     ex);
             }
         }
+
+        private static ValidationError GetDecryptionError(
+            JwtTokenDecryptionParameters decryptionParameters,
+            bool algorithmNotSupportedByCryptoProvider,
+            StringBuilder exceptionStrings,
+            StringBuilder keysAttempted,
+#pragma warning disable CA1801 // Review unused parameters
+            CallContext callContext)
+#pragma warning restore CA1801 // Review unused parameters
+        {
+            if (keysAttempted is not null)
+                return new ValidationError(
+                    new MessageDetail(
+                        TokenLogMessages.IDX10603,
+                        LogHelper.MarkAsNonPII(keysAttempted.ToString()),
+                        exceptionStrings?.ToString() ?? string.Empty,
+                        LogHelper.MarkAsSecurityArtifact(decryptionParameters.EncodedToken, SafeLogJwtToken)),
+                    ValidationFailureType.TokenDecryptionFailed,
+                    typeof(SecurityTokenDecryptionFailedException),
+                    ValidationError.GetCurrentStackFrame());
+            else if (algorithmNotSupportedByCryptoProvider)
+                return new ValidationError(
+                    new MessageDetail(
+                        TokenLogMessages.IDX10619,
+                        LogHelper.MarkAsNonPII(decryptionParameters.Alg),
+                        LogHelper.MarkAsNonPII(decryptionParameters.Enc)),
+                    ValidationFailureType.TokenDecryptionFailed,
+                    typeof(SecurityTokenDecryptionFailedException),
+                    ValidationError.GetCurrentStackFrame());
+            else
+                return new ValidationError(
+                    new MessageDetail(
+                        TokenLogMessages.IDX10609,
+                        LogHelper.MarkAsSecurityArtifact(decryptionParameters.EncodedToken, SafeLogJwtToken)),
+                    ValidationFailureType.TokenDecryptionFailed,
+                    typeof(SecurityTokenDecryptionFailedException),
+                    ValidationError.GetCurrentStackFrame());
+        }
+
     }
 }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -12,7 +12,6 @@ using System.Text.RegularExpressions;
 using Microsoft.IdentityModel.Abstractions;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.IdentityModel.Tokens.Experimental;
 using Microsoft.IdentityModel.Tokens.Json;
 
 using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
@@ -284,7 +283,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     if (!cryptoProviderFactory.IsSupportedAlgorithm(decryptionParameters.Enc, key))
                     {
                         if (LogHelper.IsEnabled(EventLogLevel.Warning))
-                            LogHelper.LogWarning(TokenLogMessages.IDX10611, LogHelper.MarkAsNonPII(decryptionParameters.Enc), LogHelper.MarkAsNonPII(key.KeyId));
+                            LogHelper.LogWarning(
+                                TokenLogMessages.IDX10611,
+                                LogHelper.MarkAsNonPII(decryptionParameters.Enc),
+                                LogHelper.MarkAsNonPII(key.KeyId));
 
                         algorithmNotSupportedByCryptoProvider = true;
                         continue;
@@ -313,17 +315,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                     (keysAttempted ??= new StringBuilder()).AppendLine(key.KeyId);
             }
 
-            if (!decryptionSucceeded)
-            {
-                ValidationError validationError = GetDecryptionError(
-                    decryptionParameters,
-                    algorithmNotSupportedByCryptoProvider,
-                    exceptionStrings,
-                    keysAttempted,
-                    null);
-
-                throw LogHelper.LogExceptionMessage(validationError.GetException());
-            }
+            ValidateDecryption(decryptionParameters, decryptionSucceeded, algorithmNotSupportedByCryptoProvider, exceptionStrings, keysAttempted);
 
             try
             {
@@ -334,46 +326,38 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             }
             catch (Exception ex)
             {
-                throw LogHelper.LogExceptionMessage(new SecurityTokenDecompressionFailedException(GetIDX10679LogMessage(zipAlgorithm), ex));
+                throw LogHelper.LogExceptionMessage(
+                    new SecurityTokenDecompressionFailedException(
+                        GetIDX10679LogMessage(zipAlgorithm),
+                        ex));
             }
         }
 
-        private static ValidationError GetDecryptionError(
-            JwtTokenDecryptionParameters decryptionParameters,
-            bool algorithmNotSupportedByCryptoProvider,
-            StringBuilder exceptionStrings,
-            StringBuilder keysAttempted,
-#pragma warning disable CA1801 // Review unused parameters
-            CallContext callContext)
-#pragma warning restore CA1801 // Review unused parameters
+        private static void ValidateDecryption(JwtTokenDecryptionParameters decryptionParameters, bool decryptionSucceeded, bool algorithmNotSupportedByCryptoProvider, StringBuilder exceptionStrings, StringBuilder keysAttempted)
         {
-            if (keysAttempted is not null)
-                return new ValidationError(
-                    new MessageDetail(
-                        TokenLogMessages.IDX10603,
-                        LogHelper.MarkAsNonPII(keysAttempted.ToString()),
-                        exceptionStrings?.ToString() ?? string.Empty,
-                        LogHelper.MarkAsSecurityArtifact(decryptionParameters.EncodedToken, SafeLogJwtToken)),
-                    ValidationFailureType.TokenDecryptionFailed,
-                    typeof(SecurityTokenDecryptionFailedException),
-                    ValidationError.GetCurrentStackFrame());
-            else if (algorithmNotSupportedByCryptoProvider)
-                return new ValidationError(
-                    new MessageDetail(
-                        TokenLogMessages.IDX10619,
-                        LogHelper.MarkAsNonPII(decryptionParameters.Alg),
-                        LogHelper.MarkAsNonPII(decryptionParameters.Enc)),
-                    ValidationFailureType.TokenDecryptionFailed,
-                    typeof(SecurityTokenDecryptionFailedException),
-                    ValidationError.GetCurrentStackFrame());
-            else
-                return new ValidationError(
-                    new MessageDetail(
-                        TokenLogMessages.IDX10609,
-                        LogHelper.MarkAsSecurityArtifact(decryptionParameters.EncodedToken, SafeLogJwtToken)),
-                    ValidationFailureType.TokenDecryptionFailed,
-                    typeof(SecurityTokenDecryptionFailedException),
-                    ValidationError.GetCurrentStackFrame());
+            if (!decryptionSucceeded && keysAttempted is not null)
+                throw LogHelper.LogExceptionMessage(
+                    new SecurityTokenDecryptionFailedException(
+                        LogHelper.FormatInvariant(
+                            TokenLogMessages.IDX10603,
+                            LogHelper.MarkAsNonPII(keysAttempted.ToString()),
+                            (object)exceptionStrings ?? string.Empty,
+                            LogHelper.MarkAsSecurityArtifact(decryptionParameters.EncodedToken, SafeLogJwtToken))));
+
+            if (!decryptionSucceeded && algorithmNotSupportedByCryptoProvider)
+                throw LogHelper.LogExceptionMessage(
+                    new SecurityTokenDecryptionFailedException(
+                        LogHelper.FormatInvariant(
+                            TokenLogMessages.IDX10619,
+                            LogHelper.MarkAsNonPII(decryptionParameters.Alg),
+                            LogHelper.MarkAsNonPII(decryptionParameters.Enc))));
+
+            if (!decryptionSucceeded)
+                throw LogHelper.LogExceptionMessage(
+                    new SecurityTokenDecryptionFailedException(
+                        LogHelper.FormatInvariant(
+                            TokenLogMessages.IDX10609,
+                            LogHelper.MarkAsSecurityArtifact(decryptionParameters.EncodedToken, SafeLogJwtToken))));
         }
 
         private static byte[] DecryptToken(CryptoProviderFactory cryptoProviderFactory, SecurityKey key, string encAlg, byte[] ciphertext, byte[] headerAscii, byte[] initializationVector, byte[] authenticationTag)

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlTokenUtilities.Experimental.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlTokenUtilities.Experimental.cs
@@ -1,0 +1,67 @@
+﻿
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens.Experimental;
+using Microsoft.IdentityModel.Xml;
+
+namespace Microsoft.IdentityModel.Tokens.Saml
+{
+    /// <summary>
+    /// A class which contains useful methods for processing saml tokens.
+    /// </summary>
+    internal partial class SamlTokenUtilities
+    {
+        /// <summary>
+        /// Returns a <see cref="SecurityKey"/> to use when validating the signature of a token.
+        /// </summary>
+        /// <param name="tokenKeyInfo">The <see cref="KeyInfo"/> field of the token being validated</param>
+        /// <param name="validationParameters">The <see cref="ValidationParameters"/> to be used for validating the token.</param>
+        /// <returns>Returns a <see cref="SecurityKey"/> to use for signature validation.</returns>
+        /// <remarks>If key fails to resolve, then null is returned</remarks>
+        internal static SecurityKey ResolveTokenSigningKey(KeyInfo tokenKeyInfo, ValidationParameters validationParameters)
+        {
+            if (tokenKeyInfo is null || validationParameters.IssuerSigningKeys is null)
+                return null;
+
+            for (int i = 0; i < validationParameters.IssuerSigningKeys.Count; i++)
+            {
+                if (tokenKeyInfo.MatchesKey(validationParameters.IssuerSigningKeys[i]))
+                    return validationParameters.IssuerSigningKeys[i];
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Fetches current configuration from the ConfigurationManager of <paramref name="validationParameters"/>
+        /// and populates ValidIssuers and IssuerSigningKeys.
+        /// </summary>
+        /// <param name="validationParameters"> the token validation parameters to update.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns> New ValidationParameters with ValidIssuers and IssuerSigningKeys updated.</returns>
+        internal static async Task<ValidationParameters> PopulateValidationParametersWithCurrentConfigurationAsync(
+            ValidationParameters validationParameters,
+            CancellationToken cancellationToken)
+        {
+            if (validationParameters.ConfigurationManager == null)
+            {
+                return validationParameters;
+            }
+
+            var currentConfiguration = await validationParameters.ConfigurationManager.GetBaseConfigurationAsync(cancellationToken).ConfigureAwait(false);
+            var validationParametersCloned = validationParameters.Clone();
+
+            validationParametersCloned.ValidIssuers.Add(currentConfiguration.Issuer);
+
+            foreach (SecurityKey key in currentConfiguration.SigningKeys)
+            {
+                validationParametersCloned.IssuerSigningKeys.Add(key);
+            }
+
+            return validationParametersCloned;
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlTokenUtilities.cs
@@ -12,14 +12,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Logging;
 using TokenLogMessages = Microsoft.IdentityModel.Tokens.LogMessages;
-using Microsoft.IdentityModel.Tokens.Experimental;
 
 namespace Microsoft.IdentityModel.Tokens.Saml
 {
     /// <summary>
     /// A class which contains useful methods for processing saml tokens.
     /// </summary>
-    internal class SamlTokenUtilities
+    internal partial class SamlTokenUtilities
     {
         /// <summary>
         /// Returns a <see cref="SecurityKey"/> to use when validating the signature of a token.
@@ -47,29 +46,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml
 
             return null;
         }
-
-        /// <summary>
-        /// Returns a <see cref="SecurityKey"/> to use when validating the signature of a token.
-        /// </summary>
-        /// <param name="tokenKeyInfo">The <see cref="KeyInfo"/> field of the token being validated</param>
-        /// <param name="validationParameters">The <see cref="ValidationParameters"/> to be used for validating the token.</param>
-        /// <returns>Returns a <see cref="SecurityKey"/> to use for signature validation.</returns>
-        /// <remarks>If key fails to resolve, then null is returned</remarks>
-        internal static SecurityKey ResolveTokenSigningKey(KeyInfo tokenKeyInfo, ValidationParameters validationParameters)
-        {
-            if (tokenKeyInfo is null || validationParameters.IssuerSigningKeys is null)
-                return null;
-
-            for (int i = 0; i < validationParameters.IssuerSigningKeys.Count; i++)
-            {
-                if (tokenKeyInfo.MatchesKey(validationParameters.IssuerSigningKeys[i]))
-                    return validationParameters.IssuerSigningKeys[i];
-            }
-
-            return null;
-        }
-
-
 
         /// <summary>
         /// Creates <see cref="Claim"/>'s from <paramref name="claimsCollection"/>.
@@ -175,36 +151,6 @@ namespace Microsoft.IdentityModel.Tokens.Saml
 
             validationParametersCloned.ValidIssuers = (validationParametersCloned.ValidIssuers == null ? issuers : validationParametersCloned.ValidIssuers.Concat(issuers));
             validationParametersCloned.IssuerSigningKeys = (validationParametersCloned.IssuerSigningKeys == null ? currentConfiguration.SigningKeys : validationParametersCloned.IssuerSigningKeys.Concat(currentConfiguration.SigningKeys));
-            return validationParametersCloned;
-
-        }
-
-        /// <summary>
-        /// Fetches current configuration from the ConfigurationManager of <paramref name="validationParameters"/>
-        /// and populates ValidIssuers and IssuerSigningKeys.
-        /// </summary>
-        /// <param name="validationParameters"> the token validation parameters to update.</param>
-        /// <param name="cancellationToken"></param>
-        /// <returns> New ValidationParameters with ValidIssuers and IssuerSigningKeys updated.</returns>
-        internal static async Task<ValidationParameters> PopulateValidationParametersWithCurrentConfigurationAsync(
-            ValidationParameters validationParameters,
-            CancellationToken cancellationToken)
-        {
-            if (validationParameters.ConfigurationManager == null)
-            {
-                return validationParameters;
-            }
-
-            var currentConfiguration = await validationParameters.ConfigurationManager.GetBaseConfigurationAsync(cancellationToken).ConfigureAwait(false);
-            var validationParametersCloned = validationParameters.Clone();
-
-            validationParametersCloned.ValidIssuers.Add(currentConfiguration.Issuer);
-
-            foreach (SecurityKey key in currentConfiguration.SigningKeys)
-            {
-                validationParametersCloned.IssuerSigningKeys.Add(key);
-            }
-
             return validationParametersCloned;
         }
     }

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.Experimental.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.Experimental.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using Microsoft.IdentityModel.Tokens.Experimental;
+
+#if !NET8_0_OR_GREATER
+using System.Text;
+#endif
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Represents a security token exception.
+    /// </summary>
+    public partial class SecurityTokenException : Exception
+    {
+        [NonSerialized]
+        private string _stackTrace;
+
+        [NonSerialized]
+        private ValidationError _validationError;
+
+        /// <summary>
+        /// Sets the <see cref="ValidationError"/> that caused the exception.
+        /// </summary>
+        /// <param name="validationError"></param>
+        internal void SetValidationError(ValidationError validationError)
+        {
+            _validationError = validationError;
+        }
+
+        /// <summary>
+        /// Gets the stack trace that is captured when the exception is created.
+        /// </summary>
+        public override string StackTrace
+        {
+            get
+            {
+                if (_stackTrace == null)
+                {
+                    if (_validationError == null)
+                        return base.StackTrace;
+#if NET8_0_OR_GREATER
+                    _stackTrace = new StackTrace(_validationError.StackFrames).ToString();
+#else
+                    StringBuilder sb = new();
+                    foreach (StackFrame frame in _validationError.StackFrames)
+                    {
+                        sb.Append(frame.ToString());
+                        sb.Append(Environment.NewLine);
+                    }
+
+                    _stackTrace = sb.ToString();
+#endif
+                }
+
+                return _stackTrace;
+            }
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Exceptions/SecurityTokenException.cs
@@ -2,19 +2,11 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
 using System.Runtime.Serialization;
 
 #if NET472 || NETSTANDARD2_0 || NET6_0_OR_GREATER
 using Microsoft.IdentityModel.Logging;
 #endif
-
-using Microsoft.IdentityModel.Tokens.Experimental;
-
-#if !NET8_0_OR_GREATER
-using System.Text;
-#endif
-
 
 namespace Microsoft.IdentityModel.Tokens
 {
@@ -22,13 +14,8 @@ namespace Microsoft.IdentityModel.Tokens
     /// Represents a security token exception.
     /// </summary>
     [Serializable]
-    public class SecurityTokenException : Exception
+    public partial class SecurityTokenException : Exception
     {
-        [NonSerialized]
-        private string _stackTrace;
-
-        private ValidationError _validationError;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="SecurityTokenException"/> class.
         /// </summary>
@@ -68,44 +55,6 @@ namespace Microsoft.IdentityModel.Tokens
         protected SecurityTokenException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-        }
-
-        /// <summary>
-        /// Sets the <see cref="ValidationError"/> that caused the exception.
-        /// </summary>
-        /// <param name="validationError"></param>
-        internal void SetValidationError(ValidationError validationError)
-        {
-            _validationError = validationError;
-        }
-
-        /// <summary>
-        /// Gets the stack trace that is captured when the exception is created.
-        /// </summary>
-        public override string StackTrace
-        {
-            get
-            {
-                if (_stackTrace == null)
-                {
-                    if (_validationError == null)
-                        return base.StackTrace;
-#if NET8_0_OR_GREATER
-                    _stackTrace = new StackTrace(_validationError.StackFrames).ToString();
-#else
-                    StringBuilder sb = new();
-                    foreach (StackFrame frame in _validationError.StackFrames)
-                    {
-                        sb.Append(frame.ToString());
-                        sb.Append(Environment.NewLine);
-                    }
-
-                    _stackTrace = sb.ToString();
-#endif
-                }
-
-                return _stackTrace;
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/TokenHandler.Internal.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenHandler.Internal.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Tokens.Experimental;
@@ -41,6 +42,25 @@ namespace Microsoft.IdentityModel.Tokens
                         LogMessages.IDX10267,
                         MarkAsNonPII("internal virtual Task<ValidationResult<ValidatedToken, ValidationError>> " +
                         "ValidateTokenAsync(SecurityToken token, ValidationParameters validationParameters, CallContext callContext, CancellationToken cancellationToken)"),
+                        MarkAsNonPII(GetType().FullName))));
+        }
+
+        /// <summary>
+        /// Called by base class to create a <see cref="ClaimsIdentity"/>.
+        /// Currently only used by the JsonWebTokenHandler when called with ValidationParameters to allow for a Lazy creation.
+        /// </summary>
+        /// <param name="securityToken">the <see cref="SecurityToken"/> that has the Claims.</param>
+        /// <param name="validationParameters">the <see cref="ValidationParameters"/> that was used to validate the token.</param>
+        /// <param name="issuer">the 'issuer' to use by default when creating a Claim.</param>
+        /// <returns>A <see cref="ClaimsIdentity"/>.</returns>
+        /// <exception cref="NotImplementedException"></exception>
+        internal virtual ClaimsIdentity CreateClaimsIdentityInternal(SecurityToken securityToken, ValidationParameters validationParameters, string issuer)
+        {
+            throw LogExceptionMessage(
+                new NotImplementedException(
+                    FormatInvariant(
+                        LogMessages.IDX10267,
+                        MarkAsNonPII("internal virtual ClaimsIdentity CreateClaimsIdentityInternal(SecurityToken securityToken, ValidationParameters validationParameters, string issuer)"),
                         MarkAsNonPII(GetType().FullName))));
         }
     }

--- a/src/Microsoft.IdentityModel.Tokens/TokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenHandler.cs
@@ -5,7 +5,6 @@ using System;
 using System.ComponentModel;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using Microsoft.IdentityModel.Tokens.Experimental;
 using static Microsoft.IdentityModel.Logging.LogHelper;
 
 namespace Microsoft.IdentityModel.Tokens
@@ -123,25 +122,6 @@ namespace Microsoft.IdentityModel.Tokens
                     FormatInvariant(
                         LogMessages.IDX10267,
                         MarkAsNonPII("internal virtual ClaimsIdentity CreateClaimsIdentityInternal(SecurityToken securityToken, TokenValidationParameters tokenValidationParameters, string issuer)"),
-                        MarkAsNonPII(GetType().FullName))));
-        }
-
-        /// <summary>
-        /// Called by base class to create a <see cref="ClaimsIdentity"/>.
-        /// Currently only used by the JsonWebTokenHandler when called with ValidationParameters to allow for a Lazy creation.
-        /// </summary>
-        /// <param name="securityToken">the <see cref="SecurityToken"/> that has the Claims.</param>
-        /// <param name="validationParameters">the <see cref="ValidationParameters"/> that was used to validate the token.</param>
-        /// <param name="issuer">the 'issuer' to use by default when creating a Claim.</param>
-        /// <returns>A <see cref="ClaimsIdentity"/>.</returns>
-        /// <exception cref="NotImplementedException"></exception>
-        internal virtual ClaimsIdentity CreateClaimsIdentityInternal(SecurityToken securityToken, ValidationParameters validationParameters, string issuer)
-        {
-            throw LogExceptionMessage(
-                new NotImplementedException(
-                    FormatInvariant(
-                        LogMessages.IDX10267,
-                        MarkAsNonPII("internal virtual ClaimsIdentity CreateClaimsIdentityInternal(SecurityToken securityToken, ValidationParameters validationParameters, string issuer)"),
                         MarkAsNonPII(GetType().FullName))));
         }
         #endregion

--- a/src/Microsoft.IdentityModel.Tokens/Validation/Results/TokenValidationResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validation/Results/TokenValidationResult.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Security.Claims;
 using System.Threading;
 using Microsoft.IdentityModel.Logging;
-using Microsoft.IdentityModel.Tokens.Experimental;
 
 namespace Microsoft.IdentityModel.Tokens
 {
@@ -18,7 +17,6 @@ namespace Microsoft.IdentityModel.Tokens
     public class TokenValidationResult
     {
         private readonly TokenValidationParameters _tokenValidationParameters;
-        private readonly ValidationParameters _validationParameters;
         private readonly TokenHandler _tokenHandler;
 
         // Fields lazily initialized in a thread-safe manner. _claimsIdentity is protected by the _claimsIdentitySyncObj
@@ -39,10 +37,6 @@ namespace Microsoft.IdentityModel.Tokens
         private ClaimsIdentity _claimsIdentity;
         private Dictionary<string, object> _claims;
         private Dictionary<string, object> _propertyBag;
-        // TODO - lazy creation of _validationResults
-        private List<ValidatedToken> _validationResults;
-
-        private ValidationError _validationError;
         private Exception _exception;
         private bool _isValid;
 
@@ -60,63 +54,17 @@ namespace Microsoft.IdentityModel.Tokens
         /// <param name="tokenHandler"></param>
         /// <param name="tokenValidationParameters"></param>
         /// <param name="issuer"></param>
-        /// <param name="validationResults"></param>
         /// <remarks>This constructor is used by JsonWebTokenHandler as part of delaying creation of ClaimsIdentity.</remarks>
         internal TokenValidationResult(
             SecurityToken securityToken,
             TokenHandler tokenHandler,
             TokenValidationParameters tokenValidationParameters,
-            string issuer,
-            List<ValidatedToken> validationResults)
+            string issuer)
         {
             _tokenValidationParameters = tokenValidationParameters;
             _tokenHandler = tokenHandler;
-            _validationResults = validationResults;
             Issuer = issuer;
             SecurityToken = securityToken;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="TokenValidationResult"/> using <see cref="ValidationParameters"/>.
-        /// </summary>
-        /// <param name="securityToken">The</param>
-        /// <param name="tokenHandler"></param>
-        /// <param name="validationParameters"></param>
-        /// <param name="issuer"></param>
-        /// <param name="validationResults"></param>
-        /// <param name="validationError"></param>
-        /// <remarks>This constructor is used by JsonWebTokenHandler as part of delaying creation of ClaimsIdentity.</remarks>
-        internal TokenValidationResult(
-            SecurityToken securityToken,
-            TokenHandler tokenHandler,
-            ValidationParameters validationParameters,
-            string issuer,
-            List<ValidatedToken> validationResults,
-            ValidationError validationError)
-        {
-            _validationParameters = validationParameters;
-            _tokenHandler = tokenHandler;
-            _validationResults = validationResults;
-            Issuer = issuer;
-            SecurityToken = securityToken;
-            _validationError = validationError;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of <see cref="TokenValidationResult"/> using <see cref="ValidationParameters"/>.
-        /// </summary>
-        /// <param name="tokenHandler"></param>
-        /// <param name="validationError"></param>
-        /// <param name="validationParameters"></param>
-        /// <remarks>This constructor is used by JsonWebTokenHandler as part of delaying creation of ClaimsIdentity.</remarks>
-        internal TokenValidationResult(
-            TokenHandler tokenHandler,
-            ValidationParameters validationParameters,
-            ValidationError validationError)
-        {
-            _tokenHandler = tokenHandler;
-            _validationError = validationError;
-            _validationParameters = validationParameters;
         }
 
         /// <summary>
@@ -183,8 +131,6 @@ namespace Microsoft.IdentityModel.Tokens
                     {
                         if (_tokenValidationParameters != null)
                             _claimsIdentity = _tokenHandler.CreateClaimsIdentityInternal(SecurityToken, _tokenValidationParameters, Issuer);
-                        else if (_validationParameters != null)
-                            _claimsIdentity = _tokenHandler.CreateClaimsIdentityInternal(SecurityToken, _validationParameters, Issuer);
                     }
 
                     _claimsIdentityInitialized = true;
@@ -242,9 +188,6 @@ namespace Microsoft.IdentityModel.Tokens
             get
             {
                 HasValidOrExceptionWasRead = true;
-                if (_exception is null && _validationError is not null)
-                    return _validationError.GetException();
-
                 return _exception;
             }
             set

--- a/src/Microsoft.IdentityModel.Xml/Exceptions/XmlValidationException.Experimental.cs
+++ b/src/Microsoft.IdentityModel.Xml/Exceptions/XmlValidationException.Experimental.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using Microsoft.IdentityModel.Tokens.Experimental;
+
+#if !NET8_0_OR_GREATER
+using System.Text;
+#endif
+
+namespace Microsoft.IdentityModel.Xml
+{
+    /// <summary>
+    /// This exception is thrown when a problem occurs when validating the XML &lt;Signature>.
+    /// </summary>
+    public partial class XmlValidationException : XmlException
+    {
+        [NonSerialized]
+        private string _stackTrace;
+
+        [NonSerialized]
+        private ValidationError _validationError;
+
+        /// <summary>
+        /// Sets the <see cref="ValidationError"/> that caused the exception.
+        /// </summary>
+        /// <param name="validationError"></param>
+        internal void SetValidationError(ValidationError validationError)
+        {
+            _validationError = validationError;
+        }
+
+        /// <summary>
+        /// Gets the stack trace that is captured when the exception is created.
+        /// </summary>
+        public override string StackTrace
+        {
+            get
+            {
+                if (_stackTrace == null)
+                {
+                    if (_validationError == null)
+                        return base.StackTrace;
+#if NET8_0_OR_GREATER
+                    _stackTrace = new StackTrace(_validationError.StackFrames).ToString();
+#else
+                    StringBuilder sb = new();
+                    foreach (StackFrame frame in _validationError.StackFrames)
+                    {
+                        sb.Append(frame.ToString());
+                        sb.Append(Environment.NewLine);
+                    }
+
+                    _stackTrace = sb.ToString();
+#endif
+                }
+
+                return _stackTrace;
+            }
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Xml/Exceptions/XmlValidationException.cs
+++ b/src/Microsoft.IdentityModel.Xml/Exceptions/XmlValidationException.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Diagnostics;
 using System.Runtime.Serialization;
 #pragma warning disable IDE0005 // Using directive is unnecessary.
 using System.Text;
 #pragma warning restore IDE0005 // Using directive is unnecessary.
-using Microsoft.IdentityModel.Tokens.Experimental;
 
 namespace Microsoft.IdentityModel.Xml
 {
@@ -15,13 +13,8 @@ namespace Microsoft.IdentityModel.Xml
     /// This exception is thrown when a problem occurs when validating the XML &lt;Signature>.
     /// </summary>
     [Serializable]
-    public class XmlValidationException : XmlException
+    public partial class XmlValidationException : XmlException
     {
-        [NonSerialized]
-        private string _stackTrace;
-
-        private ValidationError _validationError;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="XmlValidationException"/> class.
         /// </summary>
@@ -58,44 +51,6 @@ namespace Microsoft.IdentityModel.Xml
         protected XmlValidationException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-        }
-
-        /// <summary>
-        /// Sets the <see cref="ValidationError"/> that caused the exception.
-        /// </summary>
-        /// <param name="validationError"></param>
-        internal void SetValidationError(ValidationError validationError)
-        {
-            _validationError = validationError;
-        }
-
-        /// <summary>
-        /// Gets the stack trace that is captured when the exception is created.
-        /// </summary>
-        public override string StackTrace
-        {
-            get
-            {
-                if (_stackTrace == null)
-                {
-                    if (_validationError == null)
-                        return base.StackTrace;
-#if NET8_0_OR_GREATER
-                    _stackTrace = new StackTrace(_validationError.StackFrames).ToString();
-#else
-                    StringBuilder sb = new();
-                    foreach (StackFrame frame in _validationError.StackFrames)
-                    {
-                        sb.Append(frame.ToString());
-                        sb.Append(Environment.NewLine);
-                    }
-
-                    _stackTrace = sb.ToString();
-#endif
-                }
-
-                return _stackTrace;
-            }
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Xml/Reference.Experimental.cs
+++ b/src/Microsoft.IdentityModel.Xml/Reference.Experimental.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Experimental;
+
+namespace Microsoft.IdentityModel.Xml
+{
+    /// <summary>
+    /// Represents a XmlDsig Reference element as per: https://www.w3.org/TR/2001/PR-xmldsig-core-20010820/#sec-Reference
+    /// </summary>
+    public partial class Reference : DSigElement
+    {
+#nullable enable
+        /// <summary>
+        /// Verifies that the <see cref="DigestValue" /> equals the hashed value of the <see cref="TokenStream"/> after
+        /// <see cref="Transforms"/> have been applied.
+        /// </summary>
+        /// <param name="cryptoProviderFactory">supplies the <see cref="HashAlgorithm"/>.</param>
+        /// <param name="callContext"> contextual information for diagnostics.</param>
+        /// <exception cref="ArgumentNullException">if <paramref name="cryptoProviderFactory"/> is null.</exception>
+        internal SignatureValidationError? Verify(
+            CryptoProviderFactory cryptoProviderFactory,
+#pragma warning disable CA1801 // Review unused parameters
+            CallContext callContext)
+#pragma warning restore CA1801
+        {
+            if (cryptoProviderFactory == null)
+                return SignatureValidationError.NullParameter(
+                    nameof(cryptoProviderFactory),
+                    ValidationError.GetCurrentStackFrame());
+
+            if (!Utility.AreEqual(ComputeDigest(cryptoProviderFactory), Convert.FromBase64String(DigestValue)))
+                return new SignatureValidationError(
+                    new MessageDetail(
+                        LogMessages.IDX30201,
+                        Uri ?? Id),
+                    ValidationFailureType.XmlValidationFailed,
+                    typeof(SecurityTokenInvalidSignatureException),
+                    ValidationError.GetCurrentStackFrame());
+
+            return null;
+        }
+#nullable restore
+    }
+}

--- a/src/Microsoft.IdentityModel.Xml/Reference.cs
+++ b/src/Microsoft.IdentityModel.Xml/Reference.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Xml;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.IdentityModel.Tokens.Experimental;
 using static Microsoft.IdentityModel.Logging.LogHelper;
 using static Microsoft.IdentityModel.Xml.XmlUtil;
 
@@ -16,7 +15,7 @@ namespace Microsoft.IdentityModel.Xml
     /// <summary>
     /// Represents a XmlDsig Reference element as per: https://www.w3.org/TR/2001/PR-xmldsig-core-20010820/#sec-Reference
     /// </summary>
-    public class Reference : DSigElement
+    public partial class Reference : DSigElement
     {
         private CanonicalizingTransfrom _canonicalizingTransfrom;
         private string _digestMethod;
@@ -126,38 +125,6 @@ namespace Microsoft.IdentityModel.Xml
             if (!Utility.AreEqual(ComputeDigest(cryptoProviderFactory), Convert.FromBase64String(DigestValue)))
                 throw LogValidationException(LogMessages.IDX30201, Uri ?? Id);
         }
-
-#nullable enable
-        /// <summary>
-        /// Verifies that the <see cref="DigestValue" /> equals the hashed value of the <see cref="TokenStream"/> after
-        /// <see cref="Transforms"/> have been applied.
-        /// </summary>
-        /// <param name="cryptoProviderFactory">supplies the <see cref="HashAlgorithm"/>.</param>
-        /// <param name="callContext"> contextual information for diagnostics.</param>
-        /// <exception cref="ArgumentNullException">if <paramref name="cryptoProviderFactory"/> is null.</exception>
-        internal SignatureValidationError? Verify(
-            CryptoProviderFactory cryptoProviderFactory,
-#pragma warning disable CA1801 // Review unused parameters
-            CallContext callContext)
-#pragma warning restore CA1801
-        {
-            if (cryptoProviderFactory == null)
-                return SignatureValidationError.NullParameter(
-                    nameof(cryptoProviderFactory),
-                    ValidationError.GetCurrentStackFrame());
-
-            if (!Utility.AreEqual(ComputeDigest(cryptoProviderFactory), Convert.FromBase64String(DigestValue)))
-                return new SignatureValidationError(
-                    new MessageDetail(
-                        LogMessages.IDX30201,
-                        Uri ?? Id),
-                    ValidationFailureType.XmlValidationFailed,
-                    typeof(SecurityTokenInvalidSignatureException),
-                    ValidationError.GetCurrentStackFrame());
-
-            return null;
-        }
-#nullable restore
 
         /// <summary>
         /// Writes into a stream and then hashes the bytes.

--- a/src/Microsoft.IdentityModel.Xml/Signature.Experimental.cs
+++ b/src/Microsoft.IdentityModel.Xml/Signature.Experimental.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using Microsoft.IdentityModel.Logging;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Experimental;
+
+namespace Microsoft.IdentityModel.Xml
+{
+    /// <summary>
+    /// Represents a XmlDsig Signature element as per: https://www.w3.org/TR/2001/PR-xmldsig-core-20010820/#sec-Signature
+    /// </summary>
+    public partial class Signature : DSigElement
+    {
+#nullable enable
+        internal SignatureValidationError? Verify(
+            SecurityKey key,
+            CryptoProviderFactory cryptoProviderFactory,
+#pragma warning disable CA1801 // Review unused parameters
+            CallContext callContext)
+#pragma warning restore CA1801
+        {
+            if (key is null)
+                return SignatureValidationError.NullParameter(
+                    nameof(key),
+                    ValidationError.GetCurrentStackFrame());
+
+            if (cryptoProviderFactory is null)
+                return SignatureValidationError.NullParameter(
+                    nameof(cryptoProviderFactory),
+                    ValidationError.GetCurrentStackFrame());
+
+            if (SignedInfo is null)
+                return new SignatureValidationError(
+                    new MessageDetail(LogMessages.IDX30212),
+                    ValidationFailureType.SignatureValidationFailed,
+                    typeof(SecurityTokenInvalidSignatureException),
+                    ValidationError.GetCurrentStackFrame());
+
+            if (!cryptoProviderFactory.IsSupportedAlgorithm(SignedInfo.SignatureMethod, key))
+                return new SignatureValidationError(
+                    new MessageDetail(LogMessages.IDX30207, SignedInfo.SignatureMethod, cryptoProviderFactory.GetType()),
+                    ValidationFailureType.XmlValidationFailed,
+                    typeof(SecurityTokenInvalidSignatureException),
+                    ValidationError.GetCurrentStackFrame());
+
+            var signatureProvider = cryptoProviderFactory.CreateForVerifying(key, SignedInfo.SignatureMethod);
+            if (signatureProvider is null)
+                return new SignatureValidationError(
+                    new MessageDetail(LogMessages.IDX30203, cryptoProviderFactory, LogHelper.MarkAsNonPII(key.KeyId), SignedInfo.SignatureMethod),
+                    ValidationFailureType.XmlValidationFailed,
+                    typeof(SecurityTokenInvalidSignatureException),
+                    ValidationError.GetCurrentStackFrame());
+
+            SignatureValidationError? validationError = null;
+
+            try
+            {
+                using (var memoryStream = new MemoryStream())
+                {
+                    SignedInfo.GetCanonicalBytes(memoryStream);
+                    if (!signatureProvider.Verify(memoryStream.ToArray(), Convert.FromBase64String(SignatureValue)))
+                    {
+                        validationError = new SignatureValidationError(
+                            new MessageDetail(LogMessages.IDX30200, cryptoProviderFactory, LogHelper.MarkAsNonPII(key.KeyId)),
+                            ValidationFailureType.XmlValidationFailed,
+                            typeof(SecurityTokenInvalidSignatureException),
+                            ValidationError.GetCurrentStackFrame());
+                    }
+                }
+
+                if (validationError is null)
+                {
+                    validationError = SignedInfo.Verify(cryptoProviderFactory, callContext);
+                    validationError?.AddCurrentStackFrame();
+                }
+            }
+            finally
+            {
+                if (signatureProvider is not null)
+                    cryptoProviderFactory.ReleaseSignatureProvider(signatureProvider);
+            }
+
+            if (validationError is not null)
+                return validationError;
+
+            return null; // no error
+        }
+#nullable restore
+    }
+}

--- a/src/Microsoft.IdentityModel.Xml/Signature.cs
+++ b/src/Microsoft.IdentityModel.Xml/Signature.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.IdentityModel.Tokens.Experimental;
 using static Microsoft.IdentityModel.Logging.LogHelper;
 using static Microsoft.IdentityModel.Xml.XmlUtil;
 
@@ -14,7 +13,7 @@ namespace Microsoft.IdentityModel.Xml
     /// <summary>
     /// Represents a XmlDsig Signature element as per: https://www.w3.org/TR/2001/PR-xmldsig-core-20010820/#sec-Signature
     /// </summary>
-    public class Signature : DSigElement
+    public partial class Signature : DSigElement
     {
         private string _signatureValue;
         private SignedInfo _signedInfo;
@@ -126,81 +125,5 @@ namespace Microsoft.IdentityModel.Xml
                     cryptoProviderFactory.ReleaseSignatureProvider(signatureProvider);
             }
         }
-
-#nullable enable
-        internal SignatureValidationError? Verify(
-            SecurityKey key,
-            CryptoProviderFactory cryptoProviderFactory,
-#pragma warning disable CA1801 // Review unused parameters
-            CallContext callContext)
-#pragma warning restore CA1801
-        {
-            if (key is null)
-                return SignatureValidationError.NullParameter(
-                    nameof(key),
-                    ValidationError.GetCurrentStackFrame());
-
-            if (cryptoProviderFactory is null)
-                return SignatureValidationError.NullParameter(
-                    nameof(cryptoProviderFactory),
-                    ValidationError.GetCurrentStackFrame());
-
-            if (SignedInfo is null)
-                return new SignatureValidationError(
-                    new MessageDetail(LogMessages.IDX30212),
-                    ValidationFailureType.SignatureValidationFailed,
-                    typeof(SecurityTokenInvalidSignatureException),
-                    ValidationError.GetCurrentStackFrame());
-
-            if (!cryptoProviderFactory.IsSupportedAlgorithm(SignedInfo.SignatureMethod, key))
-                return new SignatureValidationError(
-                    new MessageDetail(LogMessages.IDX30207, SignedInfo.SignatureMethod, cryptoProviderFactory.GetType()),
-                    ValidationFailureType.XmlValidationFailed,
-                    typeof(SecurityTokenInvalidSignatureException),
-                    ValidationError.GetCurrentStackFrame());
-
-            var signatureProvider = cryptoProviderFactory.CreateForVerifying(key, SignedInfo.SignatureMethod);
-            if (signatureProvider is null)
-                return new SignatureValidationError(
-                    new MessageDetail(LogMessages.IDX30203, cryptoProviderFactory, LogHelper.MarkAsNonPII(key.KeyId), SignedInfo.SignatureMethod),
-                    ValidationFailureType.XmlValidationFailed,
-                    typeof(SecurityTokenInvalidSignatureException),
-                    ValidationError.GetCurrentStackFrame());
-
-            SignatureValidationError? validationError = null;
-
-            try
-            {
-                using (var memoryStream = new MemoryStream())
-                {
-                    SignedInfo.GetCanonicalBytes(memoryStream);
-                    if (!signatureProvider.Verify(memoryStream.ToArray(), Convert.FromBase64String(SignatureValue)))
-                    {
-                        validationError = new SignatureValidationError(
-                            new MessageDetail(LogMessages.IDX30200, cryptoProviderFactory, LogHelper.MarkAsNonPII(key.KeyId)),
-                            ValidationFailureType.XmlValidationFailed,
-                            typeof(SecurityTokenInvalidSignatureException),
-                            ValidationError.GetCurrentStackFrame());
-                    }
-                }
-
-                if (validationError is null)
-                {
-                    validationError = SignedInfo.Verify(cryptoProviderFactory, callContext);
-                    validationError?.AddCurrentStackFrame();
-                }
-            }
-            finally
-            {
-                if (signatureProvider is not null)
-                    cryptoProviderFactory.ReleaseSignatureProvider(signatureProvider);
-            }
-
-            if (validationError is not null)
-                return validationError;
-
-            return null; // no error
-        }
-#nullable restore
     }
 }

--- a/src/Microsoft.IdentityModel.Xml/SignedInfo.Experimental.cs
+++ b/src/Microsoft.IdentityModel.Xml/SignedInfo.Experimental.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Experimental;
+
+namespace Microsoft.IdentityModel.Xml
+{
+    /// <summary>
+    /// Represents a XmlDsig SignedInfo element as per: https://www.w3.org/TR/2001/PR-xmldsig-core-20010820/#sec-SignedInfo
+    /// </summary>
+    public partial class SignedInfo : DSigElement
+    {
+#nullable enable
+        /// <summary>
+        /// Verifies the digest of all <see cref="References"/>
+        /// </summary>
+        /// <param name="cryptoProviderFactory">supplies any required cryptographic operators.</param>
+        /// <param name="callContext"> contextual information for diagnostics.</param>
+        internal SignatureValidationError? Verify(
+            CryptoProviderFactory cryptoProviderFactory,
+#pragma warning disable CA1801
+            CallContext callContext)
+#pragma warning restore CA1801
+        {
+            if (cryptoProviderFactory == null)
+                return SignatureValidationError.NullParameter(
+                    nameof(cryptoProviderFactory),
+                    ValidationError.GetCurrentStackFrame());
+
+            SignatureValidationError? validationError = null;
+
+            for (int i = 0; i < References.Count; i++)
+            {
+                var reference = References[i];
+                validationError = reference.Verify(cryptoProviderFactory, callContext);
+
+                if (validationError is not null)
+                {
+                    validationError.AddCurrentStackFrame();
+                    break;
+                }
+            }
+
+            return validationError;
+        }
+#nullable restore
+    }
+}

--- a/src/Microsoft.IdentityModel.Xml/SignedInfo.cs
+++ b/src/Microsoft.IdentityModel.Xml/SignedInfo.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Xml;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.IdentityModel.Tokens.Experimental;
+//using Microsoft.IdentityModel.Tokens.Experimental;
 using static Microsoft.IdentityModel.Logging.LogHelper;
 
 namespace Microsoft.IdentityModel.Xml
@@ -15,7 +15,7 @@ namespace Microsoft.IdentityModel.Xml
     /// <summary>
     /// Represents a XmlDsig SignedInfo element as per: https://www.w3.org/TR/2001/PR-xmldsig-core-20010820/#sec-SignedInfo
     /// </summary>
-    public class SignedInfo : DSigElement
+    public partial class SignedInfo : DSigElement
     {
         private DSigSerializer _dsigSerializer = DSigSerializer.Default;
         private string _canonicalizationMethod = SecurityAlgorithms.ExclusiveC14n;
@@ -112,41 +112,6 @@ namespace Microsoft.IdentityModel.Xml
             foreach (var reference in References)
                 reference.Verify(cryptoProviderFactory);
         }
-
-#nullable enable
-        /// <summary>
-        /// Verifies the digest of all <see cref="References"/>
-        /// </summary>
-        /// <param name="cryptoProviderFactory">supplies any required cryptographic operators.</param>
-        /// <param name="callContext"> contextual information for diagnostics.</param>
-        internal SignatureValidationError? Verify(
-            CryptoProviderFactory cryptoProviderFactory,
-#pragma warning disable CA1801
-            CallContext callContext)
-#pragma warning restore CA1801
-        {
-            if (cryptoProviderFactory == null)
-                return SignatureValidationError.NullParameter(
-                    nameof(cryptoProviderFactory),
-                    ValidationError.GetCurrentStackFrame());
-
-            SignatureValidationError? validationError = null;
-
-            for (int i = 0; i < References.Count; i++)
-            {
-                var reference = References[i];
-                validationError = reference.Verify(cryptoProviderFactory, callContext);
-
-                if (validationError is not null)
-                {
-                    validationError.AddCurrentStackFrame();
-                    break;
-                }
-            }
-
-            return validationError;
-        }
-#nullable restore
 
         /// <summary>
         /// Writes the Canonicalized bytes into a stream.


### PR DESCRIPTION
Experimental code leaked into TokenValidationResult from early prototypes where we thought we could introduce a new 'non throwing' model using existing objects.

This turned out to be hard and confusing, so we moved to new types, however this code was left in the repo.