### PR TITLE
Backport: Add IgnoreCaseWhenValidatingAudience flag to audience validation (#3558)

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Experimental/Validation/ValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Experimental/Validation/ValidationParameters.cs
@@ -75,6 +75,7 @@ namespace Microsoft.IdentityModel.Tokens.Experimental
             DebugId = other.DebugId;
             IncludeTokenOnFailedValidation = other.IncludeTokenOnFailedValidation;
             IgnoreTrailingSlashWhenValidatingAudience = other.IgnoreTrailingSlashWhenValidatingAudience;
+            IgnoreCaseWhenValidatingAudience = other.IgnoreCaseWhenValidatingAudience;
             SignatureKeyResolver = other.SignatureKeyResolver;
             _signingKeys = other.SigningKeys is not null ? new List<SecurityKey>(other.SigningKeys) : null;
             SignatureKeyValidator = other.SignatureKeyValidator;
@@ -264,6 +265,13 @@ namespace Microsoft.IdentityModel.Tokens.Experimental
         /// </summary>
         [DefaultValue(true)]
         public bool IgnoreTrailingSlashWhenValidatingAudience { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a boolean that controls if case is ignored when validating the audience.
+        /// The default is <c>false</c>, meaning audience comparison is case-sensitive (ordinal).
+        /// </summary>
+        [DefaultValue(false)]
+        public bool IgnoreCaseWhenValidatingAudience { get; set; }
 
         /// <summary>
         /// Gets or sets the flag that indicates whether to include the <see cref="SecurityToken"/> when the validation fails.

--- a/src/Microsoft.IdentityModel.Tokens/Experimental/Validation/Validators.Audience.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Experimental/Validation/Validators.Audience.cs
@@ -118,7 +118,8 @@ namespace Microsoft.IdentityModel.Tokens
             string? validAudience = ValidTokenAudience(
                 tokenAudiences,
                 validationParameters.ValidAudiences,
-                validationParameters.IgnoreTrailingSlashWhenValidatingAudience);
+                validationParameters.IgnoreTrailingSlashWhenValidatingAudience,
+                validationParameters.IgnoreCaseWhenValidatingAudience);
 
             if (validAudience != null)
                 return validAudience;
@@ -147,8 +148,13 @@ namespace Microsoft.IdentityModel.Tokens
         private static string? ValidTokenAudience(
             IList<string> tokenAudiences,
             IList<string> validAudiences,
-            bool ignoreTrailingSlashWhenValidatingAudience)
+            bool ignoreTrailingSlashWhenValidatingAudience,
+            bool ignoreCaseWhenValidatingAudience)
         {
+            StringComparison comparisonType = ignoreCaseWhenValidatingAudience
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
             for (int i = 0; i < tokenAudiences.Count; i++)
             {
                 if (string.IsNullOrEmpty(tokenAudiences[i]))
@@ -159,7 +165,7 @@ namespace Microsoft.IdentityModel.Tokens
                     if (string.IsNullOrEmpty(validAudiences[j]))
                         continue;
 
-                    if (AudienceMatches(ignoreTrailingSlashWhenValidatingAudience, tokenAudiences[i], validAudiences[j]))
+                    if (AudienceMatches(ignoreTrailingSlashWhenValidatingAudience, tokenAudiences[i], validAudiences[j], comparisonType))
                     {
                         if (LogHelper.IsEnabled(EventLogLevel.Informational))
                             LogHelper.LogInformation(LogMessages.IDX10234, LogHelper.MarkAsNonPII(tokenAudiences[i]));
@@ -172,17 +178,17 @@ namespace Microsoft.IdentityModel.Tokens
             return null;
         }
 
-        private static bool AudienceMatches(bool ignoreTrailingSlashWhenValidatingAudience, string tokenAudience, string validAudience)
+        private static bool AudienceMatches(bool ignoreTrailingSlashWhenValidatingAudience, string tokenAudience, string validAudience, StringComparison comparisonType)
         {
             if (validAudience.Length == tokenAudience.Length)
-                return string.Equals(validAudience, tokenAudience);
-            else if (ignoreTrailingSlashWhenValidatingAudience && AudienceMatchesIgnoringTrailingSlash(tokenAudience, validAudience))
+                return string.Equals(validAudience, tokenAudience, comparisonType);
+            else if (ignoreTrailingSlashWhenValidatingAudience && AudienceMatchesIgnoringTrailingSlash(tokenAudience, validAudience, comparisonType))
                 return true;
 
             return false;
         }
 
-        private static bool AudienceMatchesIgnoringTrailingSlash(string tokenAudience, string validAudience)
+        private static bool AudienceMatchesIgnoringTrailingSlash(string tokenAudience, string validAudience, StringComparison comparisonType)
         {
             int length = -1;
 
@@ -195,7 +201,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (length == -1)
                 return false;
 
-            if (string.CompareOrdinal(validAudience, 0, tokenAudience, 0, length) == 0)
+            if (string.Compare(validAudience, 0, tokenAudience, 0, length, comparisonType) == 0)
             {
                 if (LogHelper.IsEnabled(EventLogLevel.Informational))
                     LogHelper.LogInformation(LogMessages.IDX10234, LogHelper.MarkAsNonPII(tokenAudience));

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+Microsoft.IdentityModel.Tokens.Experimental.ValidationParameters.IgnoreCaseWhenValidatingAudience.get -> bool
+Microsoft.IdentityModel.Tokens.Experimental.ValidationParameters.IgnoreCaseWhenValidatingAudience.set -> void
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.IgnoreCaseWhenValidatingAudience.get -> bool
+Microsoft.IdentityModel.Tokens.TokenValidationParameters.IgnoreCaseWhenValidatingAudience.set -> void

--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -58,6 +58,7 @@ namespace Microsoft.IdentityModel.Tokens
             DebugId = other.DebugId;
             IncludeTokenOnFailedValidation = other.IncludeTokenOnFailedValidation;
             IgnoreTrailingSlashWhenValidatingAudience = other.IgnoreTrailingSlashWhenValidatingAudience;
+            IgnoreCaseWhenValidatingAudience = other.IgnoreCaseWhenValidatingAudience;
             IssuerSigningKey = other.IssuerSigningKey;
             IssuerSigningKeyResolver = other.IssuerSigningKeyResolver;
             IssuerSigningKeyResolverUsingConfiguration = other.IssuerSigningKeyResolverUsingConfiguration;
@@ -280,6 +281,13 @@ namespace Microsoft.IdentityModel.Tokens
         /// </summary>
         [DefaultValue(true)]
         public bool IgnoreTrailingSlashWhenValidatingAudience { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a boolean that controls if case is ignored when validating the audience.
+        /// The default is <c>false</c>, meaning audience comparison is case-sensitive (ordinal).
+        /// </summary>
+        [DefaultValue(false)]
+        public bool IgnoreCaseWhenValidatingAudience { get; set; }
 
         /// <summary>
         /// Gets or sets the flag that indicates whether to include the <see cref="SecurityToken"/> when the validation fails.

--- a/src/Microsoft.IdentityModel.Tokens/Validators.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Validators.cs
@@ -182,18 +182,22 @@ namespace Microsoft.IdentityModel.Tokens
 
         private static bool AudiencesMatch(TokenValidationParameters validationParameters, string tokenAudience, string validAudience)
         {
+            StringComparison comparisonType = validationParameters.IgnoreCaseWhenValidatingAudience
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+
             if (validAudience.Length == tokenAudience.Length)
             {
-                if (string.Equals(validAudience, tokenAudience))
+                if (string.Equals(validAudience, tokenAudience, comparisonType))
                     return true;
             }
-            else if (validationParameters.IgnoreTrailingSlashWhenValidatingAudience && AudiencesMatchIgnoringTrailingSlash(tokenAudience, validAudience))
+            else if (validationParameters.IgnoreTrailingSlashWhenValidatingAudience && AudiencesMatchIgnoringTrailingSlash(tokenAudience, validAudience, comparisonType))
                 return true;
 
             return false;
         }
 
-        private static bool AudiencesMatchIgnoringTrailingSlash(string tokenAudience, string validAudience)
+        private static bool AudiencesMatchIgnoringTrailingSlash(string tokenAudience, string validAudience, StringComparison comparisonType)
         {
             int length = -1;
 
@@ -206,7 +210,7 @@ namespace Microsoft.IdentityModel.Tokens
             if (length == -1)
                 return false;
 
-            if (string.CompareOrdinal(validAudience, 0, tokenAudience, 0, length) == 0)
+            if (string.Compare(validAudience, 0, tokenAudience, 0, length, comparisonType) == 0)
             {
                 if (LogHelper.IsEnabled(EventLogLevel.Informational))
                     LogHelper.LogInformation(LogMessages.IDX10234, LogHelper.MarkAsNonPII(tokenAudience));

--- a/test/Microsoft.IdentityModel.TestUtils/TestUtilities.cs
+++ b/test/Microsoft.IdentityModel.TestUtils/TestUtilities.cs
@@ -49,6 +49,7 @@ namespace Microsoft.IdentityModel.TestUtils
             validationParameters.DebugId = tokenValidationParameters.DebugId;
             validationParameters.IncludeTokenOnFailedValidation = tokenValidationParameters.IncludeTokenOnFailedValidation;
             validationParameters.IgnoreTrailingSlashWhenValidatingAudience = tokenValidationParameters.IgnoreTrailingSlashWhenValidatingAudience;
+            validationParameters.IgnoreCaseWhenValidatingAudience = tokenValidationParameters.IgnoreCaseWhenValidatingAudience;
 
             //validationParameters.IssuerSigningKeyResolver = tokenValidationParameters.IssuerSigningKeyResolver;
             if (tokenValidationParameters.IssuerSigningKeys != null)

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidationParametersTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
 {
     public class TokenValidationParametersTests
     {
-        int ExpectedPropertyCount = 62;
+        int ExpectedPropertyCount = 63;
 
         // GetSets() compares the total property count which includes internal properties, against a list of public properties, minus delegates.
         // This allows us to keep track of any properties we are including in the total that are not public nor delegates.
@@ -205,6 +205,7 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                     new KeyValuePair<string, List<object>>("CryptoProviderFactory", new List<object>{(CryptoProviderFactory)null, new CryptoProviderFactory(), new CryptoProviderFactory() }),
                     new KeyValuePair<string, List<object>>("DebugId", new List<object>{(string)null, "DebugId", "DebugId" }),
                     new KeyValuePair<string, List<object>>("IgnoreTrailingSlashWhenValidatingAudience",  new List<object>{true, false, true}),
+                    new KeyValuePair<string, List<object>>("IgnoreCaseWhenValidatingAudience",  new List<object>{false, true, false}),
                     new KeyValuePair<string, List<object>>("IncludeTokenOnFailedValidation",  new List<object>{false, true, true}),
                     new KeyValuePair<string, List<object>>("IsClone",  new List<object>{ false, true, true }),
                     new KeyValuePair<string, List<object>>("InstancePropertyBag",  new List<object>{ new Dictionary<string, object>(), new Dictionary<string, object>(), new Dictionary<string, object>()}),

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/AudienceValidationResultTests.cs
@@ -257,6 +257,23 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                             audiences1,
                             [audience2])
                     },
+                    new AudienceValidationTheoryData("CaseDiffers_IgnoreCaseDefaultNotMatched")
+                    {
+                        TokenAudiences = audiences1,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10215:"),
+                        ValidationParameters = new ValidationParameters(),
+                        ValidAudiences = [audience1.ToUpperInvariant()],
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        OperationResult = new AudienceValidationError(
+                            new MessageDetail(
+                                LogMessages.IDX10215,
+                                LogHelper.MarkAsNonPII(commaAudience1),
+                                LogHelper.MarkAsNonPII(audience1.ToUpperInvariant())),
+                            AudienceValidationFailure.AudienceDidNotMatch,
+                            null,
+                            audiences1,
+                            [audience1.ToUpperInvariant()])
+                    },
                     new AudienceValidationTheoryData("AudiencesValidAudienceWithSlashNotMatched")
                     {
                         TokenAudiences = audiences1,
@@ -540,6 +557,21 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
                         ValidationParameters = new ValidationParameters(),
                         ValidAudiences = [audience1],
                         OperationResult = audience1Slash
+                    },
+                    new AudienceValidationTheoryData("CaseDiffers_IgnoreCaseTrueMatched")
+                    {
+                        TokenAudiences = audiences1,
+                        ValidationParameters = new ValidationParameters{ IgnoreCaseWhenValidatingAudience = true },
+                        ValidAudiences = [audience1.ToUpperInvariant()],
+                        SecurityToken = JsonUtilities.CreateUnsignedJsonWebToken(JwtRegisteredClaimNames.Iss, "Issuer"),
+                        OperationResult = audience1
+                    },
+                    new AudienceValidationTheoryData("CaseDiffersAndSlash_IgnoreCaseTrueMatched")
+                    {
+                        TokenAudiences = audiences1,
+                        ValidationParameters = new ValidationParameters{ IgnoreCaseWhenValidatingAudience = true },
+                        ValidAudiences = [audience1.ToUpperInvariant() + "/"],
+                        OperationResult = audience1
                     }
                 };
             }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidatorsTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidatorsTests.cs
@@ -287,6 +287,39 @@ namespace Microsoft.IdentityModel.Tokens.Tests
                         {
                             ValidAudiences = new List<string>()  // Empty list should still return false through optimized path
                         }
+                    },
+                    new AudienceValidationTheoryData("CaseDiffersIgnoreCaseDefaultNotMatched")
+                    {
+                        Audiences = audiences1,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TokenValidationParameters = new TokenValidationParameters{ ValidAudience = audience1.ToUpperInvariant() }
+                    },
+                    new AudienceValidationTheoryData("CaseDiffersIgnoreCaseFalseNotMatched")
+                    {
+                        Audiences = audiences1,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TokenValidationParameters = new TokenValidationParameters{ IgnoreCaseWhenValidatingAudience = false, ValidAudience = audience1.ToUpperInvariant() }
+                    },
+                    new AudienceValidationTheoryData("CaseDiffersIgnoreCaseTrueMatched")
+                    {
+                        Audiences = audiences1,
+                        TokenValidationParameters = new TokenValidationParameters{ IgnoreCaseWhenValidatingAudience = true, ValidAudience = audience1.ToUpperInvariant() }
+                    },
+                    new AudienceValidationTheoryData("CaseDiffersInValidAudiencesIgnoreCaseTrueMatched")
+                    {
+                        Audiences = audiences1,
+                        TokenValidationParameters = new TokenValidationParameters{ IgnoreCaseWhenValidatingAudience = true, ValidAudiences = new List<string> { "", audience1.ToUpperInvariant() } }
+                    },
+                    new AudienceValidationTheoryData("CaseDiffersAndTrailingSlashIgnoreCaseTrueMatched")
+                    {
+                        Audiences = audiences1,
+                        TokenValidationParameters = new TokenValidationParameters{ IgnoreCaseWhenValidatingAudience = true, ValidAudience = audience1.ToUpperInvariant() + "/" }
+                    },
+                    new AudienceValidationTheoryData("CaseDiffersAndTrailingSlashIgnoreTrailingSlashFalseNotMatched")
+                    {
+                        Audiences = audiences1,
+                        ExpectedException = ExpectedException.SecurityTokenInvalidAudienceException("IDX10214:"),
+                        TokenValidationParameters = new TokenValidationParameters{ IgnoreCaseWhenValidatingAudience = true, IgnoreTrailingSlashWhenValidatingAudience = false, ValidAudience = audience1.ToUpperInvariant() + "/" }
                     }
                 };
             }


### PR DESCRIPTION
* Add IgnoreCaseWhenValidatingAudience flag to audience validation

Introduces a new opt-in TokenValidationParameters.IgnoreCaseWhenValidatingAudience flag (mirrored on the experimental ValidationParameters) that, when enabled, makes audience comparison case-insensitive (OrdinalIgnoreCase). The default remains false, preserving the existing case-sensitive (ordinal) behavior.

AudiencesMatch and AudiencesMatchIgnoringTrailingSlash now select the StringComparison based on the flag, so both exact and trailing-slash-tolerant comparisons honor it. This complements the existing IgnoreTrailingSlashWhenValidatingAudience flag.

Adds PublicAPI.Unshipped.txt entries and unit tests covering case-insensitive matches (exact and combined with trailing-slash tolerance).

* Update TokenValidationParametersTests for IgnoreCaseWhenValidatingAudience

Bumps the expected property count (62 -> 63), adds the new IgnoreCaseWhenValidatingAudience property to the GetSets get/set matrix (default false), and copies it in the TVP -> ValidationParameters test helper, so Publics/GetSets no longer fail on the newly added public property.