### PR TITLE
use SHA for specific action version

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -32,15 +32,15 @@ jobs:
           git config --system core.longpaths true
 
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
     - name: Setup .NET 6.x
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         dotnet-version: '6.x'
 
     - name: Setup .NET SDK from global.json
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
       with:
         global-json-file: ./global.json
 


### PR DESCRIPTION
Addresses [Bug 3504824](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3504824): Wilson - Mutable GitHub Action tag increases CI supply-chain risk
