### PR TITLE
Re-add CHANGELOG entry for version 9.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ See the [releases](https://github.com/AzureAD/azure-activedirectory-identitymode
 ## Bug Fixes
 - Fix CI build failures: remove unused log message and add missing DPoP API entries. See [PR #3551](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3551).
 
+9.0.0
+====
+## Bug Fixes
+- Align Signed HTTP Request `p` (path) claim comparison with RFC 3986 section 3.3 by comparing the path case-sensitively; previously `/Admin/resource` matched `/admin/resource`. An AppContext opt out is available during transition. See [PR #3526](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3526).
+- Normalize hexadecimal letter casing inside percent-encoded triplets during Signed HTTP Request `p` claim validation. Literal path-letter comparison remains controlled by `UseCaseSensitivePClaimComparison`, and `p` claim creation output is unchanged.
+
 7.7.2
 ====
 ## Bug Fixes


### PR DESCRIPTION
Re-added version 9.0.0 to changelog, which was accidentally removed in during a merge resolution in another changelog update: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3556/changes/edf433251eea0c904b8b4b96a2bc5ebddfed08cd
