### PR TITLE
Ssathe/claim type mapping missing groups

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/ClaimTypeMapping.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/ClaimTypeMapping.cs
@@ -70,6 +70,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             { "endpointpath", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-endpoint-absolute-path" },
             { "forwardedclientip", "http://schemas.microsoft.com/2012/01/requestcontext/claims/x-ms-forwarded-client-ip" },
             { "group", "http://schemas.xmlsoap.org/claims/Group" },
+            { "groups", "http://schemas.microsoft.com/ws/2008/06/identity/claims/groups"},
             { "groupsid", ClaimTypes.GroupSid },
             { "idp", "http://schemas.microsoft.com/identity/claims/identityprovider" },
             { "insidecorporatenetwork", "http://schemas.microsoft.com/ws/2012/01/insidecorporatenetwork" },

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -4700,6 +4700,94 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 }
             };
         }
+
+        [Theory, MemberData(nameof(GroupsClaimMappingTheoryData), DisableDiscoveryEnumeration = true)]
+        public async Task ValidateGroupsClaimMapping(JwtTheoryData theoryData)
+        {
+            TestUtilities.WriteHeader($"{this}.ValidateGroupsClaimMapping", theoryData);
+
+            try
+            {
+                var handler = new JsonWebTokenHandler();
+                var validationResult = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
+
+                Assert.True(validationResult.IsValid);
+
+                // Verify the groups claim is in the claims dictionary
+                if (validationResult.Claims != null && validationResult.Claims.TryGetValue("groups", out var groupsValue))
+                {
+                    Assert.NotNull(groupsValue);
+                }
+
+                theoryData.ExpectedException.ProcessNoException();
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex);
+            }
+        }
+
+        public static TheoryData<JwtTheoryData> GroupsClaimMappingTheoryData()
+        {
+            var handler = new JsonWebTokenHandler();
+            var theoryData = new TheoryData<JwtTheoryData>();
+
+            // Test Case 1: Single groups claim
+            var descriptor = new SecurityTokenDescriptor
+            {
+                Issuer = Default.Issuer,
+                Audience = Default.Audience,
+                SigningCredentials = Default.AsymmetricSigningCredentials,
+                Claims = new Dictionary<string, object>
+                {
+                    { "groups", "Admin" }
+                }
+            };
+            var token = handler.CreateToken(descriptor);
+
+            theoryData.Add(new JwtTheoryData
+            {
+                TestId = "SingleGroupsClaim",
+                Token = token,
+                ValidationParameters = new TokenValidationParameters
+                {
+                    RequireSignedTokens = true,
+                    ValidateAudience = false,
+                    ValidateIssuer = false,
+                    ValidateLifetime = false,
+                    IssuerSigningKey = Default.AsymmetricSigningKey,
+                }
+            });
+
+            // Test Case 2: Multiple groups claims
+            var multiDescriptor = new SecurityTokenDescriptor
+            {
+                Issuer = Default.Issuer,
+                Audience = Default.Audience,
+                SigningCredentials = Default.AsymmetricSigningCredentials,
+                Claims = new Dictionary<string, object>
+                {
+                    { "groups", new[] { "Admin", "Users", "Developers" } }
+                }
+            };
+            var multiToken = handler.CreateToken(multiDescriptor);
+
+            theoryData.Add(new JwtTheoryData
+            {
+                TestId = "MultipleGroupsClaims",
+                Token = multiToken,
+                ValidationParameters = new TokenValidationParameters
+                {
+                    RequireSignedTokens = true,
+                    ValidateAudience = false,
+                    ValidateIssuer = false,
+                    ValidateLifetime = false,
+                    IssuerSigningKey = Default.AsymmetricSigningKey,
+                }
+            });
+
+            return theoryData;
+        }
     }
 
     public class CreateTokenTheoryData : TheoryDataBase

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -3262,6 +3262,111 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
                 },
             };
         }
+
+        [Theory, MemberData(nameof(GroupsClaimMappingTheoryData), DisableDiscoveryEnumeration = true)]
+        public void ValidateGroupsClaimMapping(JwtTheoryData theoryData)
+        {
+            TestUtilities.WriteHeader($"{this}. ValidateGroupsClaimMapping", theoryData);
+
+            try
+            {
+                var handler = new JwtSecurityTokenHandler();
+                SecurityToken validatedToken;
+                var claimsPrincipal = handler.ValidateToken(theoryData.Token, theoryData.ValidationParameters, out validatedToken);
+
+                Assert.NotNull(claimsPrincipal);
+
+                var identity = claimsPrincipal.Identity as ClaimsIdentity;
+                Assert.NotNull(identity);
+
+                // Verify the groups claim is mapped to the expected long claim type
+                var groupsClaims = identity.FindAll("http://schemas.microsoft.com/ws/2008/06/identity/claims/groups").ToList();
+                Assert.NotEmpty(groupsClaims);
+
+                // Verify the short claim type is preserved in properties
+                foreach (var claim in groupsClaims)
+                {
+                    Assert.True(claim.Properties.ContainsKey(JwtSecurityTokenHandler.ShortClaimTypeProperty));
+                    Assert.Equal("groups", claim.Properties[JwtSecurityTokenHandler.ShortClaimTypeProperty]);
+                }
+
+                theoryData.ExpectedException.ProcessNoException();
+            }
+            catch (Exception ex)
+            {
+                theoryData.ExpectedException.ProcessException(ex);
+            }
+        }
+
+        public static TheoryData<JwtTheoryData> GroupsClaimMappingTheoryData()
+        {
+            var handler = new JwtSecurityTokenHandler();
+            var theoryData = new TheoryData<JwtTheoryData>();
+
+            // Test Case 1: Single groups claim
+            var identity = new CaseSensitiveClaimsIdentity(new List<Claim>
+            {
+                new Claim("groups", "Admin")
+            });
+
+            var descriptor = new SecurityTokenDescriptor
+            {
+                Issuer = Default.Issuer,
+                Audience = Default.Audience,
+                SigningCredentials = Default.AsymmetricSigningCredentials,
+                Subject = identity
+            };
+
+            var token = handler.CreateEncodedJwt(descriptor);
+
+            theoryData.Add(new JwtTheoryData
+            {
+                TestId = "SingleGroupsClaim",
+                Token = token,
+                ValidationParameters = new TokenValidationParameters
+                {
+                    RequireSignedTokens = true,
+                    ValidateAudience = false,
+                    ValidateIssuer = false,
+                    ValidateLifetime = false,
+                    IssuerSigningKey = Default.AsymmetricSigningKey,
+                }
+            });
+
+            // Test Case 2: Multiple groups claims
+            var multiIdentity = new CaseSensitiveClaimsIdentity(new List<Claim>
+            {
+                new Claim("groups", "Admin"),
+                new Claim("groups", "Users"),
+                new Claim("groups", "Developers")
+            });
+
+            var multiDescriptor = new SecurityTokenDescriptor
+            {
+                Issuer = Default.Issuer,
+                Audience = Default.Audience,
+                SigningCredentials = Default.AsymmetricSigningCredentials,
+                Subject = multiIdentity
+            };
+
+            var multiToken = handler.CreateEncodedJwt(multiDescriptor);
+
+            theoryData.Add(new JwtTheoryData
+            {
+                TestId = "MultipleGroupsClaims",
+                Token = multiToken,
+                ValidationParameters = new TokenValidationParameters
+                {
+                    RequireSignedTokens = true,
+                    ValidateAudience = false,
+                    ValidateIssuer = false,
+                    ValidateLifetime = false,
+                    IssuerSigningKey = Default.AsymmetricSigningKey,
+                }
+            });
+
+            return theoryData;
+        }
     }
 
     public class KeyWrapTokenTheoryData : TheoryDataBase

--- a/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
+++ b/test/System.IdentityModel.Tokens.Jwt.Tests/JwtSecurityTokenHandlerTests.cs
@@ -991,6 +991,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             adfsStrings.Add(new KeyValuePair<string, string>("commonname", "http://schemas.xmlsoap.org/claims/CommonName"));
             adfsStrings.Add(new KeyValuePair<string, string>("adfs1email", "http://schemas.xmlsoap.org/claims/EmailAddress"));
             adfsStrings.Add(new KeyValuePair<string, string>("group", "http://schemas.xmlsoap.org/claims/Group"));
+            adfsStrings.Add(new KeyValuePair<string, string>("groups", "http://schemas.microsoft.com/ws/2008/06/identity/claims/groups"));
             adfsStrings.Add(new KeyValuePair<string, string>("adfs1upn", "http://schemas.xmlsoap.org/claims/UPN"));
             adfsStrings.Add(new KeyValuePair<string, string>("role", "http://schemas.microsoft.com/ws/2008/06/identity/claims/role"));
             adfsStrings.Add(new KeyValuePair<string, string>("family_name", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"));
@@ -1127,9 +1128,10 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
         public void MapInboundClaims()
         {
             var handler = new JwtSecurityTokenHandler();
+            const int expectedDefaultMappingCount = 74;
 
             // By default, JwtSecurityTokenHandler.DefaultMapInboundClaims should be true so make sure we initialize the InboundClaimTypeMap with the default mappings.
-            Assert.Equal(73, handler.InboundClaimTypeMap.Count);
+            Assert.Equal(expectedDefaultMappingCount, handler.InboundClaimTypeMap.Count);
 
             JwtSecurityTokenHandler.DefaultMapInboundClaims = false;
             handler = new JwtSecurityTokenHandler();
@@ -1152,7 +1154,7 @@ namespace System.IdentityModel.Tokens.Jwt.Tests
             handler.MapInboundClaims = true;
 
             // Check to make sure that setting MapInboundClaims to true initializes the InboundClaimType map with the default mappings if it was previously empty.
-            Assert.Equal(73, handler.InboundClaimTypeMap.Count);
+            Assert.Equal(expectedDefaultMappingCount, handler.InboundClaimTypeMap.Count);
 
             // Check to make sure that changing the instance property did not alter the static property.
             Assert.True(JwtSecurityTokenHandler.DefaultMapInboundClaims == false);


### PR DESCRIPTION
# Add missing 'groups' claim type mapping
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [*] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [*] You've included unit or integration tests for your change, where applicable.
- [*] You've included inline docs for your change, where applicable.
- [*] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [*] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Summary

Adds the missing `"groups"` claim type mapping to `ClaimTypeMapping. cs`.

## Description

The `"groups"` claim is defined in both the [Microsoft Identity Platform documentation](https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference) and the [official IANA JWT assignments](https://www.iana.org/assignments/jwt/jwt.xhtml), but was not included in the inbound claim type mapping. 

This was likely an oversight since: 
- The similar `"group"` claim is already mapped
- Both `"role"` and `"roles"` are mapped

### Changes

- Added `"groups"` → `"http://schemas.microsoft.com/ws/2008/06/identity/claims/groups"` mapping in `ClaimTypeMapping.cs`
- Added end-to-end validation tests for `JsonWebTokenHandler` and `JwtSecurityTokenHandler`
- Updated existing tests to include the new mapping and adjusted expected mapping count from 73 to 74

Fixes #3360