### PR TITLE
Add missing 'else' at JwtSecurityTokenHandler.cs:1384 so that IssuerS…

### DIFF
--- a/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/JwtSecurityTokenHandler.cs
@@ -1333,7 +1333,7 @@ namespace System.IdentityModel.Tokens.Jwt
             {
                 keys = validationParameters.IssuerSigningKeyResolverUsingConfiguration(token, jwtToken, jwtToken.Header.Kid, validationParameters, configuration);
             }
-            if (validationParameters.IssuerSigningKeyResolver != null)
+            else if (validationParameters.IssuerSigningKeyResolver != null)
             {
                 keys = validationParameters.IssuerSigningKeyResolver(token, jwtToken, jwtToken.Header.Kid, validationParameters);
             }


### PR DESCRIPTION
…igningKeyResolverUsingConfiguration takes priority over IssuerSigningKeyResolver and default kid-based resolution, matching the documented contract and the correct behavior already present in JsonWebTokenHandler.

# Fix missing else keyword in JwtSecurityTokenHandler key resolution
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Add missing 'else' at JwtSecurityTokenHandler.cs:1384 so that IssuerSigningKeyResolverUsingConfiguration takes priority over IssuerSigningKeyResolver and default kid-based resolution, matching the documented contract and the correct behavior already present in JsonWebTokenHandler.

Fixes #{bug number} (in this specific format)
