### PR TITLE
Add supported algorithm tests

### DIFF
--- a/test/Microsoft.IdentityModel.Tokens.Tests/SupportedAlgorithmTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SupportedAlgorithmTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.IdentityModel.TestUtils;
 using Xunit;
 
@@ -169,6 +170,24 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     true,
                     "X509_CustomCryptoProviderFactory",
                     theoryData);
+
+                // Add "none" and "noNe" test cases for all key types
+                var keyTypes = new Dictionary<string, SecurityKey>
+                {
+                    { "JsonWebKey_Ecdsa", KeyingMaterial.JsonWebKeyP256 },
+                    { "JsonWebKey_Rsa", KeyingMaterial.JsonWebKeyRsa_2048 },
+                    { "JsonWebKey_Symmetric", KeyingMaterial.JsonWebKeySymmetric256 },
+                    { "Rsa", KeyingMaterial.RsaSecurityKey_2048 },
+                    { "Symmetric", KeyingMaterial.DefaultSymmetricSecurityKey_256 },
+                    { "X509", KeyingMaterial.X509SecurityKeySelfSigned2048_SHA256 },
+                    { "Ecdsa", KeyingMaterial.Ecdsa384Key }
+                };
+
+                foreach (var keyType in keyTypes)
+                {
+                    SupportedAlgorithmTheoryData.AddTestCase("none", keyType.Value, false, $"{keyType.Key}_none", theoryData);
+                    SupportedAlgorithmTheoryData.AddTestCase("noNe", keyType.Value, false, $"{keyType.Key}_noNe", theoryData);
+                }
 
                 return theoryData;
             }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/SupportedAlgorithmTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/SupportedAlgorithmTests.cs
@@ -183,10 +183,33 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     { "Ecdsa", KeyingMaterial.Ecdsa384Key }
                 };
 
+                // All permutations of "none" with different capitalizations
+                var nonePermutations = new[]
+                {
+                    "none",
+                    "None",
+                    "nOne",
+                    "noNe",
+                    "nonE",
+                    "NOne",
+                    "NONe",
+                    "NOnE",
+                    "noNE",
+                    "nONE",
+                    "NoNe",
+                    "NoNE",
+                    "NOnE",
+                    "nONe",
+                    "nonE",
+                    "NONE"
+                };
+
                 foreach (var keyType in keyTypes)
                 {
-                    SupportedAlgorithmTheoryData.AddTestCase("none", keyType.Value, false, $"{keyType.Key}_none", theoryData);
-                    SupportedAlgorithmTheoryData.AddTestCase("noNe", keyType.Value, false, $"{keyType.Key}_noNe", theoryData);
+                    foreach (var permutation in nonePermutations)
+                    {
+                        SupportedAlgorithmTheoryData.AddTestCase(permutation, keyType.Value, false, $"{keyType.Key}_{permutation}", theoryData);
+                    }
                 }
 
                 return theoryData;


### PR DESCRIPTION
## Description
This PR adds negative test cases for the 'alg' header claim to ensure proper rejection of insecure or invalid algorithm values like 'none' and 'noNe'. This helps prevent security regressions where these algorithms might be inadvertently accepted.

Adds test cases for "none" and "noNe" algorithm values across all supported key types
Ensures these insecure algorithms are properly rejected (expected result: false)
