### PR TITLE
Align pipeline build with test phase by passing TargetNetNext to build & pack (fixes missing net10.0 test dll)

### DIFF
--- a/build/template-Build-run-tests-sign.yml
+++ b/build/template-Build-run-tests-sign.yml
@@ -1,9 +1,9 @@
 # template-Build-run-tests-sign.yml
 
 parameters:
-  - name: TargetNetNext
-    type: string
-    default: 'True'
+    - name: TargetNetNext
+      type: string
+      default: "True"
 
 steps:
     - script: echo $(BuildConfiguration)
@@ -158,7 +158,7 @@ steps:
       displayName: "Pack libraries"
       inputs:
           command: "pack"
-          arguments: "--no-restore /p:TargetNetNext=${{ parameters.TargetNetNext }}"
+          arguments: "--no-restore"
           packDirectory: '$(Build.SourcesDirectory)\artifacts'
           nobuild: true
           verbosityPack: "Minimal"

--- a/build/template-Build-run-tests-sign.yml
+++ b/build/template-Build-run-tests-sign.yml
@@ -1,234 +1,241 @@
 # template-Build-run-tests-sign.yml
 
+parameters:
+  - name: TargetNetNext
+    type: string
+    default: 'True'
+
 steps:
-- script: echo $(BuildConfiguration)
-  displayName: 'display Build Configuration'
+    - script: echo $(BuildConfiguration)
+      displayName: "display Build Configuration"
 
-- script: echo $(MicrosoftIdentityModelVersion)
-  displayName: 'display MicrosoftIdentityModelVersion'
+    - script: echo $(MicrosoftIdentityModelVersion)
+      displayName: "display MicrosoftIdentityModelVersion"
 
-# Primary SDK from global.json
-- task: UseDotNet@2
-  displayName: 'Use .NET SDK from global.json'
-  inputs:
-    useGlobalJson: true
-    installationPath: $(Agent.ToolsDirectory)/dotnet
+    # Primary SDK from global.json
+    - task: UseDotNet@2
+      displayName: "Use .NET SDK from global.json"
+      inputs:
+          useGlobalJson: true
+          installationPath: $(Agent.ToolsDirectory)/dotnet
 
-# Additional .NET SDKs needed for targeting older frameworks
-- task: UseDotNet@2
-  displayName: 'Use .Net Core SDK 2.x'
-  inputs:
-    version: 2.x
-    installationPath: $(Agent.ToolsDirectory)/dotnet
+    # Additional .NET SDKs needed for targeting older frameworks
+    - task: UseDotNet@2
+      displayName: "Use .Net Core SDK 2.x"
+      inputs:
+          version: 2.x
+          installationPath: $(Agent.ToolsDirectory)/dotnet
 
-- task: UseDotNet@2
-  displayName: 'Use .Net Core SDK 6.x'
-  inputs:
-    version: 6.x
-    installationPath: $(Agent.ToolsDirectory)/dotnet
+    - task: UseDotNet@2
+      displayName: "Use .Net Core SDK 6.x"
+      inputs:
+          version: 6.x
+          installationPath: $(Agent.ToolsDirectory)/dotnet
 
-- task: UseDotNet@2
-  displayName: 'Use .Net Core SDK 8.x'
-  inputs:
-    version: 8.x
-    installationPath: $(Agent.ToolsDirectory)/dotnet
+    - task: UseDotNet@2
+      displayName: "Use .Net Core SDK 8.x"
+      inputs:
+          version: 8.x
+          installationPath: $(Agent.ToolsDirectory)/dotnet
 
-- task: UseDotNet@2
-  displayName: 'Use .Net Core SDK 10.x'
-  inputs:
-    useGlobalJson: false
-    includePreviewVersions: true
-    version: 10.x
-    installationPath: $(Agent.ToolsDirectory)/dotnet
+    - task: UseDotNet@2
+      displayName: "Use .Net Core SDK 10.x"
+      inputs:
+          useGlobalJson: false
+          includePreviewVersions: true
+          version: 10.x
+          installationPath: $(Agent.ToolsDirectory)/dotnet
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet --list-sdks'
-  inputs:
-    command: custom
-    custom: '--list-sdks'
+    - task: DotNetCoreCLI@2
+      displayName: "dotnet --list-sdks"
+      inputs:
+          command: custom
+          custom: "--list-sdks"
 
-- task: PowerShell@2
-  displayName: 'Verify error messages are all used.'
-  inputs:
-    filePath: $(Build.SourcesDirectory)\$(WilsonSourceDirectory)Tools\VerifyResourceUsage.ps1
+    - task: PowerShell@2
+      displayName: "Verify error messages are all used."
+      inputs:
+          filePath: $(Build.SourcesDirectory)\$(WilsonSourceDirectory)Tools\VerifyResourceUsage.ps1
 
-- powershell: |
-    regedit /s .\build\strongNameBypass.reg
-  displayName: 'Strong Name Bypass'
+    - powershell: |
+          regedit /s .\build\strongNameBypass.reg
+      displayName: "Strong Name Bypass"
 
-- powershell: |
-    $nugetSourceIsExternal = (dotnet nuget list source --format Short).Contains("https://api.nuget.org/v3/index.json")
-    if ($nugetSourceIsExternal) {
-        dotnet nuget remove source NuGet
-        dotnet nuget add source https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json -n IDDP
-        dotnet nuget list source
-    }
-  workingDirectory: '$(Build.SourcesDirectory)\$(WilsonSourceDirectory)'
-  displayName: 'Remove external "NuGet" Source and add "IDDP artifacts" as a NuGet Source, if needed.'
-  env:
-    DOTNET_NOLOGO: 1
+    - powershell: |
+          $nugetSourceIsExternal = (dotnet nuget list source --format Short).Contains("https://api.nuget.org/v3/index.json")
+          if ($nugetSourceIsExternal) {
+              dotnet nuget remove source NuGet
+              dotnet nuget add source https://identitydivision.pkgs.visualstudio.com/_packaging/IDDP/nuget/v3/index.json -n IDDP
+              dotnet nuget list source
+          }
+      workingDirectory: '$(Build.SourcesDirectory)\$(WilsonSourceDirectory)'
+      displayName: 'Remove external "NuGet" Source and add "IDDP artifacts" as a NuGet Source, if needed.'
+      env:
+          DOTNET_NOLOGO: 1
 
-- task: DotNetCoreCLI@2
-  displayName: Build
-  inputs:
-    command: 'build'
-    projects: '$(WilsonSourceDirectory)Product.proj'
-    arguments: '/r:True /p:Configuration=$(BuildConfiguration) /p:Platform="Any CPU" /verbosity:m /p:SourceLinkCreate=true /p:TargetNetNext=$(TargetNetNext)'
+    - task: DotNetCoreCLI@2
+      displayName: Build
+      inputs:
+          command: "build"
+          projects: "$(WilsonSourceDirectory)Product.proj"
+          arguments: '/r:True /p:Configuration=$(BuildConfiguration) /p:Platform="Any CPU" /verbosity:m /p:SourceLinkCreate=true /p:TargetNetNext=${{ parameters.TargetNetNext }}'
 
-- task: PowerShell@2
-  displayName: 'Run Tests'
-  inputs:
-    targetType: filePath
-    filePath: ./$(WilsonSourceDirectory)runTests.ps1
-    arguments: '-buildType $(BuildConfiguration) -runningInCI $True'
+    - task: PowerShell@2
+      displayName: "Run Tests"
+      inputs:
+          targetType: filePath
+          filePath: ./$(WilsonSourceDirectory)runTests.ps1
+          arguments: "-buildType $(BuildConfiguration) -runningInCI $True"
+      env:
+          TargetNetNext: ${{ parameters.TargetNetNext }}
 
-- task: PublishTestResults@2
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: 'XUnit'
-    testResultsFiles: '**/*.trx'
-    searchFolder: '$(Agent.TempDirectory)'
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+          testResultsFormat: "XUnit"
+          testResultsFiles: "**/*.trx"
+          searchFolder: "$(Agent.TempDirectory)"
 
-- task: PublishCodeCoverageResults@2
-  condition: succeededOrFailed()
-  inputs:
-    summaryFileLocation: '$(Agent.TempDirectory)/**/*.cobertura.xml'
+    - task: PublishCodeCoverageResults@2
+      condition: succeededOrFailed()
+      inputs:
+          summaryFileLocation: "$(Agent.TempDirectory)/**/*.cobertura.xml"
 
-- task: CopyFiles@2
-  displayName: 'Copy Files to: [staging]\ProductBinaries'
-  inputs:
-    SourceFolder: $(WilsonSourceDirectory)src
-    Contents: |
-      **\bin\$(BuildConfiguration)\**\Microsoft.IdentityModel.*.dll
-      **\bin\$(BuildConfiguration)\**\Microsoft.IdentityModel.*.pdb
-      **\bin\$(BuildConfiguration)\**\System.IdentityModel.Tokens.Jwt.dll
-      **\bin\$(BuildConfiguration)\**\System.IdentityModel.Tokens.Jwt.pdb
-    TargetFolder: '$(Build.ArtifactStagingDirectory)\ProductBinaries'
-  condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
+    - task: CopyFiles@2
+      displayName: 'Copy Files to: [staging]\ProductBinaries'
+      inputs:
+          SourceFolder: $(WilsonSourceDirectory)src
+          Contents: |
+              **\bin\$(BuildConfiguration)\**\Microsoft.IdentityModel.*.dll
+              **\bin\$(BuildConfiguration)\**\Microsoft.IdentityModel.*.pdb
+              **\bin\$(BuildConfiguration)\**\System.IdentityModel.Tokens.Jwt.dll
+              **\bin\$(BuildConfiguration)\**\System.IdentityModel.Tokens.Jwt.pdb
+          TargetFolder: '$(Build.ArtifactStagingDirectory)\ProductBinaries'
+      condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
-  displayName: 'Run PoliCheck'
-  inputs:
-    targetType: F
-    result: PoliCheck.xml
-    optionsFC: 0
-    optionsXS: 0
-    optionsHMENABLE: 0
-  condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
+      displayName: "Run PoliCheck"
+      inputs:
+          targetType: F
+          result: PoliCheck.xml
+          optionsFC: 0
+          optionsXS: 0
+          optionsHMENABLE: 0
+      condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
-  displayName: 'Run CredScan'
-  inputs:
-    outputFormat: pre
-    suppressionsFile: 'build/credscan-exclusion.json'
-    debugMode: false
-  condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
+      displayName: "Run CredScan"
+      inputs:
+          outputFormat: pre
+          suppressionsFile: "build/credscan-exclusion.json"
+          debugMode: false
+      condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
-  displayName: 'Run Roslyn Analyzers'
-  condition: and(eq(variables['TargetNet8'], 'False'), eq(variables['PipelineType'], 'legacy'))
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@2
+      displayName: "Run Roslyn Analyzers"
+      condition: and(eq(variables['TargetNet8'], 'False'), eq(variables['PipelineType'], 'legacy'))
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
-  displayName: 'Run BinSkim'
-  inputs:
-    AnalyzeSymPath: '$(Build.ArtifactStagingDirectory)\ProductBinaries'
-    AnalyzeVerbose: true
-    AnalyzeHashes: true
-  condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
+      displayName: "Run BinSkim"
+      inputs:
+          AnalyzeSymPath: '$(Build.ArtifactStagingDirectory)\ProductBinaries'
+          AnalyzeVerbose: true
+          AnalyzeHashes: true
+      condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
-  displayName: 'Publish Security Analysis Logs'
-  continueOnError: true
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
+      displayName: "Publish Security Analysis Logs"
+      continueOnError: true
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
-  displayName: 'Post SDL Analysis'
-  continueOnError: true
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
+      displayName: "Post SDL Analysis"
+      continueOnError: true
 
-#Sign Wilson 7x task group
-- template: template-sign-wilson.yaml
+    #Sign Wilson 7x task group
+    - template: template-sign-wilson.yaml
 
-- task: DotNetCoreCLI@2
-  displayName: 'Pack libraries'
-  inputs:
-    command: 'pack'
-    arguments: '--no-restore /p:TargetNetNext=$(TargetNetNext)'
-    packDirectory: '$(Build.SourcesDirectory)\artifacts'
-    nobuild: true
-    verbosityPack: 'Minimal'
-    configuration: $(BuildConfiguration)
-    packagesToPack: '$(WilsonSourceDirectory)Product.proj'
-    externalFeedCredentials: 'Internal Analyzers'
+    - task: DotNetCoreCLI@2
+      displayName: "Pack libraries"
+      inputs:
+          command: "pack"
+          arguments: "--no-restore /p:TargetNetNext=${{ parameters.TargetNetNext }}"
+          packDirectory: '$(Build.SourcesDirectory)\artifacts'
+          nobuild: true
+          verbosityPack: "Minimal"
+          configuration: $(BuildConfiguration)
+          packagesToPack: "$(WilsonSourceDirectory)Product.proj"
+          externalFeedCredentials: "Internal Analyzers"
 
-- task: onebranch.pipeline.signing@1
-  displayName: 'Sign Packages with OneBranch'
-  inputs:
-    command: 'sign'
-    signing_profile: 'CP-401405'
-    files_to_sign: '**/*.nupkg'
-    search_root: '$(Build.SourcesDirectory)\artifacts'
-  condition: and(succeeded(), eq(variables['PipelineType'], 'onebranch'))
+    - task: onebranch.pipeline.signing@1
+      displayName: "Sign Packages with OneBranch"
+      inputs:
+          command: "sign"
+          signing_profile: "CP-401405"
+          files_to_sign: "**/*.nupkg"
+          search_root: '$(Build.SourcesDirectory)\artifacts'
+      condition: and(succeeded(), eq(variables['PipelineType'], 'onebranch'))
 
-# Copy all packages out to staging
-- task: CopyFiles@2
-  displayName: 'Copy Files from $(Build.SourcesDirectory) to: $(Build.ArtifactStagingDirectory)\packages'
-  inputs:
-    SourceFolder: '$(Build.SourcesDirectory)'
-    Contents: '**\*nupkg'
-    TargetFolder: '$(Build.ArtifactStagingDirectory)\packages'
-    flattenFolders: true
-  condition: and(succeeded(), eq(variables['PipelineType'], 'onebranch'))
+    # Copy all packages out to staging
+    - task: CopyFiles@2
+      displayName: 'Copy Files from $(Build.SourcesDirectory) to: $(Build.ArtifactStagingDirectory)\packages'
+      inputs:
+          SourceFolder: "$(Build.SourcesDirectory)"
+          Contents: '**\*nupkg'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)\packages'
+          flattenFolders: true
+      condition: and(succeeded(), eq(variables['PipelineType'], 'onebranch'))
 
-- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-  displayName: 'Component Detection'
-  inputs:
-    scanType: 'Register'
-    verbosity: 'Verbose'
-    alertWarningLevel: 'High'
-  condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: "Component Detection"
+      inputs:
+          scanType: "Register"
+          verbosity: "Verbose"
+          alertWarningLevel: "High"
+      condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
 
-- task: PublishSymbols@2
-  displayName: 'Publish symbols on symweb (cross publish)'
-  inputs:
-    SearchPattern: '**\bin\**\*.IdentityModel.*'
-    SymbolServerType: TeamServices
-    TreatNotIndexedAsWarning: true
+    - task: PublishSymbols@2
+      displayName: "Publish symbols on symweb (cross publish)"
+      inputs:
+          SearchPattern: '**\bin\**\*.IdentityModel.*'
+          SymbolServerType: TeamServices
+          TreatNotIndexedAsWarning: true
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
-  displayName: 'TSA upload to Codebase: WILSON Stamp: Azure'
-  inputs:
-    GdnPublishTsaOnboard: false
-    GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/build/tsaConfig.json'
-  continueOnError: true
-  condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
+    - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
+      displayName: "TSA upload to Codebase: WILSON Stamp: Azure"
+      inputs:
+          GdnPublishTsaOnboard: false
+          GdnPublishTsaConfigFile: "$(Build.SourcesDirectory)/build/tsaConfig.json"
+      continueOnError: true
+      condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
 
-- task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-  displayName: 'Manifest Generator'
-  inputs:
-    BuildDropPath: '$(Build.SourcesDirectory)\$(WilsonSourceDirectory)src'
-    ManifestDirPath: '$(Build.SourcesDirectory)\artifacts'
+    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+      displayName: "Manifest Generator"
+      inputs:
+          BuildDropPath: '$(Build.SourcesDirectory)\$(WilsonSourceDirectory)src'
+          ManifestDirPath: '$(Build.SourcesDirectory)\artifacts'
 
-- task: NuGetCommand@2
-  displayName: 'Upload NuGet Package to VSTS NuGet'
-  condition: eq(variables['MicrosoftIdentityModelVersion'], '')
-  inputs:
-    command: push
-    packagesToPush: '$(Build.Repository.LocalPath)\artifacts\*.nupkg'
-    publishVstsFeed: '46419298-b96c-437f-bd4c-12c8df7f868d'
-    allowPackageConflicts: true
+    - task: NuGetCommand@2
+      displayName: "Upload NuGet Package to VSTS NuGet"
+      condition: eq(variables['MicrosoftIdentityModelVersion'], '')
+      inputs:
+          command: push
+          packagesToPush: '$(Build.Repository.LocalPath)\artifacts\*.nupkg'
+          publishVstsFeed: "46419298-b96c-437f-bd4c-12c8df7f868d"
+          allowPackageConflicts: true
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish NuGet Package Artifact'
-  inputs:
-    PathtoPublish: '$(Build.SourcesDirectory)\artifacts'
-    ArtifactName: '$(Build.BuildNumber)-nuget-package'
+    - task: PublishBuildArtifacts@1
+      displayName: "Publish NuGet Package Artifact"
+      inputs:
+          PathtoPublish: '$(Build.SourcesDirectory)\artifacts'
+          ArtifactName: "$(Build.BuildNumber)-nuget-package"
 
-- task: BuildQualityChecks@9
-  displayName: 'Check Warnings'
-  inputs:
-    checkWarnings: true
-    warningFailOption: 'build'
-    showStatistics: true
+    - task: BuildQualityChecks@9
+      displayName: "Check Warnings"
+      inputs:
+          checkWarnings: true
+          warningFailOption: "build"
+          showStatistics: true
 
-- task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
-  displayName: 'Clean Agent Directories'
-  condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))
+    - task: mspremier.PostBuildCleanup.PostBuildCleanup-task.PostBuildCleanup@3
+      displayName: "Clean Agent Directories"
+      condition: and(succeeded(), eq(variables['PipelineType'], 'legacy'))

--- a/build/template-Build-run-tests-sign.yml
+++ b/build/template-Build-run-tests-sign.yml
@@ -158,7 +158,7 @@ steps:
       displayName: "Pack libraries"
       inputs:
           command: "pack"
-          arguments: "--no-restore"
+          arguments: "--no-restore /p:TargetNetNext=${{ parameters.TargetNetNext }}"
           packDirectory: '$(Build.SourcesDirectory)\artifacts'
           nobuild: true
           verbosityPack: "Minimal"

--- a/build/template-Build-run-tests-sign.yml
+++ b/build/template-Build-run-tests-sign.yml
@@ -79,6 +79,8 @@ steps:
           command: "build"
           projects: "$(WilsonSourceDirectory)Product.proj"
           arguments: '/r:True /p:Configuration=$(BuildConfiguration) /p:Platform="Any CPU" /verbosity:m /p:SourceLinkCreate=true /p:TargetNetNext=${{ parameters.TargetNetNext }}'
+      env:
+          TargetNetNext: ${{ parameters.TargetNetNext }}
 
     - task: PowerShell@2
       displayName: "Run Tests"
@@ -158,13 +160,15 @@ steps:
       displayName: "Pack libraries"
       inputs:
           command: "pack"
-          arguments: "--no-restore /p:TargetNetNext=${{ parameters.TargetNetNext }}"
+          arguments: "--no-restore /p:TargetNetNext=${{ parameters.TargetNetNext }} /p:WarningsNotAsErrors=NU5128"
           packDirectory: '$(Build.SourcesDirectory)\artifacts'
           nobuild: true
           verbosityPack: "Minimal"
           configuration: $(BuildConfiguration)
           packagesToPack: "$(WilsonSourceDirectory)Product.proj"
           externalFeedCredentials: "Internal Analyzers"
+      env:
+          TargetNetNext: ${{ parameters.TargetNetNext }}
 
     - task: onebranch.pipeline.signing@1
       displayName: "Sign Packages with OneBranch"

--- a/build/template-Build-run-tests-sign.yml
+++ b/build/template-Build-run-tests-sign.yml
@@ -73,7 +73,7 @@ steps:
   inputs:
     command: 'build'
     projects: '$(WilsonSourceDirectory)Product.proj'
-    arguments: '/r:True /p:Configuration=$(BuildConfiguration) /p:Platform="Any CPU" /verbosity:m /p:SourceLinkCreate=true'
+    arguments: '/r:True /p:Configuration=$(BuildConfiguration) /p:Platform="Any CPU" /verbosity:m /p:SourceLinkCreate=true /p:TargetNetNext=$(TargetNetNext)'
 
 - task: PowerShell@2
   displayName: 'Run Tests'
@@ -151,7 +151,7 @@ steps:
   displayName: 'Pack libraries'
   inputs:
     command: 'pack'
-    arguments: '--no-restore'
+    arguments: '--no-restore /p:TargetNetNext=$(TargetNetNext)'
     packDirectory: '$(Build.SourcesDirectory)\artifacts'
     nobuild: true
     verbosityPack: 'Minimal'

--- a/runTests.ps1
+++ b/runTests.ps1
@@ -30,7 +30,10 @@ function WriteSectionFooter($sectionName)
 
 ################################################# Functions ############################################################
 
-$env:TargetNetNext = "True"
+# Set TargetNetNext to True by default if not already set
+if (-not $env:TargetNetNext) {
+    $env:TargetNetNext = "True"
+}
 
 WriteSectionHeader("runTests.ps1");
 Write-Host "buildType:       " $buildType;


### PR DESCRIPTION
[Pipelines - Run 20250930.2](https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=1539960&view=results)

The pipeline was failing during the VSTest phase with: The test source file ...\net10.0\Microsoft.IdentityModel.Logging.Tests.dll was not found. Root cause: runTests.ps1 (or related props) enables the next .NET target (net10.0) via TargetNetNext, causing test discovery to look for net10.0 test assemblies. The earlier solution build step in template-Build-run-tests-sign.yml did not pass /p:TargetNetNext, so net10.0 binaries were never built. VSTest then failed when attempting to execute the non-existent net10.0 test DLL.