### PR TITLE
Upgrade OpenTelemetry.Api from 1.6.0 to 1.15.3 to fix NU1902

### DIFF
--- a/build/dependenciesTest.props
+++ b/build/dependenciesTest.props
@@ -13,7 +13,7 @@
     <MoqVersion>[4.16.1]</MoqVersion>
     <NetStandardVersion>2.0.3</NetStandardVersion>
     <NewtonsoftVersion>13.0.3</NewtonsoftVersion>
-    <OpenTelemetryVersion>1.6.0</OpenTelemetryVersion>
+    <OpenTelemetryVersion>1.15.3</OpenTelemetryVersion>
     <SystemNetHttp>4.3.4</SystemNetHttp>
     <SystemSecurityClaimsVersion>4.3.0</SystemSecurityClaimsVersion>
     <SystemTextJsonVersion>8.0.5</SystemTextJsonVersion>


### PR DESCRIPTION

#Upgrade OpenTelemetry.Api from 1.6.0 to 1.15.3 to fix NU1902
<!-- Thank you for submitting a pull request to our repo. -->


Bump OpenTelemetryVersion to 1.15.3 (minimum patched version).

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x ] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [x ] You've included unit or integration tests for your change, where applicable.
- [x ] You've included inline docs for your change, where applicable.
- [x ] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [x ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

OpenTelemetry.Api 1.6.0 has a known moderate severity vulnerability (GHSA-g94r-2vxg-569j / CVE-2026-40894). Since the repo enables TreatWarningsAsErrors for NuGet, NU1902 breaks restore on test projects that reference OpenTelemetry packages.

Fixes #{bug number} (in this specific format)
