### PR TITLE
Normalize percent-encoding hex case in SHR p-claim validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ See the [releases](https://github.com/AzureAD/azure-activedirectory-identitymode
 ====
 ## Bug Fixes
 - Align Signed HTTP Request `p` (path) claim comparison with RFC 3986 section 3.3 by comparing the path case-sensitively; previously `/Admin/resource` matched `/admin/resource`. An AppContext opt out is available during transition. See [PR #3526](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3526).
+- Normalize hexadecimal letter casing inside percent-encoded triplets during Signed HTTP Request `p` claim validation. Literal path-letter comparison remains controlled by `UseCaseSensitivePClaimComparison`, and `p` claim creation output is unchanged.
 
 7.7.2
 ====

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -819,8 +819,8 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(LogMessages.IDX23003, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P))));
 
             // relax comparison by trimming start and ending forward slashes
-            pClaimValue = pClaimValue.Trim('/');
-            var expectedPClaimValue = httpRequestUri.AbsolutePath.Trim('/');
+            pClaimValue = NormalizePercentEncodingHexCase(pClaimValue.Trim('/'));
+            var expectedPClaimValue = NormalizePercentEncodingHexCase(httpRequestUri.AbsolutePath.Trim('/'));
 
             // URI path components are case-sensitive per RFC 3986 section 3.3, so the comparison is ordinal (case-sensitive) by default.
             // The AppContext switch allows a consumer to restore the legacy case-insensitive comparison during transition.
@@ -1282,6 +1282,70 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
 #endif
 
             return Base64UrlEncoder.Encode(hashedBytes);
+        }
+
+        private static string NormalizePercentEncodingHexCase(string value)
+        {
+            for (int i = 0; i < value.Length - 2; i++)
+            {
+                if (value[i] != '%')
+                    continue;
+
+                char firstHexCharacter = value[i + 1];
+                char secondHexCharacter = value[i + 2];
+                bool firstCharacterIsHex =
+                    (firstHexCharacter >= '0' && firstHexCharacter <= '9') ||
+                    (firstHexCharacter >= 'A' && firstHexCharacter <= 'F') ||
+                    (firstHexCharacter >= 'a' && firstHexCharacter <= 'f');
+                bool secondCharacterIsHex =
+                    (secondHexCharacter >= '0' && secondHexCharacter <= '9') ||
+                    (secondHexCharacter >= 'A' && secondHexCharacter <= 'F') ||
+                    (secondHexCharacter >= 'a' && secondHexCharacter <= 'f');
+
+                if (!firstCharacterIsHex || !secondCharacterIsHex)
+                    continue;
+
+                bool firstCharacterNeedsNormalization = firstHexCharacter >= 'a' && firstHexCharacter <= 'f';
+                bool secondCharacterNeedsNormalization = secondHexCharacter >= 'a' && secondHexCharacter <= 'f';
+                if (!firstCharacterNeedsNormalization && !secondCharacterNeedsNormalization)
+                {
+                    i += 2;
+                    continue;
+                }
+
+                char[] normalizedValue = value.ToCharArray();
+                for (int j = i; j < normalizedValue.Length - 2; j++)
+                {
+                    if (normalizedValue[j] != '%')
+                        continue;
+
+                    firstHexCharacter = normalizedValue[j + 1];
+                    secondHexCharacter = normalizedValue[j + 2];
+                    firstCharacterIsHex =
+                        (firstHexCharacter >= '0' && firstHexCharacter <= '9') ||
+                        (firstHexCharacter >= 'A' && firstHexCharacter <= 'F') ||
+                        (firstHexCharacter >= 'a' && firstHexCharacter <= 'f');
+                    secondCharacterIsHex =
+                        (secondHexCharacter >= '0' && secondHexCharacter <= '9') ||
+                        (secondHexCharacter >= 'A' && secondHexCharacter <= 'F') ||
+                        (secondHexCharacter >= 'a' && secondHexCharacter <= 'f');
+
+                    if (!firstCharacterIsHex || !secondCharacterIsHex)
+                        continue;
+
+                    if (firstHexCharacter >= 'a' && firstHexCharacter <= 'f')
+                        normalizedValue[j + 1] = (char)(firstHexCharacter - ('a' - 'A'));
+
+                    if (secondHexCharacter >= 'a' && secondHexCharacter <= 'f')
+                        normalizedValue[j + 2] = (char)(secondHexCharacter - ('a' - 'A'));
+
+                    j += 2;
+                }
+
+                return new string(normalizedValue);
+            }
+
+            return value;
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestCreationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestCreationTests.cs
@@ -449,6 +449,24 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                         ExpectedClaimValue = $@"{{""p"":""/pa%20th1""}}",
                         HttpRequestUri = new Uri("http://www.contoso.com:81/pa th1")
                     },
+                    new CreateSignedHttpRequestTheoryData("ValidPLowerHexPreserved")
+                    {
+                        ExpectedClaim = SignedHttpRequestClaimTypes.P,
+                        ExpectedClaimValue = $@"{{""p"":""/foo%2fbar""}}",
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2fbar")
+                    },
+                    new CreateSignedHttpRequestTheoryData("ValidPUpperHexPreserved")
+                    {
+                        ExpectedClaim = SignedHttpRequestClaimTypes.P,
+                        ExpectedClaimValue = $@"{{""p"":""/foo%2Fbar""}}",
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar")
+                    },
+                    new CreateSignedHttpRequestTheoryData("ValidPDoubleEncodingPreserved")
+                    {
+                        ExpectedClaim = SignedHttpRequestClaimTypes.P,
+                        ExpectedClaimValue = $@"{{""p"":""/foo%252Fbar""}}",
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%252Fbar")
+                    },
                     new CreateSignedHttpRequestTheoryData("NoPath")
                     {
                         ExpectedClaim = SignedHttpRequestClaimTypes.P,

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -342,20 +342,20 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         [ResetAppContextSwitches]
         public void ValidatePClaim_IsCaseInsensitive_WhenSwitchDisabled()
         {
-            // Arrange - request path and signed 'p' claim differ only by case; disable the switch to opt in to legacy behavior.
+            // Arrange - request path and signed 'p' claim differ by literal case and percent-triplet hex case.
             AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, false);
             var handler = new SignedHttpRequestHandler();
             var theoryData = new ValidateSignedHttpRequestTheoryData
             {
-                HttpRequestUri = new Uri("https://www.contoso.com/path1"),
-                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/Path1")),
+                HttpRequestUri = new Uri("https://www.contoso.com/Foo%2Fbar"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
             };
             var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
 
-            // Act - with the switch disabled the comparison is case-insensitive (OrdinalIgnoreCase).
+            // Act
             var exception = Record.Exception(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
 
-            // Assert - the case-only mismatch is accepted.
+            // Assert
             Assert.Null(exception);
         }
 
@@ -363,18 +363,42 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         [ResetAppContextSwitches]
         public void ValidatePClaim_IsCaseSensitive_WhenSwitchEnabled()
         {
-            // Arrange - request path and signed 'p' claim differ only by case; enable the switch (also the default on this line).
+            // Arrange - request path and signed 'p' claim differ by literal case and percent-triplet hex case.
             AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, true);
             var handler = new SignedHttpRequestHandler();
             var theoryData = new ValidateSignedHttpRequestTheoryData
             {
-                HttpRequestUri = new Uri("https://www.contoso.com/path1"),
-                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/Path1")),
+                HttpRequestUri = new Uri("https://www.contoso.com/Foo%2Fbar"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
             };
             var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
 
-            // Act & Assert - with the switch enabled the comparison is ordinal (case-sensitive), so the case-only mismatch is rejected.
-            Assert.Throws<SignedHttpRequestInvalidPClaimException>(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
+            // Act
+            var exception = Assert.Throws<SignedHttpRequestInvalidPClaimException>(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
+
+            // Assert
+            Assert.Contains("IDX23011", exception.Message);
+        }
+
+        [Fact]
+        [ResetAppContextSwitches]
+        public void ValidatePClaim_NormalizesPercentEncodingHexCase_WhenSwitchEnabled()
+        {
+            // Arrange
+            AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, true);
+            var handler = new SignedHttpRequestHandler();
+            var theoryData = new ValidateSignedHttpRequestTheoryData
+            {
+                HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
+            };
+            var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
+
+            // Act
+            var exception = Record.Exception(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
+
+            // Assert
+            Assert.Null(exception);
         }
 
         public static TheoryData<ValidateSignedHttpRequestTheoryData> ValidatePClaimTheoryData
@@ -463,18 +487,107 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                     },
                     new ValidateSignedHttpRequestTheoryData
                     {
-                        // Percent-encoding hex case is preserved by Uri.AbsolutePath; equal hex case validates under the ordinal comparison.
                         HttpRequestUri = new Uri("https://www.contoso.com/foo%2fbar"),
                         SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
-                        TestId = "ValidPHexCaseMatch",
+                        TestId = "ValidPHexCaseMatchLower",
                     },
                     new ValidateSignedHttpRequestTheoryData
                     {
-                        // %2F (upper) and %2f (lower) differ under the ordinal comparison and must be rejected; they would fold under OrdinalIgnoreCase.
                         HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar"),
                         SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
+                        TestId = "ValidPHexCaseMismatchUpperRequest",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2Fbar")),
+                        TestId = "ValidPHexCaseMismatchLowerRequest",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%ABbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%aBbar")),
+                        TestId = "ValidPMixedHexCase",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/Foo%2Fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
                         ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
-                        TestId = "InvalidPHexCaseMismatch",
+                        TestId = "InvalidPLiteralCaseAndHexCaseMismatch",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo/bar")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPEncodedSlashVsLiteralSlash",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo/bar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2Fbar")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPLiteralSlashVsEncodedSlash",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%25bar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%25bar")),
+                        TestId = "ValidPEncodedPercent",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%252Fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%252Fbar")),
+                        TestId = "ValidPDoubleEncodedSlash",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%252Fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2Fbar")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPDoubleEncodedVsSingleEncoded",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%25"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPTrailingPercent",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%252"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPTruncatedTriplet",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%25zz"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%zz")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPNonHexTriplet",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%25bar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%bar")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPValidLowerHexDifferentOctet",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/")),
+                        TestId = "ValidPRootSlash",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, string.Empty)),
+                        TestId = "ValidPRootEmptyClaim",
                     },
                     new ValidateSignedHttpRequestTheoryData
                     {


### PR DESCRIPTION
## Summary
- normalize ASCII hexadecimal letter casing inside valid `%XX` triplets during Signed HTTP Request `p` claim validation
- preserve literal path-case behavior through `UseCaseSensitivePClaimComparison`, slash tolerance, encoded delimiters, and unchanged `p` claim creation output
- add validation and creation compatibility coverage and document the validation-only change

## Testing
- `dotnet clean Wilson.sln -c Debug`
- `dotnet build Wilson.sln -c Debug` (0 warnings, 0 errors)
- `dotnet test Wilson.sln -c Debug --no-build` (21,813 passed, 8 skipped, 0 failed across net6.0/net8.0/net9.0/net10.0)
- focused `PClaim` tests passed on net6.0, net8.0, net9.0, and net10.0
- net462/net472 builds succeeded locally, but test execution requires the repository strong-name bypass configured in CI

Work item: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3699975/
AB#3699975