### PR TITLE
Make Validate_CanFetchMetadataWithoutConfigurationProvider run offline (Bug 3669406)

### DIFF
--- a/test/Microsoft.IdentityModel.Validators.Tests/MicrosoftIdentityIssuerValidatorTest.cs
+++ b/test/Microsoft.IdentityModel.Validators.Tests/MicrosoftIdentityIssuerValidatorTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IdentityModel.Tokens.Jwt;
+using System.Net;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading;
@@ -22,6 +23,16 @@ namespace Microsoft.IdentityModel.Validators.Tests
     public class MicrosoftIdentityIssuerValidatorTest
     {
         private readonly HttpClient _httpClient;
+
+        // URL markers and fixtures for the offline metadata-mocking tests below. The mock handler routes
+        // requests by these path fragments, and PlaceholderJwksUri is the jwks_uri advertised in the mock
+        // metadata so the key-set fetch is routed back to the handler. Issuer validation itself only reads
+        // the metadata issuer ({tenantid} template) and JwksUri.
+        private const string OpenIdConfigurationPath = "/.well-known/openid-configuration";
+        private const string DiscoveryPathMarker = "/discovery/";
+        private const string KeysPathMarker = "/keys";
+        private const string UnexpectedUrlMessagePrefix = "Unexpected URL in offline test: ";
+        private const string PlaceholderJwksUri = "https://example.com/discovery/keys";
 
         public MicrosoftIdentityIssuerValidatorTest()
         {
@@ -982,7 +993,35 @@ namespace Microsoft.IdentityModel.Validators.Tests
             var jwtSecurityToken = new JwtSecurityToken(issuer: issuer, claims: new[] { issClaim, tidClaim });
 
             var authority = authorityUrlProvider(authorityVersion);
-            var validator = AadIssuerValidator.GetAadIssuerValidator(authority, _httpClient);
+
+            // Serve OpenID Connect metadata and a JWKS from in-memory fixtures through a mock HTTP handler
+            // instead of calling the live pre-production metadata endpoint, which is not reachable from CI
+            // runners. Every layer below the HTTP transport stays real, so the retriever, serializer, and
+            // key-set parsing run exactly as they would against the live document.
+            // The metadata issuer is the same {tenantid} template the live endpoint returns, so the validator
+            // still matches the token issuer through its normal tenant-substitution logic. Issuer validation
+            // only reads Issuer and JwksUri, so a minimal metadata document is sufficient.
+            string issuerTemplate = issuer.Replace(ValidatorConstants.TenantIdAsGuid, AadIssuerValidator.TenantIdTemplate);
+            string metadataJson = OpenIdConnectConfiguration.Write(
+                new OpenIdConnectConfiguration { Issuer = issuerTemplate, JwksUri = PlaceholderJwksUri });
+            string jwksJson = KeyingMaterial.AADJWKS;
+
+            var handler = new DelegateHttpMessageHandler((request, ct) =>
+            {
+                string url = request.RequestUri.AbsoluteUri;
+
+                if (url.EndsWith(OpenIdConfigurationPath, StringComparison.OrdinalIgnoreCase))
+                    return Task.FromResult(HttpResponseMessageUtils.CreateHttpResponseMessage(metadataJson));
+
+                if (url.IndexOf(DiscoveryPathMarker, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    url.EndsWith(KeysPathMarker, StringComparison.OrdinalIgnoreCase))
+                    return Task.FromResult(HttpResponseMessageUtils.CreateHttpResponseMessage(jwksJson));
+
+                throw new InvalidOperationException(UnexpectedUrlMessagePrefix + url);
+            });
+
+            using var mockHttpClient = new HttpClient(handler);
+            var validator = AadIssuerValidator.GetAadIssuerValidator(authority, mockHttpClient);
 
             ValidationResult<ValidatedIssuer, IssuerValidationError> validationResult = await ValidateIssuerAsync(issuer, jwtSecurityToken, validator);
             var actualIssuer = validator.Validate(issuer, jwtSecurityToken, new TokenValidationParameters());
@@ -990,6 +1029,52 @@ namespace Microsoft.IdentityModel.Validators.Tests
             Assert.True(validationResult.Succeeded);
             IdentityComparer.AreEqual(issuer, validationResult.Result.Issuer, context);
             IdentityComparer.AreEqual(issuer, actualIssuer, context);
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        // Negative coverage for the metadata-fetch-failure path. When the mock handler rejects the discovery
+        // request (for example, a 403), the validator surfaces IDX40001. This deterministically exercises
+        // HttpDocumentRetriever's failure path and AadIssuerValidator's catch that maps the fetch failure to
+        // IDX40001, which previously ran only when the live endpoint happened to fail.
+        [Fact]
+        public void Validate_WithoutConfigurationProvider_MetadataFetchForbidden_ThrowsIDX40001()
+        {
+            var context = new CompareContext();
+            var issuer = ValidatorConstants.AadIssuerPPE;
+            var authority = ValidatorConstants.AuthorityCommonTenantWithV2PPE;
+
+            // Build a token whose issuer and tenant id match the authority, so validation gets past the
+            // issuer/tenant checks and reaches the on-demand metadata fetch.
+            var issClaim = new Claim(ValidatorConstants.ClaimNameIss, issuer);
+            var tidClaim = new Claim(ValidatorConstants.ClaimNameTid, ValidatorConstants.TenantIdAsGuid);
+            var jwtSecurityToken = new JwtSecurityToken(issuer: issuer, claims: new[] { issClaim, tidClaim });
+
+            // Reject the OpenID Connect discovery request with 403 to simulate an unreachable metadata
+            // endpoint. Validation fails before the JWKS is requested, so any other URL is unexpected here.
+            var handler = new DelegateHttpMessageHandler((request, ct) =>
+            {
+                string url = request.RequestUri.AbsoluteUri;
+
+                if (url.EndsWith(OpenIdConfigurationPath, StringComparison.OrdinalIgnoreCase))
+                    return Task.FromResult(HttpResponseMessageUtils.CreateHttpResponseMessage(string.Empty, HttpStatusCode.Forbidden));
+
+                throw new InvalidOperationException(UnexpectedUrlMessagePrefix + url);
+            });
+
+            using var mockHttpClient = new HttpClient(handler);
+            var validator = AadIssuerValidator.GetAadIssuerValidator(authority, mockHttpClient);
+
+            // The failed metadata fetch leaves the validator without issuer metadata, so it reports IDX40001.
+            var expectedErrorMessage = string.Format(
+                CultureInfo.InvariantCulture,
+                LogMessages.IDX40001,
+                issuer);
+
+            // Validate surfaces the failure as SecurityTokenInvalidIssuerException carrying the IDX40001 message.
+            var exception = Assert.Throws<SecurityTokenInvalidIssuerException>(() =>
+                validator.Validate(issuer, jwtSecurityToken, new TokenValidationParameters()));
+
+            IdentityComparer.AreEqual(expectedErrorMessage, exception.Message, context);
             TestUtilities.AssertFailIfErrors(context);
         }
 


### PR DESCRIPTION
## Summary
1. `Validate_CanFetchMetadataWithoutConfigurationProvider` now serves OpenID Connect metadata and keys from in-memory mock fixtures instead of calling a live pre-production metadata endpoint.
2. Test-only change. No product code under `src/` is modified.
3. This mirrors the suite's existing practice of unit-testing the validator against mocked configuration or handlers instead of the live network, for example [Validate_WithAuthorityUsingConfigurationProvider](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/168714d244b2d8f27b1d5b769c3480ccb0a87da0/test/Microsoft.IdentityModel.Validators.Tests/MicrosoftIdentityIssuerValidatorTest.cs#L742), [Validate_UsesLKGWithConfigurationProvider](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/168714d244b2d8f27b1d5b769c3480ccb0a87da0/test/Microsoft.IdentityModel.Validators.Tests/MicrosoftIdentityIssuerValidatorTest.cs#L997), [Validate_UsesLKGWithoutConfigurationProvider](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/168714d244b2d8f27b1d5b769c3480ccb0a87da0/test/Microsoft.IdentityModel.Validators.Tests/MicrosoftIdentityIssuerValidatorTest.cs#L831), [Validate_NoHttpclientFactory_ReturnsIssuer](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/168714d244b2d8f27b1d5b769c3480ccb0a87da0/test/Microsoft.IdentityModel.Validators.Tests/MicrosoftIdentityIssuerValidatorTest.cs#L227), and [GetAadIssuerValidator_ReturnsInstance_WithAndWithoutProvider](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/168714d244b2d8f27b1d5b769c3480ccb0a87da0/test/Microsoft.IdentityModel.Validators.Tests/AadIssuerValidatorTests.cs#L37).

## Problem
1. The "Run unit tests" job fails on every pull request. The single failing test is `Validate_CanFetchMetadataWithoutConfigurationProvider`, whose 9 rows fail with `IDX40001`.
2. The test downloaded metadata from a live pre-production metadata endpoint over a real `HttpClient`. That endpoint is not reachable from GitHub-hosted CI runners and returns 403 Forbidden, so the validator has no issuer metadata and fails. Because CI runs the whole solution, this one test fails the entire job and blocks unrelated pull requests.
3. It is environmental, not a code regression: the same rows fail on bare `dev`, and the test file was unchanged for months before the failure began.

## What changed
1. Inside the one test method, the shared `HttpClient` is replaced with a method-local `HttpClient` backed by a mock `DelegateHttpMessageHandler` that returns fixed metadata for the discovery request and a fixed JWKS for the keys request, and throws on any other URL. No network call is made.
2. The mocked metadata issuer uses the same tenant-id template the live endpoint returns, so the validator still matches the token issuer through its normal tenant-substitution logic.
3. The existing 2-argument overload `AadIssuerValidator.GetAadIssuerValidator(authority, httpClient)` is kept, so the test still exercises on-demand metadata fetch with no configuration provider supplied.
4. Fixture endpoint values that issuer validation never reads use placeholder URLs; only the issuer and the JWKS URI are meaningful, and shared literals are pulled into named constants.
5. Adds a negative test `Validate_WithoutConfigurationProvider_MetadataFetchForbidden_ThrowsIDX40001` that returns 403 from the mock handler and asserts `IDX40001`, covering the metadata-fetch-failure path deterministically.

## Why this is safe
1. No file under `src/` changes, so product behavior is unchanged.
2. The shared `HttpClient` and the `CreateIssuerValidator` helper are untouched, so no other test changes behavior.
3. Coverage is preserved: the mocked metadata carries a `jwks_uri` and the handler serves a JWKS, so the retriever, serializer, key-set parsing, and issuer-matching paths all still run. The only lines not exercised are the network-error lines, which are already covered by `HttpDocumentRetrieverTests` and `Validate_InvalidIssuerToValidate`, and now deterministically by the new negative test.
4. Routing uses `IndexOf(string, StringComparison)` rather than `Contains(string, StringComparison)`, which is unavailable on net462/net472/netstandard2.0.

## Testing
- Test-only change. CI ("Run unit tests") executes the rewritten `Validate_CanFetchMetadataWithoutConfigurationProvider` (9 rows) and the new negative test across net6.0, net462, net472, net8.0, net9.0, net10.0.
