### PR TITLE
Fix typo in XML documentation comment

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/Configuration/HttpDocumentRetriever.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/HttpDocumentRetriever.cs
@@ -72,7 +72,7 @@ namespace Microsoft.IdentityModel.Protocols
         }
 
         /// <summary>
-        /// Requires Https secure channel for sending requests.. This is turned ON by default for security reasons. It is RECOMMENDED that you do not allow retrieval from http addresses by default.
+        /// Requires Https secure channel for sending requests. This is turned ON by default for security reasons. It is RECOMMENDED that you do not allow retrieval from http addresses by default.
         /// </summary>
         public bool RequireHttps { get; set; } = true;
 


### PR DESCRIPTION
# Fix typo in XML documentation comment

Fix typo.

## Description

Fix double period in XML comment for `HttpDocumentRetriever.RequireHttps`.
