### PR TITLE
Configure SHR path comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ See the [releases](https://github.com/AzureAD/azure-activedirectory-identitymode
 9.0.0
 ====
 ## Bug Fixes
-- Align Signed HTTP Request `p` (path) claim comparison with RFC 3986 section 3.3 by comparing the path case-sensitively; previously `/Admin/resource` matched `/admin/resource`. An AppContext opt out is available during transition. See [PR #3526](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3526).
-- Normalize hexadecimal letter casing inside percent-encoded triplets during Signed HTTP Request `p` claim validation. Literal path-letter comparison remains controlled by `UseCaseSensitivePClaimComparison`, and `p` claim creation output is unchanged.
+- Compare Signed HTTP Request `p` claim paths case-sensitively by default. Configure with `SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison`; the legacy AppContext setting seeds its initial value. See [PR #3539](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3539).
+- Ignore hexadecimal casing in percent-encoded `p` claim path triplets.
 
 7.7.2
 ====

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/InternalAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+const Microsoft.IdentityModel.Protocols.SignedHttpRequest.SignedHttpRequestValidationParameters.DefaultUseCaseSensitivePClaimComparison = true -> bool
+const Microsoft.IdentityModel.Protocols.SignedHttpRequest.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparisonSwitch = "Switch.Microsoft.IdentityModel.SignedHttpRequest.UseCaseSensitivePClaimComparison" -> string

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.IdentityModel.Protocols.SignedHttpRequest.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison.get -> bool
+Microsoft.IdentityModel.Protocols.SignedHttpRequest.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison.set -> void

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -823,8 +823,9 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             ReadOnlySpan<char> expectedPClaimValueSpan = httpRequestUri.AbsolutePath.AsSpan().Trim('/');
 
             // URI path components are case-sensitive per RFC 3986 section 3.3, so the comparison is ordinal (case-sensitive) by default.
-            // The AppContext switch allows a consumer to restore the legacy case-insensitive comparison during transition.
-            var comparison = AppContextSwitches.UseCaseSensitivePClaimComparison ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+            var comparison = signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison
+                ? StringComparison.Ordinal
+                : StringComparison.OrdinalIgnoreCase;
             if (expectedPClaimValueSpan.Equals(pClaimValueSpan, comparison))
                 return;
 

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestValidationParameters.cs
@@ -82,6 +82,8 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
     /// </summary>
     public class SignedHttpRequestValidationParameters
     {
+        internal const bool DefaultUseCaseSensitivePClaimComparison = true;
+        internal const string UseCaseSensitivePClaimComparisonSwitch = "Switch.Microsoft.IdentityModel.SignedHttpRequest.UseCaseSensitivePClaimComparison";
         private TimeSpan _signedHttpRequestLifetime = DefaultSignedHttpRequestLifetime;
         private TokenHandler _tokenHandler = new JsonWebTokenHandler();
         private ICollection<string> _allowedDomainsForJkuRetrieval;
@@ -242,6 +244,18 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         public bool ValidateP { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="SignedHttpRequestClaimTypes.P"/> claim is compared
+        /// case-sensitively with the request path.
+        /// </summary>
+        /// <remarks>
+        /// The default is <see langword="true"/>. If the AppContext switch
+        /// "Switch.Microsoft.IdentityModel.SignedHttpRequest.UseCaseSensitivePClaimComparison" is configured before
+        /// this instance is created, its value is used as the initial value. Assigning this property overrides that
+        /// initial value. AppContext changes made after construction do not affect this instance.
+        /// </remarks>
+        public bool UseCaseSensitivePClaimComparison { get; set; } = GetUseCaseSensitivePClaimComparison();
+
+        /// <summary>
         /// Gets or sets a value indicating whether the <see cref="SignedHttpRequestClaimTypes.Q"/> claim should be validated or not.
         /// </summary>
         /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-3</remarks>  
@@ -266,5 +280,12 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// Allows for validation of a claim if present, even if the validation option for the claim is set to <c>false</c>.
         /// </remarks>
         public bool ValidatePresentClaims { get; set; }
+
+        private static bool GetUseCaseSensitivePClaimComparison()
+        {
+            return AppContext.TryGetSwitch(UseCaseSensitivePClaimComparisonSwitch, out bool useCaseSensitivePClaimComparison)
+                ? useCaseSensitivePClaimComparison
+                : DefaultUseCaseSensitivePClaimComparison;
+        }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -107,20 +107,6 @@ namespace Microsoft.IdentityModel.Tokens
         internal static bool SuccessValidationLogsAsInformation => _successValidationLogsAsInformation ??= (AppContext.TryGetSwitch(SuccessValidationLogsAsInformationSwitch, out bool successLogsAsInfo) && successLogsAsInfo);
 
         /// <summary>
-        /// Controls whether the Signed HTTP Request 'p' (path) claim is compared case-sensitively (ordinal) per RFC 3986 section 3.3.
-        /// On this line the comparison is case-sensitive by default; set the switch to <c>false</c> to restore the legacy case-insensitive (OrdinalIgnoreCase) comparison.
-        /// </summary>
-        internal const string UseCaseSensitivePClaimComparisonSwitch = "Switch.Microsoft.IdentityModel.SignedHttpRequest.UseCaseSensitivePClaimComparison";
-
-        // Single source of truth for the default, referenced by both the property below and ResetAllSwitches() so they cannot diverge.
-        // 9.x (this line): true (secure, case-sensitive). 8.x servicing backport: false (legacy, case-insensitive).
-        internal const bool UseCaseSensitivePClaimComparisonDefault = true;
-
-        private static bool? _useCaseSensitivePClaimComparison;
-
-        internal static bool UseCaseSensitivePClaimComparison => _useCaseSensitivePClaimComparison ??= (AppContext.TryGetSwitch(UseCaseSensitivePClaimComparisonSwitch, out bool useCaseSensitivePClaimComparison) ? useCaseSensitivePClaimComparison : UseCaseSensitivePClaimComparisonDefault);
-
-        /// <summary>
         /// Used for testing to reset all switches to its default value.
         /// </summary>
         internal static void ResetAllSwitches()
@@ -148,11 +134,6 @@ namespace Microsoft.IdentityModel.Tokens
 
             _successValidationLogsAsInformation = null;
             AppContext.SetSwitch(SuccessValidationLogsAsInformationSwitch, false);
-
-            // Opt-out switch (default true on this line). Reset to the declared default rather than a hardcoded false,
-            // because AppContext cannot truly un-set a switch and writing false would select the legacy behavior.
-            _useCaseSensitivePClaimComparison = null;
-            AppContext.SetSwitch(UseCaseSensitivePClaimComparisonSwitch, UseCaseSensitivePClaimComparisonDefault);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -125,6 +125,3 @@ const Microsoft.IdentityModel.Tokens.LogMessages.IDX10722 = "IDX10722: The AKP J
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10723 = "IDX10723: Unable to extract the private key from the X.509 certificate for algorithm '{0}' (Key: '{1}'). Private key extraction may not be supported on this platform." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10724 = "IDX10724: Unable to compute a JWK thumbprint, public key extraction from the X.509 certificate is not supported on this platform (Key: '{0}')." -> string
 const Microsoft.IdentityModel.Tokens.LogMessages.IDX10725 = "IDX10725: Unable to create a SignatureProvider for algorithm '{0}' (Key: '{1}'). The X.509 certificate key could not be extracted. This may indicate the platform does not support the certificate's key type." -> string
-const Microsoft.IdentityModel.Tokens.AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch = "Switch.Microsoft.IdentityModel.SignedHttpRequest.UseCaseSensitivePClaimComparison" -> string
-const Microsoft.IdentityModel.Tokens.AppContextSwitches.UseCaseSensitivePClaimComparisonDefault = true -> bool
-static Microsoft.IdentityModel.Tokens.AppContextSwitches.UseCaseSensitivePClaimComparison.get -> bool

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestConfigurationTestCollection.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestConfigurationTestCollection.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
+{
+    [CollectionDefinition("SignedHttpRequest Configuration", DisableParallelization = true)]
+    public class SignedHttpRequestConfigurationTestCollection
+    {
+    }
+}

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestConfigurationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestConfigurationTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
+{
+    [Collection("SignedHttpRequest Configuration")]
+    public class SignedHttpRequestConfigurationTests
+    {
+        [Fact]
+        public void UseCaseSensitivePClaimComparison_SeedsFromAppContext()
+        {
+            try
+            {
+                // Arrange
+                AppContext.SetSwitch(SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparisonSwitch, false);
+
+                // Act
+                var validationParameters = new SignedHttpRequestValidationParameters();
+
+                // Assert
+                Assert.False(validationParameters.UseCaseSensitivePClaimComparison);
+            }
+            finally
+            {
+                RestoreUseCaseSensitivePClaimComparisonSwitch();
+            }
+        }
+
+        [Fact]
+        public void UseCaseSensitivePClaimComparison_ExplicitPropertyOverridesSeed()
+        {
+            try
+            {
+                // Arrange
+                AppContext.SetSwitch(SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparisonSwitch, false);
+
+                // Act
+                var validationParameters = new SignedHttpRequestValidationParameters
+                {
+                    UseCaseSensitivePClaimComparison = true
+                };
+
+                // Assert
+                Assert.True(validationParameters.UseCaseSensitivePClaimComparison);
+            }
+            finally
+            {
+                RestoreUseCaseSensitivePClaimComparisonSwitch();
+            }
+        }
+
+        [Fact]
+        public void UseCaseSensitivePClaimComparison_CapturesAppContextValueAtConstruction()
+        {
+            try
+            {
+                // Arrange
+                AppContext.SetSwitch(SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparisonSwitch, false);
+                var validationParameters = new SignedHttpRequestValidationParameters();
+
+                // Act
+                AppContext.SetSwitch(
+                    SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparisonSwitch,
+                    !SignedHttpRequestValidationParameters.DefaultUseCaseSensitivePClaimComparison);
+
+                // Assert
+                Assert.False(validationParameters.UseCaseSensitivePClaimComparison);
+            }
+            finally
+            {
+                RestoreUseCaseSensitivePClaimComparisonSwitch();
+            }
+        }
+
+        [Fact]
+        public void UseCaseSensitivePClaimComparison_DefaultsToTrueOn9x()
+        {
+            Assert.True(SignedHttpRequestValidationParameters.DefaultUseCaseSensitivePClaimComparison);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public async Task ValidateSignedHttpRequestAsync_UsesExplicitPathComparisonConfiguration(
+            bool useCaseSensitiveComparison,
+            bool expectedValid)
+        {
+            // Arrange
+            var validationParameters = CreatePathValidationParameters(useCaseSensitiveComparison);
+            var validationContext = CreateValidationContext(validationParameters);
+            var handler = new SignedHttpRequestHandler();
+
+            // Act
+            var result = await handler.ValidateSignedHttpRequestAsync(validationContext, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(expectedValid, result.IsValid);
+            if (expectedValid)
+                Assert.Null(result.Exception);
+            else
+                Assert.IsType<SignedHttpRequestInvalidPClaimException>(result.Exception);
+        }
+
+        [Fact]
+        public async Task ValidateSignedHttpRequestAsync_DefaultContextUses9xPathComparison()
+        {
+            // Arrange
+            RestoreUseCaseSensitivePClaimComparisonSwitch();
+            var signedHttpRequest = CreateSignedHttpRequestWithPath("/Path1");
+            var httpRequestData = CreateHttpRequestData();
+            var validationContext = new SignedHttpRequestValidationContext(
+                signedHttpRequest,
+                httpRequestData,
+                SignedHttpRequestTestUtils.DefaultTokenValidationParameters);
+            var handler = new SignedHttpRequestHandler();
+
+            // Act
+            var result = await handler.ValidateSignedHttpRequestAsync(validationContext, CancellationToken.None);
+
+            // Assert
+            Assert.True(validationContext.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison);
+            Assert.False(result.IsValid);
+            Assert.IsType<SignedHttpRequestInvalidPClaimException>(result.Exception);
+        }
+
+        [Fact]
+        public async Task ValidateSignedHttpRequestAsync_DefaultContextUsesAppContextSeed()
+        {
+            try
+            {
+                // Arrange
+                AppContext.SetSwitch(SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparisonSwitch, false);
+                var signedHttpRequest = CreateSignedHttpRequestWithPath("/Path1");
+                var httpRequestData = CreateHttpRequestData();
+                var validationContext = new SignedHttpRequestValidationContext(
+                    signedHttpRequest,
+                    httpRequestData,
+                    SignedHttpRequestTestUtils.DefaultTokenValidationParameters);
+                var handler = new SignedHttpRequestHandler();
+
+                // Act
+                var result = await handler.ValidateSignedHttpRequestAsync(validationContext, CancellationToken.None);
+
+                // Assert
+                Assert.False(validationContext.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison);
+                Assert.True(result.IsValid);
+                Assert.Null(result.Exception);
+            }
+            finally
+            {
+                RestoreUseCaseSensitivePClaimComparisonSwitch();
+            }
+        }
+
+        private static SignedHttpRequestValidationParameters CreatePathValidationParameters(bool useCaseSensitiveComparison)
+        {
+            return new SignedHttpRequestValidationParameters
+            {
+                UseCaseSensitivePClaimComparison = useCaseSensitiveComparison,
+                ValidateB = false,
+                ValidateH = false,
+                ValidateM = false,
+                ValidateP = true,
+                ValidateQ = false,
+                ValidateTs = false,
+                ValidateU = false
+            };
+        }
+
+        private static SignedHttpRequestValidationContext CreateValidationContext(
+            SignedHttpRequestValidationParameters validationParameters)
+        {
+            return new SignedHttpRequestValidationContext(
+                CreateSignedHttpRequestWithPath("/Path1"),
+                CreateHttpRequestData(),
+                SignedHttpRequestTestUtils.DefaultTokenValidationParameters,
+                validationParameters);
+        }
+
+        private static HttpRequestData CreateHttpRequestData()
+        {
+            return new HttpRequestData
+            {
+                Method = "GET",
+                Uri = new Uri("https://www.contoso.com/path1")
+            };
+        }
+
+        private static string CreateSignedHttpRequestWithPath(string path)
+        {
+            return SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(
+                new JProperty(SignedHttpRequestClaimTypes.P, path)).EncodedToken;
+        }
+
+        private static void RestoreUseCaseSensitivePClaimComparisonSwitch()
+        {
+            AppContext.SetSwitch(
+                SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparisonSwitch,
+                SignedHttpRequestValidationParameters.DefaultUseCaseSensitivePClaimComparison);
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -18,6 +18,7 @@ using Xunit;
 
 namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
 {
+    [Collection("SignedHttpRequest Configuration")]
     public class SignedHttpRequestValidationTests
     {
         [Fact]
@@ -319,7 +320,6 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         }
 
         [Theory, MemberData(nameof(ValidatePClaimTheoryData), DisableDiscoveryEnumeration = true)]
-        [ResetAppContextSwitches]
         public void ValidatePClaim(ValidateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidatePClaim", theoryData);
@@ -339,17 +339,16 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         }
 
         [Fact]
-        [ResetAppContextSwitches]
-        public void ValidatePClaim_IsCaseInsensitive_WhenSwitchDisabled()
+        public void ValidatePClaim_IsCaseInsensitive_WhenConfigurationDisabled()
         {
             // Arrange - request path and signed 'p' claim differ by literal case and percent-triplet hex case.
-            AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, false);
             var handler = new SignedHttpRequestHandler();
             var theoryData = new ValidateSignedHttpRequestTheoryData
             {
                 HttpRequestUri = new Uri("https://www.contoso.com/Foo%2Fbar"),
                 SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
             };
+            theoryData.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison = false;
             var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
 
             // Act
@@ -360,17 +359,16 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         }
 
         [Fact]
-        [ResetAppContextSwitches]
-        public void ValidatePClaim_IsCaseSensitive_WhenSwitchEnabled()
+        public void ValidatePClaim_IsCaseSensitive_WhenConfigurationEnabled()
         {
             // Arrange - request path and signed 'p' claim differ by literal case and percent-triplet hex case.
-            AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, true);
             var handler = new SignedHttpRequestHandler();
             var theoryData = new ValidateSignedHttpRequestTheoryData
             {
                 HttpRequestUri = new Uri("https://www.contoso.com/Foo%2Fbar"),
                 SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
             };
+            theoryData.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison = true;
             var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
 
             // Act
@@ -403,17 +401,16 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         [InlineData("/foo%2Fbar", "/foo/bar", true, false)]
         [InlineData("/fooABC", "/fooAB%", false, false)]
         [InlineData("/fooABCD", "/fooAB%2", false, false)]
-        [ResetAppContextSwitches]
         public void ValidatePClaim_ComparisonMatrix(string requestPath, string pClaim, bool useCaseSensitiveComparison, bool expectedValid)
         {
             // Arrange
-            AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, useCaseSensitiveComparison);
             var handler = new SignedHttpRequestHandler();
             var theoryData = new ValidateSignedHttpRequestTheoryData
             {
                 HttpRequestUri = new Uri($"https://www.contoso.com{requestPath}"),
                 SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, pClaim)),
             };
+            theoryData.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison = useCaseSensitiveComparison;
             var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
 
             // Act
@@ -429,17 +426,16 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        [ResetAppContextSwitches]
         public void ValidatePClaim_PreservesPercentEncodingHexCaseInException(bool useCaseSensitiveComparison)
         {
             // Arrange
-            AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, useCaseSensitiveComparison);
             var handler = new SignedHttpRequestHandler();
             var theoryData = new ValidateSignedHttpRequestTheoryData
             {
                 HttpRequestUri = new Uri("https://www.contoso.com/Expected%2fPath"),
                 SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/Actual%2aPath")),
             };
+            theoryData.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison = useCaseSensitiveComparison;
             var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
 
             // Act


### PR DESCRIPTION
Moves Signed HTTP Request path comparison control to SignedHttpRequestValidationParameters while preserving the legacy AppContext setting as a construction-time seed. The 9.x default remains case-sensitive. Adds configuration and validation-flow coverage and removes the centralized SHR AppContext switch implementation.

Tests: dotnet test Wilson.sln -c Debug --no-build --nologo