### PR TITLE
Improve validation of "jku" claim (7.x)

### DIFF
--- a/Tools/VerifyResourceUsage.ps1
+++ b/Tools/VerifyResourceUsage.ps1
@@ -1,0 +1,51 @@
+$folderPath = $PSScriptRoot + "/../src"
+
+# Get LogMessages C# files
+$files = Get-ChildItem -Path $folderPath -Filter LogMessages.cs -Recurse
+
+# Dictionary to hold constants and their usage status
+$constants = @{}
+
+# Extract constants
+foreach ($file in $files) {
+    $content = Get-Content -Path $file.FullName
+    foreach ($line in $content) {
+        if (($line -match 'const\s+\w+\s+(\w+)\s*=') -and !($line.Contains("//"))) {
+            $constantName = $matches[1]
+            $constants[$constantName] = [PSCustomObject]@{
+                File = $file.FullName
+                ConstantName = $constantName
+                Found = $false
+            }
+        }
+    }
+}
+
+$files = Get-ChildItem -Path $folderPath -Filter *.cs -Exclude LogMessages.cs -Recurse
+$keys = @($constants.Keys)
+
+# Check for usage
+foreach ($file in $files) {
+    $content = Get-Content -Path $file.FullName
+    foreach ($constantName in $keys) {
+        if (Select-String -InputObject $content -Pattern $constantName) {
+            $constants[$constantName].Found = $true
+        }
+    }
+}
+
+# Output unused constants
+$unusedConstants = $constants.GetEnumerator() | Where-Object { $_.Value.Found -eq $false }
+if ($unusedConstants.Count -eq 0) {
+    Write-Output "No unused constants found."
+} else {
+    Write-Output "Unused constants:"
+    foreach ($unused in $unusedConstants) {
+        $constName = $unused.Value.ConstantName
+        $filePath = $unused.Value.File
+        $message = "'$constName' in file '$filePath'"
+        Write-Output $message
+    }
+
+    throw "found unused constants"
+}

--- a/Tools/mark-shipped.ps1
+++ b/Tools/mark-shipped.ps1
@@ -1,0 +1,52 @@
+[CmdletBinding(PositionalBinding=$false)]
+param ()
+
+Set-StrictMode -version 2.0
+$ErrorActionPreference = "Stop"
+
+function MarkShipped([Parameter(mandatory=$true)][string]$dir,
+                     [Parameter(mandatory=$true)][string]$access) {
+    $shippedFileName = $access + "API.Shipped.txt"
+    $shippedFilePath = Join-Path $dir $shippedFileName
+    $shipped = @()
+    $shipped += Get-Content $shippedFilePath
+
+    $unshippedFileName = $access + "API.Unshipped.txt"
+    $unshippedFilePath = Join-Path $dir $unshippedFileName
+    $unshipped = Get-Content $unshippedFilePath
+    $removed = @()
+    $removedPrefix = "*REMOVED*";
+    Write-Host "Processing $dir : $access"
+
+    foreach ($item in $unshipped) {
+        if ($item.Length -gt 0) {
+            if ($item.StartsWith($removedPrefix)) {
+                $item = $item.Substring($removedPrefix.Length)
+                $removed += $item
+            }
+            else {
+                $shipped += $item
+            }
+        }
+    }
+
+    $shipped | Sort-Object -Unique |Where-Object { -not $removed.Contains($_) } | Out-File $shippedFilePath -Encoding Ascii
+    Clear-Content $unshippedFilePath
+}
+
+try {
+    foreach ($file in Get-ChildItem -re -in "PublicApi.Shipped.txt") {
+        $dir = Split-Path -parent $file
+        MarkShipped $dir "Public"
+    }
+
+    foreach ($file in Get-ChildItem -re -in "InternalApi.Shipped.txt") {
+        $dir = Split-Path -parent $file
+        MarkShipped $dir "Internal"
+    }
+}
+catch {
+    Write-Host $_
+    Write-Host $_.Exception
+    exit 1
+}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,10 @@
+{
+    "sdk": {
+        "version": "10.0.103",
+        "allowPrerelease": false,
+        "rollForward": "latestFeature"
+    },
+    "msbuild-sdks": {
+        "Microsoft.Build.NoTargets": "3.7.56"
+    }
+}

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -1309,7 +1309,9 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                 return false;
 
             var uri = new Uri(jkuSetUrl, UriKind.RelativeOrAbsolute);
-            return signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.AllowedDomainsForJkuRetrieval.Any(domain => uri.Host.EndsWith(domain, StringComparison.OrdinalIgnoreCase));
+            return signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.AllowedDomainsForJkuRetrieval.Any(domain =>
+                uri.Host.Equals(domain, StringComparison.OrdinalIgnoreCase) ||
+                uri.Host.EndsWith("." + domain, StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs
@@ -490,17 +490,11 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                     },
                     new ResolvePopKeyTheoryData
                     {
-                        CallContext = new CallContext()
-                        {
-                            PropertyBag = new Dictionary<string, object>()
-                            {
-                                // to simulate http call and satisfy test requirements
-                                {"mockGetPopKeysFromJkuAsync_return1Key", null }
-                            }
-                        },
+                        // TLD-only entries should NOT match arbitrary domains (security fix)
                         JkuSetUrl = "https://www.contoso.com",
                         SignedHttpRequestValidationParameters = { AllowResolvingPopKeyFromJku = true, AllowedDomainsForJkuRetrieval = { ".com" }},
-                        TestId = "JkuTurnedOnTopLevelDomainMatch"
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPopKeyException), string.Format(LogMessages.IDX23038, "https://www.contoso.com", ".com")),
+                        TestId = "JkuTurnedOnTopLevelDomainNoMatch"
                     },
                     new ResolvePopKeyTheoryData
                     {
@@ -557,6 +551,59 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                         JkuSetUrl = "https://localhost/keys",
                         SignedHttpRequestValidationParameters = { AllowResolvingPopKeyFromJku = true, AllowedDomainsForJkuRetrieval = { "localhost" }},
                         TestId = "JkuTurnedOnLocalUrl"
+                    },
+                    // Security fix: Malicious domain suffix bypass attempts should fail
+                    new ResolvePopKeyTheoryData
+                    {
+                        // evilcontoso.com should NOT match allowlist entry "contoso.com"
+                        JkuSetUrl = "https://evilcontoso.com/jwks",
+                        SignedHttpRequestValidationParameters = { AllowResolvingPopKeyFromJku = true, AllowedDomainsForJkuRetrieval = { "contoso.com" }},
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPopKeyException), string.Format(LogMessages.IDX23038, "https://evilcontoso.com/jwks", "contoso.com")),
+                        TestId = "JkuDomainBypassAttempt_SuffixWithoutDot_ShouldFail"
+                    },
+                    new ResolvePopKeyTheoryData
+                    {
+                        // evil-contoso.com should NOT match allowlist entry "contoso.com"
+                        JkuSetUrl = "https://evil-contoso.com/jwks",
+                        SignedHttpRequestValidationParameters = { AllowResolvingPopKeyFromJku = true, AllowedDomainsForJkuRetrieval = { "contoso.com" }},
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPopKeyException), string.Format(LogMessages.IDX23038, "https://evil-contoso.com/jwks", "contoso.com")),
+                        TestId = "JkuDomainBypassAttempt_HyphenatedSuffix_ShouldFail"
+                    },
+                    new ResolvePopKeyTheoryData
+                    {
+                        // notcontoso.com should NOT match allowlist entry "contoso.com"
+                        JkuSetUrl = "https://notcontoso.com/jwks",
+                        SignedHttpRequestValidationParameters = { AllowResolvingPopKeyFromJku = true, AllowedDomainsForJkuRetrieval = { "contoso.com" }},
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPopKeyException), string.Format(LogMessages.IDX23038, "https://notcontoso.com/jwks", "contoso.com")),
+                        TestId = "JkuDomainBypassAttempt_PrefixedSuffix_ShouldFail"
+                    },
+                    new ResolvePopKeyTheoryData
+                    {
+                        CallContext = new CallContext()
+                        {
+                            PropertyBag = new Dictionary<string, object>()
+                            {
+                                {"mockGetPopKeysFromJkuAsync_return1Key", null }
+                            }
+                        },
+                        // Legitimate subdomain keys.contoso.com SHOULD match allowlist entry "contoso.com"
+                        JkuSetUrl = "https://keys.contoso.com/jwks",
+                        SignedHttpRequestValidationParameters = { AllowResolvingPopKeyFromJku = true, AllowedDomainsForJkuRetrieval = { "contoso.com" }},
+                        TestId = "JkuLegitimateSubdomain_ShouldPass"
+                    },
+                    new ResolvePopKeyTheoryData
+                    {
+                        CallContext = new CallContext()
+                        {
+                            PropertyBag = new Dictionary<string, object>()
+                            {
+                                {"mockGetPopKeysFromJkuAsync_return1Key", null }
+                            }
+                        },
+                        // Exact domain match contoso.com SHOULD match allowlist entry "contoso.com"
+                        JkuSetUrl = "https://contoso.com/jwks",
+                        SignedHttpRequestValidationParameters = { AllowResolvingPopKeyFromJku = true, AllowedDomainsForJkuRetrieval = { "contoso.com" }},
+                        TestId = "JkuExactDomainMatch_ShouldPass"
                     }
                 };
             }


### PR DESCRIPTION
Currently, when validating the "jku" claim against the list from AllowedDomainsForJkuRetrieval we use Host.EndsWith for the string comparison, allowing invalid domains like "wrongcontoso.com" to bypass restrictions intended for "contoso.com"

This PR improves the validation by updating the domain matching to require either:
- An exact match
- A proper subdomain (dot-bounded) match

---

This is a cherry-pick of commit 6cec3246d7e9446f485a7c092aa990f9aead6880 from `dev` to `dev7x`.

**Files changed:**
- `src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs`
- `test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/PopKeyResolvingTests.cs`