### PR TITLE
Backport: JsonWebToken header replacement via ReplaceTokenHeader (#3530) to dev8x

### DIFF
--- a/benchmark/Microsoft.IdentityModel.Benchmarks/JsonWebTokenHeaderReplacementBenchmarks.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/JsonWebTokenHeaderReplacementBenchmarks.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Microsoft.IdentityModel.Benchmarks
+{
+    // Isolates the cost of building a header-replaced JsonWebToken two ways:
+    //   * Reparse:            parse a reassembled "header.payload.signature" string (header AND payload parsed).
+    //   * ReuseParsedPayload: new JsonWebToken(source, encodedHeader) reuses the source's parsed payload (header only parsed).
+    // Three payload sizes show the win scaling with payload. Approximate encoded token sizes:
+    //   Minimal ~0.7 KB (standard claims), Small ~1.9 KB (+50 claims), Typical ~4 KB (+125 claims, ~ a real Graph user token).
+    // The reassembled strings are built once in setup so the benchmark body measures construction, not the concat.
+    //
+    // dotnet run -c release -f net8.0 --filter Microsoft.IdentityModel.Benchmarks.JsonWebTokenHeaderReplacementBenchmarks*
+
+    [MemoryDiagnoser]
+    public class JsonWebTokenHeaderReplacementBenchmarks
+    {
+        private const int SmallExtraClaims = 50;
+        private const int TypicalExtraClaims = 125;
+
+        private JsonWebToken _minimalSource;
+        private string _minimalHeader;
+        private string _minimalReassembled;
+
+        private JsonWebToken _smallSource;
+        private string _smallHeader;
+        private string _smallReassembled;
+
+        private JsonWebToken _typicalSource;
+        private string _typicalHeader;
+        private string _typicalReassembled;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var handler = new JsonWebTokenHandler();
+
+            (_minimalSource, _minimalHeader, _minimalReassembled) = BuildCase(handler, 0);
+            (_smallSource, _smallHeader, _smallReassembled) = BuildCase(handler, SmallExtraClaims);
+            (_typicalSource, _typicalHeader, _typicalReassembled) = BuildCase(handler, TypicalExtraClaims);
+        }
+
+        private static (JsonWebToken source, string header, string reassembled) BuildCase(JsonWebTokenHandler handler, int extraClaims)
+        {
+            var claims = new Dictionary<string, object>(BenchmarkUtils.Claims);
+            for (int i = 0; i < extraClaims; i++)
+                claims[$"claim{i}"] = $"value{i}";
+
+            string encoded = handler.CreateToken(new SecurityTokenDescriptor
+            {
+                SigningCredentials = BenchmarkUtils.SigningCredentialsRsaSha256,
+                Claims = claims
+            });
+
+            var source = new JsonWebToken(encoded);
+            string header = source.EncodedHeader;
+            string reassembled = header + "." + source.EncodedPayload + "." + source.EncodedSignature;
+            return (source, header, reassembled);
+        }
+
+        [Benchmark(Baseline = true)]
+        public JsonWebToken Reparse_Minimal()
+        {
+            return new JsonWebToken(_minimalReassembled);
+        }
+
+        [Benchmark]
+        public JsonWebToken ReuseParsedPayload_Minimal()
+        {
+            return new JsonWebToken(_minimalSource, _minimalHeader);
+        }
+
+        [Benchmark]
+        public JsonWebToken Reparse_Small()
+        {
+            return new JsonWebToken(_smallReassembled);
+        }
+
+        [Benchmark]
+        public JsonWebToken ReuseParsedPayload_Small()
+        {
+            return new JsonWebToken(_smallSource, _smallHeader);
+        }
+
+        [Benchmark]
+        public JsonWebToken Reparse_Typical()
+        {
+            return new JsonWebToken(_typicalReassembled);
+        }
+
+        [Benchmark]
+        public JsonWebToken ReuseParsedPayload_Typical()
+        {
+            return new JsonWebToken(_typicalSource, _typicalHeader);
+        }
+    }
+}

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/JsonWebTokenHeaderReplacementBenchmarks.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/JsonWebTokenHeaderReplacementBenchmarks.cs
@@ -23,6 +23,8 @@ namespace Microsoft.IdentityModel.Benchmarks
         private const int SmallExtraClaims = 50;
         private const int TypicalExtraClaims = 125;
 
+        private readonly JsonWebTokenHandler _handler = new JsonWebTokenHandler();
+
         private JsonWebToken _minimalSource;
         private string _minimalHeader;
         private string _minimalReassembled;
@@ -38,11 +40,9 @@ namespace Microsoft.IdentityModel.Benchmarks
         [GlobalSetup]
         public void Setup()
         {
-            var handler = new JsonWebTokenHandler();
-
-            (_minimalSource, _minimalHeader, _minimalReassembled) = BuildCase(handler, 0);
-            (_smallSource, _smallHeader, _smallReassembled) = BuildCase(handler, SmallExtraClaims);
-            (_typicalSource, _typicalHeader, _typicalReassembled) = BuildCase(handler, TypicalExtraClaims);
+            (_minimalSource, _minimalHeader, _minimalReassembled) = BuildCase(_handler, 0);
+            (_smallSource, _smallHeader, _smallReassembled) = BuildCase(_handler, SmallExtraClaims);
+            (_typicalSource, _typicalHeader, _typicalReassembled) = BuildCase(_handler, TypicalExtraClaims);
         }
 
         private static (JsonWebToken source, string header, string reassembled) BuildCase(JsonWebTokenHandler handler, int extraClaims)
@@ -72,7 +72,7 @@ namespace Microsoft.IdentityModel.Benchmarks
         [Benchmark]
         public JsonWebToken ReuseParsedPayload_Minimal()
         {
-            return new JsonWebToken(_minimalSource, _minimalHeader);
+            return _handler.ReplaceTokenHeader(_minimalSource, _minimalHeader);
         }
 
         [Benchmark]
@@ -84,7 +84,7 @@ namespace Microsoft.IdentityModel.Benchmarks
         [Benchmark]
         public JsonWebToken ReuseParsedPayload_Small()
         {
-            return new JsonWebToken(_smallSource, _smallHeader);
+            return _handler.ReplaceTokenHeader(_smallSource, _smallHeader);
         }
 
         [Benchmark]
@@ -96,7 +96,7 @@ namespace Microsoft.IdentityModel.Benchmarks
         [Benchmark]
         public JsonWebToken ReuseParsedPayload_Typical()
         {
-            return new JsonWebToken(_typicalSource, _typicalHeader);
+            return _handler.ReplaceTokenHeader(_typicalSource, _typicalHeader);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -262,7 +262,26 @@ namespace Microsoft.IdentityModel.JsonWebTokens
 
             string encodedPayload = jsonWebToken.EncodedPayload;
             string encodedSignature = jsonWebToken.EncodedSignature;
+
+#if NET6_0_OR_GREATER
+            int totalLength = encodedHeader.Length + 1 + encodedPayload.Length + 1 + encodedSignature.Length;
+            string encodedToken = string.Create(
+                totalLength,
+                (encodedHeader, encodedPayload, encodedSignature),
+                static (span, state) =>
+                {
+                    var (header, payload, signature) = state;
+                    header.AsSpan().CopyTo(span);
+                    int pos = header.Length;
+                    span[pos++] = '.';
+                    payload.AsSpan().CopyTo(span.Slice(pos));
+                    pos += payload.Length;
+                    span[pos++] = '.';
+                    signature.AsSpan().CopyTo(span.Slice(pos));
+                });
+#else
             string encodedToken = encodedHeader + "." + encodedPayload + "." + encodedSignature;
+#endif
 
             Dot1 = encodedHeader.Length;
             Dot2 = Dot1 + 1 + encodedPayload.Length;

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -239,8 +239,10 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <param name="jsonWebToken">The <see cref="JsonWebToken"/> whose payload and signature are reused. Must be a JWS, not a JWE.</param>
         /// <param name="encodedHeader">The Base64UrlEncoded header that replaces the header of <paramref name="jsonWebToken"/>.</param>
         /// <remarks>
+        /// This is the implementation behind <see cref="JsonWebTokenHandler.ReplaceTokenHeader"/>; use that method to perform a header replacement.
         /// The new token is formed as 'encodedHeader.EncodedPayload.EncodedSignature' using the <see cref="EncodedPayload"/> and <see cref="EncodedSignature"/> from <paramref name="jsonWebToken"/>.
         /// The already parsed payload of <paramref name="jsonWebToken"/> is reused, so the payload is not decoded or parsed again; only the replacement header is decoded and parsed.
+        /// The signature is reused verbatim, so it only remains valid when <paramref name="encodedHeader"/> reconstructs the originally signed header.
         /// <para>
         /// The contents of the returned <see cref="JsonWebToken"/> have not been validated, the JSON Web Token is simply decoded. Validation can be accomplished using the validation methods in <see cref="JsonWebTokenHandler"/>
         /// </para>
@@ -248,7 +250,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="jsonWebToken"/> is null.</exception>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="encodedHeader"/> is null or empty.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="jsonWebToken"/> is an encrypted token (JWE), as its payload cannot be reused.</exception>
-        public JsonWebToken(JsonWebToken jsonWebToken, string encodedHeader)
+        internal JsonWebToken(JsonWebToken jsonWebToken, string encodedHeader)
         {
             _ = jsonWebToken ?? throw LogHelper.LogArgumentNullException(nameof(jsonWebToken));
 

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -234,6 +234,46 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="JsonWebToken"/> class by replacing the header of an existing <see cref="JsonWebToken"/> while reusing its payload and signature.
+        /// </summary>
+        /// <param name="jsonWebToken">The <see cref="JsonWebToken"/> whose payload and signature are reused. Must be a JWS, not a JWE.</param>
+        /// <param name="encodedHeader">The Base64UrlEncoded header that replaces the header of <paramref name="jsonWebToken"/>.</param>
+        /// <remarks>
+        /// The new token is formed as 'encodedHeader.EncodedPayload.EncodedSignature' using the <see cref="EncodedPayload"/> and <see cref="EncodedSignature"/> from <paramref name="jsonWebToken"/>.
+        /// The already parsed payload of <paramref name="jsonWebToken"/> is reused, so the payload is not decoded or parsed again; only the replacement header is decoded and parsed.
+        /// <para>
+        /// The contents of the returned <see cref="JsonWebToken"/> have not been validated, the JSON Web Token is simply decoded. Validation can be accomplished using the validation methods in <see cref="JsonWebTokenHandler"/>
+        /// </para>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="jsonWebToken"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="encodedHeader"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="jsonWebToken"/> is an encrypted token (JWE), as its payload cannot be reused.</exception>
+        public JsonWebToken(JsonWebToken jsonWebToken, string encodedHeader)
+        {
+            _ = jsonWebToken ?? throw LogHelper.LogArgumentNullException(nameof(jsonWebToken));
+
+            if (string.IsNullOrEmpty(encodedHeader))
+                throw LogHelper.LogArgumentNullException(nameof(encodedHeader));
+
+            if (jsonWebToken.IsEncrypted)
+                throw LogHelper.LogExceptionMessage(new ArgumentException(LogMessages.IDX14117, nameof(jsonWebToken)));
+
+            string encodedPayload = jsonWebToken.EncodedPayload;
+            string encodedSignature = jsonWebToken.EncodedSignature;
+            string encodedToken = encodedHeader + "." + encodedPayload + "." + encodedSignature;
+
+            Dot1 = encodedHeader.Length;
+            Dot2 = Dot1 + 1 + encodedPayload.Length;
+            Dot3 = -1;
+            IsSigned = encodedSignature.Length > 0;
+
+            Header = CreateClaimSet(encodedToken.AsSpan(), 0, Dot1, createHeaderClaimSet: true);
+            Payload = jsonWebToken.Payload;
+
+            _encodedToken = encodedToken;
+        }
+
+        /// <summary>
         /// Gets or sets the delegate that will be called when reading JSON Web Token header and payload claims.
         /// </summary>
         /// <remarks>

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.cs
@@ -562,6 +562,29 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         }
 
         /// <summary>
+        /// Creates a new <see cref="JsonWebToken"/> by replacing the header of an existing <see cref="JsonWebToken"/>, reusing its already parsed payload and signature.
+        /// </summary>
+        /// <param name="jsonWebToken">The signed <see cref="JsonWebToken"/> (JWS) whose payload and signature are reused.</param>
+        /// <param name="encodedHeader">The Base64UrlEncoded header that replaces the header of <paramref name="jsonWebToken"/>.</param>
+        /// <returns>A <see cref="JsonWebToken"/> formed as 'encodedHeader.EncodedPayload.EncodedSignature'.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="jsonWebToken"/> is null.</exception>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="encodedHeader"/> is null or empty.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="jsonWebToken"/> is an encrypted token (JWE), as its payload cannot be reused.</exception>
+        /// <remarks>
+        /// This is an intentional transform for header-only rewrites (for example, hashing a Protected Forwarded Token nonce). Only the replacement header is decoded and parsed; the payload is reused from <paramref name="jsonWebToken"/> without re-parsing.
+        /// <para>
+        /// The signature of <paramref name="jsonWebToken"/> is reused verbatim and is NOT recomputed. The resulting token therefore only validates when <paramref name="encodedHeader"/> reconstructs the header over which the original signature was computed; supplying an arbitrary header produces a token whose signature will fail validation.
+        /// </para>
+        /// <para>
+        /// The returned token is NOT validated. Use <see cref="ValidateToken(string, TokenValidationParameters)"/> or <see cref="ValidateTokenAsync(string, TokenValidationParameters)"/> to ensure the token is acceptable.
+        /// </para>
+        /// </remarks>
+        public virtual JsonWebToken ReplaceTokenHeader(JsonWebToken jsonWebToken, string encodedHeader)
+        {
+            return new JsonWebToken(jsonWebToken, encodedHeader);
+        }
+
+        /// <summary>
         /// Converts a string into an instance of <see cref="JsonWebToken"/>.
         /// </summary>
         /// <param name="token">A JSON Web Token (JWT) in JWS or JWE Compact Serialization format.</param>

--- a/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
@@ -28,6 +28,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         internal const string IDX14114 = "IDX14114: Both '{0}.{1}' and '{0}.{2}' are null or empty.";
         // internal const string IDX14115 = "IDX14115:";
         internal const string IDX14116 = "IDX14116: '{0}' cannot contain the following claims: '{1}'. These values are added by default (if necessary) during security token creation.";
+        internal const string IDX14117 = "IDX14117: Cannot create a 'JsonWebToken' with a replaced header from an encrypted (JWE) token. The provided token must be a JWS so that its decoded payload can be reused.";
         // number of sections 'dots' is not correct
         internal const string IDX14120 = "IDX14120: JWT is not well formed, there is only one dot (.).\nThe token needs to be in JWS or JWE Compact Serialization Format. (JWS): 'EncodedHeader.EncodedPayload.EncodedSignature'. (JWE): 'EncodedProtectedHeader.EncodedEncryptedKey.EncodedInitializationVector.EncodedCiphertext.EncodedAuthenticationTag'.";
         internal const string IDX14121 = "IDX14121: JWT is not a well formed JWE, there must be four dots (.).\nThe token needs to be in JWS or JWE Compact Serialization Format. (JWS): 'EncodedHeader.EncodedPayload.EncodedSignature'. (JWE): 'EncodedProtectedHeader.EncodedEncryptedKey.EncodedInitializationVector.EncodedCiphertext.EncodedAuthenticationTag'.";

--- a/src/Microsoft.IdentityModel.JsonWebTokens/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-Microsoft.IdentityModel.JsonWebTokens.JsonWebToken.JsonWebToken(Microsoft.IdentityModel.JsonWebTokens.JsonWebToken jsonWebToken, string encodedHeader) -> void
+~virtual Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler.ReplaceTokenHeader(Microsoft.IdentityModel.JsonWebTokens.JsonWebToken jsonWebToken, string encodedHeader) -> Microsoft.IdentityModel.JsonWebTokens.JsonWebToken

--- a/src/Microsoft.IdentityModel.JsonWebTokens/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.IdentityModel.JsonWebTokens.JsonWebToken.JsonWebToken(Microsoft.IdentityModel.JsonWebTokens.JsonWebToken jsonWebToken, string encodedHeader) -> void

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
@@ -294,7 +294,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             JsonWebToken original = new JsonWebToken(jwtString);
 
             // Act
-            JsonWebToken swapped = new JsonWebToken(original, original.EncodedHeader);
+            JsonWebToken swapped = handler.ReplaceTokenHeader(original, original.EncodedHeader);
 
             // Assert
             Assert.Equal(original.EncodedToken, swapped.EncodedToken);
@@ -322,7 +322,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             string newEncodedHeader = Base64UrlEncoder.Encode(@"{""alg"":""HS256"",""typ"":""JWT"",""nonce"":""abc123""}");
 
             // Act
-            JsonWebToken swapped = new JsonWebToken(original, newEncodedHeader);
+            JsonWebToken swapped = handler.ReplaceTokenHeader(original, newEncodedHeader);
 
             // Assert
             Assert.Equal(newEncodedHeader, swapped.EncodedHeader);
@@ -350,7 +350,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             string newEncodedHeader = Base64UrlEncoder.Encode(@"{""alg"":""HS256"",""typ"":""JWT"",""nonce"":""xyz""}");
 
             // Act
-            JsonWebToken swapped = new JsonWebToken(original, newEncodedHeader);
+            JsonWebToken swapped = handler.ReplaceTokenHeader(original, newEncodedHeader);
             JsonWebToken reparsed = new JsonWebToken(newEncodedHeader + "." + original.EncodedPayload + "." + original.EncodedSignature);
 
             // Assert
@@ -378,7 +378,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             var signingCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
             string jwtString = handler.CreateToken(Default.PayloadString, signingCredentials);
             JsonWebToken original = new JsonWebToken(jwtString);
-            JsonWebToken swapped = new JsonWebToken(original, original.EncodedHeader);
+            JsonWebToken swapped = handler.ReplaceTokenHeader(original, original.EncodedHeader);
             var validationParameters = new TokenValidationParameters
             {
                 IssuerSigningKey = key,
@@ -398,10 +398,11 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
         public void JsonWebToken_ReplaceHeader_NullJsonWebToken_Throws()
         {
             // Arrange
+            var handler = new JsonWebTokenHandler();
             string encodedHeader = Base64UrlEncoder.Encode(@"{""alg"":""none""}");
 
             // Act & Assert
-            var exception = Assert.Throws<ArgumentNullException>(() => new JsonWebToken((JsonWebToken)null, encodedHeader));
+            var exception = Assert.Throws<ArgumentNullException>(() => handler.ReplaceTokenHeader(null, encodedHeader));
             Assert.Equal("jsonWebToken", exception.ParamName);
         }
 
@@ -416,7 +417,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             JsonWebToken jsonWebToken = new JsonWebToken(handler.CreateToken(Default.PayloadString, signingCredentials));
 
             // Act & Assert
-            var exception = Assert.Throws<ArgumentNullException>(() => new JsonWebToken(jsonWebToken, encodedHeader));
+            var exception = Assert.Throws<ArgumentNullException>(() => handler.ReplaceTokenHeader(jsonWebToken, encodedHeader));
             Assert.Equal("encodedHeader", exception.ParamName);
         }
 
@@ -438,7 +439,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             string encodedHeader = Base64UrlEncoder.Encode(@"{""alg"":""none""}");
 
             // Act & Assert
-            var exception = Assert.Throws<ArgumentException>(() => new JsonWebToken(jwe, encodedHeader));
+            var exception = Assert.Throws<ArgumentException>(() => handler.ReplaceTokenHeader(jwe, encodedHeader));
             Assert.Contains("IDX14117", exception.Message);
         }
 

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenTests.cs
@@ -280,6 +280,168 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             TestUtilities.AssertFailIfErrors(context);
         }
 
+        // The header-replacement constructor reuses the payload and signature of an existing token while swapping only the header.
+        // When the header is unchanged, the resulting token is identical to the original.
+        [Fact]
+        public void JsonWebToken_ReplaceHeader_SameHeader_ProducesEquivalentToken()
+        {
+            // Arrange
+            var context = new CompareContext();
+            var handler = new JsonWebTokenHandler();
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('a', 128)));
+            var signingCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+            string jwtString = handler.CreateToken(Default.PayloadString, signingCredentials);
+            JsonWebToken original = new JsonWebToken(jwtString);
+
+            // Act
+            JsonWebToken swapped = new JsonWebToken(original, original.EncodedHeader);
+
+            // Assert
+            Assert.Equal(original.EncodedToken, swapped.EncodedToken);
+            Assert.Equal(original.EncodedHeader, swapped.EncodedHeader);
+            Assert.Equal(original.EncodedPayload, swapped.EncodedPayload);
+            Assert.Equal(original.EncodedSignature, swapped.EncodedSignature);
+            Assert.Equal(original.Dot1, swapped.Dot1);
+            Assert.Equal(original.Dot2, swapped.Dot2);
+            Assert.Equal(original.IsSigned, swapped.IsSigned);
+            IdentityComparer.AreEqual(original.Claims, swapped.Claims, context);
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        // When the header is changed, the payload and signature are reused and the parsed payload instance is shared (not re-parsed).
+        [Fact]
+        public void JsonWebToken_ReplaceHeader_DifferentHeader_ReusesPayloadAndSignature()
+        {
+            // Arrange
+            var context = new CompareContext();
+            var handler = new JsonWebTokenHandler();
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('a', 128)));
+            var signingCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+            string jwtString = handler.CreateToken(Default.PayloadString, signingCredentials);
+            JsonWebToken original = new JsonWebToken(jwtString);
+            string newEncodedHeader = Base64UrlEncoder.Encode(@"{""alg"":""HS256"",""typ"":""JWT"",""nonce"":""abc123""}");
+
+            // Act
+            JsonWebToken swapped = new JsonWebToken(original, newEncodedHeader);
+
+            // Assert
+            Assert.Equal(newEncodedHeader, swapped.EncodedHeader);
+            Assert.Equal(original.EncodedPayload, swapped.EncodedPayload);
+            Assert.Equal(original.EncodedSignature, swapped.EncodedSignature);
+            Assert.Equal(newEncodedHeader + "." + original.EncodedPayload + "." + original.EncodedSignature, swapped.EncodedToken);
+            Assert.Equal("abc123", swapped.GetHeaderValue<string>("nonce"));
+            // The parsed payload instance is reused (the win: no second payload parse).
+            Assert.Same(original.Payload, swapped.Payload);
+            IdentityComparer.AreEqual(original.Claims, swapped.Claims, context);
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        // The reconstructed token is observably identical to one produced by re-parsing the assembled string (the path this constructor replaces).
+        [Fact]
+        public void JsonWebToken_ReplaceHeader_EquivalentToReparsedToken()
+        {
+            // Arrange
+            var context = new CompareContext();
+            var handler = new JsonWebTokenHandler();
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('a', 128)));
+            var signingCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+            string jwtString = handler.CreateToken(Default.PayloadString, signingCredentials);
+            JsonWebToken original = new JsonWebToken(jwtString);
+            string newEncodedHeader = Base64UrlEncoder.Encode(@"{""alg"":""HS256"",""typ"":""JWT"",""nonce"":""xyz""}");
+
+            // Act
+            JsonWebToken swapped = new JsonWebToken(original, newEncodedHeader);
+            JsonWebToken reparsed = new JsonWebToken(newEncodedHeader + "." + original.EncodedPayload + "." + original.EncodedSignature);
+
+            // Assert
+            Assert.Equal(reparsed.EncodedToken, swapped.EncodedToken);
+            Assert.Equal(reparsed.EncodedHeader, swapped.EncodedHeader);
+            Assert.Equal(reparsed.EncodedPayload, swapped.EncodedPayload);
+            Assert.Equal(reparsed.EncodedSignature, swapped.EncodedSignature);
+            Assert.Equal(reparsed.Dot1, swapped.Dot1);
+            Assert.Equal(reparsed.Dot2, swapped.Dot2);
+            Assert.Equal(reparsed.IsSigned, swapped.IsSigned);
+            Assert.Equal(reparsed.Alg, swapped.Alg);
+            Assert.Equal(reparsed.Kid, swapped.Kid);
+            Assert.Equal(reparsed.Issuer, swapped.Issuer);
+            IdentityComparer.AreEqual(reparsed.Claims, swapped.Claims, context);
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        // The reconstructed token (same header) still passes signature validation with the original signing key.
+        [Fact]
+        public async Task JsonWebToken_ReplaceHeader_SameHeader_SignatureStillValidates()
+        {
+            // Arrange
+            var handler = new JsonWebTokenHandler();
+            var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('a', 128)));
+            var signingCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+            string jwtString = handler.CreateToken(Default.PayloadString, signingCredentials);
+            JsonWebToken original = new JsonWebToken(jwtString);
+            JsonWebToken swapped = new JsonWebToken(original, original.EncodedHeader);
+            var validationParameters = new TokenValidationParameters
+            {
+                IssuerSigningKey = key,
+                ValidateIssuer = false,
+                ValidateAudience = false,
+                ValidateLifetime = false,
+            };
+
+            // Act
+            TokenValidationResult result = await handler.ValidateTokenAsync(swapped.EncodedToken, validationParameters);
+
+            // Assert
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        public void JsonWebToken_ReplaceHeader_NullJsonWebToken_Throws()
+        {
+            // Arrange
+            string encodedHeader = Base64UrlEncoder.Encode(@"{""alg"":""none""}");
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentNullException>(() => new JsonWebToken((JsonWebToken)null, encodedHeader));
+            Assert.Equal("jsonWebToken", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void JsonWebToken_ReplaceHeader_NullOrEmptyHeader_Throws(string encodedHeader)
+        {
+            // Arrange
+            var handler = new JsonWebTokenHandler();
+            var signingCredentials = new SigningCredentials(new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('a', 128))), SecurityAlgorithms.HmacSha256);
+            JsonWebToken jsonWebToken = new JsonWebToken(handler.CreateToken(Default.PayloadString, signingCredentials));
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentNullException>(() => new JsonWebToken(jsonWebToken, encodedHeader));
+            Assert.Equal("encodedHeader", exception.ParamName);
+        }
+
+        // An encrypted (JWE) token has no reusable plaintext payload, so header replacement must be rejected.
+        [Fact]
+        public void JsonWebToken_ReplaceHeader_EncryptedToken_Throws()
+        {
+            // Arrange
+            var handler = new JsonWebTokenHandler();
+            var signingCredentials = new SigningCredentials(new SymmetricSecurityKey(Encoding.UTF8.GetBytes(new string('a', 128))), SecurityAlgorithms.HmacSha256);
+            var encryptingCredentials = new EncryptingCredentials(KeyingMaterial.RsaSecurityKey_2048, SecurityAlgorithms.RsaPKCS1, SecurityAlgorithms.Aes128CbcHmacSha256);
+            var tokenDescriptor = new SecurityTokenDescriptor
+            {
+                Claims = new Dictionary<string, object> { ["sub"] = "user" },
+                SigningCredentials = signingCredentials,
+                EncryptingCredentials = encryptingCredentials,
+            };
+            JsonWebToken jwe = new JsonWebToken(handler.CreateToken(tokenDescriptor));
+            string encodedHeader = Base64UrlEncoder.Encode(@"{""alg"":""none""}");
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>(() => new JsonWebToken(jwe, encodedHeader));
+            Assert.Contains("IDX14117", exception.Message);
+        }
+
         // Test checks to make sure that the 'Audiences' claim can be successfully retrieved when multiple audiences are present.
         // It also checks that the rest of the claims match up as well
         [Fact]


### PR DESCRIPTION
Cherry-pick of #3530 (3 commits: 6de5c48f, bd23ab64, a47c5b07) onto `dev8x`.

Adds `JsonWebTokenHandler.ReplaceTokenHeader` to replace a PFT/JWT header without re-parsing the payload.

Resolved `PublicAPI.Unshipped.txt` conflicts (dev8x had an empty unshipped set; kept only the new `ReplaceTokenHeader` API introduced by this PR). Targeted build of Microsoft.IdentityModel.JsonWebTokens (net9.0) passes with 0 warnings/errors (PublicApiAnalyzer clean).

Note: source PR #3530 is still open against `dev`; this backport mirrors its current final state.