### PR TITLE
Revert "Don't target NET 10 SDK for dotnetcore.yml"

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -18,7 +18,7 @@ on:
       - dev
 
 env:
-  TargetNetNext: false
+  TargetNetNext: True
 
 jobs:
   build:
@@ -44,11 +44,10 @@ jobs:
       with:
         global-json-file: ./global.json
 
-    # Fails test coverage generation
-    #- name: Setup latest .NET 10 preview SDK
-    #  uses: actions/setup-dotnet@v4
-    #  with:
-    #    dotnet-version: '10.0.x'
+    - name: Setup latest .NET 10 preview SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '10.0.x'
 
     - name: Strong name bypass
       run: |


### PR DESCRIPTION
Reverts AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet#3335

Restore building with NET10 preview after upgrading dependencies.