### PR TITLE
Fix NullReferenceException when signing with an RSA JWK containing both private key and x5c

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/JsonWebKeyConverter.cs
+++ b/src/Microsoft.IdentityModel.Tokens/JsonWebKeyConverter.cs
@@ -304,10 +304,15 @@ namespace Microsoft.IdentityModel.Tokens
             {
                 if (JsonWebAlgorithmsKeyTypes.RSA.Equals(webKey.Kty))
                 {
-                    if (TryConvertToX509SecurityKey(webKey, out key))
+                    // Prefer RSA over X509: a JWK carrying RSA key material (and especially the
+                    // private parameters) must convert to an RsaSecurityKey. Converting to an
+                    // X509SecurityKey from x5c[0] yields a public-only certificate, which silently
+                    // discards the private key and throws a NullReferenceException when signing.
+                    // See https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/3260.
+                    if (TryCreateToRsaSecurityKey(webKey, out key))
                         return true;
 
-                    if (TryCreateToRsaSecurityKey(webKey, out key))
+                    if (TryConvertToX509SecurityKey(webKey, out key))
                         return true;
                 }
                 else if (JsonWebAlgorithmsKeyTypes.EllipticCurve.Equals(webKey.Kty))

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -30,6 +30,28 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
     public class JsonWebTokenHandlerTests
     {
         [Fact]
+        public void CreateToken_RsaJsonWebKeyWithPrivateKeyAndX5c_Signs()
+        {
+            // Regression: signing with a JWK that carries both private RSA parameters and x5c
+            // threw a NullReferenceException, because the key was converted to an X509SecurityKey
+            // from the public-only x5c[0] and the private key was null at sign time.
+            // See https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/3260.
+            var signingKey = KeyingMaterial.JsonWebKeyX509_2048_As_RSA;
+            signingKey.X5c.Add(Convert.ToBase64String(KeyingMaterial.DefaultCert_2048.RawData));
+
+            var handler = new JsonWebTokenHandler();
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Issuer = "issuer",
+                SigningCredentials = new SigningCredentials(signingKey, SecurityAlgorithms.RsaSha256),
+            };
+
+            var jwt = handler.CreateToken(tokenDescriptor);
+
+            Assert.Equal(3, jwt.Split('.').Length);
+        }
+
+        [Fact]
         public void JsonWebTokenHandler_CreateToken_SameTypeMultipleValues()
         {
             var identity = new CaseSensitiveClaimsIdentity("Test");

--- a/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyConverterTest.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/JsonWebKeyConverterTest.cs
@@ -74,6 +74,20 @@ namespace Microsoft.IdentityModel.Tokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
+        [Fact]
+        public void TryConvertToSecurityKey_RsaJsonWebKeyWithPrivateKeyAndX5c_ConvertsToRsaSecurityKey()
+        {
+            // A JWK that carries BOTH private RSA parameters AND x5c must convert to an
+            // RsaSecurityKey, not an X509SecurityKey built from the public-only x5c[0]
+            // (which discards the private key and throws a NullReferenceException when signing).
+            // See https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/3260.
+            var jsonWebKey = KeyingMaterial.JsonWebKeyX509_2048_As_RSA;
+            jsonWebKey.X5c.Add(Convert.ToBase64String(KeyingMaterial.DefaultCert_2048.RawData));
+
+            Assert.True(JsonWebKeyConverter.TryConvertToSecurityKey(jsonWebKey, out SecurityKey securityKey));
+            Assert.IsType<RsaSecurityKey>(securityKey);
+        }
+
         public static TheoryData<JsonWebKeyConverterTheoryData> ConversionKeyTheoryData
         {
             get


### PR DESCRIPTION
Fixes #3260

## Problem

`JsonWebKeyConverter.TryConvertToSecurityKey` tries `TryConvertToX509SecurityKey` before `TryCreateToRsaSecurityKey` for `kty=RSA`. A JWK that carries both private RSA parameters (`d`/`p`/`q`/…) **and** `x5c` is therefore converted to an `X509SecurityKey` built from `x5c[0]` — a public-only certificate — and the private RSA parameters are discarded.

When that key is used to sign:

- `AsymmetricAdapter.InitializeUsingX509SecurityKey` calls `InitializeUsingRsa(x509SecurityKey.PrivateKey as RSA, …)` with `requirePrivateKey: true`.
- `X509SecurityKey.PrivateKey` returns `null` (`Certificate.GetRSAPrivateKey()` on a public-only cert), so the adapter stores a null `RSA`.
- The first sign operation dereferences it → `NullReferenceException` in `AsymmetricAdapter.SignUsingSpanRsa`.

Removing `x5c` from the same key (forcing the `RsaSecurityKey` conversion) signs successfully, which confirms the precedence is the cause. This is the signing-correctness angle of #3260, in addition to the memory consideration the issue was originally filed for.

## Fix

Reorder the two attempts in the `kty=RSA` branch so RSA key material is used when present:

```csharp
if (TryCreateToRsaSecurityKey(webKey, out key))
    return true;
if (TryConvertToX509SecurityKey(webKey, out key))
    return true;
```

An `x5c`-only JWK still converts to an `X509SecurityKey`, because `TryCreateToRsaSecurityKey` returns `false` unless both `n` and `e` are present.

## Behavior change

A JWK that carries both `n`/`e` and `x5c` now converts to an `RsaSecurityKey` instead of an `X509SecurityKey`. Cryptographic operations are unaffected; the difference is the concrete `SecurityKey` type a caller observes (and the avoided `X509Certificate2` load). This is the prioritization requested in #3260.

## Tests

- `JsonWebKeyConverterTest.TryConvertToSecurityKey_RsaJsonWebKeyWithPrivateKeyAndX5c_ConvertsToRsaSecurityKey` — asserts a JWK with private RSA parameters and `x5c` converts to an `RsaSecurityKey`.
- `JsonWebTokenHandlerTests.CreateToken_RsaJsonWebKeyWithPrivateKeyAndX5c_Signs` — end-to-end signing test that reproduced the `NullReferenceException` before this change.

Both tests fail on the prior ordering (the converter yields `X509SecurityKey`, and signing throws the NRE at `AsymmetricAdapter.SignUsingSpanRsa`) and pass with the reorder.
