### PR TITLE
Fix FileVersion format to use two-digit year and day of year

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -11,7 +11,7 @@
     <Version Condition="'$(MicrosoftIdentityModelVersion)' != ''">$(MicrosoftIdentityModelVersion)</Version>
     <VersionSuffix Condition="'$(MicrosoftIdentityModelVersion)' == ''">$(PreviewVersionSuffix)</VersionSuffix>
     <VersionPrefix Condition="'$(MicrosoftIdentityModelVersion)' == ''">$(MicrosoftIdentityModelCurrentVersion)</VersionPrefix>
-    <FileVersion Condition="'$(MicrosoftIdentityModelVersion)' != '' and '$(IsCustomPreview)' != 'true' ">$(MicrosoftIdentityModelVersion).$([System.DateTime]::Now.AddYears(-2019).Year)$([System.DateTime]::Now.ToString("MMdd"))</FileVersion>
-    <FileVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">$(MicrosoftIdentityModelCurrentVersion).$([System.DateTime]::Now.AddYears(-2019).Year)$([System.DateTime]::Now.ToString("MMdd"))</FileVersion>
+    <FileVersion Condition="'$(MicrosoftIdentityModelVersion)' != '' and '$(IsCustomPreview)' != 'true' ">$(MicrosoftIdentityModelVersion).$([System.DateTime]::Now.ToString("yy"))$([System.DateTime]::Now.DayOfYear.ToString("000"))</FileVersion>
+    <FileVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">$(MicrosoftIdentityModelCurrentVersion).$([System.DateTime]::Now.ToString("yy"))$([System.DateTime]::Now.DayOfYear.ToString("000"))</FileVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Fix FileVersion format to use two-digit year and day of year
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Summary
The FileVersion assembly attribute generates a revision number that exceeds the 16-bit unsigned integer limit (65,535).

## Description

Root Cause
The FileVersion assembly attribute generates a revision number that exceeds the 16-bit unsigned integer limit (65,535).

Current Format: {Version}.{YearsSince2019}{MMdd}

Example for Jan 5, 2026: 8.12.1.70105
Major: 8
Minor: 12
Build: 1
Revision: 70105 (7 for year + 0105 for date)
The Issue:

.NET assembly version components must be ≤ 65,535
Starting January 1, 2026 (year 7 since 2019), the revision number exceeds this limit
Any date in 2026 produces: 70001 to 71231 (all > 65,535)

Fix: 
Use YYDDD (Day of Year)
Format: {YY}{DDD} where DDD is day of year (001-366)

Example Jan 5, 2026: 8.12.1.26005
Range: 26001 to 26366
Valid until: 2029 (year 10 would create 100XX

Fixes #{Bug 3481482} (https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3481482)
