### PR TITLE
Emit warning for package version mismatch

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -76,5 +76,22 @@
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
-  
+
+  <!--
+    Ship version-mismatch detection targets inside every NuGet package.
+    The .targets file must be named <PackageId>.targets per NuGet convention.
+    The .cs file containing the inline task logic is placed alongside it so that
+    the Source= attribute in the .targets file resolves correctly in consumers.
+    Using buildTransitive ensures the check flows to all consuming projects,
+    even those that reference IdentityModel packages only transitively.
+  -->
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\src\Common\Microsoft.IdentityModel.VersionMismatch.targets"
+          Pack="true"
+          PackagePath="buildTransitive\$(PackageId).targets" />
+    <None Include="$(MSBuildThisFileDirectory)..\src\Common\Microsoft.IdentityModel.VersionMismatchTask.cs"
+          Pack="true"
+          PackagePath="buildTransitive\Microsoft.IdentityModel.VersionMismatchTask.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/Common/Microsoft.IdentityModel.VersionMismatch.targets
+++ b/src/Common/Microsoft.IdentityModel.VersionMismatch.targets
@@ -1,0 +1,57 @@
+<!--
+  Microsoft.IdentityModel Version Mismatch Detection
+
+  This MSBuild targets file is shipped inside every Microsoft.IdentityModel.* and
+  System.IdentityModel.* NuGet package under the buildTransitive/ folder. It runs
+  after NuGet package resolution and warns when the resolved package versions are
+  not all the same — a common source of hard-to-diagnose runtime failures.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    Allow consumers to opt out of the check by setting
+    DisableIdentityModelVersionMismatchCheck=true in their project file.
+  -->
+  <PropertyGroup Condition="'$(_IdentityModelVersionCheckImported)' == ''">
+    <_IdentityModelVersionCheckImported>true</_IdentityModelVersionCheckImported>
+    <DisableIdentityModelVersionMismatchCheck Condition="'$(DisableIdentityModelVersionMismatchCheck)' == ''">false</DisableIdentityModelVersionMismatchCheck>
+  </PropertyGroup>
+
+  <!--
+    The target hooks into ResolvePackageAssets. There is used @(RuntimeCopyLocalItems)
+    where each item carries NuGetPackageId and NuGetPackageVersion metadata,
+    which allow detecting all resolved IdentityModel packages and their versions.
+    The guard condition '_IdentityModelVersionCheckExecuted' prevents running more
+    than once when multiple IdentityModel packages are referenced.
+  -->
+  <Target Name="_CheckIdentityModelVersions"
+          AfterTargets="ResolvePackageAssets"
+          Condition="'$(DisableIdentityModelVersionMismatchCheck)' != 'true' and '$(DesignTimeBuild)' != 'true' and '$(_IdentityModelVersionCheckExecuted)' != 'true'">
+
+    <PropertyGroup>
+      <_IdentityModelVersionCheckExecuted>true</_IdentityModelVersionCheckExecuted>
+    </PropertyGroup>
+
+    <_IdentityModelVersionMismatchTask ResolvedPackages="@(RuntimeCopyLocalItems)" />
+  </Target>
+
+  <!--
+    Inline task: the C# implementation is kept in a separate file for easier
+    maintenance and testing. RoslynCodeTaskFactory compiles it on first use.
+  -->
+  <UsingTask TaskName="_IdentityModelVersionMismatchTask"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <ResolvedPackages ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.Collections.Generic" />
+      <Using Namespace="System.Linq" />
+      <Code Type="Fragment" Language="cs"
+            Source="$(MSBuildThisFileDirectory)Microsoft.IdentityModel.VersionMismatchTask.cs" />
+    </Task>
+  </UsingTask>
+
+</Project>

--- a/src/Common/Microsoft.IdentityModel.VersionMismatchTask.cs
+++ b/src/Common/Microsoft.IdentityModel.VersionMismatchTask.cs
@@ -5,14 +5,6 @@
 // MSBuild inline task (<Code Type="Fragment">). It inspects the resolved NuGet
 // package graph for Microsoft.IdentityModel.* / System.IdentityModel.* packages
 // and emits a build warning when multiple different versions are detected.
-//
-// Because this is a code fragment, the code below is placed directly inside the
-// Execute() method body. Early "return true" statements are valid and indicate
-// successful task completion (no warning needed). At the end of a fragment,
-// MSBuild auto-appends "return !Log.HasLoggedErrors;" so no explicit final
-// return is required.
-//
-// See: https://learn.microsoft.com/visualstudio/msbuild/msbuild-roslyncodetaskfactory
 
 // Explicit list of Microsoft.IdentityModel / System.IdentityModel packages
 // shipped from this repository (matching the project directories under src/).

--- a/src/Common/Microsoft.IdentityModel.VersionMismatchTask.cs
+++ b/src/Common/Microsoft.IdentityModel.VersionMismatchTask.cs
@@ -150,4 +150,4 @@ sb.AppendLine("Note: Disabling this check is not recommended. Mismatched package
 sb.AppendLine("runtime errors such as TypeLoadException, MissingMethodException, or other hard-to-diagnose failures.");
 sb.AppendLine();
 
-Log.LogWarning(null, "IDMODEL001", null, null, 0, 0, 0, 0, sb.ToString());
+Log.LogWarning(null, "IDX00001", null, null, 0, 0, 0, 0, sb.ToString());

--- a/src/Common/Microsoft.IdentityModel.VersionMismatchTask.cs
+++ b/src/Common/Microsoft.IdentityModel.VersionMismatchTask.cs
@@ -2,14 +2,41 @@
 // Licensed under the MIT License.
 
 // This file is compiled at build-time by RoslynCodeTaskFactory and runs as an
-// MSBuild inline task. It inspects the resolved NuGet package graph for
-// Microsoft.IdentityModel.* / System.IdentityModel.* packages and emits a
-// build warning when multiple different versions are detected.
+// MSBuild inline task (<Code Type="Fragment">). It inspects the resolved NuGet
+// package graph for Microsoft.IdentityModel.* / System.IdentityModel.* packages
+// and emits a build warning when multiple different versions are detected.
+//
+// Because this is a code fragment, the code below is placed directly inside the
+// Execute() method body. Early "return true" statements are valid and indicate
+// successful task completion (no warning needed). At the end of a fragment,
+// MSBuild auto-appends "return !Log.HasLoggedErrors;" so no explicit final
+// return is required.
+//
+// See: https://learn.microsoft.com/visualstudio/msbuild/msbuild-roslyncodetaskfactory
 
-// Collect all Microsoft.IdentityModel.* and System.IdentityModel.* packages
-// from the resolved RuntimeCopyLocalItems. Each item carries NuGetPackageId and
-// NuGetPackageVersion metadata. A deduplication is performed because multiple
-// upstream dependencies can come from the same package.
+// Explicit list of Microsoft.IdentityModel / System.IdentityModel packages
+// shipped from this repository (matching the project directories under src/).
+var identityModelPackageNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+{
+    "Microsoft.IdentityModel.Abstractions",
+    "Microsoft.IdentityModel.JsonWebTokens",
+    "Microsoft.IdentityModel.Logging",
+    "Microsoft.IdentityModel.LoggingExtensions",
+    "Microsoft.IdentityModel.Protocols",
+    "Microsoft.IdentityModel.Protocols.OpenIdConnect",
+    "Microsoft.IdentityModel.Protocols.SignedHttpRequest",
+    "Microsoft.IdentityModel.Protocols.WsFederation",
+    "Microsoft.IdentityModel.TestExtensions",
+    "Microsoft.IdentityModel.Tokens",
+    "Microsoft.IdentityModel.Tokens.Saml",
+    "Microsoft.IdentityModel.Validators",
+    "Microsoft.IdentityModel.Xml",
+    "System.IdentityModel.Tokens.Jwt",
+};
+
+// Collect matching packages from the resolved RuntimeCopyLocalItems. Each item
+// carries NuGetPackageId and NuGetPackageVersion metadata. A deduplication is
+// performed because multiple upstream dependencies can come from the same package.
 var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 var identityModelPackages = new List<KeyValuePair<string, string>>();
 
@@ -25,8 +52,7 @@ if (ResolvedPackages != null)
             continue;
         }
 
-        if (packageId.StartsWith("Microsoft.IdentityModel.", StringComparison.OrdinalIgnoreCase) ||
-            packageId.StartsWith("System.IdentityModel.", StringComparison.OrdinalIgnoreCase))
+        if (identityModelPackageNames.Contains(packageId))
         {
             var key = packageId + "/" + version;
             if (seen.Add(key))
@@ -121,6 +147,15 @@ foreach (var pkgId in packagesToUpgrade)
 }
 
 sb.AppendLine("  </ItemGroup>");
+sb.AppendLine();
+sb.AppendLine("To suppress this warning, set the MSBuild property DisableIdentityModelVersionMismatchCheck to true in your project file:");
+sb.AppendLine();
+sb.AppendLine("  <PropertyGroup>");
+sb.AppendLine("    <DisableIdentityModelVersionMismatchCheck>true</DisableIdentityModelVersionMismatchCheck>");
+sb.AppendLine("  </PropertyGroup>");
+sb.AppendLine();
+sb.AppendLine("Note: Disabling this check is not recommended. Mismatched package versions can cause unexpected");
+sb.AppendLine("runtime errors such as TypeLoadException, MissingMethodException, or other hard-to-diagnose failures.");
 sb.AppendLine();
 
 Log.LogWarning(null, "IDMODEL001", null, null, 0, 0, 0, 0, sb.ToString());

--- a/src/Common/Microsoft.IdentityModel.VersionMismatchTask.cs
+++ b/src/Common/Microsoft.IdentityModel.VersionMismatchTask.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// This file is compiled at build-time by RoslynCodeTaskFactory and runs as an
+// MSBuild inline task. It inspects the resolved NuGet package graph for
+// Microsoft.IdentityModel.* / System.IdentityModel.* packages and emits a
+// build warning when multiple different versions are detected.
+
+// Collect all Microsoft.IdentityModel.* and System.IdentityModel.* packages
+// from the resolved RuntimeCopyLocalItems. Each item carries NuGetPackageId and
+// NuGetPackageVersion metadata. A deduplication is performed because multiple
+// upstream dependencies can come from the same package.
+var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+var identityModelPackages = new List<KeyValuePair<string, string>>();
+
+if (ResolvedPackages != null)
+{
+    foreach (var item in ResolvedPackages)
+    {
+        var packageId = item.GetMetadata("NuGetPackageId");
+        var version = item.GetMetadata("NuGetPackageVersion");
+
+        if (string.IsNullOrEmpty(packageId) || string.IsNullOrEmpty(version))
+        {
+            continue;
+        }
+
+        if (packageId.StartsWith("Microsoft.IdentityModel.", StringComparison.OrdinalIgnoreCase) ||
+            packageId.StartsWith("System.IdentityModel.", StringComparison.OrdinalIgnoreCase))
+        {
+            var key = packageId + "/" + version;
+            if (seen.Add(key))
+            {
+                identityModelPackages.Add(new KeyValuePair<string, string>(packageId, version));
+            }
+        }
+    }
+}
+
+if (identityModelPackages.Count <= 1)
+{
+    return true; // Nothing to compare
+}
+
+// Find distinct versions.
+var distinctVersions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+foreach (var pkg in identityModelPackages)
+{
+    distinctVersions.Add(pkg.Value);
+}
+
+if (distinctVersions.Count <= 1)
+{
+    return true; // All versions match — no warning needed
+}
+
+// Parse a NuGet version string into a comparable tuple.
+// Strips any prerelease suffix (e.g. "1.2.3-preview456" -> "1.2.3")
+// and uses System.Version for numeric comparison. Prerelease versions are
+// considered lower than the same base version without a suffix.
+Func<string, Tuple<System.Version, bool, string>> parseVersion = (raw) =>
+{
+    var hyphen = raw.IndexOf('-');
+    var isPrerelease = hyphen >= 0;
+    var versionPart = isPrerelease ? raw.Substring(0, hyphen) : raw;
+
+    System.Version parsed;
+    if (!System.Version.TryParse(versionPart, out parsed))
+    {
+        parsed = new System.Version(0, 0);
+    }
+
+    return Tuple.Create(parsed, !isPrerelease, raw);
+};
+
+// Determine the highest version for the upgrade suggestion.
+var maxVersion = identityModelPackages
+    .Select(item => item.Value)
+    .OrderByDescending(item =>
+    {
+        var version = parseVersion(item);
+        return version;
+    }, Comparer<Tuple<System.Version, bool, string>>.Default)
+    .First();
+
+// Build the warning message.
+var sb = new System.Text.StringBuilder();
+sb.AppendLine();
+sb.AppendLine("All Microsoft.IdentityModel.* and System.IdentityModel.* packages must have the same version to avoid hard-to-diagnose runtime errors.");
+sb.AppendLine("The following packages were resolved with different versions:");
+sb.AppendLine();
+
+// Sort alphabetically for consistent, readable output.
+identityModelPackages.Sort((a, b) => StringComparer.OrdinalIgnoreCase.Compare(a.Key, b.Key));
+
+var packagesToUpgrade = new List<string>();
+
+foreach (var pkg in identityModelPackages)
+{
+    var marker = StringComparer.OrdinalIgnoreCase.Equals(pkg.Value, maxVersion)
+        ? ""
+        : " <-- upgrade to " + maxVersion;
+
+    sb.AppendLine("  - " + pkg.Key + " " + pkg.Value + marker);
+
+    if (!StringComparer.OrdinalIgnoreCase.Equals(pkg.Value, maxVersion))
+    {
+        packagesToUpgrade.Add(pkg.Key);
+    }
+}
+
+sb.AppendLine();
+sb.Append("To fix this, add explicit PackageReference entries for the packages with lower versions to upgrade them to " + maxVersion + ":");
+sb.AppendLine();
+sb.AppendLine();
+sb.AppendLine("  <ItemGroup>");
+
+foreach (var pkgId in packagesToUpgrade)
+{
+    sb.AppendLine("    <PackageReference Include=\"" + pkgId + "\" Version=\"" + maxVersion + "\" />");
+}
+
+sb.AppendLine("  </ItemGroup>");
+sb.AppendLine();
+
+Log.LogWarning(null, "IDMODEL001", null, null, 0, 0, 0, 0, sb.ToString());


### PR DESCRIPTION
## Description

Add build task which detects whether Microsoft.IdentityModel.* or System.IdentityModel.* packages, which were resolved for a given project, have version mismatch. This warning aims to reduce runtime failures caused by version skew.

It's opt-out task which can be disabled by following project setting:

```xml
<PropertyGroup>
  <DisableIdentityModelVersionMismatchCheck>true</DisableIdentityModelVersionMismatchCheck>
</PropertyGroup>
```

## Validation

Validation was done by building a project which introduces version mismatch (`9.0.0` there is example of released version with that build task):

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net8.0</TargetFramework>
  </PropertyGroup>
  <ItemGroup>
    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="9.0.0" />
  </ItemGroup>
</Project>
```

Build output:

```cmd
> dotnet build
   
Restore complete (0.6s)
  IdentityModelVersionMismatch net8.0 succeeded with 1 warning(s) (1.3s) → bin\Debug\net8.0\IdentityModelVersionMismatch.dll
    C:\Users\username\.nuget\packages\microsoft.identitymodel.tokens\9.0.0\buildTransitive\Microsoft.IdentityModel.Tokens.targets(35,5): warning IDMODEL001: 

      All Microsoft.IdentityModel.* and System.IdentityModel.* packages must have the same version to avoid hard-to-diagnose runtime errors.
      The following packages were resolved with different versions:

        - Microsoft.IdentityModel.Abstractions 9.0.0
        - Microsoft.IdentityModel.JsonWebTokens 7.1.2 <-- upgrade to 9.0.0
        - Microsoft.IdentityModel.Logging 9.0.0
        - Microsoft.IdentityModel.Protocols 7.1.2 <-- upgrade to 9.0.0
        - Microsoft.IdentityModel.Protocols.OpenIdConnect 7.1.2 <-- upgrade to 9.0.0
        - Microsoft.IdentityModel.Tokens 9.0.0
        - System.IdentityModel.Tokens.Jwt 7.1.2 <-- upgrade to 9.0.0

      To fix this, add explicit PackageReference entries for the packages with lower versions to upgrade them to 9.0.0:

        <ItemGroup>
          <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="9.0.0" />
          <PackageReference Include="Microsoft.IdentityModel.Protocols" Version="9.0.0" />
          <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="9.0.0" />
          <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="9.0.0" />
        </ItemGroup>
```

Actual resolved versions:

```
> dotnet list package --include-transitive

Restore complete (0.6s)
                                                                                                                                                                             
Build succeeded in 0.7s
Project 'IdentityModelVersionMismatch' has the following package references
   [net8.0]: 
   Top-level Package                                    Requested                 Resolved
   > Microsoft.AspNetCore.Authentication.JwtBearer      8.0.2                     8.0.2
   > Microsoft.IdentityModel.Tokens                     9.0.0   9.0.0

   Transitive Package                                           Resolved
   > Microsoft.Extensions.DependencyInjection.Abstractions      8.0.0
   > Microsoft.Extensions.Logging.Abstractions                  8.0.0
   > Microsoft.IdentityModel.Abstractions                       9.0.0
   > Microsoft.IdentityModel.JsonWebTokens                      7.1.2
   > Microsoft.IdentityModel.Logging                            9.0.0
   > Microsoft.IdentityModel.Protocols                          7.1.2
   > Microsoft.IdentityModel.Protocols.OpenIdConnect            7.1.2
   > System.IdentityModel.Tokens.Jwt                            7.1.2
```

Applying proposed package references resolves the warning.