### PR TITLE
Fix DateTime claim value type recognition for ISO8601 strings with and without trailing zeros

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JwtTokenUtilities.cs
@@ -619,11 +619,9 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             if (!string.IsNullOrEmpty(claimType) && !AppContextSwitches.TryAllStringClaimsAsDateTime && JsonSerializerPrimitives.IsKnownToNotBeDateTime(claimType))
                 return ClaimValueTypes.String;
 
-            if (DateTime.TryParse(str, out DateTime dateTimeValue))
+            if (DateTime.TryParse(str, null, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out _))
             {
-                string dtUniversal = dateTimeValue.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture);
-                if (dtUniversal.Equals(str, StringComparison.Ordinal))
-                    return ClaimValueTypes.DateTime;
+                return ClaimValueTypes.DateTime;
             }
 
             return ClaimValueTypes.String;

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JwtTokenUtilitiesTests.cs
@@ -8,6 +8,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Claims;
 using System.Text;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -217,6 +218,21 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             resolvedKey = JwtTokenUtilities.ResolveTokenSigningKey(null, null, tvp, GetConfigurationNoMatchingKeyMock());
             Assert.Null(resolvedKey);
         }
+
+        #region GetStringClaimValueType
+
+        [Fact]
+        public void GetStringClaimValueType_ReturnsDateTime_ForIso8601WithOrWithoutTrailingZeros()
+        {
+            var iso8601WithTrailingZeros = "2025-11-26T09:30:45.1234560Z";
+            var iso8601WithoutTrailingZeros = "2025-11-26T09:30:45.123456Z";
+            var resultWithTrailingZeros = JwtTokenUtilities.GetStringClaimValueType(iso8601WithTrailingZeros);
+            var resultWithoutTrailingZeros = JwtTokenUtilities.GetStringClaimValueType(iso8601WithoutTrailingZeros);
+            Assert.Equal(ClaimValueTypes.DateTime, resultWithTrailingZeros);
+            Assert.Equal(ClaimValueTypes.DateTime, resultWithoutTrailingZeros);
+        }
+
+        #endregion
 
         #region DecryptJwtToken Tests
         [Fact]

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtPayloadTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Security.Claims;
 using System.Text;
+using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.TestUtils;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.IdentityModel.Tokens.Json;
@@ -180,6 +181,23 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
 
             Assert.True(string.Equals(dateTimeClaim.ValueType, ClaimValueTypes.DateTime), "dateTimeClaim.Type != ClaimValueTypes.DateTime");
             Assert.True(string.Equals(dateTimeClaim.Value, dateTime.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture)), "dateTimeClaim.Value != dateTime.ToUniversalTime('o', CultureInfo.InvariantCulture).ToString()");
+        }
+
+        [Fact]
+        public void TestReturnsDateTime_ForIso8601WithOrWithoutTrailingZeros()
+        {
+            var iso8601WithTrailingZeros = "2025-11-26T09:30:45.1234560Z";
+            var iso8601WithoutTrailingZeros = "2025-11-26T09:30:45.123456Z";
+            var jwtpayload = new JwtPayload
+            {
+                { "dateWithTrailingZeros", iso8601WithTrailingZeros },
+                { "dateWithoutTrailingZeros", iso8601WithoutTrailingZeros }
+            };
+
+            var claimWithTrailingZeros = jwtpayload.Claims.First(c => c.Type == "dateWithTrailingZeros");
+            var claimWithoutTrailingZeros = jwtpayload.Claims.First(c => c.Type == "dateWithoutTrailingZeros");
+            Assert.Equal(ClaimValueTypes.DateTime, claimWithTrailingZeros.ValueType);
+            Assert.Equal(ClaimValueTypes.DateTime, claimWithoutTrailingZeros.ValueType);
         }
 
         [Fact]


### PR DESCRIPTION
## Background
Currently, the method `GetStringClaimValueType` returns `ClaimValueTypes.DateTime` only if the input string matches exactly the output of `DateTime.ToUniversalTime().ToString("o", ...)`. 
This leads to inconsistent behavior for ISO8601 UTC strings with or without trailing zeros, e.g.:
- "2025-11-26T07:18:45.1234560Z" → DateTime
- "2025-11-26T07:18:45.123456Z"  → String

## Fix
With this change, all strings that can be successfully parsed as a valid DateTime will return `ClaimValueTypes.DateTime`, regardless of trailing zeroes.

## Impact
This fix ensures that semantically equivalent ISO8601 UTC time strings are consistently recognized as DateTime claims.

## Tests
- Added/Updated tests for ISO8601 datetime strings with and without trailing zeros.