### PR TITLE
Backport SHR `p` (path) claim case-sensitive comparison to 8.x (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 See the [releases](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases) for details on bug fixes and added features.
 
+8.19.2
+====
+## Bug Fixes
+- Align Signed HTTP Request `p` (path) claim comparison with RFC 3986 section 3.3. Case-sensitive comparison is opt-in on the 8.x line via the `Switch.Microsoft.IdentityModel.SignedHttpRequest.UseCaseSensitivePClaimComparison` AppContext switch (default off, non-breaking). Backport of PR #3539.
+
 8.15.0
 ====
 ## New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 See the [releases](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/releases) for details on bug fixes and added features.
 
-8.19.2
-====
-## Bug Fixes
-- Align Signed HTTP Request `p` (path) claim comparison with RFC 3986 section 3.3. Case-sensitive comparison is opt-in on the 8.x line via the `Switch.Microsoft.IdentityModel.SignedHttpRequest.UseCaseSensitivePClaimComparison` AppContext switch (default off, non-breaking). Backport of PR #3539.
-
 8.15.0
 ====
 ## New Features

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -829,7 +829,10 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             pClaimValue = pClaimValue.Trim('/');
             var expectedPClaimValue = httpRequestUri.AbsolutePath.Trim('/');
 
-            if (!string.Equals(expectedPClaimValue, pClaimValue, StringComparison.OrdinalIgnoreCase))
+            // URI path components are case-sensitive per RFC 3986 section 3.3. On the 8.x line this stricter comparison is opt-in:
+            // it is case-insensitive (OrdinalIgnoreCase) by default and becomes ordinal (case-sensitive) only when the AppContext switch is enabled.
+            var comparison = AppContextSwitches.UseCaseSensitivePClaimComparison ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+            if (!string.Equals(expectedPClaimValue, pClaimValue, comparison))
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(LogMessages.IDX23011, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P), expectedPClaimValue, pClaimValue)));
         }
 

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -99,6 +99,20 @@ namespace Microsoft.IdentityModel.Tokens
         internal static bool UseCapitalizedXMLTypeAttr => _useCapitalizedXMLTypeAttr ??= (AppContext.TryGetSwitch(UseCapitalizedXMLTypeAttrSwitch, out bool useCapitalizedXMLTypeAttr) && useCapitalizedXMLTypeAttr);
 
         /// <summary>
+        /// Controls whether the Signed HTTP Request 'p' (path) claim is compared case-sensitively (ordinal) per RFC 3986 section 3.3.
+        /// On the 8.x line the comparison is case-insensitive (OrdinalIgnoreCase) by default; set the switch to <c>true</c> to opt in to the case-sensitive (Ordinal) comparison.
+        /// </summary>
+        internal const string UseCaseSensitivePClaimComparisonSwitch = "Switch.Microsoft.IdentityModel.SignedHttpRequest.UseCaseSensitivePClaimComparison";
+
+        // Single source of truth for the default, referenced by both the property below and ResetAllSwitches() so they cannot diverge.
+        // 9.x: true (secure, case-sensitive). 8.x servicing (this line): false (legacy, case-insensitive) to stay non-breaking.
+        internal const bool UseCaseSensitivePClaimComparisonDefault = false;
+
+        private static bool? _useCaseSensitivePClaimComparison;
+
+        internal static bool UseCaseSensitivePClaimComparison => _useCaseSensitivePClaimComparison ??= (AppContext.TryGetSwitch(UseCaseSensitivePClaimComparisonSwitch, out bool useCaseSensitivePClaimComparison) ? useCaseSensitivePClaimComparison : UseCaseSensitivePClaimComparisonDefault);
+
+        /// <summary>
         /// Used for testing to reset all switches to its default value.
         /// </summary>
         internal static void ResetAllSwitches()
@@ -123,6 +137,11 @@ namespace Microsoft.IdentityModel.Tokens
 
             _useCapitalizedXMLTypeAttr = null;
             AppContext.SetSwitch(UseCapitalizedXMLTypeAttrSwitch, false);
+
+            // Opt-in switch (default false on the 8.x line). Reset to the declared default rather than a hardcoded value
+            // because AppContext cannot truly un-set a switch.
+            _useCaseSensitivePClaimComparison = null;
+            AppContext.SetSwitch(UseCaseSensitivePClaimComparisonSwitch, UseCaseSensitivePClaimComparisonDefault);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+const Microsoft.IdentityModel.Tokens.AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch = "Switch.Microsoft.IdentityModel.SignedHttpRequest.UseCaseSensitivePClaimComparison" -> string
+const Microsoft.IdentityModel.Tokens.AppContextSwitches.UseCaseSensitivePClaimComparisonDefault = false -> bool
+static Microsoft.IdentityModel.Tokens.AppContextSwitches.UseCaseSensitivePClaimComparison.get -> bool

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -319,6 +319,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         }
 
         [Theory, MemberData(nameof(ValidatePClaimTheoryData), DisableDiscoveryEnumeration = true)]
+        [ResetAppContextSwitches]
         public void ValidatePClaim(ValidateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidatePClaim", theoryData);
@@ -335,6 +336,45 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             }
 
             TestUtilities.AssertFailIfErrors(context);
+        }
+
+        [Fact]
+        [ResetAppContextSwitches]
+        public void ValidatePClaim_IsCaseInsensitive_WhenSwitchDisabled()
+        {
+            // Arrange - request path and signed 'p' claim differ only by case; disable the switch to select the case-insensitive (OrdinalIgnoreCase) comparison, which is the default on the 8.x line.
+            AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, false);
+            var handler = new SignedHttpRequestHandler();
+            var theoryData = new ValidateSignedHttpRequestTheoryData
+            {
+                HttpRequestUri = new Uri("https://www.contoso.com/path1"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/Path1")),
+            };
+            var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
+
+            // Act - with the switch disabled the comparison is case-insensitive (OrdinalIgnoreCase).
+            var exception = Record.Exception(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
+
+            // Assert - the case-only mismatch is accepted.
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [ResetAppContextSwitches]
+        public void ValidatePClaim_IsCaseSensitive_WhenSwitchEnabled()
+        {
+            // Arrange - request path and signed 'p' claim differ only by case; enable the switch to opt in to the case-sensitive (Ordinal) comparison (not the default on the 8.x line).
+            AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, true);
+            var handler = new SignedHttpRequestHandler();
+            var theoryData = new ValidateSignedHttpRequestTheoryData
+            {
+                HttpRequestUri = new Uri("https://www.contoso.com/path1"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/Path1")),
+            };
+            var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
+
+            // Act & Assert - with the switch enabled the comparison is ordinal (case-sensitive), so the case-only mismatch is rejected.
+            Assert.Throws<SignedHttpRequestInvalidPClaimException>(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
         }
 
         public static TheoryData<ValidateSignedHttpRequestTheoryData> ValidatePClaimTheoryData
@@ -404,6 +444,13 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                         SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/path2")),
                         ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
                         TestId = "InvalidMismatch",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        // Percent-encoding hex case is preserved by Uri.AbsolutePath; equal hex case validates under the ordinal comparison.
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
+                        TestId = "ValidPHexCaseMatch",
                     },
                     new ValidateSignedHttpRequestTheoryData
                     {


### PR DESCRIPTION
Backports #3539 to 8.x.

The Signed HTTP Request `p` (path) claim is compared case-sensitively (ordinal, per RFC 3986 section 3.3) only when the `Switch.Microsoft.IdentityModel.SignedHttpRequest.UseCaseSensitivePClaimComparison` AppContext switch is enabled. On 8.x the switch defaults to off, so behavior is unchanged (case-insensitive) unless a caller opts in.

Unit tests cover both switch states.