### PR TITLE
Add synchronous JsonWebTokenHandler.ValidateToken pipeline

### DIFF
--- a/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateTokenSyncTests.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/ValidateTokenSyncTests.cs
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Telemetry;
+using Microsoft.IdentityModel.Tokens;
+
+#pragma warning disable CS0618 // The legacy synchronous entry points are the benchmark targets.
+
+namespace Microsoft.IdentityModel.Benchmarks
+{
+    // dotnet run -c release -f net8.0 --filter Microsoft.IdentityModel.Benchmarks.ValidateTokenSyncTests*
+
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    public class ValidateTokenSyncTests
+    {
+        private JsonWebTokenHandler _jsonWebTokenHandler;
+        private JwtSecurityTokenHandler _jwtSecurityTokenHandler;
+        private string _jwsExtendedClaims;
+        private TokenValidationParameters _tokenValidationParameters;
+        private TokenValidationParameters _invalidTokenValidationParameters;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var tokenDescriptorExtendedClaims = new SecurityTokenDescriptor
+            {
+                Claims = BenchmarkUtils.ClaimsExtendedExample,
+                SigningCredentials = BenchmarkUtils.SigningCredentialsRsaSha256,
+            };
+
+            _jsonWebTokenHandler = new JsonWebTokenHandler();
+            _jwsExtendedClaims = _jsonWebTokenHandler.CreateToken(tokenDescriptorExtendedClaims);
+
+            _jwtSecurityTokenHandler = new JwtSecurityTokenHandler();
+            _jwtSecurityTokenHandler.SetDefaultTimesOnTokenCreation = false;
+
+            _tokenValidationParameters = new TokenValidationParameters
+            {
+                ValidAudience = BenchmarkUtils.Audience,
+                ValidateLifetime = true,
+                ValidIssuer = BenchmarkUtils.Issuer,
+                IssuerSigningKey = BenchmarkUtils.SigningCredentialsRsaSha256.Key,
+            };
+
+            _invalidTokenValidationParameters = new TokenValidationParameters
+            {
+                ValidAudience = BenchmarkUtils.Audience,
+                ValidateLifetime = true,
+                ValidIssuer = BenchmarkUtils.Issuer,
+                ValidateIssuerSigningKey = true,
+                ValidateTokenReplay = true,
+                ValidateSignatureLast = true,
+            };
+        }
+
+        [BenchmarkCategory("ValidateTokenSync_Success"), Benchmark]
+        public ClaimsPrincipal JwtSecurityTokenHandler_ValidateToken()
+        {
+            return _jwtSecurityTokenHandler.ValidateToken(
+                _jwsExtendedClaims,
+                _tokenValidationParameters,
+                out _);
+        }
+
+        [BenchmarkCategory("ValidateTokenSync_Success"), Benchmark(Baseline = true)]
+        public TokenValidationResult JsonWebTokenHandler_ValidateTokenWithTVP()
+        {
+            return _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _tokenValidationParameters);
+        }
+
+        [BenchmarkCategory("ValidateTokenSync_Success"), Benchmark]
+        public TokenValidationResult JsonWebTokenHandler_ValidateTokenWithTVPUsingModifiedClone()
+        {
+            var tokenValidationParameters = _tokenValidationParameters.Clone();
+            tokenValidationParameters.ValidIssuer = "different-issuer";
+            tokenValidationParameters.ValidAudience = "different-audience";
+            tokenValidationParameters.ValidateLifetime = false;
+            return _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, tokenValidationParameters);
+        }
+
+        [BenchmarkCategory("ValidateTokenSync_FailTwiceBeforeSuccess"), Benchmark(Baseline = true)]
+        public TokenValidationResult JsonWebTokenHandler_ValidateTokenWithTVP_SucceedOnThirdAttempt()
+        {
+            TokenValidationResult result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _invalidTokenValidationParameters);
+            result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _invalidTokenValidationParameters);
+            result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _tokenValidationParameters);
+
+            return result;
+        }
+
+        [BenchmarkCategory("ValidateTokenSync_FailTwiceBeforeSuccess"), Benchmark]
+        public TokenValidationResult JsonWebTokenHandler_ValidateTokenWithTVPUsingClone_SucceedOnThirdAttempt()
+        {
+            TokenValidationResult result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _invalidTokenValidationParameters.Clone());
+            result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _invalidTokenValidationParameters.Clone());
+            result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _tokenValidationParameters.Clone());
+
+            return result;
+        }
+
+        [BenchmarkCategory("ValidateTokenSync_FailFourTimesBeforeSuccess"), Benchmark(Baseline = true)]
+        public TokenValidationResult JsonWebTokenHandler_ValidateTokenWithTVP_SucceedOnFifthAttempt()
+        {
+            TokenValidationResult result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _invalidTokenValidationParameters);
+            result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _invalidTokenValidationParameters);
+            result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _invalidTokenValidationParameters);
+            result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _invalidTokenValidationParameters);
+            result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _tokenValidationParameters);
+
+            return result;
+        }
+
+        [BenchmarkCategory("ValidateTokenSync_FailFourTimesBeforeSuccess"), Benchmark]
+        public TokenValidationResult JsonWebTokenHandler_ValidateTokenWithTVPUsingClone_SucceedOnFifthAttempt()
+        {
+            TokenValidationResult result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _invalidTokenValidationParameters.Clone());
+            result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _invalidTokenValidationParameters.Clone());
+            result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _invalidTokenValidationParameters.Clone());
+            result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _invalidTokenValidationParameters.Clone());
+            result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _tokenValidationParameters.Clone());
+
+            return result;
+        }
+
+        [BenchmarkCategory("ValidateTokenSyncClaimAccess"), Benchmark]
+        public List<Claim> JsonWebTokenHandler_ValidateTokenWithTVP_CreateClaims()
+        {
+            TokenValidationResult result = _jsonWebTokenHandler.ValidateToken(_jwsExtendedClaims, _tokenValidationParameters);
+            return result.ClaimsIdentity.Claims.ToList();
+        }
+    }
+
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    public class ValidateTokenSyncTests_TelemetryImpact
+    {
+        private const int IterationCount = 10000;
+        private JsonWebTokenHandler _jsonWebTokenHandler;
+        private string _jwsClaims;
+        private TokenValidationParameters _tokenValidationParameters;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            var tokenDescriptorClaims = new SecurityTokenDescriptor
+            {
+                Claims = BenchmarkUtils.Claims,
+                SigningCredentials = BenchmarkUtils.SigningCredentialsRsaSha256,
+            };
+
+            _jsonWebTokenHandler = new JsonWebTokenHandler();
+            _jwsClaims = _jsonWebTokenHandler.CreateToken(tokenDescriptorClaims);
+
+            _tokenValidationParameters = new TokenValidationParameters
+            {
+                ValidAudience = BenchmarkUtils.Audience,
+                ValidateLifetime = true,
+                ValidIssuer = BenchmarkUtils.Issuer,
+                IssuerSigningKey = BenchmarkUtils.SigningCredentialsRsaSha256.Key,
+            };
+        }
+
+        [IterationSetup(Target = nameof(JsonWebTokenHandler_ValidateToken_TelemetryDisabled))]
+        public void Setup_TelemetryDisabled()
+        {
+            CryptoTelemetry.EnableSignatureValidationTelemetry(false, null);
+        }
+
+        [BenchmarkCategory("ValidateTokenSync_TelemetryImpact"), Benchmark(Baseline = true, OperationsPerInvoke = IterationCount)]
+        public TokenValidationResult JsonWebTokenHandler_ValidateToken_TelemetryDisabled()
+        {
+            return _jsonWebTokenHandler.ValidateToken(_jwsClaims, _tokenValidationParameters);
+        }
+
+        [IterationSetup(Target = nameof(JsonWebTokenHandler_ValidateToken_TelemetryEnabledNoTracking))]
+        public void Setup_TelemetryEnabledNoTracking()
+        {
+            CryptoTelemetry.EnableSignatureValidationTelemetry(true, null);
+        }
+
+        [BenchmarkCategory("ValidateTokenSync_TelemetryImpact"), Benchmark(OperationsPerInvoke = IterationCount)]
+        public TokenValidationResult JsonWebTokenHandler_ValidateToken_TelemetryEnabledNoTracking()
+        {
+            return _jsonWebTokenHandler.ValidateToken(_jwsClaims, _tokenValidationParameters);
+        }
+
+        [IterationSetup(Target = nameof(JsonWebTokenHandler_ValidateToken_TelemetryEnabledWithTracking))]
+        public void Setup_TelemetryEnabledWithTracking()
+        {
+            CryptoTelemetry.EnableSignatureValidationTelemetry(true, new[] { "contoso.com" });
+        }
+
+        [BenchmarkCategory("ValidateTokenSync_TelemetryImpact"), Benchmark(OperationsPerInvoke = IterationCount)]
+        public TokenValidationResult JsonWebTokenHandler_ValidateToken_TelemetryEnabledWithTracking()
+        {
+            return _jsonWebTokenHandler.ValidateToken(_jwsClaims, _tokenValidationParameters);
+        }
+    }
+}
+
+#pragma warning restore CS0618

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.ValidateToken.cs
@@ -129,6 +129,128 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             }
         }
 
+        internal TokenValidationResult ValidateJWESync(
+            JsonWebToken jwtToken,
+            TokenValidationParameters validationParameters,
+            BaseConfiguration configuration)
+        {
+            return ValidateJWESync(jwtToken, validationParameters, configuration, CancellationToken.None);
+        }
+
+        internal TokenValidationResult ValidateJWESync(
+            JsonWebToken jwtToken,
+            TokenValidationParameters validationParameters,
+            BaseConfiguration configuration,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                TokenValidationResult tokenValidationResult = ReadToken(DecryptToken(jwtToken, validationParameters, configuration), validationParameters);
+                if (!tokenValidationResult.IsValid)
+                    return tokenValidationResult;
+
+                tokenValidationResult = ValidateJWSSync(
+                    tokenValidationResult.SecurityToken as JsonWebToken,
+                    validationParameters,
+                    configuration,
+                    cancellationToken);
+
+                if (!tokenValidationResult.IsValid)
+                    return tokenValidationResult;
+
+                jwtToken.InnerToken = tokenValidationResult.SecurityToken as JsonWebToken;
+                jwtToken.Payload = (tokenValidationResult.SecurityToken as JsonWebToken).Payload;
+                return new TokenValidationResult
+                {
+                    SecurityToken = jwtToken,
+                    ClaimsIdentityNoLocking = tokenValidationResult.ClaimsIdentityNoLocking,
+                    IsValid = true,
+                    TokenType = tokenValidationResult.TokenType
+                };
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return new TokenValidationResult
+                {
+                    Exception = ex,
+                    IsValid = false,
+                    TokenOnFailedValidation = validationParameters.IncludeTokenOnFailedValidation ? jwtToken : null
+                };
+            }
+        }
+
+        internal TokenValidationResult ValidateJWSSync(
+            JsonWebToken jsonWebToken,
+            TokenValidationParameters validationParameters,
+            BaseConfiguration configuration)
+        {
+            return ValidateJWSSync(jsonWebToken, validationParameters, configuration, CancellationToken.None);
+        }
+
+        internal TokenValidationResult ValidateJWSSync(
+            JsonWebToken jsonWebToken,
+            TokenValidationParameters validationParameters,
+            BaseConfiguration configuration,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                TokenValidationResult tokenValidationResult;
+                if (validationParameters.TransformBeforeSignatureValidation != null)
+                    jsonWebToken = validationParameters.TransformBeforeSignatureValidation(jsonWebToken, validationParameters) as JsonWebToken;
+
+                if (validationParameters.SignatureValidator != null || validationParameters.SignatureValidatorUsingConfiguration != null)
+                {
+                    var validatedToken = ValidateSignatureUsingDelegates(jsonWebToken, validationParameters);
+                    tokenValidationResult = ValidateTokenPayloadSync(
+                        validatedToken,
+                        validationParameters,
+                        configuration,
+                        cancellationToken);
+
+                    Validators.ValidateIssuerSecurityKey(validatedToken.SigningKey, validatedToken, validationParameters);
+                }
+                else
+                {
+                    if (validationParameters.ValidateSignatureLast)
+                    {
+                        tokenValidationResult = ValidateTokenPayloadSync(
+                            jsonWebToken,
+                            validationParameters,
+                            configuration,
+                            cancellationToken);
+
+                        if (tokenValidationResult.IsValid)
+                            tokenValidationResult.SecurityToken = ValidateSignatureAndIssuerSecurityKey(jsonWebToken, validationParameters, configuration);
+                    }
+                    else
+                    {
+                        var validatedToken = ValidateSignatureAndIssuerSecurityKey(jsonWebToken, validationParameters, configuration);
+                        tokenValidationResult = ValidateTokenPayloadSync(
+                            validatedToken,
+                            validationParameters,
+                            configuration,
+                            cancellationToken);
+                    }
+                }
+
+                return tokenValidationResult;
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                return new TokenValidationResult
+                {
+                    Exception = ex,
+                    IsValid = false,
+                    TokenOnFailedValidation = validationParameters.IncludeTokenOnFailedValidation ? jsonWebToken : null
+                };
+            }
+        }
+
         private JsonWebToken ValidateSignatureAndIssuerSecurityKey(JsonWebToken jsonWebToken, TokenValidationParameters validationParameters, BaseConfiguration configuration)
         {
             JsonWebToken validatedToken = ValidateSignature(jsonWebToken, validationParameters, configuration);
@@ -475,7 +597,41 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         [Obsolete("`JsonWebTokens.ValidateToken(string, TokenValidationParameters)` has been deprecated and will be removed in a future release. Use `JsonWebTokens.ValidateTokenAsync(string, TokenValidationParameters)` instead. For more information, see https://aka.ms/IdentityModel/7-breaking-changes", false)]
         public virtual TokenValidationResult ValidateToken(string token, TokenValidationParameters validationParameters)
         {
+#if NET5_0_OR_GREATER
+            if (!AppContextSwitches.PreserveLegacySyncBehavior)
+            {
+                if (string.IsNullOrEmpty(token))
+                    return new TokenValidationResult { Exception = LogHelper.LogArgumentNullException(nameof(token)), IsValid = false };
+
+                if (validationParameters == null)
+                    return new TokenValidationResult { Exception = LogHelper.LogArgumentNullException(nameof(validationParameters)), IsValid = false };
+
+                if (token.Length > MaximumTokenSizeInBytes)
+                    return new TokenValidationResult { Exception = LogHelper.LogExceptionMessage(new ArgumentException(LogHelper.FormatInvariant(TokenLogMessages.IDX10209, LogHelper.MarkAsNonPII(token.Length), LogHelper.MarkAsNonPII(MaximumTokenSizeInBytes)))), IsValid = false };
+
+                try
+                {
+                    TokenValidationResult result = ReadToken(token, validationParameters);
+                    if (result.IsValid)
+                        return ValidateTokenSync((JsonWebToken)result.SecurityToken, validationParameters, CancellationToken.None);
+
+                    return result;
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+                {
+                    return new TokenValidationResult
+                    {
+                        Exception = ex,
+                        IsValid = false
+                    };
+                }
+            }
+#endif
+#pragma warning disable VSTHRD002 // Preserve sync-over-async below .NET 5 and when explicitly requested.
             return ValidateTokenAsync(token, validationParameters).ConfigureAwait(false).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
         }
 
         /// <summary>
@@ -652,6 +808,112 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             return tokenValidationResult;
         }
 
+        /// <summary>
+        ///  Internal synchronous method for token validation, mirroring <see cref="ValidateTokenAsync(JsonWebToken, TokenValidationParameters)"/>, responsible for:
+        ///  (1) Obtaining a configuration from the <see cref="TokenValidationParameters.ConfigurationManager"/>.
+        ///  (2) Revalidating using the Last Known Good Configuration (if present), and obtaining a refreshed configuration (if necessary) and revalidating using it.
+        /// </summary>
+        /// <param name="jsonWebToken">The JWT token.</param>
+        /// <param name="validationParameters">The <see cref="TokenValidationParameters"/> to be used for validating the token.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to request cancellation of the operation.</param>
+        /// <returns>A <see cref="TokenValidationResult"/>.</returns>
+        internal TokenValidationResult ValidateTokenSync(
+            JsonWebToken jsonWebToken,
+            TokenValidationParameters validationParameters,
+            CancellationToken cancellationToken)
+        {
+            BaseConfiguration currentConfiguration = null;
+            BaseConfigurationManagerSync configurationManager = validationParameters.ConfigurationManagerSync;
+
+            if (configurationManager != null)
+            {
+                try
+                {
+                    currentConfiguration = configurationManager.GetBaseConfigurationSync(cancellationToken);
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception ex)
+#pragma warning restore CA1031 // Do not catch general exception types
+                {
+                    // The exception is not re-thrown as the TokenValidationParameters may have the issuer and signing key set
+                    // directly on them, allowing the library to continue with token validation.
+                    if (LogHelper.IsEnabled(EventLogLevel.Warning))
+                        LogHelper.LogWarning(LogHelper.FormatInvariant(TokenLogMessages.IDX10261, configurationManager.MetadataAddress, ex.ToString()));
+                }
+            }
+
+            TokenValidationResult tokenValidationResult = jsonWebToken.IsEncrypted ?
+                ValidateJWESync(jsonWebToken, validationParameters, currentConfiguration, cancellationToken) :
+                ValidateJWSSync(jsonWebToken, validationParameters, currentConfiguration, cancellationToken);
+
+            if (configurationManager != null)
+            {
+                if (tokenValidationResult.IsValid)
+                {
+                    // Set current configuration as LKG if it exists.
+                    if (currentConfiguration != null)
+                        configurationManager.LastKnownGoodConfiguration = currentConfiguration;
+
+                    return tokenValidationResult;
+                }
+                else if (TokenUtilities.IsRecoverableException(tokenValidationResult.Exception, (currentConfiguration != null && currentConfiguration.TokenDecryptionKeys.Count > 0)))
+                {
+                    // If we were still unable to validate, attempt to refresh the configuration and validate using it
+                    // but ONLY if the currentConfiguration is not null. We want to avoid refreshing the configuration on
+                    // retrieval error as this case should have already been hit before. This refresh handles the case
+                    // where a new valid configuration was somehow published during validation time.
+                    if (currentConfiguration != null)
+                    {
+                        TelemetryClient.IncrementConfigurationRefreshRequestCounter(
+                            configurationManager.MetadataAddress,
+                            TelemetryConstants.Protocols.Lkg,
+                            TelemetryConstants.Protocols.ConfigurationSourceUnknown);
+
+                        configurationManager.RequestRefresh();
+                        validationParameters.RefreshBeforeValidation = true;
+                        var lastConfig = currentConfiguration;
+                        currentConfiguration = configurationManager.GetBaseConfigurationSync(cancellationToken);
+
+                        // Only try to re-validate using the newly obtained config if it doesn't reference equal the previously used configuration.
+                        if (lastConfig != currentConfiguration)
+                        {
+                            tokenValidationResult = jsonWebToken.IsEncrypted ?
+                                ValidateJWESync(jsonWebToken, validationParameters, currentConfiguration, cancellationToken) :
+                                ValidateJWSSync(jsonWebToken, validationParameters, currentConfiguration, cancellationToken);
+
+                            if (tokenValidationResult.IsValid)
+                            {
+                                configurationManager.LastKnownGoodConfiguration = currentConfiguration;
+                                return tokenValidationResult;
+                            }
+                        }
+                    }
+
+                    if (configurationManager.UseLastKnownGoodConfiguration)
+                    {
+                        validationParameters.RefreshBeforeValidation = false;
+                        validationParameters.ValidateWithLKG = true;
+                        var recoverableException = tokenValidationResult.Exception;
+
+                        foreach (BaseConfiguration lkgConfiguration in configurationManager.GetValidLkgConfigurations())
+                        {
+                            if (!lkgConfiguration.Equals(currentConfiguration) && TokenUtilities.IsRecoverableConfiguration(jsonWebToken.Kid, currentConfiguration, lkgConfiguration, recoverableException))
+                            {
+                                tokenValidationResult = jsonWebToken.IsEncrypted ?
+                                    ValidateJWESync(jsonWebToken, validationParameters, lkgConfiguration, cancellationToken) :
+                                    ValidateJWSSync(jsonWebToken, validationParameters, lkgConfiguration, cancellationToken);
+
+                                if (tokenValidationResult.IsValid)
+                                    return tokenValidationResult;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return tokenValidationResult;
+        }
+
         internal async ValueTask<TokenValidationResult> ValidateTokenPayloadAsync(
             JsonWebToken jsonWebToken,
             TokenValidationParameters validationParameters,
@@ -675,6 +937,54 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 // this code will still work properly.
                 TokenValidationResult tokenValidationResult =
                     await ValidateTokenAsync(jsonWebToken.Actor, validationParameters.ActorValidationParameters ?? validationParameters).ConfigureAwait(false);
+
+                if (!tokenValidationResult.IsValid)
+                    return tokenValidationResult;
+            }
+
+            string tokenType = Validators.ValidateTokenType(jsonWebToken.Typ, jsonWebToken, validationParameters);
+            return new TokenValidationResult(jsonWebToken, this, validationParameters.Clone(), issuer)
+            {
+                IsValid = true,
+                TokenType = tokenType
+            };
+        }
+
+        internal TokenValidationResult ValidateTokenPayloadSync(
+            JsonWebToken jsonWebToken,
+            TokenValidationParameters validationParameters,
+            BaseConfiguration configuration)
+        {
+            return ValidateTokenPayloadSync(jsonWebToken, validationParameters, configuration, CancellationToken.None);
+        }
+
+        internal TokenValidationResult ValidateTokenPayloadSync(
+            JsonWebToken jsonWebToken,
+            TokenValidationParameters validationParameters,
+            BaseConfiguration configuration,
+            CancellationToken cancellationToken)
+        {
+            var expires = jsonWebToken.HasPayloadClaim(JwtRegisteredClaimNames.Exp) ? (DateTime?)jsonWebToken.ValidTo : null;
+            var notBefore = jsonWebToken.HasPayloadClaim(JwtRegisteredClaimNames.Nbf) ? (DateTime?)jsonWebToken.ValidFrom : null;
+
+            Validators.ValidateLifetime(notBefore, expires, jsonWebToken, validationParameters);
+            Validators.ValidateAudience(jsonWebToken.Audiences, jsonWebToken, validationParameters);
+            string issuer = Validators.ValidateIssuer(jsonWebToken.Issuer, jsonWebToken, validationParameters, configuration);
+
+            Validators.ValidateTokenReplay(expires, jsonWebToken.EncodedToken, validationParameters);
+            if (validationParameters.ValidateActor && !string.IsNullOrWhiteSpace(jsonWebToken.Actor))
+            {
+                // Infinite recursion should not occur here, as the JsonWebToken passed into this method is (1) constructed from a string
+                // AND (2) the signature is successfully validated on it. (1) implies that even if there are nested actor tokens,
+                // they must end at some point since they cannot reference one another. (2) means that the token has a valid signature
+                // and (since issuer validation occurs first) came from a trusted authority.
+                // NOTE: More than one nested actor token should not be considered a valid token, but if we somehow encounter one,
+                // this code will still work properly.
+                TokenValidationParameters actorValidationParameters = validationParameters.ActorValidationParameters ?? validationParameters;
+                TokenValidationResult actorReadResult = ReadToken(jsonWebToken.Actor, actorValidationParameters);
+                TokenValidationResult tokenValidationResult = actorReadResult.IsValid ?
+                    ValidateTokenSync(actorReadResult.SecurityToken as JsonWebToken, actorValidationParameters, cancellationToken) :
+                    actorReadResult;
 
                 if (!tokenValidationResult.IsValid)
                     return tokenValidationResult;

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenSyncTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.ValidateTokenSyncTests.cs
@@ -1,0 +1,202 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.TestExtensions;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Microsoft.IdentityModel.JsonWebTokens.Tests
+{
+    public class JsonWebTokenHandlerValidateTokenSyncTests
+    {
+        private readonly TestTokenCreator _testTokenCreator = new()
+        {
+            SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials
+        };
+
+        private readonly JsonWebTokenHandler _jsonWebTokenHandler = new();
+
+        [Fact]
+        public void TestNotYetValidToken()
+        {
+            TokenValidationResult validationResult = ValidateToken(_testTokenCreator.CreateNotYetValidToken());
+
+            Assert.False(validationResult.IsValid);
+            Assert.Null(validationResult.SecurityToken);
+            Assert.IsType<SecurityTokenNotYetValidException>(validationResult.Exception);
+        }
+
+        [Fact]
+        public void TestTokenWithFutureIssuedAt()
+        {
+            TokenValidationResult validationResult = ValidateToken(_testTokenCreator.CreateTokenWithFutureIssuedAt());
+
+            Assert.True(validationResult.IsValid);
+            Assert.NotNull(validationResult.SecurityToken);
+            Assert.Null(validationResult.Exception);
+        }
+
+        [Fact]
+        public void TestTokenWithMissingIssuedAt()
+        {
+            TokenValidationResult validationResult = ValidateToken(_testTokenCreator.CreateTokenWithMissingIssuedAt());
+
+            Assert.True(validationResult.IsValid);
+            Assert.NotNull(validationResult.SecurityToken);
+            Assert.Null(validationResult.Exception);
+        }
+
+        [Fact]
+        public void TestTokenWithMissingNotBefore()
+        {
+            TokenValidationResult validationResult = ValidateToken(_testTokenCreator.CreateTokenWithMissingNotBefore());
+
+            Assert.True(validationResult.IsValid);
+            Assert.NotNull(validationResult.SecurityToken);
+            Assert.Null(validationResult.Exception);
+        }
+
+        [Fact]
+        public void TestTokenSucceeds()
+        {
+            TokenValidationResult validationResult = ValidateToken(_testTokenCreator.CreateDefaultValidToken());
+
+            Assert.True(validationResult.IsValid);
+            Assert.NotNull(validationResult.SecurityToken);
+            Assert.Null(validationResult.Exception);
+        }
+
+#if NET5_0_OR_GREATER
+        [Fact]
+        public void ValidateToken_UsesSeparateSyncConfigurationManager()
+        {
+            AppContextSwitches.ResetAllSwitches();
+            AppContext.SetSwitch(AppContextSwitches.PreserveLegacySyncBehaviorSwitch, false);
+
+            try
+            {
+                var syncConfiguration = new OpenIdConnectConfiguration
+                {
+                    Issuer = "http://Default.Issuer.com",
+                };
+                syncConfiguration.SigningKeys.Add(KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key);
+
+                var asyncConfiguration = new OpenIdConnectConfiguration
+                {
+                    Issuer = "different-issuer",
+                };
+
+                TokenValidationParameters validationParameters = new()
+                {
+                    ConfigurationManager = new StaticConfigurationManager<OpenIdConnectConfiguration>(asyncConfiguration),
+                    ConfigurationManagerSync = new TestConfigurationManagerSync(syncConfiguration),
+                    ValidAudiences = ["http://Default.Audience.com"],
+                };
+
+#pragma warning disable CS0618 // Legacy synchronous overload is intentionally exercised here.
+                TokenValidationResult validationResult = _jsonWebTokenHandler.ValidateToken(
+                    _testTokenCreator.CreateDefaultValidToken(),
+                    validationParameters);
+#pragma warning restore CS0618
+
+                Assert.True(validationResult.IsValid);
+                Assert.Same(
+                    validationParameters.ConfigurationManagerSync,
+                    validationParameters.Clone().ConfigurationManagerSync);
+            }
+            finally
+            {
+                AppContextSwitches.ResetAllSwitches();
+            }
+        }
+#endif
+
+        [Theory]
+#if NET5_0_OR_GREATER
+        [InlineData(false, false, true)]
+#else
+        [InlineData(false, true, false)]
+#endif
+        [InlineData(true, true, false)]
+        public void PreserveLegacySyncBehavior_SelectsValidationPath(
+            bool preserveLegacySyncBehavior,
+            bool expectedAsyncValidator,
+            bool expectedSyncValidator)
+        {
+            AppContextSwitches.ResetAllSwitches();
+            AppContext.SetSwitch(AppContextSwitches.PreserveLegacySyncBehaviorSwitch, preserveLegacySyncBehavior);
+
+            bool asyncValidatorCalled = false;
+            bool syncValidatorCalled = false;
+
+            try
+            {
+                TokenValidationParameters validationParameters = CreateTokenValidationParameters();
+                validationParameters.IssuerValidatorAsync = (issuer, token, parameters) =>
+                {
+                    asyncValidatorCalled = true;
+                    return new ValueTask<string>(issuer);
+                };
+                validationParameters.IssuerValidatorSync = (issuer, token, parameters) =>
+                {
+                    syncValidatorCalled = true;
+                    return issuer;
+                };
+
+#pragma warning disable CS0618 // Legacy synchronous overload is intentionally exercised here.
+                TokenValidationResult validationResult = _jsonWebTokenHandler.ValidateToken(
+                    _testTokenCreator.CreateDefaultValidToken(),
+                    validationParameters);
+#pragma warning restore CS0618
+
+                Assert.True(validationResult.IsValid);
+                Assert.Equal(expectedAsyncValidator, asyncValidatorCalled);
+                Assert.Equal(expectedSyncValidator, syncValidatorCalled);
+            }
+            finally
+            {
+                AppContextSwitches.ResetAllSwitches();
+            }
+        }
+
+        private TokenValidationResult ValidateToken(string token)
+        {
+#pragma warning disable CS0618 // Legacy synchronous overload is intentionally exercised here.
+            return _jsonWebTokenHandler.ValidateToken(token, CreateTokenValidationParameters());
+#pragma warning restore CS0618
+        }
+
+        private static TokenValidationParameters CreateTokenValidationParameters() =>
+            new()
+            {
+                ValidAudiences = ["http://Default.Audience.com"],
+                ValidIssuers = ["http://Default.Issuer.com"],
+                IssuerSigningKeys = [KeyingMaterial.JsonWebKeyRsa256SigningCredentials.Key],
+            };
+
+        private sealed class TestConfigurationManagerSync : BaseConfigurationManagerSync
+        {
+            private readonly BaseConfiguration _configuration;
+
+            public TestConfigurationManagerSync(BaseConfiguration configuration)
+            {
+                _configuration = configuration;
+            }
+
+            internal override BaseConfiguration GetBaseConfigurationSync(CancellationToken cancellationToken)
+            {
+                return _configuration;
+            }
+
+            public override void RequestRefresh()
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is PR number 4 of the synchronous token validation pipeline process. 

This PR adds the entrypoints `JsonWebTokenHandler.ValidateToken` to mirror existing `....ValidateTokenAsync` behavior. `ValidateToken` is gated to .NET 5+, as the `HttpClient.Send` synchronous fetch method doesn't exist until after .NET 5. 

Setting the new `AppContextSwitches.PreserveLegacySyncBehavior` to true makes `ValidateToken` do the legacy sync-over-async behavior

Full performance benchmark runs are shown [here](https://microsoft-my.sharepoint.com/:w:/p/t-lukevin/cQpVdsiLDsOkQYO3TM0nm2zZEgUCdLn1rMrwXiiP9rxMrIYW8A)