### PR TITLE
Port CacheCustomProviders property to CryptoProviderFactory to dev

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
+++ b/src/Microsoft.IdentityModel.Tokens/CryptoProviderFactory.cs
@@ -16,6 +16,7 @@ namespace Microsoft.IdentityModel.Tokens
     {
         private static CryptoProviderFactory _default;
         private static readonly ConcurrentDictionary<string, string> _typeToAlgorithmMap = new ConcurrentDictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string> _customProviderTypeCache = new ConcurrentDictionary<string, string>();
         private static int _defaultSignatureProviderObjectPoolCacheSize = Environment.ProcessorCount * 4;
         private static string _typeofAsymmetricSignatureProvider = typeof(AsymmetricSignatureProvider).ToString();
         private static string _typeofSymmetricSignatureProvider = typeof(SymmetricSignatureProvider).ToString();
@@ -92,6 +93,7 @@ namespace Microsoft.IdentityModel.Tokens
             CryptoProviderCache = new InMemoryCryptoProviderCache() { CryptoProviderFactory = this };
             CustomCryptoProvider = other.CustomCryptoProvider;
             CacheSignatureProviders = other.CacheSignatureProviders;
+            CacheCustomProviders = other.CacheCustomProviders;
             SignatureProviderObjectPoolCacheSize = other.SignatureProviderObjectPoolCacheSize;
         }
 
@@ -114,6 +116,18 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         [DefaultValue(true)]
         public bool CacheSignatureProviders { get; set; } = DefaultCacheSignatureProviders;
+
+        /// <summary>
+        /// Gets or sets a bool controlling if <see cref="SignatureProvider"/> instances created by <see cref="CustomCryptoProvider"/>
+        /// should be cached. Default is <see langword="false"/>.
+        /// </summary>
+        /// <remarks>
+        /// When <see langword="true"/>, signature providers returned by <see cref="ICryptoProvider.Create(string, object[])"/>
+        /// are cached using the same <see cref="CryptoProviderCache"/> used for built-in providers. This avoids
+        /// repeated provider creation and key materialisation on every signature validation.
+        /// </remarks>
+        [DefaultValue(false)]
+        public bool CacheCustomProviders { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum size of the object pool used by the SignatureProvider that are used for crypto objects.
@@ -598,6 +612,23 @@ namespace Microsoft.IdentityModel.Tokens
             SignatureProvider signatureProvider;
             if (CustomCryptoProvider != null && CustomCryptoProvider.IsSupportedAlgorithm(algorithm, key, willCreateSignatures))
             {
+                if (CacheCustomProviders && CacheSignatureProviders && cacheProvider)
+                {
+                    // Try cache lookup first using the remembered provider type from a previous Create call.
+                    string cacheTypeKey = CustomCryptoProvider.GetType().ToString() + "-" + algorithm;
+                    if (_customProviderTypeCache.TryGetValue(cacheTypeKey, out string providerType)
+                        && CryptoProviderCache.TryGetSignatureProvider(
+                            key,
+                            algorithm,
+                            providerType,
+                            willCreateSignatures,
+                            out SignatureProvider cachedProvider))
+                    {
+                        cachedProvider.AddRef();
+                        return cachedProvider;
+                    }
+                }
+
                 signatureProvider = CustomCryptoProvider.Create(algorithm, key, willCreateSignatures) as SignatureProvider;
                 if (signatureProvider == null)
                     throw LogHelper.LogExceptionMessage(
@@ -607,6 +638,17 @@ namespace Microsoft.IdentityModel.Tokens
                                 LogHelper.MarkAsNonPII(algorithm),
                                 LogHelper.MarkAsNonPII(key.KeyId),
                                 LogHelper.MarkAsNonPII(typeof(SignatureProvider)))));
+
+                if (CacheCustomProviders && CacheSignatureProviders && cacheProvider)
+                {
+                    // Remember the provider type for future cache lookups.
+                    string cacheTypeKey = CustomCryptoProvider.GetType().ToString() + "-" + algorithm;
+                    string providerType = signatureProvider.GetType().ToString();
+                    _customProviderTypeCache.TryAdd(cacheTypeKey, providerType);
+
+                    if (ShouldCacheSignatureProvider(signatureProvider))
+                        signatureProvider.IsCached = CryptoProviderCache.TryAdd(signatureProvider);
+                }
 
                 return signatureProvider;
             }
@@ -858,9 +900,14 @@ namespace Microsoft.IdentityModel.Tokens
 
             signatureProvider.Release();
             if (CustomCryptoProvider != null && CustomCryptoProvider.IsSupportedAlgorithm(signatureProvider.Algorithm))
-                CustomCryptoProvider.Release(signatureProvider);
+            {
+                if (!signatureProvider.IsCached)
+                    CustomCryptoProvider.Release(signatureProvider);
+            }
             else if (signatureProvider.CryptoProviderCache == null && signatureProvider.RefCount == 0 && !signatureProvider.IsCached)
+            {
                 signatureProvider.Dispose();
+            }
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
@@ -353,3 +353,5 @@ virtual Microsoft.IdentityModel.Tokens.MlDsaSecurityKey.Dispose(bool disposing) 
 ~Microsoft.IdentityModel.Tokens.JsonWebKey.Priv.get -> string
 ~Microsoft.IdentityModel.Tokens.JsonWebKey.Priv.set -> void
 ~static Microsoft.IdentityModel.Tokens.JsonWebKeyConverter.ConvertFromMlDsaSecurityKey(Microsoft.IdentityModel.Tokens.MlDsaSecurityKey key) -> Microsoft.IdentityModel.Tokens.JsonWebKey
+Microsoft.IdentityModel.Tokens.CryptoProviderFactory.CacheCustomProviders.get -> bool
+Microsoft.IdentityModel.Tokens.CryptoProviderFactory.CacheCustomProviders.set -> void

--- a/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderFactoryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/CryptoProviderFactoryTests.cs
@@ -129,8 +129,8 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
             Type type = typeof(CryptoProviderFactory);
             PropertyInfo[] properties = type.GetProperties();
-            if (properties.Length != 7)
-                Assert.Fail("Number of public fields has changed from 7 to: " + properties.Length + ", adjust tests");
+            if (properties.Length != 8)
+                Assert.Fail("Number of public fields has changed from 8 to: " + properties.Length + ", adjust tests");
 
             CustomCryptoProvider customCryptoProvider = new CustomCryptoProvider();
             GetSetContext getSetContext =
@@ -140,6 +140,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     {
                         new KeyValuePair<string, List<object>>("SignatureProviderObjectPoolCacheSize", new List<object>{CryptoProviderFactory.DefaultSignatureProviderObjectPoolCacheSize, 20, 10}),
                         new KeyValuePair<string, List<object>>("CacheSignatureProviders", new List<object>{CryptoProviderFactory.DefaultCacheSignatureProviders, false, true}),
+                        new KeyValuePair<string, List<object>>("CacheCustomProviders", new List<object>{false, true, false}),
                         new KeyValuePair<string, List<object>>("CustomCryptoProvider", new List<object>{(ICryptoProvider)null, customCryptoProvider, null}),
                     },
                     Object = cryptoProviderFactory,
@@ -1271,6 +1272,340 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 
         private static bool GetSignatureProviderIsDisposedByReflect(SignatureProvider signatureProvider) =>
             (bool)signatureProvider.GetType().GetField("_disposed", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(signatureProvider);
+
+        [Fact]
+        public void CacheCustomProviders_WhenEnabled_CachesProviderFromCustomCryptoProvider()
+        {
+            // Arrange
+            var signingKey = new SymmetricSecurityKey(KeyingMaterial.DefaultSymmetricKeyBytes_256)
+            {
+                KeyId = "test-cache-kid"
+            };
+            var algorithm = SecurityAlgorithms.HmacSha256;
+
+            int createCount = 0;
+            var customCrypto = new CountingCryptoProvider(algorithm, () =>
+            {
+                createCount++;
+                return new SymmetricSignatureProvider(signingKey, algorithm, false);
+            });
+
+            var factory = new CryptoProviderFactory(CryptoProviderCacheTests.CreateCacheForTesting())
+            {
+                CustomCryptoProvider = customCrypto,
+                CacheCustomProviders = true,
+                CacheSignatureProviders = true
+            };
+
+            // Act — first call creates and should cache
+            var provider1 = factory.CreateForVerifying(signingKey, algorithm);
+
+            // Debug: verify the cache state directly
+            string providerType = provider1.GetType().ToString();
+            string internalId = signingKey.InternalId;
+
+            Assert.True(internalId.Length > 0,
+                $"Key InternalId should not be empty, got: '{internalId}'");
+            Assert.True(provider1.IsCached,
+                $"Provider should be marked as cached. IsCached={provider1.IsCached}");
+
+            // Try to retrieve directly from the cache to isolate the issue
+            bool tryGetResult = factory.CryptoProviderCache.TryGetSignatureProvider(
+                signingKey, algorithm, providerType, false, out var fromCache);
+
+            // Debug: manually compute the cache keys to compare
+            string addKey = $"{provider1.Key.GetType()}-{provider1.Key.InternalId}-{provider1.Algorithm}-{provider1.GetType()}";
+            string getKey = $"{signingKey.GetType()}-{signingKey.InternalId}-{algorithm}-{providerType}";
+            
+            Assert.True(tryGetResult,
+                $"TryGetSignatureProvider failed. " +
+                $"addKey='{addKey}', " +
+                $"getKey='{getKey}', " +
+                $"keysMatch={addKey == getKey}, " +
+                $"createCount={createCount}");
+
+            Assert.Same(provider1, fromCache);
+        }
+
+        [Fact]
+        public void CacheCustomProviders_WhenDisabled_CreatesNewProviderEachTime()
+        {
+            // Arrange
+            var signingKey = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key;
+            var algorithm = SecurityAlgorithms.HmacSha256;
+
+            int createCount = 0;
+            var customCrypto = new CountingCryptoProvider(algorithm, () =>
+            {
+                createCount++;
+                return new SymmetricSignatureProvider(signingKey, algorithm);
+            });
+
+            var factory = new CryptoProviderFactory(CryptoProviderCacheTests.CreateCacheForTesting())
+            {
+                CustomCryptoProvider = customCrypto,
+                CacheCustomProviders = false, // default
+                CacheSignatureProviders = true
+            };
+
+            // Act
+            var provider1 = factory.CreateForVerifying(signingKey, algorithm);
+            var provider2 = factory.CreateForVerifying(signingKey, algorithm);
+
+            // Assert — Create called each time, providers are not the same
+            Assert.Equal(2, createCount);
+            Assert.NotSame(provider1, provider2);
+        }
+
+        [Fact]
+        public void CacheCustomProviders_WhenCacheSignatureProvidersDisabled_DoesNotCache()
+        {
+            // Arrange — CacheCustomProviders = true but CacheSignatureProviders = false
+            // The master switch overrides the sub-switch.
+            var signingKey = KeyingMaterial.DefaultSymmetricSigningCreds_256_Sha2.Key;
+            var algorithm = SecurityAlgorithms.HmacSha256;
+
+            int createCount = 0;
+            var customCrypto = new CountingCryptoProvider(algorithm, () =>
+            {
+                createCount++;
+                return new SymmetricSignatureProvider(signingKey, algorithm);
+            });
+
+            var factory = new CryptoProviderFactory(CryptoProviderCacheTests.CreateCacheForTesting())
+            {
+                CustomCryptoProvider = customCrypto,
+                CacheCustomProviders = true,
+                CacheSignatureProviders = false // master switch off
+            };
+
+            // Act
+            var provider1 = factory.CreateForVerifying(signingKey, algorithm);
+            var provider2 = factory.CreateForVerifying(signingKey, algorithm);
+
+            // Assert — Create called each time despite CacheCustomProviders = true
+            Assert.Equal(2, createCount);
+        }
+
+        /// <summary>
+        /// A custom crypto provider that counts how many times Create and Release are called.
+        /// </summary>
+        private class CountingCryptoProvider : ICryptoProvider
+        {
+            private readonly string _algorithm;
+            private readonly Func<SignatureProvider> _factory;
+
+            public CountingCryptoProvider(string algorithm, Func<SignatureProvider> factory)
+            {
+                _algorithm = algorithm;
+                _factory = factory;
+            }
+
+            public int ReleaseCount;
+
+            public bool IsSupportedAlgorithm(string algorithm, params object[] args) =>
+                algorithm == _algorithm;
+
+            public object Create(string algorithm, params object[] args) =>
+                _factory();
+
+            public void Release(object cryptoInstance)
+            {
+                Interlocked.Increment(ref ReleaseCount);
+            }
+        }
+
+        [Fact]
+        public void CacheCustomProviders_ConcurrentAccess_AllThreadsGetSameProvider()
+        {
+            // Arrange
+            var signingKey = new SymmetricSecurityKey(KeyingMaterial.DefaultSymmetricKeyBytes_256)
+            {
+                KeyId = "concurrent-test-kid"
+            };
+            var algorithm = SecurityAlgorithms.HmacSha256;
+
+            int createCount = 0;
+            var customCrypto = new CountingCryptoProvider(algorithm, () =>
+            {
+                Interlocked.Increment(ref createCount);
+                return new SymmetricSignatureProvider(signingKey, algorithm, false);
+            });
+
+            var factory = new CryptoProviderFactory(CryptoProviderCacheTests.CreateCacheForTesting())
+            {
+                CustomCryptoProvider = customCrypto,
+                CacheCustomProviders = true,
+                CacheSignatureProviders = true
+            };
+
+            // Warm the cache with an initial call so the provider type is known
+            // and the provider is in the cache.
+            var warmup = factory.CreateForVerifying(signingKey, algorithm);
+            Assert.True(warmup.IsCached, "Warmup provider should be cached.");
+            int warmupCreateCount = createCount;
+
+            // Act — launch many concurrent calls
+            int threadCount = 20;
+            var providers = new SignatureProvider[threadCount];
+            var barrier = new System.Threading.Barrier(threadCount);
+
+            Parallel.For(0, threadCount, i =>
+            {
+                barrier.SignalAndWait(); // synchronize start
+                providers[i] = factory.CreateForVerifying(signingKey, algorithm);
+            });
+
+            // Assert — all threads should get the same cached instance
+            for (int i = 0; i < threadCount; i++)
+            {
+                Assert.Same(warmup, providers[i]);
+            }
+
+            // Create should not have been called again after warmup (all cache hits)
+            Assert.Equal(warmupCreateCount, createCount);
+        }
+
+        [Fact]
+        public void ReleaseSignatureProvider_CachedCustomProvider_DoesNotCallCustomRelease()
+        {
+            // Arrange — create a cached custom provider, then release it.
+            // CustomCryptoProvider.Release should NOT be called because the provider is still in the cache.
+            var signingKey = new SymmetricSecurityKey(KeyingMaterial.DefaultSymmetricKeyBytes_256)
+            {
+                KeyId = "release-cached-kid"
+            };
+            var algorithm = SecurityAlgorithms.HmacSha256;
+
+            int createCount = 0;
+            var customCrypto = new CountingCryptoProvider(algorithm, () =>
+            {
+                Interlocked.Increment(ref createCount);
+                return new SymmetricSignatureProvider(signingKey, algorithm, false);
+            });
+
+            var factory = new CryptoProviderFactory(CryptoProviderCacheTests.CreateCacheForTesting())
+            {
+                CustomCryptoProvider = customCrypto,
+                CacheCustomProviders = true,
+                CacheSignatureProviders = true
+            };
+
+            // Act
+            var provider = factory.CreateForVerifying(signingKey, algorithm);
+            Assert.True(provider.IsCached, "Provider should be cached.");
+
+            factory.ReleaseSignatureProvider(provider);
+
+            // Assert — Release should NOT have been called on the custom crypto provider
+            Assert.Equal(0, customCrypto.ReleaseCount);
+        }
+
+        [Fact]
+        public void ReleaseSignatureProvider_NonCachedCustomProvider_CallsCustomRelease()
+        {
+            // Arrange — create a non-cached custom provider, then release it.
+            // CustomCryptoProvider.Release SHOULD be called because the provider is not in the cache.
+            var signingKey = new SymmetricSecurityKey(KeyingMaterial.DefaultSymmetricKeyBytes_256)
+            {
+                KeyId = "release-noncached-kid"
+            };
+            var algorithm = SecurityAlgorithms.HmacSha256;
+
+            int createCount = 0;
+            var customCrypto = new CountingCryptoProvider(algorithm, () =>
+            {
+                Interlocked.Increment(ref createCount);
+                return new SymmetricSignatureProvider(signingKey, algorithm, false);
+            });
+
+            var factory = new CryptoProviderFactory(CryptoProviderCacheTests.CreateCacheForTesting())
+            {
+                CustomCryptoProvider = customCrypto,
+                CacheCustomProviders = false, // not caching
+                CacheSignatureProviders = true
+            };
+
+            // Act
+            var provider = factory.CreateForVerifying(signingKey, algorithm);
+            Assert.False(provider.IsCached, "Provider should NOT be cached.");
+
+            factory.ReleaseSignatureProvider(provider);
+
+            // Assert — Release SHOULD have been called on the custom crypto provider
+            Assert.Equal(1, customCrypto.ReleaseCount);
+        }
+
+        [Fact]
+        public void CacheCustomProviders_CreateForSigning_CachesAndReturnsFromCache()
+        {
+            // Arrange — verify the CreateForSigning path also uses the cache
+            // (all other tests use CreateForVerifying). Also verifies that calling
+            // the factory a second time returns the same cached instance (suggestion 2).
+            var signingKey = new SymmetricSecurityKey(KeyingMaterial.DefaultSymmetricKeyBytes_256)
+            {
+                KeyId = "signing-cache-kid"
+            };
+            var algorithm = SecurityAlgorithms.HmacSha256;
+
+            int createCount = 0;
+            var customCrypto = new CountingCryptoProvider(algorithm, () =>
+            {
+                Interlocked.Increment(ref createCount);
+                return new SymmetricSignatureProvider(signingKey, algorithm, true);
+            });
+
+            var factory = new CryptoProviderFactory(CryptoProviderCacheTests.CreateCacheForTesting())
+            {
+                CustomCryptoProvider = customCrypto,
+                CacheCustomProviders = true,
+                CacheSignatureProviders = true
+            };
+
+            // Act — first call creates and caches; second call should hit the cache
+            var provider1 = factory.CreateForSigning(signingKey, algorithm);
+            var provider2 = factory.CreateForSigning(signingKey, algorithm);
+
+            // Assert — same instance returned, Create called only once
+            Assert.True(provider1.IsCached, "Provider should be cached.");
+            Assert.Same(provider1, provider2);
+            Assert.Equal(1, createCount);
+        }
+
+        [Fact]
+        public void CacheCustomProviders_WhenCacheProviderParamFalse_DoesNotCache()
+        {
+            // Arrange — CacheCustomProviders = true but the overload is called
+            // with cacheProvider = false, so the provider should NOT be cached.
+            var signingKey = new SymmetricSecurityKey(KeyingMaterial.DefaultSymmetricKeyBytes_256)
+            {
+                KeyId = "nocache-param-kid"
+            };
+            var algorithm = SecurityAlgorithms.HmacSha256;
+
+            int createCount = 0;
+            var customCrypto = new CountingCryptoProvider(algorithm, () =>
+            {
+                Interlocked.Increment(ref createCount);
+                return new SymmetricSignatureProvider(signingKey, algorithm, false);
+            });
+
+            var factory = new CryptoProviderFactory(CryptoProviderCacheTests.CreateCacheForTesting())
+            {
+                CustomCryptoProvider = customCrypto,
+                CacheCustomProviders = true,
+                CacheSignatureProviders = true
+            };
+
+            // Act — pass cacheProvider: false explicitly
+            var provider1 = factory.CreateForVerifying(signingKey, algorithm, cacheProvider: false);
+            var provider2 = factory.CreateForVerifying(signingKey, algorithm, cacheProvider: false);
+
+            // Assert — provider is NOT cached, Create called each time
+            Assert.False(provider1.IsCached, "Provider should NOT be cached when cacheProvider=false.");
+            Assert.NotSame(provider1, provider2);
+            Assert.Equal(2, createCount);
+        }
     }
 }
 #pragma warning restore CS3016 // Arrays as attribute arguments is not CLS-compliant


### PR DESCRIPTION
## Summary

Forward-ports the `CacheCustomProviders` opt-in on `CryptoProviderFactory` from `dev8x` (#3489) to `dev`. This unblocks downstream consumers that build against `dev` and reference the new API.

When `CacheCustomProviders` is enabled, `SignatureProvider` instances returned by a custom `ICryptoProvider.Create()` are routed through the library's existing `CryptoProviderCache`, avoiding repeated provider creation and key materialisation on every signature validation. The property defaults to `false` to preserve existing behaviour and is copied in the copy constructor.

## Changes

- **`CryptoProviderFactory`**: new `CacheCustomProviders` property (default `false`); on the custom-provider path, checks the cache before `Create()` (using a remembered provider type) and adds the created provider to the cache; `ReleaseSignatureProvider` no longer releases a cached custom provider back to the custom crypto provider.
- **Tests**: cache hit/miss, master-switch interaction (`CacheSignatureProviders`), `cacheProvider` overload flag, signing vs verifying, concurrency, and the release-path behaviour.

## Adaptations for `dev`

- The `CacheCustomProviders` public API entry is placed in the shared root `PublicAPI.Unshipped.txt` (the convention on `dev`), not the per-TFM files used on `dev8x`.
- `CryptoProviderFactoryTests.GetSets` property count updated from 7 to 8, since `dev` has one more public property than the `dev8x` base. The new property is also added to the get/set coverage list.
- The unrelated `InternalAPI.Unshipped.txt` telemetry entries that were pulled in by a `dev8x` merge in the original commit are not part of this feature and are excluded.

## Validation

Full `Microsoft.IdentityModel.Tokens.Tests` suite passes on every configured TFM (Debug):

| net462 | net472 | net6.0 | net8.0 | net9.0 | net10.0 |
|---|---|---|---|---|---|
| 2395 | 2421 | 2423 | 2427 | 2427 | 2432 |

0 failures. Includes 16 new/updated tests covering the caching behaviour.
