### PR TITLE
 fix-3359-bootstrapcontext-test

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
@@ -60,13 +60,18 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
                 jwtToken.InnerToken = tokenValidationResult.SecurityToken as JsonWebToken;
                 jwtToken.Payload = (tokenValidationResult.SecurityToken as JsonWebToken).Payload;
-                return new TokenValidationResult
+                var jweResult = new TokenValidationResult
                 {
                     SecurityToken = jwtToken,
                     ClaimsIdentityNoLocking = tokenValidationResult.ClaimsIdentityNoLocking,
+                    ClaimsIdentity = tokenValidationResult.ClaimsIdentity,
                     IsValid = true,
                     TokenType = tokenValidationResult.TokenType
                 };
+                if (validationParameters.SaveSigninToken)
+                    jweResult.ClaimsIdentity.BootstrapContext = jwtToken.EncodedToken;
+
+                return jweResult;
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
@@ -746,11 +751,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             }
 
             string tokenType = Validators.ValidateTokenType(jsonWebToken.Typ, jsonWebToken, validationParameters);
-            return new TokenValidationResult(jsonWebToken, this, validationParameters.Clone(), issuer)
+            var result = new TokenValidationResult(jsonWebToken, this, validationParameters.Clone(), issuer)
             {
                 IsValid = true,
                 TokenType = tokenType
             };
+            if (validationParameters.SaveSigninToken)
+                result.ClaimsIdentity.BootstrapContext = jsonWebToken.EncodedToken;
+
+            return result;
         }
     }
 }

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -4649,6 +4649,70 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
                 }
             };
         }
+        [Theory]
+        [MemberData(nameof(BootstrapContextTestData),
+    DisableDiscoveryEnumeration = true)]
+        public async Task BootstrapContext_JsonWebTokenHandler(
+    BootstrapContextTheoryData theoryData)
+        {
+            var handler = new JsonWebTokenHandler();
+
+            var result = await handler.ValidateTokenAsync(theoryData.Token, theoryData.ValidationParameters);
+
+            Assert.True(result.IsValid, $"Validation failed: {result.Exception?.Message}");
+
+            var bootstrapContext = result.ClaimsIdentity.BootstrapContext as string;
+
+            if (theoryData.SaveSigninToken)
+            {
+                Assert.NotNull(bootstrapContext);
+                var result2 = await handler.ValidateTokenAsync(bootstrapContext, theoryData.ValidationParameters);
+                Assert.True(result2.IsValid, $"Re-validation failed: {result2.Exception?.Message}");
+            }
+            else
+            {
+                Assert.Null(bootstrapContext);
+            }
+        }
+
+        public static TheoryData<BootstrapContextTheoryData> BootstrapContextTestData
+        {
+            get
+            {
+                var theoryData = new TheoryData<BootstrapContextTheoryData>();
+
+                // SaveSigninToken = true — BootstrapContext should be set
+                var validationParametersWithSave = Default.AsymmetricSignTokenValidationParameters.Clone();
+                validationParametersWithSave.SaveSigninToken = true;
+                theoryData.Add(new BootstrapContextTheoryData
+                {
+                    TestId = "SaveSigninToken_True",
+                    Token = Default.AsymmetricJwt,
+                    ValidationParameters = validationParametersWithSave,
+                    SaveSigninToken = true
+                });
+
+                // SaveSigninToken = false — BootstrapContext should be null
+                var validationParametersWithoutSave = Default.AsymmetricSignTokenValidationParameters.Clone();
+                validationParametersWithoutSave.SaveSigninToken = false;
+                theoryData.Add(new BootstrapContextTheoryData
+                {
+                    TestId = "SaveSigninToken_False",
+                    Token = Default.AsymmetricJwt,
+                    ValidationParameters = validationParametersWithoutSave,
+                    SaveSigninToken = false
+                });
+
+                return theoryData;
+            }
+        }
+
+        public class BootstrapContextTheoryData : TheoryDataBase
+        {
+            public string Token { get; set; }
+            public TokenValidationParameters ValidationParameters { get; set; }
+            public bool SaveSigninToken { get; set; }
+        }
 
         [Theory, MemberData(nameof(ReadJsonWebTokenSpanTheoryData))]
         public void ReadJsonWebToken_Span(JwtTheoryData theoryData)


### PR DESCRIPTION
# Add BootstrapContext tests for JsonWebTokenHandler

Fixes #3359

## Description

Adds test coverage for `JsonWebTokenHandler` BootstrapContext behavior when `TokenValidationParameters.SaveSigninToken` is enabled.

### Changes

* Added `BootstrapContext_JsonWebTokenHandler` theory test.
* Added `BootstrapContextTestData` theory data source.
* Added `BootstrapContextTheoryData` helper class.
* Verified that when `SaveSigninToken = true`, the original JWT is stored in `ClaimsIdentity.BootstrapContext`.
* Verified that the bootstrap token can be revalidated successfully.
* Verified that when `SaveSigninToken = false`, `ClaimsIdentity.BootstrapContext` is null.

### Testing

Validated the following scenarios:

* `SaveSigninToken_True`

  * Token validation succeeds.
  * `BootstrapContext` contains the original JWT.
  * Re-validation of the bootstrap token succeeds.
* `SaveSigninToken_False`

  * Token validation succeeds.
  * `BootstrapContext` is null.

This change adds test coverage for the behavior introduced in issue #3359.
