### PR TITLE
Add SignatureValidatorWithToken delegate with opt-in/decline pattern

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
@@ -84,13 +84,23 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
                 if (validationParameters.SignatureValidator != null || validationParameters.SignatureValidatorUsingConfiguration != null)
                 {
-                    var validatedToken = ValidateSignatureUsingDelegates(jsonWebToken, validationParameters);
+                    var validatedToken = ValidateSignatureUsingDelegates(jsonWebToken, validationParameters, configuration);
                     tokenValidationResult = await ValidateTokenPayloadAsync(
                         validatedToken,
                         validationParameters,
                         configuration).ConfigureAwait(false);
 
-                    Validators.ValidateIssuerSecurityKey(validatedToken.SigningKey, validatedToken, validationParameters);
+                    Validators.ValidateIssuerSecurityKey(validatedToken.SigningKey, validatedToken, validationParameters, configuration);
+                }
+                else if (validationParameters.SignatureValidatorWithToken != null
+                    && ValidateSignatureUsingTokenDelegate(jsonWebToken, validationParameters, configuration) is { } delegateValidatedToken)
+                {
+                    tokenValidationResult = await ValidateTokenPayloadAsync(
+                        delegateValidatedToken,
+                        validationParameters,
+                        configuration).ConfigureAwait(false);
+
+                    Validators.ValidateIssuerSecurityKey(delegateValidatedToken.SigningKey, delegateValidatedToken, validationParameters, configuration);
                 }
                 else
                 {
@@ -436,12 +446,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             }
         }
 
-        private static JsonWebToken ValidateSignatureUsingDelegates(JsonWebToken jsonWebToken, TokenValidationParameters validationParameters)
+        private static JsonWebToken ValidateSignatureUsingDelegates(JsonWebToken jsonWebToken, TokenValidationParameters validationParameters, BaseConfiguration configuration)
         {
             if (validationParameters.SignatureValidatorUsingConfiguration != null)
             {
-                // TODO - get configuration from validationParameters
-                BaseConfiguration configuration = null;
                 var validatedToken = validationParameters.SignatureValidatorUsingConfiguration(jsonWebToken.EncodedToken, validationParameters, configuration);
                 if (validatedToken == null)
                     throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10505, jsonWebToken)));
@@ -464,6 +472,43 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             }
 
             throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10505, jsonWebToken)));
+        }
+
+        /// <summary>
+        /// Invokes the <see cref="TokenValidationParameters.SignatureValidatorWithToken"/> delegate
+        /// and returns the validated token if the delegate handled the signature, or <see langword="null"/>
+        /// if the delegate declined.
+        /// </summary>
+        private JsonWebToken ValidateSignatureUsingTokenDelegate(JsonWebToken jsonWebToken, TokenValidationParameters validationParameters, BaseConfiguration configuration)
+        {
+            try
+            {
+                var delegateResult = validationParameters.SignatureValidatorWithToken(jsonWebToken, validationParameters, configuration);
+
+                if (!delegateResult.Handled)
+                    return null;
+
+                if (delegateResult.Token is not JsonWebToken validatedJsonWebToken)
+                    throw LogHelper.LogExceptionMessage(new SecurityTokenInvalidSignatureException(LogHelper.FormatInvariant(TokenLogMessages.IDX10506, LogHelper.MarkAsNonPII(typeof(JsonWebToken)), LogHelper.MarkAsNonPII(delegateResult.Token?.GetType()), jsonWebToken)));
+
+                RecordSignatureValidationTelemetry(
+                    TelemetryClient,
+                    TelemetryConstants.SignatureValidationErrors.None,
+                    jsonWebToken,
+                    validatedJsonWebToken.SigningKey);
+
+                return validatedJsonWebToken;
+            }
+            catch
+            {
+                RecordSignatureValidationTelemetry(
+                    TelemetryClient,
+                    TelemetryConstants.SignatureValidationErrors.SignatureVerificationFailed,
+                    jsonWebToken,
+                    jsonWebToken.SigningKey);
+
+                throw;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Tokens/Delegates.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Delegates.cs
@@ -137,6 +137,28 @@ namespace Microsoft.IdentityModel.Tokens
     public delegate SecurityToken SignatureValidatorUsingConfiguration(string token, TokenValidationParameters validationParameters, BaseConfiguration configuration);
 
     /// <summary>
+    /// Validates the signature of an already-parsed token, with the ability to decline handling.
+    /// </summary>
+    /// <param name="token">The parsed <see cref="SecurityToken"/>.</param>
+    /// <param name="validationParameters">The <see cref="TokenValidationParameters"/> to be used for validating the token.</param>
+    /// <param name="configuration">The configuration required for validation.</param>
+    /// <returns>
+    /// A <see cref="SignatureValidationDelegateResult"/> indicating whether the delegate handled the
+    /// signature validation. Return <see cref="SignatureValidationDelegateResult.Success"/> with the
+    /// validated token (and <see cref="SecurityToken.SigningKey"/> set) when the delegate validates
+    /// the signature. Return <see cref="SignatureValidationDelegateResult.NotHandled"/> to let the
+    /// handler fall through to its default signature validation logic. Throw an appropriate exception
+    /// (e.g., <see cref="SecurityTokenInvalidSignatureException"/>) if the signature is invalid.
+    /// </returns>
+    /// <remarks>
+    /// This delegate is evaluated only when <see cref="TokenValidationParameters.SignatureValidator"/>
+    /// and <see cref="TokenValidationParameters.SignatureValidatorUsingConfiguration"/> are not set.
+    /// Unlike those delegates, this one receives the already-parsed <see cref="SecurityToken"/> and
+    /// can decline to handle the signature, allowing the handler to validate it using its built-in logic.
+    /// </remarks>
+    public delegate SignatureValidationDelegateResult SignatureValidatorWithToken(SecurityToken token, TokenValidationParameters validationParameters, BaseConfiguration configuration);
+
+    /// <summary>
     /// Reads the security token.
     /// </summary>
     /// <param name="token">The security token.</param>

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,16 @@
 ~Microsoft.IdentityModel.Tokens.CaseSensitiveClaimsIdentity.SecurityToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Handled.get -> bool
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.SignatureValidationDelegateResult() -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Token.get -> Microsoft.IdentityModel.Tokens.SecurityToken?
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.NotHandled.get -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Success(Microsoft.IdentityModel.Tokens.SecurityToken token) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+~virtual Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken.Invoke(Microsoft.IdentityModel.Tokens.SecurityToken token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, Microsoft.IdentityModel.Tokens.BaseConfiguration configuration) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.get -> Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult other) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(object obj) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.GetHashCode() -> int
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator ==(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator !=(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,16 @@
 ~Microsoft.IdentityModel.Tokens.CaseSensitiveClaimsIdentity.SecurityToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Handled.get -> bool
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.SignatureValidationDelegateResult() -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Token.get -> Microsoft.IdentityModel.Tokens.SecurityToken?
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.NotHandled.get -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Success(Microsoft.IdentityModel.Tokens.SecurityToken token) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+~virtual Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken.Invoke(Microsoft.IdentityModel.Tokens.SecurityToken token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, Microsoft.IdentityModel.Tokens.BaseConfiguration configuration) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.get -> Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult other) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(object obj) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.GetHashCode() -> int
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator ==(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator !=(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,1 +1,16 @@
 ~Microsoft.IdentityModel.Tokens.CaseSensitiveClaimsIdentity.SecurityToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Handled.get -> bool
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.SignatureValidationDelegateResult() -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Token.get -> Microsoft.IdentityModel.Tokens.SecurityToken?
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.NotHandled.get -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Success(Microsoft.IdentityModel.Tokens.SecurityToken token) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+~virtual Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken.Invoke(Microsoft.IdentityModel.Tokens.SecurityToken token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, Microsoft.IdentityModel.Tokens.BaseConfiguration configuration) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.get -> Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult other) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(object obj) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.GetHashCode() -> int
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator ==(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator !=(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net6.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net6.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,16 @@
 ~Microsoft.IdentityModel.Tokens.CaseSensitiveClaimsIdentity.SecurityToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Handled.get -> bool
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.SignatureValidationDelegateResult() -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Token.get -> Microsoft.IdentityModel.Tokens.SecurityToken?
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.NotHandled.get -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Success(Microsoft.IdentityModel.Tokens.SecurityToken token) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+~virtual Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken.Invoke(Microsoft.IdentityModel.Tokens.SecurityToken token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, Microsoft.IdentityModel.Tokens.BaseConfiguration configuration) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.get -> Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult other) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(object obj) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.GetHashCode() -> int
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator ==(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator !=(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,16 @@
 ~Microsoft.IdentityModel.Tokens.CaseSensitiveClaimsIdentity.SecurityToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Handled.get -> bool
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.SignatureValidationDelegateResult() -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Token.get -> Microsoft.IdentityModel.Tokens.SecurityToken?
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.NotHandled.get -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Success(Microsoft.IdentityModel.Tokens.SecurityToken token) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+~virtual Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken.Invoke(Microsoft.IdentityModel.Tokens.SecurityToken token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, Microsoft.IdentityModel.Tokens.BaseConfiguration configuration) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.get -> Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult other) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(object obj) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.GetHashCode() -> int
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator ==(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator !=(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,16 @@
 ~Microsoft.IdentityModel.Tokens.CaseSensitiveClaimsIdentity.SecurityToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Handled.get -> bool
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.SignatureValidationDelegateResult() -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Token.get -> Microsoft.IdentityModel.Tokens.SecurityToken?
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.NotHandled.get -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Success(Microsoft.IdentityModel.Tokens.SecurityToken token) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+~virtual Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken.Invoke(Microsoft.IdentityModel.Tokens.SecurityToken token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, Microsoft.IdentityModel.Tokens.BaseConfiguration configuration) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.get -> Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult other) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(object obj) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.GetHashCode() -> int
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator ==(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator !=(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,16 @@
 ~Microsoft.IdentityModel.Tokens.CaseSensitiveClaimsIdentity.SecurityToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Handled.get -> bool
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.SignatureValidationDelegateResult() -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Token.get -> Microsoft.IdentityModel.Tokens.SecurityToken?
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.NotHandled.get -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Success(Microsoft.IdentityModel.Tokens.SecurityToken token) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+~virtual Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken.Invoke(Microsoft.IdentityModel.Tokens.SecurityToken token, Microsoft.IdentityModel.Tokens.TokenValidationParameters validationParameters, Microsoft.IdentityModel.Tokens.BaseConfiguration configuration) -> Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.get -> Microsoft.IdentityModel.Tokens.SignatureValidatorWithToken
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.SignatureValidatorWithToken.set -> void
+Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult other) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.Equals(object obj) -> bool
+override Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.GetHashCode() -> int
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator ==(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool
+static Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult.operator !=(Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult left, Microsoft.IdentityModel.Tokens.SignatureValidationDelegateResult right) -> bool

--- a/src/Microsoft.IdentityModel.Tokens/SignatureValidationDelegateResult.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SignatureValidationDelegateResult.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+#nullable enable
+
+namespace Microsoft.IdentityModel.Tokens
+{
+    /// <summary>
+    /// Represents the result of a <see cref="SignatureValidatorWithToken"/> delegate invocation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This type allows a signature validation delegate to indicate whether it handled the signature
+    /// validation or whether it declined, allowing the handler to fall through to its default
+    /// signature validation logic.
+    /// </para>
+    /// <para>
+    /// Use <see cref="Success"/> when the delegate has validated the signature successfully.
+    /// Use <see cref="NotHandled"/> when the delegate does not handle the token's algorithm and
+    /// wants the handler to validate the signature using its built-in logic.
+    /// If the delegate determines the signature is invalid, it should throw an appropriate exception
+    /// (e.g., <see cref="SecurityTokenInvalidSignatureException"/>).
+    /// </para>
+    /// </remarks>
+    public readonly struct SignatureValidationDelegateResult : IEquatable<SignatureValidationDelegateResult>
+    {
+        /// <summary>
+        /// Gets a value indicating whether the delegate handled the signature validation.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if the delegate validated the signature; <see langword="false"/>
+        /// if the delegate declined and the handler should validate the signature using its default logic.
+        /// </value>
+        public bool Handled { get; }
+
+        /// <summary>
+        /// Gets the validated <see cref="SecurityToken"/> when <see cref="Handled"/> is <see langword="true"/>.
+        /// </summary>
+        /// <value>
+        /// The validated token with <see cref="SecurityToken.SigningKey"/> set by the delegate,
+        /// or <see langword="null"/> when <see cref="Handled"/> is <see langword="false"/>.
+        /// </value>
+        public SecurityToken? Token { get; }
+
+        private SignatureValidationDelegateResult(SecurityToken token)
+        {
+            Handled = true;
+            Token = token;
+        }
+
+        /// <summary>
+        /// Returns a result indicating the delegate did not handle the signature validation.
+        /// The handler will fall through to its default signature validation logic.
+        /// </summary>
+        public static SignatureValidationDelegateResult NotHandled => default;
+
+        /// <summary>
+        /// Returns a result indicating the delegate successfully validated the signature.
+        /// </summary>
+        /// <param name="token">The validated <see cref="SecurityToken"/> with
+        /// <see cref="SecurityToken.SigningKey"/> set to the key used for validation.</param>
+        /// <returns>A <see cref="SignatureValidationDelegateResult"/> indicating successful validation.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="token"/> is <see langword="null"/>.</exception>
+        public static SignatureValidationDelegateResult Success(SecurityToken token)
+            => new(token ?? throw new ArgumentNullException(nameof(token)));
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) =>
+            obj is SignatureValidationDelegateResult other && Equals(other);
+
+        /// <inheritdoc/>
+        public bool Equals(SignatureValidationDelegateResult other) =>
+            Handled == other.Handled && ReferenceEquals(Token, other.Token);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() =>
+            Handled.GetHashCode() ^ (Token?.GetHashCode() ?? 0);
+
+        /// <summary>Equality operator.</summary>
+        public static bool operator ==(SignatureValidationDelegateResult left, SignatureValidationDelegateResult right) =>
+            left.Equals(right);
+
+        /// <summary>Inequality operator.</summary>
+        public static bool operator !=(SignatureValidationDelegateResult left, SignatureValidationDelegateResult right) =>
+            !left.Equals(right);
+    }
+}

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -84,6 +84,7 @@ namespace Microsoft.IdentityModel.Tokens
             SaveSigninToken = other.SaveSigninToken;
             SignatureValidator = other.SignatureValidator;
             SignatureValidatorUsingConfiguration = other.SignatureValidatorUsingConfiguration;
+            SignatureValidatorWithToken = other.SignatureValidatorWithToken;
             TokenDecryptionKey = other.TokenDecryptionKey;
             TokenDecryptionKeyResolver = other.TokenDecryptionKeyResolver;
             TokenDecryptionKeys = other.TokenDecryptionKeys;
@@ -555,6 +556,25 @@ namespace Microsoft.IdentityModel.Tokens
         /// If set, this delegate will be called to validate the signature of the token, instead of default processing.
         /// </remarks>
         public SignatureValidatorUsingConfiguration SignatureValidatorUsingConfiguration { get; set; }
+
+        /// <summary>
+        /// Gets or sets a delegate that will be used to validate the signature of an already-parsed token.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This delegate is evaluated only when <see cref="SignatureValidator"/> and
+        /// <see cref="SignatureValidatorUsingConfiguration"/> are not set. Unlike those delegates,
+        /// this one receives the already-parsed <see cref="SecurityToken"/> and can decline to handle
+        /// the signature by returning <see cref="SignatureValidationDelegateResult.NotHandled"/>,
+        /// allowing the handler to validate the signature using its built-in logic.
+        /// </para>
+        /// <para>
+        /// When the delegate handles the signature, it should set <see cref="SecurityToken.SigningKey"/>
+        /// on the token and return <see cref="SignatureValidationDelegateResult.Success"/>.
+        /// If the signature is invalid, the delegate should throw an appropriate exception.
+        /// </para>
+        /// </remarks>
+        public SignatureValidatorWithToken SignatureValidatorWithToken { get; set; }
 
         /// <summary>
         /// Gets or sets the time provider.

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.SignatureValidatorWithTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.SignatureValidatorWithTokenTests.cs
@@ -1,0 +1,427 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Microsoft.IdentityModel.JsonWebTokens.Tests
+{
+    public class JsonWebTokenHandlerSignatureValidatorWithTokenTests
+    {
+        private static JsonWebTokenHandler CreateHandler() => new JsonWebTokenHandler();
+
+        private static string CreateSignedToken(SecurityKey signingKey, string algorithm)
+        {
+            var handler = CreateHandler();
+            return handler.CreateToken(new SecurityTokenDescriptor
+            {
+                SigningCredentials = new SigningCredentials(signingKey, algorithm),
+                Issuer = "https://test-issuer.example.com",
+                Audience = "https://test-audience.example.com"
+            });
+        }
+
+        private static TokenValidationParameters CreateBaseValidationParameters(SecurityKey signingKey)
+        {
+            return new TokenValidationParameters
+            {
+                ValidIssuer = "https://test-issuer.example.com",
+                ValidAudience = "https://test-audience.example.com",
+                IssuerSigningKey = signingKey,
+                ValidateLifetime = false
+            };
+        }
+
+        [Fact]
+        public async Task DelegateHandlesSignature_ValidationSucceeds()
+        {
+            // Arrange
+            var signingKey = KeyingMaterial.RsaSecurityKey_2048;
+            var tokenString = CreateSignedToken(signingKey, SecurityAlgorithms.RsaSha256);
+
+            var tvp = CreateBaseValidationParameters(signingKey);
+            tvp.SignatureValidatorWithToken = (token, validationParameters, configuration) =>
+            {
+                var jwt = (JsonWebToken)token;
+                jwt.SigningKey = validationParameters.IssuerSigningKey;
+                return SignatureValidationDelegateResult.Success(jwt);
+            };
+
+            // Act
+            var result = await CreateHandler().ValidateTokenAsync(tokenString, tvp);
+
+            // Assert
+            Assert.True(result.IsValid, $"Validation failed: {result.Exception?.Message}");
+        }
+
+        [Fact]
+        public async Task DelegateDeclines_HandlerValidatesNormally()
+        {
+            // Arrange
+            var signingKey = KeyingMaterial.RsaSecurityKey_2048;
+            var tokenString = CreateSignedToken(signingKey, SecurityAlgorithms.RsaSha256);
+
+            bool delegateWasCalled = false;
+            var tvp = CreateBaseValidationParameters(signingKey);
+            tvp.SignatureValidatorWithToken = (token, validationParameters, configuration) =>
+            {
+                delegateWasCalled = true;
+                return SignatureValidationDelegateResult.NotHandled;
+            };
+
+            // Act
+            var result = await CreateHandler().ValidateTokenAsync(tokenString, tvp);
+
+            // Assert
+            Assert.True(delegateWasCalled, "Delegate should have been called.");
+            Assert.True(result.IsValid, $"Validation failed: {result.Exception?.Message}");
+        }
+
+        [Fact]
+        public async Task DelegateThrows_ExceptionPropagatesAsInvalidResult()
+        {
+            // Arrange
+            var signingKey = KeyingMaterial.RsaSecurityKey_2048;
+            var tokenString = CreateSignedToken(signingKey, SecurityAlgorithms.RsaSha256);
+
+            var tvp = CreateBaseValidationParameters(signingKey);
+            tvp.SignatureValidatorWithToken = (token, validationParameters, configuration) =>
+            {
+                throw new SecurityTokenInvalidSignatureException("Signature is invalid.");
+            };
+
+            // Act
+            var result = await CreateHandler().ValidateTokenAsync(tokenString, tvp);
+
+            // Assert
+            Assert.False(result.IsValid);
+            Assert.IsType<SecurityTokenInvalidSignatureException>(result.Exception);
+        }
+
+        [Fact]
+        public async Task DelegateDeclines_WrongKey_ValidationFails()
+        {
+            // Arrange — sign with one key, validate with another
+            var signingKey = KeyingMaterial.RsaSecurityKey_2048;
+            var wrongKey = KeyingMaterial.RsaSecurityKey_4096;
+            var tokenString = CreateSignedToken(signingKey, SecurityAlgorithms.RsaSha256);
+
+            var tvp = CreateBaseValidationParameters(wrongKey);
+            tvp.SignatureValidatorWithToken = (token, validationParameters, configuration) =>
+            {
+                // Decline — let the handler try (and fail) with the wrong key
+                return SignatureValidationDelegateResult.NotHandled;
+            };
+
+            // Act
+            var result = await CreateHandler().ValidateTokenAsync(tokenString, tvp);
+
+            // Assert
+            Assert.False(result.IsValid);
+        }
+
+        [Fact]
+        public async Task OldDelegatesTakePriority_NewDelegateNotCalled()
+        {
+            // Arrange
+            var signingKey = KeyingMaterial.RsaSecurityKey_2048;
+            var tokenString = CreateSignedToken(signingKey, SecurityAlgorithms.RsaSha256);
+
+            bool newDelegateCalled = false;
+            var tvp = CreateBaseValidationParameters(signingKey);
+            tvp.SignatureValidatorUsingConfiguration = (token, validationParameters, configuration) =>
+            {
+                var jwt = new JsonWebToken(token);
+                jwt.SigningKey = validationParameters.IssuerSigningKey;
+                return jwt;
+            };
+            tvp.SignatureValidatorWithToken = (token, validationParameters, configuration) =>
+            {
+                newDelegateCalled = true;
+                return SignatureValidationDelegateResult.Success((JsonWebToken)token);
+            };
+
+            // Act
+            var result = await CreateHandler().ValidateTokenAsync(tokenString, tvp);
+
+            // Assert
+            Assert.True(result.IsValid, $"Validation failed: {result.Exception?.Message}");
+            Assert.False(newDelegateCalled, "New delegate should not be called when old delegate is set.");
+        }
+
+        [Fact]
+        public async Task DelegateReceivesResolvedBaseConfiguration()
+        {
+            // Arrange
+            var signingKey = KeyingMaterial.RsaSecurityKey_2048;
+            var tokenString = CreateSignedToken(signingKey, SecurityAlgorithms.RsaSha256);
+
+            BaseConfiguration capturedConfiguration = null;
+
+            var expectedConfiguration = new OpenIdConnectConfiguration
+            {
+                Issuer = "https://test-issuer.example.com"
+            };
+            expectedConfiguration.SigningKeys.Add(signingKey);
+
+            var tvp = CreateBaseValidationParameters(signingKey);
+            tvp.ConfigurationManager = new StaticConfigurationManager<BaseConfiguration>(expectedConfiguration);
+            tvp.SignatureValidatorWithToken = (token, validationParameters, configuration) =>
+            {
+                capturedConfiguration = configuration;
+                var jwt = (JsonWebToken)token;
+                jwt.SigningKey = validationParameters.IssuerSigningKey;
+                return SignatureValidationDelegateResult.Success(jwt);
+            };
+
+            // Act
+            var result = await CreateHandler().ValidateTokenAsync(tokenString, tvp);
+
+            // Assert
+            Assert.True(result.IsValid, $"Validation failed: {result.Exception?.Message}");
+            Assert.NotNull(capturedConfiguration);
+            Assert.Same(expectedConfiguration, capturedConfiguration);
+        }
+
+        [Fact]
+        public async Task DelegateDeclines_ConfigurationPassedToHandlerSignatureValidation()
+        {
+            // Arrange — use ConfigurationManager as the only source of signing keys
+            var signingKey = KeyingMaterial.RsaSecurityKey_2048;
+            var tokenString = CreateSignedToken(signingKey, SecurityAlgorithms.RsaSha256);
+
+            var expectedConfiguration = new OpenIdConnectConfiguration
+            {
+                Issuer = "https://test-issuer.example.com"
+            };
+            expectedConfiguration.SigningKeys.Add(signingKey);
+
+            var tvp = new TokenValidationParameters
+            {
+                ValidIssuer = "https://test-issuer.example.com",
+                ValidAudience = "https://test-audience.example.com",
+                ValidateLifetime = false,
+                ConfigurationManager = new StaticConfigurationManager<BaseConfiguration>(expectedConfiguration),
+                SignatureValidatorWithToken = (token, validationParameters, configuration) =>
+                {
+                    // Decline — the handler should use configuration to resolve signing key
+                    return SignatureValidationDelegateResult.NotHandled;
+                }
+            };
+
+            // Act
+            var result = await CreateHandler().ValidateTokenAsync(tokenString, tvp);
+
+            // Assert
+            Assert.True(result.IsValid, $"Validation failed: {result.Exception?.Message}");
+        }
+
+        [Fact]
+        public async Task DelegateHandled_IssuerSigningKeyValidation_ReceivesConfiguration()
+        {
+            // Arrange
+            var signingKey = KeyingMaterial.RsaSecurityKey_2048;
+            var tokenString = CreateSignedToken(signingKey, SecurityAlgorithms.RsaSha256);
+
+            BaseConfiguration capturedKeyValidationConfig = null;
+
+            var expectedConfiguration = new OpenIdConnectConfiguration
+            {
+                Issuer = "https://test-issuer.example.com"
+            };
+            expectedConfiguration.SigningKeys.Add(signingKey);
+
+            var tvp = CreateBaseValidationParameters(signingKey);
+            tvp.ValidateIssuerSigningKey = true;
+            tvp.ConfigurationManager = new StaticConfigurationManager<BaseConfiguration>(expectedConfiguration);
+            tvp.SignatureValidatorWithToken = (token, validationParameters, configuration) =>
+            {
+                var jwt = (JsonWebToken)token;
+                jwt.SigningKey = validationParameters.IssuerSigningKey;
+                return SignatureValidationDelegateResult.Success(jwt);
+            };
+            tvp.IssuerSigningKeyValidatorUsingConfiguration = (securityKey, securityToken, tvpInner, configuration) =>
+            {
+                capturedKeyValidationConfig = configuration;
+                return true;
+            };
+
+            // Act
+            var result = await CreateHandler().ValidateTokenAsync(tokenString, tvp);
+
+            // Assert
+            Assert.True(result.IsValid, $"Validation failed: {result.Exception?.Message}");
+            Assert.NotNull(capturedKeyValidationConfig);
+            Assert.Same(expectedConfiguration, capturedKeyValidationConfig);
+        }
+
+        [Fact]
+        public async Task DelegateHandled_TelemetryRecordsSuccess()
+        {
+            // Arrange
+            var signingKey = KeyingMaterial.RsaSecurityKey_2048;
+            var tokenString = CreateSignedToken(signingKey, SecurityAlgorithms.RsaSha256);
+
+            var mockTelemetry = new SignatureValidationMockTelemetryClient();
+            var handler = new JsonWebTokenHandler
+            {
+                TelemetryClient = mockTelemetry
+            };
+
+            var tvp = CreateBaseValidationParameters(signingKey);
+            tvp.SignatureValidatorWithToken = (token, validationParameters, configuration) =>
+            {
+                var jwt = (JsonWebToken)token;
+                jwt.SigningKey = validationParameters.IssuerSigningKey;
+                return SignatureValidationDelegateResult.Success(jwt);
+            };
+
+            // Act
+            Telemetry.CryptoTelemetry.EnableSignatureValidationTelemetry(true, null);
+            try
+            {
+                var result = await handler.ValidateTokenAsync(tokenString, tvp);
+
+                // Assert
+                Assert.True(result.IsValid, $"Validation failed: {result.Exception?.Message}");
+                Assert.Equal(1, mockTelemetry.SignatureValidationCallCount);
+                Assert.Equal(Telemetry.TelemetryConstants.SignatureValidationErrors.None, mockTelemetry.LastErrorType);
+            }
+            finally
+            {
+                Telemetry.CryptoTelemetry.EnableSignatureValidationTelemetry(false, null);
+            }
+        }
+
+        [Fact]
+        public async Task DelegateThrows_TelemetryRecordsFailure()
+        {
+            // Arrange
+            var signingKey = KeyingMaterial.RsaSecurityKey_2048;
+            var tokenString = CreateSignedToken(signingKey, SecurityAlgorithms.RsaSha256);
+
+            var mockTelemetry = new SignatureValidationMockTelemetryClient();
+            var handler = new JsonWebTokenHandler
+            {
+                TelemetryClient = mockTelemetry
+            };
+
+            var tvp = CreateBaseValidationParameters(signingKey);
+            tvp.SignatureValidatorWithToken = (token, validationParameters, configuration) =>
+            {
+                throw new SecurityTokenInvalidSignatureException("Bad signature.");
+            };
+
+            // Act
+            Telemetry.CryptoTelemetry.EnableSignatureValidationTelemetry(true, null);
+            try
+            {
+                var result = await handler.ValidateTokenAsync(tokenString, tvp);
+
+                // Assert
+                Assert.False(result.IsValid);
+                Assert.Equal(1, mockTelemetry.SignatureValidationCallCount);
+                Assert.Equal(Telemetry.TelemetryConstants.SignatureValidationErrors.SignatureVerificationFailed, mockTelemetry.LastErrorType);
+            }
+            finally
+            {
+                Telemetry.CryptoTelemetry.EnableSignatureValidationTelemetry(false, null);
+            }
+        }
+
+        [Fact]
+        public void SignatureValidationDelegateResult_NotHandled_HasCorrectDefaults()
+        {
+            // Act
+            var result = SignatureValidationDelegateResult.NotHandled;
+
+            // Assert
+            Assert.False(result.Handled);
+            Assert.Null(result.Token);
+        }
+
+        [Fact]
+        public void SignatureValidationDelegateResult_Success_SetsProperties()
+        {
+            // Arrange
+            var handler = CreateHandler();
+            var tokenString = CreateSignedToken(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaSha256);
+            var token = new JsonWebToken(tokenString);
+
+            // Act
+            var result = SignatureValidationDelegateResult.Success(token);
+
+            // Assert
+            Assert.True(result.Handled);
+            Assert.Same(token, result.Token);
+        }
+
+        [Fact]
+        public void SignatureValidationDelegateResult_Success_NullToken_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => SignatureValidationDelegateResult.Success(null));
+        }
+
+        [Fact]
+        public async Task CopyConstructor_CopiesSignatureValidatorWithToken()
+        {
+            // Arrange
+            var signingKey = KeyingMaterial.RsaSecurityKey_2048;
+            var tokenString = CreateSignedToken(signingKey, SecurityAlgorithms.RsaSha256);
+
+            bool delegateCalled = false;
+            var originalTvp = CreateBaseValidationParameters(signingKey);
+            originalTvp.SignatureValidatorWithToken = (token, validationParameters, configuration) =>
+            {
+                delegateCalled = true;
+                var jwt = (JsonWebToken)token;
+                jwt.SigningKey = validationParameters.IssuerSigningKey;
+                return SignatureValidationDelegateResult.Success(jwt);
+            };
+
+            // Act — clone via copy constructor
+            var clonedTvp = originalTvp.Clone();
+            var result = await CreateHandler().ValidateTokenAsync(tokenString, clonedTvp);
+
+            // Assert
+            Assert.True(delegateCalled, "Delegate from cloned TVP should have been called.");
+            Assert.True(result.IsValid, $"Validation failed: {result.Exception?.Message}");
+        }
+
+        /// <summary>
+        /// A minimal mock that captures signature validation telemetry calls.
+        /// Inherits from <see cref="Telemetry.TelemetryClient"/> and overrides nothing
+        /// except signature validation counter to capture the call.
+        /// </summary>
+        private class SignatureValidationMockTelemetryClient : Telemetry.ITelemetryClient
+        {
+            public int SignatureValidationCallCount { get; private set; }
+            public string LastErrorType { get; private set; }
+            public string LastAlgorithm { get; private set; }
+
+            void Telemetry.ITelemetryClient.IncrementSignatureValidationCounter(string errorType, string issuer, string algorithm, SecurityKey key)
+            {
+                SignatureValidationCallCount++;
+                LastErrorType = errorType;
+                LastAlgorithm = algorithm;
+            }
+
+            void Telemetry.ITelemetryClient.IncrementConfigurationRefreshRequestCounter(string metadataAddress, string operationStatus, string configurationSource) { }
+            void Telemetry.ITelemetryClient.IncrementConfigurationRefreshRequestCounter(string metadataAddress, string operationStatus, string configurationSource, Exception exception) { }
+            void Telemetry.ITelemetryClient.IncrementConfigurationRefreshRequestCounter(string metadataAddress, string operationStatus, Exception exception) { }
+            void Telemetry.ITelemetryClient.IncrementConfigurationRefreshRequestCounter(string metadataAddress, string operationStatus) { }
+            void Telemetry.ITelemetryClient.LogConfigurationRetrievalDuration(string metadataAddress, string configurationSource, TimeSpan operationDuration) { }
+            void Telemetry.ITelemetryClient.LogConfigurationRetrievalDuration(string metadataAddress, string configurationSource, TimeSpan operationDuration, Exception exception) { }
+            void Telemetry.ITelemetryClient.LogConfigurationRetrievalDuration(string metadataAddress, TimeSpan operationDuration) { }
+            void Telemetry.ITelemetryClient.LogConfigurationRetrievalDuration(string metadataAddress, TimeSpan operationDuration, Exception exception) { }
+            void Telemetry.ITelemetryClient.LogBackgroundConfigurationRefreshFailure(string metadataAddress, string configurationSource, Exception exception) { }
+            void Telemetry.ITelemetryClient.LogBackgroundConfigurationRefreshFailure(string metadataAddress, Exception exception) { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a new signature validation delegate that allows callers to either handle signature validation in full or decline, letting the handler fall through to its built-in logic.

This replaces the approach in the abandoned PR #3483, which risked recursive loops when the delegate needed to fall back to default validation.

## New public API

### `SignatureValidationDelegateResult` (readonly struct)
- `Success(SecurityToken token)` — delegate handled validation successfully
- `NotHandled` — delegate declines; handler proceeds with default logic
- If the signature is invalid, the delegate throws (e.g. `SecurityTokenInvalidSignatureException`)

### `SignatureValidatorWithToken` (delegate)
```csharp
public delegate SignatureValidationDelegateResult SignatureValidatorWithToken(
    SecurityToken token,
    TokenValidationParameters validationParameters,
    BaseConfiguration configuration);
```

### `TokenValidationParameters.SignatureValidatorWithToken` (property)

## Behaviour

1. Existing `SignatureValidator` / `SignatureValidatorUsingConfiguration` delegates retain absolute priority
2. If neither is set, `SignatureValidatorWithToken` is evaluated
3. If the new delegate returns `NotHandled`, the handler validates the signature using its default logic as if no delegate were set
4. If the new delegate returns `Success`, the validated token is used directly

## Additional fix

`BaseConfiguration` is now correctly forwarded to `SignatureValidatorUsingConfiguration` and `IssuerSigningKeyValidator` in the delegate code path (previously passed as `null`).

## Tests

14 new tests covering:
- Delegate handles / declines / throws
- Old delegate priority
- Configuration passthrough
- Telemetry (success and failure)
- Struct contract (`NotHandled`, `Success`, null guard)
- Copy constructor propagation

All 671+ existing tests pass across all 6 TFMs (net462, net472, net6.0, net8.0, net9.0, net10.0).