### PR TITLE
Allow usage of relative URIs in AuthnContextClassRef

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2AuthenticationContext.cs
@@ -68,6 +68,9 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         /// describes the authentication context declaration that follows.
         /// [Saml2Core, 2.7.2.2]
         /// </summary>
+        /// <remarks>
+        /// The check for an absoulte URI be disabled by setting <see cref="AppContextSwitches.AllowRelativeUrisInSaml2AuthnContext"/>.
+        /// </remarks>
         /// <exception cref="ArgumentNullException">if 'value' is null.</exception>
         /// <exception cref="ArgumentException">if 'value' is not an absolute Uri.</exception>
         public Uri ClassReference

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2AuthenticationContext.cs
@@ -78,7 +78,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
                 if (value == null)
                     throw LogArgumentNullException(nameof(value));
 
-                if (!value.IsAbsoluteUri)
+                if (!value.IsAbsoluteUri && !AppContextSwitches.AllowRelativeUrisInSaml2AuthnContext)
                     throw LogExceptionMessage(new ArgumentException(FormatInvariant(LogMessages.IDX13300, MarkAsNonPII(nameof(ClassReference)), value)));
 
                 _classReference = value;

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2AuthenticationContext.cs
@@ -69,7 +69,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         /// [Saml2Core, 2.7.2.2]
         /// </summary>
         /// <remarks>
-        /// The check for an absoulte URI be disabled by setting <see cref="AppContextSwitches.AllowRelativeUrisInSaml2AuthnContext"/>.
+        /// The check for an absoulte URI can be disabled by setting <see cref="AppContextSwitches.AllowRelativeUrisInSaml2AuthnContext"/>.
         /// </remarks>
         /// <exception cref="ArgumentNullException">if 'value' is null.</exception>
         /// <exception cref="ArgumentException">if 'value' is not an absolute Uri.</exception>

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2AuthenticationContext.cs
@@ -69,7 +69,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
         /// [Saml2Core, 2.7.2.2]
         /// </summary>
         /// <remarks>
-        /// The check for an absoulte URI can be disabled by setting <see cref="AppContextSwitches.AllowRelativeUrisInSaml2AuthnContext"/>.
+        /// The check for an absolute URI can be disabled by setting <see cref="AppContextSwitches.AllowRelativeUrisInSaml2AuthnContext"/>.
         /// </remarks>
         /// <exception cref="ArgumentNullException">if 'value' is null.</exception>
         /// <exception cref="ArgumentException">if 'value' is not an absolute Uri.</exception>

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -98,7 +98,9 @@ namespace Microsoft.IdentityModel.Tokens
         private static bool? _useCapitalizedXMLTypeAttr;
         internal static bool UseCapitalizedXMLTypeAttr => _useCapitalizedXMLTypeAttr ??= (AppContext.TryGetSwitch(UseCapitalizedXMLTypeAttrSwitch, out bool useCapitalizedXMLTypeAttr) && useCapitalizedXMLTypeAttr);
 
-
+        /// <summary>
+        /// When enabled, allows using relative URIs in SAML2 authentication context.
+        /// </summary>
         internal const string AllowRelativeUrisInSaml2AuthnContextSwitch = "Switch.Microsoft.IdentityModel.AllowRelativeUrisInSaml2AuthnContext";
         private static bool? _allowRelativeUrisInSaml2AuthnContext;
         internal static bool AllowRelativeUrisInSaml2AuthnContext => _allowRelativeUrisInSaml2AuthnContext ??= (AppContext.TryGetSwitch(AllowRelativeUrisInSaml2AuthnContextSwitch, out bool allowRelativeUris) && allowRelativeUris);

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -98,6 +98,12 @@ namespace Microsoft.IdentityModel.Tokens
         private static bool? _useCapitalizedXMLTypeAttr;
         internal static bool UseCapitalizedXMLTypeAttr => _useCapitalizedXMLTypeAttr ??= (AppContext.TryGetSwitch(UseCapitalizedXMLTypeAttrSwitch, out bool useCapitalizedXMLTypeAttr) && useCapitalizedXMLTypeAttr);
 
+
+        internal const string AllowRelativeUrisInSaml2AuthnContextSwitch = "Switch.Microsoft.IdentityModel.AllowRelativeUrisInSaml2AuthnContext";
+        private static bool? _allowRelativeUrisInSaml2AuthnContext;
+        internal static bool AllowRelativeUrisInSaml2AuthnContext => _allowRelativeUrisInSaml2AuthnContext ??= (AppContext.TryGetSwitch(AllowRelativeUrisInSaml2AuthnContextSwitch, out bool allowRelativeUris) && allowRelativeUris);
+
+
         /// <summary>
         /// Used for testing to reset all switches to its default value.
         /// </summary>
@@ -123,6 +129,9 @@ namespace Microsoft.IdentityModel.Tokens
 
             _useCapitalizedXMLTypeAttr = null;
             AppContext.SetSwitch(UseCapitalizedXMLTypeAttrSwitch, false);
+
+            _allowRelativeUrisInSaml2AuthnContext = null;
+            AppContext.SetSwitch(AllowRelativeUrisInSaml2AuthnContextSwitch, false);
         }
     }
 }

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2AuthenticationContextCollectionDefinition.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2AuthenticationContextCollectionDefinition.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Microsoft.IdentityModel.Tokens.Saml.Tests
+{
+    [CollectionDefinition("Saml2AuthenticationContextTests", DisableParallelization = true)]
+    public class Saml2AuthenticationContextCollectionDefinition
+    {
+        // This class is used to define a collection for the Saml2AuthenticationContext tests.
+        // It allows the tests to run sequentially and share setup/teardown logic if needed.
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2AuthenticationContextTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2AuthenticationContextTests.cs
@@ -7,6 +7,7 @@ using Microsoft.IdentityModel.Tokens.Saml2;
 
 namespace Microsoft.IdentityModel.Tokens.Saml.Tests
 {
+    [Collection("Saml2AuthenticationContextTests")]
     public class Saml2AuthenticationContextTests
     {
         [Fact]

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2AuthenticationContextWithAppContextTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2AuthenticationContextWithAppContextTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Xunit;
+using Microsoft.IdentityModel.Tokens.Saml2;
+
+namespace Microsoft.IdentityModel.Tokens.Saml.Tests
+{
+    public class Saml2AuthenticationContextWithAppContextTests
+    {
+        [Fact]
+        public void Saml2AuthenticationContext_RelativeClassReference_AllowRelativeUris_NoException()
+        {
+            try
+            {
+                var classRef = new Uri("resource", UriKind.Relative);
+                AppContext.SetSwitch(AppContextSwitches.AllowRelativeUrisInSaml2AuthnContextSwitch, true);
+                var authContext = new Saml2AuthenticationContext
+                {
+                    ClassReference = classRef
+                };
+                Assert.Equal(classRef, authContext.ClassReference);
+            }
+            finally
+            {
+                AppContextSwitches.ResetAllSwitches();
+            }
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2AuthenticationContextWithAppContextTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Saml2AuthenticationContextWithAppContextTests.cs
@@ -7,6 +7,7 @@ using Microsoft.IdentityModel.Tokens.Saml2;
 
 namespace Microsoft.IdentityModel.Tokens.Saml.Tests
 {
+    [Collection("Saml2AuthenticationContextTests")]
     public class Saml2AuthenticationContextWithAppContextTests
     {
         [Fact]


### PR DESCRIPTION
# Allow usage of relative URIs in AuthnContextClassRef

Introduces a AppContext switch, that allows to cirumvent a condition that checks for `Uri.IsAbsoulte` on `Saml2AuthenticationContext.ClassReference`

Fixes #3279 

@brentschmaltz 