### PR TITLE
Fix CI build failures: remove unused log message and add missing DPoP API entries

### DIFF
--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/net10.0/InternalAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/net10.0/InternalAPI.Shipped.txt
@@ -1,0 +1,3 @@
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeAccessTokenHash(string accessToken) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeJwkThumbprint(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ContainsPrivateKeyMaterial(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> bool

--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1,0 +1,26 @@
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Ath = "ath" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htm = "htm" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htu = "htu" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Iat = "iat" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Jti = "jti" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopNonceHeaderName = "DPoP-Nonce" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopProofTokenType = "dpop+jwt" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidRequest = "invalid_request" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidToken = "invalid_token" -> string
+Microsoft.IdentityModel.Dpop.DpopClaimTypes
+Microsoft.IdentityModel.Dpop.DpopErrorCodes
+Microsoft.IdentityModel.Dpop.DpopProofValidator
+Microsoft.IdentityModel.Dpop.DpopValidationOptions
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.get -> System.Collections.Generic.ISet<string>
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.ClockSkewInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.JtiReplayCache.get -> Microsoft.IdentityModel.Dpop.IJtiReplayCache
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationResult
+Microsoft.IdentityModel.Dpop.DpopValidationResult.ErrorCode.get -> string
+Microsoft.IdentityModel.Dpop.DpopValidationResult.IsValid.get -> bool
+Microsoft.IdentityModel.Dpop.DpopValidationResult.Nonce.get -> string
+virtual Microsoft.IdentityModel.Dpop.DpopProofValidator.ValidateAsync(string dpopProofJwt, string httpMethod, System.Uri requestUri, string accessToken, string expectedCnfJkt, Microsoft.IdentityModel.Dpop.DpopValidationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.IdentityModel.Dpop.DpopValidationResult>
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.TimeProvider.get -> System.TimeProvider
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.TimeProvider.set -> void

--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/net462/InternalAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/net462/InternalAPI.Shipped.txt
@@ -1,0 +1,3 @@
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeAccessTokenHash(string accessToken) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeJwkThumbprint(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ContainsPrivateKeyMaterial(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> bool

--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1,0 +1,24 @@
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Ath = "ath" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htm = "htm" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htu = "htu" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Iat = "iat" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Jti = "jti" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopNonceHeaderName = "DPoP-Nonce" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopProofTokenType = "dpop+jwt" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidRequest = "invalid_request" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidToken = "invalid_token" -> string
+Microsoft.IdentityModel.Dpop.DpopClaimTypes
+Microsoft.IdentityModel.Dpop.DpopErrorCodes
+Microsoft.IdentityModel.Dpop.DpopProofValidator
+Microsoft.IdentityModel.Dpop.DpopValidationOptions
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.get -> System.Collections.Generic.ISet<string>
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.ClockSkewInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.JtiReplayCache.get -> Microsoft.IdentityModel.Dpop.IJtiReplayCache
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationResult
+Microsoft.IdentityModel.Dpop.DpopValidationResult.ErrorCode.get -> string
+Microsoft.IdentityModel.Dpop.DpopValidationResult.IsValid.get -> bool
+Microsoft.IdentityModel.Dpop.DpopValidationResult.Nonce.get -> string
+virtual Microsoft.IdentityModel.Dpop.DpopProofValidator.ValidateAsync(string dpopProofJwt, string httpMethod, System.Uri requestUri, string accessToken, string expectedCnfJkt, Microsoft.IdentityModel.Dpop.DpopValidationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.IdentityModel.Dpop.DpopValidationResult>

--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/net472/InternalAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/net472/InternalAPI.Shipped.txt
@@ -1,0 +1,3 @@
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeAccessTokenHash(string accessToken) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeJwkThumbprint(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ContainsPrivateKeyMaterial(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> bool

--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,0 +1,24 @@
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Ath = "ath" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htm = "htm" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htu = "htu" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Iat = "iat" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Jti = "jti" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopNonceHeaderName = "DPoP-Nonce" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopProofTokenType = "dpop+jwt" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidRequest = "invalid_request" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidToken = "invalid_token" -> string
+Microsoft.IdentityModel.Dpop.DpopClaimTypes
+Microsoft.IdentityModel.Dpop.DpopErrorCodes
+Microsoft.IdentityModel.Dpop.DpopProofValidator
+Microsoft.IdentityModel.Dpop.DpopValidationOptions
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.get -> System.Collections.Generic.ISet<string>
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.ClockSkewInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.JtiReplayCache.get -> Microsoft.IdentityModel.Dpop.IJtiReplayCache
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationResult
+Microsoft.IdentityModel.Dpop.DpopValidationResult.ErrorCode.get -> string
+Microsoft.IdentityModel.Dpop.DpopValidationResult.IsValid.get -> bool
+Microsoft.IdentityModel.Dpop.DpopValidationResult.Nonce.get -> string
+virtual Microsoft.IdentityModel.Dpop.DpopProofValidator.ValidateAsync(string dpopProofJwt, string httpMethod, System.Uri requestUri, string accessToken, string expectedCnfJkt, Microsoft.IdentityModel.Dpop.DpopValidationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.IdentityModel.Dpop.DpopValidationResult>

--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/net6.0/InternalAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/net6.0/InternalAPI.Shipped.txt
@@ -1,0 +1,3 @@
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeAccessTokenHash(string accessToken) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeJwkThumbprint(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ContainsPrivateKeyMaterial(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> bool

--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/net6.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/net6.0/PublicAPI.Shipped.txt
@@ -1,0 +1,24 @@
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Ath = "ath" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htm = "htm" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htu = "htu" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Iat = "iat" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Jti = "jti" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopNonceHeaderName = "DPoP-Nonce" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopProofTokenType = "dpop+jwt" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidRequest = "invalid_request" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidToken = "invalid_token" -> string
+Microsoft.IdentityModel.Dpop.DpopClaimTypes
+Microsoft.IdentityModel.Dpop.DpopErrorCodes
+Microsoft.IdentityModel.Dpop.DpopProofValidator
+Microsoft.IdentityModel.Dpop.DpopValidationOptions
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.get -> System.Collections.Generic.ISet<string>
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.ClockSkewInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.JtiReplayCache.get -> Microsoft.IdentityModel.Dpop.IJtiReplayCache
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationResult
+Microsoft.IdentityModel.Dpop.DpopValidationResult.ErrorCode.get -> string
+Microsoft.IdentityModel.Dpop.DpopValidationResult.IsValid.get -> bool
+Microsoft.IdentityModel.Dpop.DpopValidationResult.Nonce.get -> string
+virtual Microsoft.IdentityModel.Dpop.DpopProofValidator.ValidateAsync(string dpopProofJwt, string httpMethod, System.Uri requestUri, string accessToken, string expectedCnfJkt, Microsoft.IdentityModel.Dpop.DpopValidationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.IdentityModel.Dpop.DpopValidationResult>

--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/net8.0/InternalAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/net8.0/InternalAPI.Shipped.txt
@@ -1,0 +1,3 @@
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeAccessTokenHash(string accessToken) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeJwkThumbprint(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ContainsPrivateKeyMaterial(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> bool

--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,0 +1,26 @@
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Ath = "ath" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htm = "htm" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htu = "htu" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Iat = "iat" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Jti = "jti" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopNonceHeaderName = "DPoP-Nonce" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopProofTokenType = "dpop+jwt" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidRequest = "invalid_request" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidToken = "invalid_token" -> string
+Microsoft.IdentityModel.Dpop.DpopClaimTypes
+Microsoft.IdentityModel.Dpop.DpopErrorCodes
+Microsoft.IdentityModel.Dpop.DpopProofValidator
+Microsoft.IdentityModel.Dpop.DpopValidationOptions
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.get -> System.Collections.Generic.ISet<string>
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.ClockSkewInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.JtiReplayCache.get -> Microsoft.IdentityModel.Dpop.IJtiReplayCache
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationResult
+Microsoft.IdentityModel.Dpop.DpopValidationResult.ErrorCode.get -> string
+Microsoft.IdentityModel.Dpop.DpopValidationResult.IsValid.get -> bool
+Microsoft.IdentityModel.Dpop.DpopValidationResult.Nonce.get -> string
+virtual Microsoft.IdentityModel.Dpop.DpopProofValidator.ValidateAsync(string dpopProofJwt, string httpMethod, System.Uri requestUri, string accessToken, string expectedCnfJkt, Microsoft.IdentityModel.Dpop.DpopValidationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.IdentityModel.Dpop.DpopValidationResult>
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.TimeProvider.get -> System.TimeProvider
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.TimeProvider.set -> void

--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/net9.0/InternalAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/net9.0/InternalAPI.Shipped.txt
@@ -1,0 +1,3 @@
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeAccessTokenHash(string accessToken) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeJwkThumbprint(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ContainsPrivateKeyMaterial(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> bool

--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -1,0 +1,26 @@
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Ath = "ath" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htm = "htm" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htu = "htu" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Iat = "iat" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Jti = "jti" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopNonceHeaderName = "DPoP-Nonce" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopProofTokenType = "dpop+jwt" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidRequest = "invalid_request" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidToken = "invalid_token" -> string
+Microsoft.IdentityModel.Dpop.DpopClaimTypes
+Microsoft.IdentityModel.Dpop.DpopErrorCodes
+Microsoft.IdentityModel.Dpop.DpopProofValidator
+Microsoft.IdentityModel.Dpop.DpopValidationOptions
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.get -> System.Collections.Generic.ISet<string>
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.ClockSkewInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.JtiReplayCache.get -> Microsoft.IdentityModel.Dpop.IJtiReplayCache
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationResult
+Microsoft.IdentityModel.Dpop.DpopValidationResult.ErrorCode.get -> string
+Microsoft.IdentityModel.Dpop.DpopValidationResult.IsValid.get -> bool
+Microsoft.IdentityModel.Dpop.DpopValidationResult.Nonce.get -> string
+virtual Microsoft.IdentityModel.Dpop.DpopProofValidator.ValidateAsync(string dpopProofJwt, string httpMethod, System.Uri requestUri, string accessToken, string expectedCnfJkt, Microsoft.IdentityModel.Dpop.DpopValidationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.IdentityModel.Dpop.DpopValidationResult>
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.TimeProvider.get -> System.TimeProvider
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.TimeProvider.set -> void

--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/netstandard2.0/InternalAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/netstandard2.0/InternalAPI.Shipped.txt
@@ -1,0 +1,3 @@
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeAccessTokenHash(string accessToken) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ComputeJwkThumbprint(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> string
+static Microsoft.IdentityModel.Dpop.DpopProofValidator.ContainsPrivateKeyMaterial(Microsoft.IdentityModel.Tokens.JsonWebKey jwk) -> bool

--- a/src/Microsoft.IdentityModel.Dpop/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Dpop/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1,0 +1,24 @@
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Ath = "ath" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htm = "htm" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Htu = "htu" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Iat = "iat" -> string
+const Microsoft.IdentityModel.Dpop.DpopClaimTypes.Jti = "jti" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopNonceHeaderName = "DPoP-Nonce" -> string
+const Microsoft.IdentityModel.Dpop.DpopConstants.DpopProofTokenType = "dpop+jwt" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidRequest = "invalid_request" -> string
+const Microsoft.IdentityModel.Dpop.DpopErrorCodes.InvalidToken = "invalid_token" -> string
+Microsoft.IdentityModel.Dpop.DpopClaimTypes
+Microsoft.IdentityModel.Dpop.DpopErrorCodes
+Microsoft.IdentityModel.Dpop.DpopProofValidator
+Microsoft.IdentityModel.Dpop.DpopValidationOptions
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.get -> System.Collections.Generic.ISet<string>
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.AllowedSigningAlgorithms.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.ClockSkewInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.JtiReplayCache.get -> Microsoft.IdentityModel.Dpop.IJtiReplayCache
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.get -> int
+Microsoft.IdentityModel.Dpop.DpopValidationOptions.MaxLifetimeInSeconds.set -> void
+Microsoft.IdentityModel.Dpop.DpopValidationResult
+Microsoft.IdentityModel.Dpop.DpopValidationResult.ErrorCode.get -> string
+Microsoft.IdentityModel.Dpop.DpopValidationResult.IsValid.get -> bool
+Microsoft.IdentityModel.Dpop.DpopValidationResult.Nonce.get -> string
+virtual Microsoft.IdentityModel.Dpop.DpopProofValidator.ValidateAsync(string dpopProofJwt, string httpMethod, System.Uri requestUri, string accessToken, string expectedCnfJkt, Microsoft.IdentityModel.Dpop.DpopValidationOptions options, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.IdentityModel.Dpop.DpopValidationResult>

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Shipped.txt
@@ -164,7 +164,6 @@ const Microsoft.IdentityModel.Tokens.LogMessages.IDX10612 = "IDX10612: Decryptio
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10615 = "IDX10615: Encryption failed. No support for: Algorithm: '{0}', SecurityKey: '{1}'." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10616 = "IDX10616: Encryption failed. EncryptionProvider failed for: Algorithm: '{0}', SecurityKey: '{1}'. See inner exception." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10617 = "IDX10617: Encryption failed. Keywrap is only supported for: '{0}', '{1}' and '{2}'. The content encryption specified is: '{3}'." -> string
-const Microsoft.IdentityModel.Tokens.LogMessages.IDX10618 = "IDX10618: Key unwrap failed using decryption Keys: '{0}'.\nExceptions caught:\n '{1}'.\ntoken: '{2}'." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10619 = "IDX10619: Decryption failed. Algorithm: '{0}'. Either the Encryption Algorithm: '{1}' or none of the Security Keys are supported by the CryptoProviderFactory." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10620 = "IDX10620: Unable to obtain a CryptoProviderFactory, both EncryptingCredentials.CryptoProviderFactory and EncryptingCredentials.Key.CrypoProviderFactory are null." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10620 = "IDX10620: Unable to obtain a CryptoProviderFactory, both EncryptingCredentials.CryptoProviderFactory and EncryptingCredentials.Key.CryptoProviderFactory are null." -> string

--- a/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.Tokens/LogMessages.cs
@@ -169,7 +169,7 @@ namespace Microsoft.IdentityModel.Tokens
         public const string IDX10615 = "IDX10615: Encryption failed. No support for: Algorithm: '{0}', SecurityKey: '{1}'.";
         public const string IDX10616 = "IDX10616: Encryption failed. EncryptionProvider failed for: Algorithm: '{0}', SecurityKey: '{1}'. See inner exception.";
         public const string IDX10617 = "IDX10617: Encryption failed. Keywrap is only supported for: '{0}', '{1}' and '{2}'. The content encryption specified is: '{3}'.";
-        public const string IDX10618 = "IDX10618: Key unwrap failed using decryption Keys: '{0}'.\nExceptions caught:\n '{1}'.\ntoken: '{2}'.";
+        // public const string IDX10618 = "IDX10618:";
         public const string IDX10619 = "IDX10619: Decryption failed. Algorithm: '{0}'. Either the Encryption Algorithm: '{1}' or none of the Security Keys are supported by the CryptoProviderFactory.";
         public const string IDX10620 = "IDX10620: Unable to obtain a CryptoProviderFactory, both EncryptingCredentials.CryptoProviderFactory and EncryptingCredentials.Key.CryptoProviderFactory are null.";
         //public const string IDX10903 = "IDX10903: Token decryption succeeded. With thumbprint: '{0}'.";


### PR DESCRIPTION
## Changes

### Remove IDX10618 log message
`IDX10618` is no longer referenced anywhere in source. The constant in `LogMessages.cs` is commented out (following the existing pattern) and its entry removed from `InternalAPI.Shipped.txt`, fixing the `VerifyResourceUsage` script failure.

### Add missing DPoP API entries to Shipped.txt files
Several public and internal symbols from `Microsoft.IdentityModel.Dpop` were present in the 8.19.2 release but absent from the per-TFM `PublicAPI.Shipped.txt` and `InternalAPI.Shipped.txt` files, causing RS0016/RS0051 errors. These entries have been added to all relevant TFM-specific API files (`net462`, `net472`, `net6.0`, `net8.0`, `net9.0`, `net10.0`, `netstandard2.0`), with `DpopValidationOptions.TimeProvider` restricted to net8.0+ as it is guarded by `#if NET8_0_OR_GREATER`.