### PR TITLE
[IdentityModel 8.x] Downgrade MicrosoftExtensionsLoggingAbstractionsVersion to 8.0.0 on .NET 10

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -22,7 +22,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <MicrosoftExtensionsLoggingAbstractionsVersion>10.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <!--
+      Keep at 8.x for compatibility for upstream users
+    -->
+    <MicrosoftExtensionsLoggingAbstractionsVersion>8.0.0</MicrosoftExtensionsLoggingAbstractionsVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net9.0'">


### PR DESCRIPTION
Some users are unable to reference Microsoft.Extensions.* 10x. 