### PR TITLE
Suppress EOL .NET 6 warning in targetTest.props 

### DIFF
--- a/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
@@ -24,8 +24,9 @@
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
   </ItemGroup>-->
 
+  <!-- Suppress NETSDK1138 ("target framework is out of support") only for net6.0 -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   
   <ItemGroup>

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
@@ -26,7 +26,7 @@
 
   <!-- Suppress NETSDK1138 ("target framework is out of support") only for net6.0 -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/Microsoft.IdentityModel.Benchmarks.csproj
@@ -26,6 +26,7 @@
 
   <!-- Suppress NETSDK1138 ("target framework is out of support") only for net6.0 -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
   

--- a/build/targetsTest.props
+++ b/build/targetsTest.props
@@ -9,6 +9,6 @@
     <TestTargets Condition="'$(LocalBuild)' == 'True'">net8.0;net9.0;net10.0</TestTargets>
     <TestTargets Condition="'$(TargetNetNext)'== 'True'">$(TestTargets)</TestTargets>
     <!-- Suppress NETSDK1138 ("target framework is out of support") only for net6.0 -->
-    <SuppressTfmSupportBuildWarnings Condition="'$(TargetFramework)' == 'net6.0'">true</SuppressTfmSupportBuildWarnings>
+    <CheckEolTargetFramework Condition="'$(TargetFramework)' == 'net6.0'">false</CheckEolTargetFramework>
 </PropertyGroup>
 </Project>

--- a/build/targetsTest.props
+++ b/build/targetsTest.props
@@ -5,8 +5,10 @@
   </PropertyGroup> -->
 
   <PropertyGroup>
-    <TestTargets Condition="'$(LocalBuild)' != 'True'">net462;net472;net8.0;net9.0;net10.0</TestTargets>
+    <TestTargets Condition="'$(LocalBuild)' != 'True'">net462;net472;net6.0;net8.0;net9.0;net10.0</TestTargets>
     <TestTargets Condition="'$(LocalBuild)' == 'True'">net8.0;net9.0;net10.0</TestTargets>
     <TestTargets Condition="'$(TargetNetNext)'== 'True'">$(TestTargets)</TestTargets>
+    <!-- Suppress NETSDK1138 ("target framework is out of support") only for net6.0 -->
+    <SuppressTfmSupportBuildWarnings Condition="'$(TargetFramework)' == 'net6.0'">true</SuppressTfmSupportBuildWarnings>
 </PropertyGroup>
 </Project>

--- a/build/targetsTest.props
+++ b/build/targetsTest.props
@@ -5,7 +5,7 @@
   </PropertyGroup> -->
 
   <PropertyGroup>
-    <TestTargets Condition="'$(LocalBuild)' != 'True'">net462;net472;net6.0;net8.0;net9.0;net10.0</TestTargets>
+    <TestTargets Condition="'$(LocalBuild)' != 'True'">net462;net472;net8.0;net9.0;net10.0</TestTargets>
     <TestTargets Condition="'$(LocalBuild)' == 'True'">net8.0;net9.0;net10.0</TestTargets>
     <TestTargets Condition="'$(TargetNetNext)'== 'True'">$(TestTargets)</TestTargets>
 </PropertyGroup>

--- a/build/targetsTest.props
+++ b/build/targetsTest.props
@@ -8,7 +8,7 @@
     <TestTargets Condition="'$(LocalBuild)' != 'True'">net462;net472;net6.0;net8.0;net9.0;net10.0</TestTargets>
     <TestTargets Condition="'$(LocalBuild)' == 'True'">net8.0;net9.0;net10.0</TestTargets>
     <TestTargets Condition="'$(TargetNetNext)'== 'True'">$(TestTargets)</TestTargets>
-    <!-- Suppress NETSDK1138 ("target framework is out of support") only for net6.0 -->
-    <CheckEolTargetFramework Condition="'$(TargetFramework)' == 'net6.0'">false</CheckEolTargetFramework>
+    <!-- Suppress TFM support build warnings (e.g. NETSDK1138) only for net6.0 -->
+    <SuppressTfmSupportBuildWarnings Condition="'$(TargetFramework)' == 'net6.0'">true</SuppressTfmSupportBuildWarnings>
 </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Suppress  EOL .NET 6 warning in targetTest.props 
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Builds are failing from increase warnings due to .NET 10 not supporting .NET 6.

Fixes #{bug number} (in this specific format)
