### PR TITLE
Update RsaSecurityKey.cs to remove Pkcs 1

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/RsaSecurityKey.cs
+++ b/src/Microsoft.IdentityModel.Tokens/RsaSecurityKey.cs
@@ -76,7 +76,7 @@ namespace Microsoft.IdentityModel.Tokens
                     {
                         // imitate signing
                         byte[] hash = new byte[20];
-                        Rsa.SignData(hash, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+                        Rsa.SignData(hash, HashAlgorithmName.SHA256, RSASignaturePadding.Pss);
                         _hasPrivateKey = true;
                     }
                     catch (CryptographicException)


### PR DESCRIPTION
# Update RsaSecurityKey.cs to remove Pkcs 1 from HasPrivateKey check

Summary of the changes (Less than 80 chars)

## Description

No functional difference, using pkcs1 will be flagged on scans and this removes it here.
