### PR TITLE
Handle percent-encoding hex case in SHR p-claim validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ See the [releases](https://github.com/AzureAD/azure-activedirectory-identitymode
 ====
 ## Bug Fixes
 - Align Signed HTTP Request `p` (path) claim comparison with RFC 3986 section 3.3 by comparing the path case-sensitively; previously `/Admin/resource` matched `/admin/resource`. An AppContext opt out is available during transition. See [PR #3526](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3526).
+- Normalize hexadecimal letter casing inside percent-encoded triplets during Signed HTTP Request `p` claim validation. Literal path-letter comparison remains controlled by `UseCaseSensitivePClaimComparison`, and `p` claim creation output is unchanged.
 
 7.7.2
 ====

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateSignedHttpRequestAsyncTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateSignedHttpRequestAsyncTests.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
-using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.SignedHttpRequest;
 using Microsoft.IdentityModel.Tokens;
 
@@ -18,31 +16,23 @@ namespace Microsoft.IdentityModel.Benchmarks
         private SignedHttpRequestHandler _signedHttpRequestHandler;
         private SignedHttpRequestValidationContext _validationContext;
 
-        [Params("path/to/resource", "path%2fto%2fresource")]
-        public string Path { get; set; }
-
         [GlobalSetup]
         public void Setup()
         {
             _signedHttpRequestHandler = new SignedHttpRequestHandler();
-            var httpRequestData = new HttpRequestData
-            {
-                Method = "GET",
-                Uri = new Uri($"https://www.relyingparty.com/{Path}")
-            };
             _validationContext = new SignedHttpRequestValidationContext(
                     _signedHttpRequestHandler.CreateSignedHttpRequest(
                         new SignedHttpRequestDescriptor(
                             BenchmarkUtils.CreateAccessTokenWithCnf(),
-                            httpRequestData,
+                            BenchmarkUtils.HttpRequestData,
                             BenchmarkUtils.SigningCredentialsRsaSha256,
                             new SignedHttpRequestCreationParameters()
                             {
                                 CreateM = true,
-                                CreateP = true,
+                                CreateP = false,
                                 CreateU = true
                             })),
-                    httpRequestData,
+                    BenchmarkUtils.HttpRequestData,
                     new TokenValidationParameters
                     {
                         IssuerSigningKey = BenchmarkUtils.SigningCredentialsRsaSha256.Key,
@@ -52,7 +42,7 @@ namespace Microsoft.IdentityModel.Benchmarks
                     },
                     new SignedHttpRequestValidationParameters
                     {
-                        ValidateP = true
+                        ValidateP = false
                     });
         }
 

--- a/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateSignedHttpRequestAsyncTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateSignedHttpRequestAsyncTests.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
+using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.SignedHttpRequest;
 using Microsoft.IdentityModel.Tokens;
 
@@ -16,23 +18,31 @@ namespace Microsoft.IdentityModel.Benchmarks
         private SignedHttpRequestHandler _signedHttpRequestHandler;
         private SignedHttpRequestValidationContext _validationContext;
 
+        [Params("path/to/resource", "path%2fto%2fresource")]
+        public string Path { get; set; }
+
         [GlobalSetup]
         public void Setup()
         {
             _signedHttpRequestHandler = new SignedHttpRequestHandler();
+            var httpRequestData = new HttpRequestData
+            {
+                Method = "GET",
+                Uri = new Uri($"https://www.relyingparty.com/{Path}")
+            };
             _validationContext = new SignedHttpRequestValidationContext(
                     _signedHttpRequestHandler.CreateSignedHttpRequest(
                         new SignedHttpRequestDescriptor(
                             BenchmarkUtils.CreateAccessTokenWithCnf(),
-                            BenchmarkUtils.HttpRequestData,
+                            httpRequestData,
                             BenchmarkUtils.SigningCredentialsRsaSha256,
                             new SignedHttpRequestCreationParameters()
                             {
                                 CreateM = true,
-                                CreateP = false,
+                                CreateP = true,
                                 CreateU = true
                             })),
-                    BenchmarkUtils.HttpRequestData,
+                    httpRequestData,
                     new TokenValidationParameters
                     {
                         IssuerSigningKey = BenchmarkUtils.SigningCredentialsRsaSha256.Key,
@@ -42,7 +52,7 @@ namespace Microsoft.IdentityModel.Benchmarks
                     },
                     new SignedHttpRequestValidationParameters
                     {
-                        ValidateP = false
+                        ValidateP = true
                     });
         }
 

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -10,7 +10,6 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Abstractions;
@@ -27,8 +26,6 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
     /// <remarks>The handler implementation is based on 'A Method for Signing HTTP Requests for OAuth' specification.</remarks>
     public class SignedHttpRequestHandler
     {
-        private const string PercentEncodedTripletPattern = "%[0-9A-Fa-f]{2}";
-
         // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-3.2
         // "Encodes the name and value of the header as "name: value" and appends it to the string buffer separated by a newline "\n" character."
         private readonly string _newlineSeparator = "\n";
@@ -821,40 +818,26 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             if (!signedHttpRequest.TryGetPayloadValue(SignedHttpRequestClaimTypes.P, out string pClaimValue) || pClaimValue == null)
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(LogMessages.IDX23003, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P))));
 
-            // relax comparison by trimming start and ending forward slashes
-            pClaimValue = pClaimValue.Trim('/');
-            var expectedPClaimValue = httpRequestUri.AbsolutePath.Trim('/');
+            // Relax comparison by trimming start and ending forward slashes without allocating new strings.
+            ReadOnlySpan<char> pClaimValueSpan = pClaimValue.AsSpan().Trim('/');
+            ReadOnlySpan<char> expectedPClaimValueSpan = httpRequestUri.AbsolutePath.AsSpan().Trim('/');
 
             // URI path components are case-sensitive per RFC 3986 section 3.3, so the comparison is ordinal (case-sensitive) by default.
             // The AppContext switch allows a consumer to restore the legacy case-insensitive comparison during transition.
             var comparison = AppContextSwitches.UseCaseSensitivePClaimComparison ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
-            // Fast path: identical values such as "/path" avoid normalization.
-            if (!string.Equals(expectedPClaimValue, pClaimValue, comparison))
-            {
-                // Only equal-length ordinal values with '%' on both sides can differ solely by hex case, such as "%2F" and "%2f".
-                bool mayMatchAfterNormalization =
-                    comparison == StringComparison.Ordinal &&
-                    expectedPClaimValue.Length == pClaimValue.Length &&
-                    expectedPClaimValue.IndexOf('%') >= 0 &&
-                    pClaimValue.IndexOf('%') >= 0;
+            if (expectedPClaimValueSpan.Equals(pClaimValueSpan, comparison))
+                return;
 
-                // A failure cannot be caused only by percent-triplet hex casing because values such as
-                // "foo%2Fbar" and "foo%2fbar" compare equal after normalization. Normalize both
-                // values before inserting them into the IDX23011 error message. For example,
-                // "foo%2fbar" and "goo%2Fbar" are logged as "foo%2Fbar" and "goo%2Fbar".
-                // This removes the irrelevant "%2f" versus "%2F" difference and makes the real
-                // "f" versus "g" mismatch clear.
-                expectedPClaimValue = NormalizePercentEncodingHexCase(expectedPClaimValue);
-                pClaimValue = NormalizePercentEncodingHexCase(pClaimValue);
+            // RFC 3986 requires an additional check because ordinal comparison distinguishes equivalent percent-encoded hexadecimal casing.
+            if (comparison == StringComparison.Ordinal &&
+                ArePClaimValuesEqual(expectedPClaimValueSpan, pClaimValueSpan))
+                return;
 
-                if (mayMatchAfterNormalization &&
-                    string.Equals(expectedPClaimValue, pClaimValue, StringComparison.Ordinal))
-                {
-                    return;
-                }
-
-                throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(LogMessages.IDX23011, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P), expectedPClaimValue, pClaimValue)));
-            }
+            throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(
+                LogMessages.IDX23011,
+                LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P),
+                expectedPClaimValueSpan.ToString(),
+                pClaimValueSpan.ToString())));
         }
 
         /// <summary>
@@ -1312,16 +1295,50 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             return Base64UrlEncoder.Encode(hashedBytes);
         }
 
-        // Uppercases hexadecimal letters only within valid percent-encoded triplets.
-        // It does not URL-decode values or modify malformed sequences.
-        // For example, "foo%2fbar%zz" becomes "foo%2Fbar%zz".
-        private static string NormalizePercentEncodingHexCase(string value)
+        // Compares p-claim path values ordinally while ignoring hexadecimal letter casing
+        // only within aligned, valid percent-encoded triplets. The triplets are not decoded:
+        // "foo%2Fbar" equals "foo%2fbar", but "foo%2Fbar" does not equal "foo/bar",
+        // and malformed "foo%2Gbar" does not equal "foo%2gbar".
+        private static bool ArePClaimValuesEqual(ReadOnlySpan<char> expectedValue, ReadOnlySpan<char> actualValue)
         {
-            return Regex.Replace(
-                value,
-                PercentEncodedTripletPattern,
-                static match => match.Value.ToUpperInvariant(),
-                RegexOptions.CultureInvariant);
+            if (expectedValue.Length != actualValue.Length)
+                return false;
+
+            for (int i = 0; i < expectedValue.Length; i++)
+            {
+                if (expectedValue[i] == '%' &&
+                    actualValue[i] == '%' &&
+                    i + 2 < expectedValue.Length)
+                {
+                    char expectedFirstHexCharacter = expectedValue[i + 1];
+                    char expectedSecondHexCharacter = expectedValue[i + 2];
+                    char actualFirstHexCharacter = actualValue[i + 1];
+                    char actualSecondHexCharacter = actualValue[i + 2];
+
+                    if (Uri.IsHexDigit(expectedFirstHexCharacter) &&
+                        Uri.IsHexDigit(expectedSecondHexCharacter) &&
+                        Uri.IsHexDigit(actualFirstHexCharacter) &&
+                        Uri.IsHexDigit(actualSecondHexCharacter))
+                    {
+                        // RFC 3986 section 6.2.2.1 defines uppercase hexadecimal letters as the canonical form for percent-encoded triplets.
+                        if (char.ToUpperInvariant(expectedFirstHexCharacter) != char.ToUpperInvariant(actualFirstHexCharacter) ||
+                            char.ToUpperInvariant(expectedSecondHexCharacter) != char.ToUpperInvariant(actualSecondHexCharacter))
+                        {
+                            return false;
+                        }
+
+                        i += 2;
+                        continue;
+                    }
+                }
+
+                if (expectedValue[i] != actualValue[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -1286,67 +1286,35 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
 
         private static string NormalizePercentEncodingHexCase(string value)
         {
-            for (int i = 0; i < value.Length - 2; i++)
+            char[] normalizedValue = null;
+            for (int i = 0; i + 2 < value.Length; i++)
             {
                 if (value[i] != '%')
                     continue;
 
                 char firstHexCharacter = value[i + 1];
                 char secondHexCharacter = value[i + 2];
-                bool firstCharacterIsHex =
-                    (firstHexCharacter >= '0' && firstHexCharacter <= '9') ||
-                    (firstHexCharacter >= 'A' && firstHexCharacter <= 'F') ||
-                    (firstHexCharacter >= 'a' && firstHexCharacter <= 'f');
-                bool secondCharacterIsHex =
-                    (secondHexCharacter >= '0' && secondHexCharacter <= '9') ||
-                    (secondHexCharacter >= 'A' && secondHexCharacter <= 'F') ||
-                    (secondHexCharacter >= 'a' && secondHexCharacter <= 'f');
-
-                if (!firstCharacterIsHex || !secondCharacterIsHex)
+                if (!Uri.IsHexDigit(firstHexCharacter) || !Uri.IsHexDigit(secondHexCharacter))
                     continue;
 
-                bool firstCharacterNeedsNormalization = firstHexCharacter >= 'a' && firstHexCharacter <= 'f';
-                bool secondCharacterNeedsNormalization = secondHexCharacter >= 'a' && secondHexCharacter <= 'f';
-                if (!firstCharacterNeedsNormalization && !secondCharacterNeedsNormalization)
+                if (IsLowerHex(firstHexCharacter) || IsLowerHex(secondHexCharacter))
                 {
-                    i += 2;
-                    continue;
+                    normalizedValue ??= value.ToCharArray();
+
+                    if (IsLowerHex(firstHexCharacter))
+                        normalizedValue[i + 1] = (char)(firstHexCharacter - ('a' - 'A'));
+
+                    if (IsLowerHex(secondHexCharacter))
+                        normalizedValue[i + 2] = (char)(secondHexCharacter - ('a' - 'A'));
                 }
 
-                char[] normalizedValue = value.ToCharArray();
-                for (int j = i; j < normalizedValue.Length - 2; j++)
-                {
-                    if (normalizedValue[j] != '%')
-                        continue;
-
-                    firstHexCharacter = normalizedValue[j + 1];
-                    secondHexCharacter = normalizedValue[j + 2];
-                    firstCharacterIsHex =
-                        (firstHexCharacter >= '0' && firstHexCharacter <= '9') ||
-                        (firstHexCharacter >= 'A' && firstHexCharacter <= 'F') ||
-                        (firstHexCharacter >= 'a' && firstHexCharacter <= 'f');
-                    secondCharacterIsHex =
-                        (secondHexCharacter >= '0' && secondHexCharacter <= '9') ||
-                        (secondHexCharacter >= 'A' && secondHexCharacter <= 'F') ||
-                        (secondHexCharacter >= 'a' && secondHexCharacter <= 'f');
-
-                    if (!firstCharacterIsHex || !secondCharacterIsHex)
-                        continue;
-
-                    if (firstHexCharacter >= 'a' && firstHexCharacter <= 'f')
-                        normalizedValue[j + 1] = (char)(firstHexCharacter - ('a' - 'A'));
-
-                    if (secondHexCharacter >= 'a' && secondHexCharacter <= 'f')
-                        normalizedValue[j + 2] = (char)(secondHexCharacter - ('a' - 'A'));
-
-                    j += 2;
-                }
-
-                return new string(normalizedValue);
+                i += 2;
             }
 
-            return value;
+            return normalizedValue == null ? value : new string(normalizedValue);
         }
+
+        private static bool IsLowerHex(char character) => character >= 'a' && character <= 'f';
 
         /// <summary>
         /// Ensures that the <paramref name="uri"/> is <see cref="UriKind.Absolute"/>.

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -827,6 +827,9 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             var comparison = AppContextSwitches.UseCaseSensitivePClaimComparison ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
             if (!ArePClaimValuesEqual(expectedPClaimValue, pClaimValue, comparison))
             {
+                // ArePClaimValuesEqual already treats percent-triplet hex digits as case-insensitive, so a failure here is never caused by hex casing alone.
+                // Normalize both values to the canonical uppercase form only for the IDX23011 message, so it does not surface a hex-case difference the comparison deliberately ignored.
+                // Example: request path "/Foo%2Fbar" versus claim "/foo%2fbar" fails on the literal "F" vs "f"; without normalization the message would also show "%2F" vs "%2f" and point at a non-cause.
                 expectedPClaimValue = NormalizePercentEncodingHexCase(expectedPClaimValue);
                 pClaimValue = NormalizePercentEncodingHexCase(pClaimValue);
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(LogMessages.IDX23011, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P), expectedPClaimValue, pClaimValue)));

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -1297,14 +1297,14 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                 if (!Uri.IsHexDigit(firstHexCharacter) || !Uri.IsHexDigit(secondHexCharacter))
                     continue;
 
-                if (IsLowerHex(firstHexCharacter) || IsLowerHex(secondHexCharacter))
+                if (char.IsLower(firstHexCharacter) || char.IsLower(secondHexCharacter))
                 {
                     normalizedValue ??= value.ToCharArray();
 
-                    if (IsLowerHex(firstHexCharacter))
+                    if (char.IsLower(firstHexCharacter))
                         normalizedValue[i + 1] = (char)(firstHexCharacter - ('a' - 'A'));
 
-                    if (IsLowerHex(secondHexCharacter))
+                    if (char.IsLower(secondHexCharacter))
                         normalizedValue[i + 2] = (char)(secondHexCharacter - ('a' - 'A'));
                 }
 
@@ -1313,8 +1313,6 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
 
             return normalizedValue == null ? value : new string(normalizedValue);
         }
-
-        private static bool IsLowerHex(char character) => character >= 'a' && character <= 'f';
 
         /// <summary>
         /// Ensures that the <paramref name="uri"/> is <see cref="UriKind.Absolute"/>.

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -819,14 +819,18 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(LogMessages.IDX23003, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P))));
 
             // relax comparison by trimming start and ending forward slashes
-            pClaimValue = NormalizePercentEncodingHexCase(pClaimValue.Trim('/'));
-            var expectedPClaimValue = NormalizePercentEncodingHexCase(httpRequestUri.AbsolutePath.Trim('/'));
+            pClaimValue = pClaimValue.Trim('/');
+            var expectedPClaimValue = httpRequestUri.AbsolutePath.Trim('/');
 
             // URI path components are case-sensitive per RFC 3986 section 3.3, so the comparison is ordinal (case-sensitive) by default.
             // The AppContext switch allows a consumer to restore the legacy case-insensitive comparison during transition.
             var comparison = AppContextSwitches.UseCaseSensitivePClaimComparison ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
-            if (!string.Equals(expectedPClaimValue, pClaimValue, comparison))
+            if (!ArePClaimValuesEqual(expectedPClaimValue, pClaimValue, comparison))
+            {
+                expectedPClaimValue = NormalizePercentEncodingHexCase(expectedPClaimValue);
+                pClaimValue = NormalizePercentEncodingHexCase(pClaimValue);
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(LogMessages.IDX23011, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P), expectedPClaimValue, pClaimValue)));
+            }
         }
 
         /// <summary>
@@ -1282,6 +1286,53 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
 #endif
 
             return Base64UrlEncoder.Encode(hashedBytes);
+        }
+
+        private static bool ArePClaimValuesEqual(string expectedValue, string actualValue, StringComparison comparison)
+        {
+            // Percent-encoding normalization does not change string length.
+            if (expectedValue.Length != actualValue.Length)
+                return false;
+
+            int comparisonStartIndex = 0;
+            for (int i = 0; i + 2 < expectedValue.Length; i++)
+            {
+                if (expectedValue[i] != '%' || actualValue[i] != '%')
+                    continue;
+
+                bool expectedHasValidHexPair = Uri.IsHexDigit(expectedValue[i + 1]) && Uri.IsHexDigit(expectedValue[i + 2]);
+                bool actualHasValidHexPair = Uri.IsHexDigit(actualValue[i + 1]) && Uri.IsHexDigit(actualValue[i + 2]);
+
+                // Only aligned, valid percent-encoded triplets need special handling.
+                if (!expectedHasValidHexPair || !actualHasValidHexPair)
+                    continue;
+
+                // Compare the literal path segment before this triplet using the configured case policy.
+                int literalSegmentLength = i - comparisonStartIndex;
+                if (string.Compare(expectedValue, comparisonStartIndex, actualValue, comparisonStartIndex, literalSegmentLength, comparison) != 0)
+                    return false;
+
+                char expectedFirstHexCharacter = expectedValue[i + 1];
+                char expectedSecondHexCharacter = expectedValue[i + 2];
+                char actualFirstHexCharacter = actualValue[i + 1];
+                char actualSecondHexCharacter = actualValue[i + 2];
+
+                // Hex digits in a valid percent-encoded triplet are equivalent regardless of case.
+                bool firstHexCharacterMatches = expectedFirstHexCharacter == actualFirstHexCharacter ||
+                    char.ToUpperInvariant(expectedFirstHexCharacter) == char.ToUpperInvariant(actualFirstHexCharacter);
+                bool secondHexCharacterMatches = expectedSecondHexCharacter == actualSecondHexCharacter ||
+                    char.ToUpperInvariant(expectedSecondHexCharacter) == char.ToUpperInvariant(actualSecondHexCharacter);
+                if (!firstHexCharacterMatches || !secondHexCharacterMatches)
+                    return false;
+
+                // Skip the two hex digits; the loop increment advances past the complete triplet.
+                i += 2;
+                comparisonStartIndex = i + 1;
+            }
+
+            // Compare the remaining literal path segment after the final triplet.
+            int remainingSegmentLength = expectedValue.Length - comparisonStartIndex;
+            return string.Compare(expectedValue, comparisonStartIndex, actualValue, comparisonStartIndex, remainingSegmentLength, comparison) == 0;
         }
 
         private static string NormalizePercentEncodingHexCase(string value)

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Abstractions;
@@ -26,6 +27,8 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
     /// <remarks>The handler implementation is based on 'A Method for Signing HTTP Requests for OAuth' specification.</remarks>
     public class SignedHttpRequestHandler
     {
+        private const string _percentEncodedTripletPattern = "%[0-9A-Fa-f]{2}";
+
         // https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-3.2
         // "Encodes the name and value of the header as "name: value" and appends it to the string buffer separated by a newline "\n" character."
         private readonly string _newlineSeparator = "\n";
@@ -825,13 +828,26 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             // URI path components are case-sensitive per RFC 3986 section 3.3, so the comparison is ordinal (case-sensitive) by default.
             // The AppContext switch allows a consumer to restore the legacy case-insensitive comparison during transition.
             var comparison = AppContextSwitches.UseCaseSensitivePClaimComparison ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
-            if (!ArePClaimValuesEqual(expectedPClaimValue, pClaimValue, comparison))
+            // Fast path: identical values such as "/path" avoid normalization.
+            if (!string.Equals(expectedPClaimValue, pClaimValue, comparison))
             {
-                // ArePClaimValuesEqual already treats percent-triplet hex digits as case-insensitive, so a failure here is never caused by hex casing alone.
-                // Normalize both values to the canonical uppercase form only for the IDX23011 message, so it does not surface a hex-case difference the comparison deliberately ignored.
-                // Example: request path "/Foo%2Fbar" versus claim "/foo%2fbar" fails on the literal "F" vs "f"; without normalization the message would also show "%2F" vs "%2f" and point at a non-cause.
+                // Only equal-length ordinal values with '%' on both sides can differ solely by hex case, such as "%2F" and "%2f".
+                bool mayMatchAfterNormalization =
+                    comparison == StringComparison.Ordinal &&
+                    expectedPClaimValue.Length == pClaimValue.Length &&
+                    expectedPClaimValue.IndexOf('%') >= 0 &&
+                    pClaimValue.IndexOf('%') >= 0;
+
+                // Canonicalize valid triplets for comparison and IDX23011, such as "%2f" to "%2F".
                 expectedPClaimValue = NormalizePercentEncodingHexCase(expectedPClaimValue);
                 pClaimValue = NormalizePercentEncodingHexCase(pClaimValue);
+
+                if (mayMatchAfterNormalization &&
+                    string.Equals(expectedPClaimValue, pClaimValue, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(LogMessages.IDX23011, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P), expectedPClaimValue, pClaimValue)));
             }
         }
@@ -1291,81 +1307,13 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             return Base64UrlEncoder.Encode(hashedBytes);
         }
 
-        private static bool ArePClaimValuesEqual(string expectedValue, string actualValue, StringComparison comparison)
-        {
-            // Percent-encoding normalization does not change string length.
-            if (expectedValue.Length != actualValue.Length)
-                return false;
-
-            int comparisonStartIndex = 0;
-            for (int i = 0; i + 2 < expectedValue.Length; i++)
-            {
-                if (expectedValue[i] != '%' || actualValue[i] != '%')
-                    continue;
-
-                bool expectedHasValidHexPair = Uri.IsHexDigit(expectedValue[i + 1]) && Uri.IsHexDigit(expectedValue[i + 2]);
-                bool actualHasValidHexPair = Uri.IsHexDigit(actualValue[i + 1]) && Uri.IsHexDigit(actualValue[i + 2]);
-
-                // Only aligned, valid percent-encoded triplets need special handling.
-                if (!expectedHasValidHexPair || !actualHasValidHexPair)
-                    continue;
-
-                // Compare the literal path segment before this triplet using the configured case policy.
-                int literalSegmentLength = i - comparisonStartIndex;
-                if (string.Compare(expectedValue, comparisonStartIndex, actualValue, comparisonStartIndex, literalSegmentLength, comparison) != 0)
-                    return false;
-
-                char expectedFirstHexCharacter = expectedValue[i + 1];
-                char expectedSecondHexCharacter = expectedValue[i + 2];
-                char actualFirstHexCharacter = actualValue[i + 1];
-                char actualSecondHexCharacter = actualValue[i + 2];
-
-                // Hex digits in a valid percent-encoded triplet are equivalent regardless of case.
-                bool firstHexCharacterMatches = expectedFirstHexCharacter == actualFirstHexCharacter ||
-                    char.ToUpperInvariant(expectedFirstHexCharacter) == char.ToUpperInvariant(actualFirstHexCharacter);
-                bool secondHexCharacterMatches = expectedSecondHexCharacter == actualSecondHexCharacter ||
-                    char.ToUpperInvariant(expectedSecondHexCharacter) == char.ToUpperInvariant(actualSecondHexCharacter);
-                if (!firstHexCharacterMatches || !secondHexCharacterMatches)
-                    return false;
-
-                // Skip the two hex digits; the loop increment advances past the complete triplet.
-                i += 2;
-                comparisonStartIndex = i + 1;
-            }
-
-            // Compare the remaining literal path segment after the final triplet.
-            int remainingSegmentLength = expectedValue.Length - comparisonStartIndex;
-            return string.Compare(expectedValue, comparisonStartIndex, actualValue, comparisonStartIndex, remainingSegmentLength, comparison) == 0;
-        }
-
         private static string NormalizePercentEncodingHexCase(string value)
         {
-            char[] normalizedValue = null;
-            for (int i = 0; i + 2 < value.Length; i++)
-            {
-                if (value[i] != '%')
-                    continue;
-
-                char firstHexCharacter = value[i + 1];
-                char secondHexCharacter = value[i + 2];
-                if (!Uri.IsHexDigit(firstHexCharacter) || !Uri.IsHexDigit(secondHexCharacter))
-                    continue;
-
-                if (char.IsLower(firstHexCharacter) || char.IsLower(secondHexCharacter))
-                {
-                    normalizedValue ??= value.ToCharArray();
-
-                    if (char.IsLower(firstHexCharacter))
-                        normalizedValue[i + 1] = (char)(firstHexCharacter - ('a' - 'A'));
-
-                    if (char.IsLower(secondHexCharacter))
-                        normalizedValue[i + 2] = (char)(secondHexCharacter - ('a' - 'A'));
-                }
-
-                i += 2;
-            }
-
-            return normalizedValue == null ? value : new string(normalizedValue);
+            return Regex.Replace(
+                value,
+                _percentEncodedTripletPattern,
+                static match => match.Value.ToUpperInvariant(),
+                RegexOptions.CultureInvariant);
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -819,8 +819,8 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(LogMessages.IDX23003, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P))));
 
             // relax comparison by trimming start and ending forward slashes
-            pClaimValue = pClaimValue.Trim('/');
-            var expectedPClaimValue = httpRequestUri.AbsolutePath.Trim('/');
+            pClaimValue = NormalizePercentEncodingHexCase(pClaimValue.Trim('/'));
+            var expectedPClaimValue = NormalizePercentEncodingHexCase(httpRequestUri.AbsolutePath.Trim('/'));
 
             // URI path components are case-sensitive per RFC 3986 section 3.3, so the comparison is ordinal (case-sensitive) by default.
             // The AppContext switch allows a consumer to restore the legacy case-insensitive comparison during transition.
@@ -1282,6 +1282,70 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
 #endif
 
             return Base64UrlEncoder.Encode(hashedBytes);
+        }
+
+        private static string NormalizePercentEncodingHexCase(string value)
+        {
+            for (int i = 0; i < value.Length - 2; i++)
+            {
+                if (value[i] != '%')
+                    continue;
+
+                char firstHexCharacter = value[i + 1];
+                char secondHexCharacter = value[i + 2];
+                bool firstCharacterIsHex =
+                    (firstHexCharacter >= '0' && firstHexCharacter <= '9') ||
+                    (firstHexCharacter >= 'A' && firstHexCharacter <= 'F') ||
+                    (firstHexCharacter >= 'a' && firstHexCharacter <= 'f');
+                bool secondCharacterIsHex =
+                    (secondHexCharacter >= '0' && secondHexCharacter <= '9') ||
+                    (secondHexCharacter >= 'A' && secondHexCharacter <= 'F') ||
+                    (secondHexCharacter >= 'a' && secondHexCharacter <= 'f');
+
+                if (!firstCharacterIsHex || !secondCharacterIsHex)
+                    continue;
+
+                bool firstCharacterNeedsNormalization = firstHexCharacter >= 'a' && firstHexCharacter <= 'f';
+                bool secondCharacterNeedsNormalization = secondHexCharacter >= 'a' && secondHexCharacter <= 'f';
+                if (!firstCharacterNeedsNormalization && !secondCharacterNeedsNormalization)
+                {
+                    i += 2;
+                    continue;
+                }
+
+                char[] normalizedValue = value.ToCharArray();
+                for (int j = i; j < normalizedValue.Length - 2; j++)
+                {
+                    if (normalizedValue[j] != '%')
+                        continue;
+
+                    firstHexCharacter = normalizedValue[j + 1];
+                    secondHexCharacter = normalizedValue[j + 2];
+                    firstCharacterIsHex =
+                        (firstHexCharacter >= '0' && firstHexCharacter <= '9') ||
+                        (firstHexCharacter >= 'A' && firstHexCharacter <= 'F') ||
+                        (firstHexCharacter >= 'a' && firstHexCharacter <= 'f');
+                    secondCharacterIsHex =
+                        (secondHexCharacter >= '0' && secondHexCharacter <= '9') ||
+                        (secondHexCharacter >= 'A' && secondHexCharacter <= 'F') ||
+                        (secondHexCharacter >= 'a' && secondHexCharacter <= 'f');
+
+                    if (!firstCharacterIsHex || !secondCharacterIsHex)
+                        continue;
+
+                    if (firstHexCharacter >= 'a' && firstHexCharacter <= 'f')
+                        normalizedValue[j + 1] = (char)(firstHexCharacter - ('a' - 'A'));
+
+                    if (secondHexCharacter >= 'a' && secondHexCharacter <= 'f')
+                        normalizedValue[j + 2] = (char)(secondHexCharacter - ('a' - 'A'));
+
+                    j += 2;
+                }
+
+                return new string(normalizedValue);
+            }
+
+            return value;
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestCreationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestCreationTests.cs
@@ -449,6 +449,24 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                         ExpectedClaimValue = $@"{{""p"":""/pa%20th1""}}",
                         HttpRequestUri = new Uri("http://www.contoso.com:81/pa th1")
                     },
+                    new CreateSignedHttpRequestTheoryData("ValidPLowerHexPreserved")
+                    {
+                        ExpectedClaim = SignedHttpRequestClaimTypes.P,
+                        ExpectedClaimValue = $@"{{""p"":""/foo%2fbar""}}",
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2fbar")
+                    },
+                    new CreateSignedHttpRequestTheoryData("ValidPUpperHexPreserved")
+                    {
+                        ExpectedClaim = SignedHttpRequestClaimTypes.P,
+                        ExpectedClaimValue = $@"{{""p"":""/foo%2Fbar""}}",
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar")
+                    },
+                    new CreateSignedHttpRequestTheoryData("ValidPDoubleEncodingPreserved")
+                    {
+                        ExpectedClaim = SignedHttpRequestClaimTypes.P,
+                        ExpectedClaimValue = $@"{{""p"":""/foo%252Fbar""}}",
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%252Fbar")
+                    },
                     new CreateSignedHttpRequestTheoryData("NoPath")
                     {
                         ExpectedClaim = SignedHttpRequestClaimTypes.P,

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -342,20 +342,20 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         [ResetAppContextSwitches]
         public void ValidatePClaim_IsCaseInsensitive_WhenSwitchDisabled()
         {
-            // Arrange - request path and signed 'p' claim differ only by case; disable the switch to opt in to legacy behavior.
+            // Arrange - request path and signed 'p' claim differ by literal case and percent-triplet hex case.
             AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, false);
             var handler = new SignedHttpRequestHandler();
             var theoryData = new ValidateSignedHttpRequestTheoryData
             {
-                HttpRequestUri = new Uri("https://www.contoso.com/path1"),
-                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/Path1")),
+                HttpRequestUri = new Uri("https://www.contoso.com/Foo%2Fbar"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
             };
             var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
 
-            // Act - with the switch disabled the comparison is case-insensitive (OrdinalIgnoreCase).
+            // Act
             var exception = Record.Exception(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
 
-            // Assert - the case-only mismatch is accepted.
+            // Assert
             Assert.Null(exception);
         }
 
@@ -363,18 +363,42 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         [ResetAppContextSwitches]
         public void ValidatePClaim_IsCaseSensitive_WhenSwitchEnabled()
         {
-            // Arrange - request path and signed 'p' claim differ only by case; enable the switch (also the default on this line).
+            // Arrange - request path and signed 'p' claim differ by literal case and percent-triplet hex case.
             AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, true);
             var handler = new SignedHttpRequestHandler();
             var theoryData = new ValidateSignedHttpRequestTheoryData
             {
-                HttpRequestUri = new Uri("https://www.contoso.com/path1"),
-                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/Path1")),
+                HttpRequestUri = new Uri("https://www.contoso.com/Foo%2Fbar"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
             };
             var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
 
-            // Act & Assert - with the switch enabled the comparison is ordinal (case-sensitive), so the case-only mismatch is rejected.
-            Assert.Throws<SignedHttpRequestInvalidPClaimException>(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
+            // Act
+            var exception = Assert.Throws<SignedHttpRequestInvalidPClaimException>(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
+
+            // Assert
+            Assert.Contains("IDX23011", exception.Message);
+        }
+
+        [Fact]
+        [ResetAppContextSwitches]
+        public void ValidatePClaim_NormalizesPercentEncodingHexCase_WhenSwitchEnabled()
+        {
+            // Arrange
+            AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, true);
+            var handler = new SignedHttpRequestHandler();
+            var theoryData = new ValidateSignedHttpRequestTheoryData
+            {
+                HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
+            };
+            var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
+
+            // Act
+            var exception = Record.Exception(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
+
+            // Assert
+            Assert.Null(exception);
         }
 
         public static TheoryData<ValidateSignedHttpRequestTheoryData> ValidatePClaimTheoryData
@@ -463,18 +487,107 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                     },
                     new ValidateSignedHttpRequestTheoryData
                     {
-                        // Percent-encoding hex case is preserved by Uri.AbsolutePath; equal hex case validates under the ordinal comparison.
                         HttpRequestUri = new Uri("https://www.contoso.com/foo%2fbar"),
                         SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
-                        TestId = "ValidPHexCaseMatch",
+                        TestId = "ValidPHexCaseMatchLower",
                     },
                     new ValidateSignedHttpRequestTheoryData
                     {
-                        // %2F (upper) and %2f (lower) differ under the ordinal comparison and must be rejected; they would fold under OrdinalIgnoreCase.
                         HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar"),
                         SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
+                        TestId = "ValidPHexCaseMismatchUpperRequest",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2Fbar")),
+                        TestId = "ValidPHexCaseMismatchLowerRequest",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%ABbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%aBbar")),
+                        TestId = "ValidPMixedHexCase",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/Foo%2Fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
                         ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
-                        TestId = "InvalidPHexCaseMismatch",
+                        TestId = "InvalidPLiteralCaseAndHexCaseMismatch",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo/bar")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPEncodedSlashVsLiteralSlash",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo/bar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2Fbar")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPLiteralSlashVsEncodedSlash",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%25bar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%25bar")),
+                        TestId = "ValidPEncodedPercent",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%252Fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%252Fbar")),
+                        TestId = "ValidPDoubleEncodedSlash",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%252Fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2Fbar")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPDoubleEncodedVsSingleEncoded",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%25"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPTrailingPercent",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%252"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPTruncatedTriplet",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%25zz"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%zz")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPNonHexTriplet",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%25bar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%bar")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPValidLowerHexDifferentOctet",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/")),
+                        TestId = "ValidPRootSlash",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, string.Empty)),
+                        TestId = "ValidPRootEmptyClaim",
                     },
                     new ValidateSignedHttpRequestTheoryData
                     {

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -385,6 +385,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         [InlineData("/path", "/path", false, true)]
         [InlineData("/foo%2Fbar", "/foo%2Fbar", true, true)]
         [InlineData("/foo%2Fbar", "/foo%2fbar", true, true)]
+        [InlineData("/foo%2Fbar", "/foo%3Fbar", true, false)]
         [InlineData("/foo%2Fbar%ABbaz", "/foo%2fbar%abbaz", true, true)]
         [InlineData("/foo%2fbar", "/foo%2fbar", false, true)]
         [InlineData("/caf%C3%A9", "/caf%c3%a9", true, true)]
@@ -395,6 +396,8 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         [InlineData("/foo%25", "/foo%", true, false)]
         [InlineData("/foo%25X", "/foo%X", false, false)]
         [InlineData("/foo%252G", "/foo%2G", true, false)]
+        [InlineData("/foo%252Gbar", "/foo%252gbar", true, false)]
+        [InlineData("/foo%252Gbar", "/foo%252gbar", false, true)]
         [InlineData("/foo%BAr", "/foo%bar", true, true)]
         [InlineData("/foo%25bar", "/foo%bar", true, false)]
         [InlineData("/foo%2Fbar", "/foo/bar", true, false)]
@@ -427,7 +430,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         [InlineData(true)]
         [InlineData(false)]
         [ResetAppContextSwitches]
-        public void ValidatePClaim_NormalizesPercentEncodingHexCaseInException(bool useCaseSensitiveComparison)
+        public void ValidatePClaim_PreservesPercentEncodingHexCaseInException(bool useCaseSensitiveComparison)
         {
             // Arrange
             AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, useCaseSensitiveComparison);
@@ -443,10 +446,10 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             var exception = Assert.Throws<SignedHttpRequestInvalidPClaimException>(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
 
             // Assert
-            Assert.Contains("Expected%2FPath", exception.Message);
-            Assert.Contains("Actual%2APath", exception.Message);
-            Assert.DoesNotContain("Expected%2fPath", exception.Message);
-            Assert.DoesNotContain("Actual%2aPath", exception.Message);
+            Assert.Contains("Expected%2fPath", exception.Message);
+            Assert.Contains("Actual%2aPath", exception.Message);
+            Assert.DoesNotContain("Expected%2FPath", exception.Message);
+            Assert.DoesNotContain("Actual%2APath", exception.Message);
         }
 
         public static TheoryData<ValidateSignedHttpRequestTheoryData> ValidatePClaimTheoryData

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -380,32 +380,12 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             Assert.Contains("IDX23011", exception.Message);
         }
 
-        [Fact]
-        [ResetAppContextSwitches]
-        public void ValidatePClaim_NormalizesPercentEncodingHexCase_WhenSwitchEnabled()
-        {
-            // Arrange
-            AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, true);
-            var handler = new SignedHttpRequestHandler();
-            var theoryData = new ValidateSignedHttpRequestTheoryData
-            {
-                HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar"),
-                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
-            };
-            var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
-
-            // Act
-            var exception = Record.Exception(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
-
-            // Assert
-            Assert.Null(exception);
-        }
-
         [Theory]
         [InlineData("/path", "/path", true, true)]
         [InlineData("/path", "/path", false, true)]
         [InlineData("/foo%2Fbar", "/foo%2Fbar", true, true)]
         [InlineData("/foo%2Fbar", "/foo%2fbar", true, true)]
+        [InlineData("/foo%2Fbar%ABbaz", "/foo%2fbar%abbaz", true, true)]
         [InlineData("/foo%2fbar", "/foo%2fbar", false, true)]
         [InlineData("/caf%C3%A9", "/caf%c3%a9", true, true)]
         [InlineData("/caf%C3%A9", "/caf%c3%a9", false, true)]
@@ -415,6 +395,11 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         [InlineData("/foo%25", "/foo%", true, false)]
         [InlineData("/foo%25X", "/foo%X", false, false)]
         [InlineData("/foo%252G", "/foo%2G", true, false)]
+        [InlineData("/foo%BAr", "/foo%bar", true, true)]
+        [InlineData("/foo%25bar", "/foo%bar", true, false)]
+        [InlineData("/foo%2Fbar", "/foo/bar", true, false)]
+        [InlineData("/fooABC", "/fooAB%", false, false)]
+        [InlineData("/fooABCD", "/fooAB%2", false, false)]
         [ResetAppContextSwitches]
         public void ValidatePClaim_ComparisonMatrix(string requestPath, string pClaim, bool useCaseSensitiveComparison, bool expectedValid)
         {
@@ -460,6 +445,8 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             // Assert
             Assert.Contains("Expected%2FPath", exception.Message);
             Assert.Contains("Actual%2APath", exception.Message);
+            Assert.DoesNotContain("Expected%2fPath", exception.Message);
+            Assert.DoesNotContain("Actual%2aPath", exception.Message);
         }
 
         public static TheoryData<ValidateSignedHttpRequestTheoryData> ValidatePClaimTheoryData

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -511,6 +511,12 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                     },
                     new ValidateSignedHttpRequestTheoryData
                     {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar%2Fbaz"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2Fbar%2fbaz")),
+                        TestId = "ValidPMultipleTripletsMixedHexCase",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
                         HttpRequestUri = new Uri("https://www.contoso.com/Foo%2Fbar"),
                         SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
                         ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -401,6 +401,67 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
             Assert.Null(exception);
         }
 
+        [Theory]
+        [InlineData("/path", "/path", true, true)]
+        [InlineData("/path", "/path", false, true)]
+        [InlineData("/foo%2Fbar", "/foo%2Fbar", true, true)]
+        [InlineData("/foo%2Fbar", "/foo%2fbar", true, true)]
+        [InlineData("/foo%2fbar", "/foo%2fbar", false, true)]
+        [InlineData("/caf%C3%A9", "/caf%c3%a9", true, true)]
+        [InlineData("/caf%C3%A9", "/caf%c3%a9", false, true)]
+        [InlineData("/Path", "/path", true, false)]
+        [InlineData("/Path", "/path", false, true)]
+        [InlineData("/path", "/paths", true, false)]
+        [InlineData("/foo%25", "/foo%", true, false)]
+        [InlineData("/foo%25X", "/foo%X", false, false)]
+        [InlineData("/foo%252G", "/foo%2G", true, false)]
+        [ResetAppContextSwitches]
+        public void ValidatePClaim_ComparisonMatrix(string requestPath, string pClaim, bool useCaseSensitiveComparison, bool expectedValid)
+        {
+            // Arrange
+            AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, useCaseSensitiveComparison);
+            var handler = new SignedHttpRequestHandler();
+            var theoryData = new ValidateSignedHttpRequestTheoryData
+            {
+                HttpRequestUri = new Uri($"https://www.contoso.com{requestPath}"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, pClaim)),
+            };
+            var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
+
+            // Act
+            var exception = Record.Exception(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
+
+            // Assert
+            if (expectedValid)
+                Assert.Null(exception);
+            else
+                Assert.IsType<SignedHttpRequestInvalidPClaimException>(exception);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [ResetAppContextSwitches]
+        public void ValidatePClaim_NormalizesPercentEncodingHexCaseInException(bool useCaseSensitiveComparison)
+        {
+            // Arrange
+            AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, useCaseSensitiveComparison);
+            var handler = new SignedHttpRequestHandler();
+            var theoryData = new ValidateSignedHttpRequestTheoryData
+            {
+                HttpRequestUri = new Uri("https://www.contoso.com/Expected%2fPath"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/Actual%2aPath")),
+            };
+            var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
+
+            // Act
+            var exception = Assert.Throws<SignedHttpRequestInvalidPClaimException>(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
+
+            // Assert
+            Assert.Contains("Expected%2FPath", exception.Message);
+            Assert.Contains("Actual%2APath", exception.Message);
+        }
+
         public static TheoryData<ValidateSignedHttpRequestTheoryData> ValidatePClaimTheoryData
         {
             get


### PR DESCRIPTION
## Problem

Signed HTTP Request `p` claim validation rejects equivalent paths when percent-encoded octets use different hexadecimal letter casing. For example, `/foo%2Fbar` does not match `/foo%2fbar`, even though RFC 3986 defines those triplets as equivalent.

Literal path letters must remain case-sensitive by default. Encoded reserved characters must also remain distinct from literal delimiters, so `%2F` must not match `/`.

## Requirements

1. Treat hexadecimal letters inside valid percent-encoded triplets as case-insensitive during `p` claim validation.
2. Preserve literal path-letter behavior controlled by `UseCaseSensitivePClaimComparison`.
3. Keep encoded characters distinct from literal delimiters and do not URL-decode values.
4. Leave malformed percent sequences unchanged.
5. Keep `p` claim creation output unchanged.

## Code Changes

1. `ValidatePClaim` trims the claim and request path with `ReadOnlySpan<char>` to avoid allocating comparison strings.
1. The trimmed spans are first compared directly with the configured `StringComparison`.
1. After an ordinal mismatch, `ArePClaimValuesEqual` traverses both spans and ignores hexadecimal letter casing only inside aligned, valid `%XX` triplets. Values are not URL-decoded.
1. If validation fails, `IDX23011` reports the original trimmed values without changing their percent-encoding casing.

## Testing

### Functional results

| Input | Flag status | Result |
|---|---|---|
| Request `/foo%2Fbar`; claim `/foo%2fbar` | Enabled | Pass |
| Request `/foo%2fbar`; claim `/foo%2Fbar` | Enabled | Pass |
| Request `/foo%2Fbar%ABbaz`; claim `/foo%2fbar%abbaz` | Enabled | Pass |
| Request `/Foo%2Fbar`; claim `/foo%2fbar` | Enabled | Fail — `IDX23011` |
| Request `/Foo%2Fbar`; claim `/foo%2fbar` | Disabled | Pass |
| Request `/foo%2Fbar`; claim `/foo/bar` | Enabled | Fail — `IDX23011` |
| Request `/foo/bar`; claim `/foo%2Fbar` | Enabled | Fail — `IDX23011` |
| Request `/foo%252Fbar`; claim `/foo%2Fbar` | Enabled | Fail — `IDX23011` |
| Request `/foo%25zz`; malformed claim `/foo%zz` | Enabled | Fail — `IDX23011` |

All 58 targeted `ValidatePClaim` tests pass on .NET 8.

#### Performance benchmark

- **A** = `dev` & **B** = `debchoudhury/shr-p-claim-percent-encoding`
- BenchmarkDotNet 0.13.12, .NET 8.0.29, X64 RyuJIT, MediumRun with 4 launches, 10 warmups, and 15 measured iterations.
- B:
  - allocates 0 bytes in every measured scenario (A allocates 144–240 bytes for the two trimmed strings)
  - is faster in 22 of the 24 comparison combinations.

| Scenario | Comparison | A mean | B mean | B/A | A allocated | B allocated |
|---|---|---:|---:|---:|---:|---:|
| Plain match | Ordinal | 53.75 ns | 7.99 ns | 0.15x | 224 B | 0 B |
| Plain match | OrdinalIgnoreCase | 64.43 ns | 20.76 ns | 0.32x | 224 B | 0 B |
| Plain mismatch | Ordinal | 55.37 ns | 44.88 ns | 0.81x | 224 B | 0 B |
| Plain mismatch | OrdinalIgnoreCase | 64.55 ns | 20.54 ns | 0.32x | 224 B | 0 B |
| Different length | Ordinal | 48.72 ns | 7.25 ns | 0.15x | 208 B | 0 B |
| Different length | OrdinalIgnoreCase | 49.08 ns | 6.19 ns | 0.13x | 208 B | 0 B |
| Uppercase triplets | Ordinal | 56.17 ns | 8.14 ns | 0.14x | 240 B | 0 B |
| Uppercase triplets | OrdinalIgnoreCase | 60.00 ns | 18.48 ns | 0.31x | 240 B | 0 B |
| Lowercase triplets on one side | Ordinal | 53.69 ns | 56.81 ns | 1.06x | 240 B | 0 B |
| Lowercase triplets on one side | OrdinalIgnoreCase | 65.46 ns | 18.75 ns | 0.29x | 240 B | 0 B |
| Lowercase triplets on both sides | Ordinal | 57.66 ns | 8.09 ns | 0.14x | 240 B | 0 B |
| Lowercase triplets on both sides | OrdinalIgnoreCase | 62.95 ns | 18.57 ns | 0.29x | 240 B | 0 B |
| Multiple mixed-case triplets | Ordinal | 56.03 ns | 56.87 ns | 1.02x | 240 B | 0 B |
| Multiple mixed-case triplets | OrdinalIgnoreCase | 64.59 ns | 18.47 ns | 0.29x | 240 B | 0 B |
| Different valid triplets | Ordinal | 52.41 ns | 33.80 ns | 0.64x | 240 B | 0 B |
| Different valid triplets | OrdinalIgnoreCase | 58.46 ns | 15.48 ns | 0.26x | 240 B | 0 B |
| Encoded slash versus literal slash | Ordinal | 53.52 ns | 7.13 ns | 0.13x | 232 B | 0 B |
| Encoded slash versus literal slash | OrdinalIgnoreCase | 46.25 ns | 6.12 ns | 0.13x | 232 B | 0 B |
| Double-encoded versus single-encoded slash | Ordinal | 52.85 ns | 6.93 ns | 0.13x | 240 B | 0 B |
| Double-encoded versus single-encoded slash | OrdinalIgnoreCase | 46.76 ns | 6.09 ns | 0.13x | 240 B | 0 B |
| Malformed triplet mismatch | Ordinal | 50.92 ns | 40.78 ns | 0.80x | 240 B | 0 B |
| Malformed triplet mismatch | OrdinalIgnoreCase | 63.01 ns | 21.70 ns | 0.34x | 240 B | 0 B |
| Truncated triplet mismatch | Ordinal | 39.75 ns | 31.66 ns | 0.80x | 144 B | 0 B |
| Truncated triplet mismatch | OrdinalIgnoreCase | 43.88 ns | 16.28 ns | 0.37x | 144 B | 0 B |
