### PR TITLE
Backport configurable SHR `p` claim path comparison to 8.x

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/InternalAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.IdentityModel.Protocols.SignedHttpRequest.SignedHttpRequestValidationParameters.DefaultUseCaseSensitivePClaimComparison = false -> bool

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.IdentityModel.Protocols.SignedHttpRequest.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison.get -> bool
+Microsoft.IdentityModel.Protocols.SignedHttpRequest.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison.set -> void

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -829,9 +829,10 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             pClaimValue = pClaimValue.Trim('/');
             var expectedPClaimValue = httpRequestUri.AbsolutePath.Trim('/');
 
-            // URI path components are case-sensitive per RFC 3986 section 3.3. On the 8.x line this stricter comparison is opt-in:
-            // it is case-insensitive (OrdinalIgnoreCase) by default and becomes ordinal (case-sensitive) only when the AppContext switch is enabled.
-            var comparison = AppContextSwitches.UseCaseSensitivePClaimComparison ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+            // URI path components are case-sensitive per RFC 3986 section 3.3. On the 8.x line this stricter comparison is opt-in.
+            var comparison = signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison
+                ? StringComparison.Ordinal
+                : StringComparison.OrdinalIgnoreCase;
             if (!string.Equals(expectedPClaimValue, pClaimValue, comparison))
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(LogMessages.IDX23011, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P), expectedPClaimValue, pClaimValue)));
         }

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestValidationParameters.cs
@@ -82,6 +82,7 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
     /// </summary>
     public class SignedHttpRequestValidationParameters
     {
+        internal const bool DefaultUseCaseSensitivePClaimComparison = false;
         private TimeSpan _signedHttpRequestLifetime = DefaultSignedHttpRequestLifetime;
         private TokenHandler _tokenHandler = new JsonWebTokenHandler();
         private ICollection<string> _allowedDomainsForJkuRetrieval;
@@ -240,6 +241,16 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         /// </summary>
         /// <remarks>https://datatracker.ietf.org/doc/html/draft-ietf-oauth-signed-http-request-03#section-3</remarks>  
         public bool ValidateP { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the <see cref="SignedHttpRequestClaimTypes.P"/> claim is compared
+        /// case-sensitively with the request path.
+        /// </summary>
+        /// <remarks>
+        /// The default is <see langword="false"/>. Set this property to <see langword="true"/> to compare paths
+        /// case-sensitively.
+        /// </remarks>
+        public bool UseCaseSensitivePClaimComparison { get; set; } = DefaultUseCaseSensitivePClaimComparison;
 
         /// <summary>
         /// Gets or sets a value indicating whether the <see cref="SignedHttpRequestClaimTypes.Q"/> claim should be validated or not.

--- a/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
+++ b/src/Microsoft.IdentityModel.Tokens/AppContextSwitches.cs
@@ -99,20 +99,6 @@ namespace Microsoft.IdentityModel.Tokens
         internal static bool UseCapitalizedXMLTypeAttr => _useCapitalizedXMLTypeAttr ??= (AppContext.TryGetSwitch(UseCapitalizedXMLTypeAttrSwitch, out bool useCapitalizedXMLTypeAttr) && useCapitalizedXMLTypeAttr);
 
         /// <summary>
-        /// Controls whether the Signed HTTP Request 'p' (path) claim is compared case-sensitively (ordinal) per RFC 3986 section 3.3.
-        /// On the 8.x line the comparison is case-insensitive (OrdinalIgnoreCase) by default; set the switch to <c>true</c> to opt in to the case-sensitive (Ordinal) comparison.
-        /// </summary>
-        internal const string UseCaseSensitivePClaimComparisonSwitch = "Switch.Microsoft.IdentityModel.SignedHttpRequest.UseCaseSensitivePClaimComparison";
-
-        // Single source of truth for the default, referenced by both the property below and ResetAllSwitches() so they cannot diverge.
-        // 9.x: true (secure, case-sensitive). 8.x servicing (this line): false (legacy, case-insensitive) to stay non-breaking.
-        internal const bool UseCaseSensitivePClaimComparisonDefault = false;
-
-        private static bool? _useCaseSensitivePClaimComparison;
-
-        internal static bool UseCaseSensitivePClaimComparison => _useCaseSensitivePClaimComparison ??= (AppContext.TryGetSwitch(UseCaseSensitivePClaimComparisonSwitch, out bool useCaseSensitivePClaimComparison) ? useCaseSensitivePClaimComparison : UseCaseSensitivePClaimComparisonDefault);
-
-        /// <summary>
         /// Used for testing to reset all switches to its default value.
         /// </summary>
         internal static void ResetAllSwitches()
@@ -138,10 +124,6 @@ namespace Microsoft.IdentityModel.Tokens
             _useCapitalizedXMLTypeAttr = null;
             AppContext.SetSwitch(UseCapitalizedXMLTypeAttrSwitch, false);
 
-            // Opt-in switch (default false on the 8.x line). Reset to the declared default rather than a hardcoded value
-            // because AppContext cannot truly un-set a switch.
-            _useCaseSensitivePClaimComparison = null;
-            AppContext.SetSwitch(UseCaseSensitivePClaimComparisonSwitch, UseCaseSensitivePClaimComparisonDefault);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/InternalAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+*REMOVED*const Microsoft.IdentityModel.Tokens.AppContextSwitches.UseCaseSensitivePClaimComparisonDefault = false -> bool
+*REMOVED*const Microsoft.IdentityModel.Tokens.AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch = "Switch.Microsoft.IdentityModel.SignedHttpRequest.UseCaseSensitivePClaimComparison" -> string
+*REMOVED*static Microsoft.IdentityModel.Tokens.AppContextSwitches.UseCaseSensitivePClaimComparison.get -> bool

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestConfigurationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestConfigurationTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
+{
+    public class SignedHttpRequestConfigurationTests
+    {
+        [Fact]
+        public void UseCaseSensitivePClaimComparison_DefaultsToCaseInsensitiveComparison()
+        {
+            // Arrange and Act
+            var validationParameters = new SignedHttpRequestValidationParameters();
+
+            // Assert
+            Assert.False(SignedHttpRequestValidationParameters.DefaultUseCaseSensitivePClaimComparison);
+            Assert.False(validationParameters.UseCaseSensitivePClaimComparison);
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public async Task ValidateSignedHttpRequestAsync_UsesExplicitPathComparisonConfiguration(
+            bool useCaseSensitiveComparison,
+            bool expectedValid)
+        {
+            // Arrange
+            var validationParameters = CreatePathValidationParameters(useCaseSensitiveComparison);
+            var validationContext = CreateValidationContext(validationParameters);
+            var handler = new SignedHttpRequestHandler();
+
+            // Act
+            var result = await handler.ValidateSignedHttpRequestAsync(validationContext, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(expectedValid, result.IsValid);
+            if (expectedValid)
+                Assert.Null(result.Exception);
+            else
+                Assert.IsType<SignedHttpRequestInvalidPClaimException>(result.Exception);
+        }
+
+        [Fact]
+        public async Task ValidateSignedHttpRequestAsync_DefaultContextUsesDefaultPathComparison()
+        {
+            // Arrange
+            var signedHttpRequest = CreateSignedHttpRequestWithPath("/Path1");
+            var httpRequestData = CreateHttpRequestData();
+            var validationContext = new SignedHttpRequestValidationContext(
+                signedHttpRequest,
+                httpRequestData,
+                SignedHttpRequestTestUtils.DefaultTokenValidationParameters);
+            var handler = new SignedHttpRequestHandler();
+
+            // Act
+            var result = await handler.ValidateSignedHttpRequestAsync(validationContext, CancellationToken.None);
+
+            // Assert
+            Assert.False(validationContext.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison);
+            Assert.True(result.IsValid);
+            Assert.Null(result.Exception);
+        }
+
+        private static SignedHttpRequestValidationParameters CreatePathValidationParameters(bool useCaseSensitiveComparison)
+        {
+            return new SignedHttpRequestValidationParameters
+            {
+                UseCaseSensitivePClaimComparison = useCaseSensitiveComparison,
+                ValidateB = false,
+                ValidateH = false,
+                ValidateM = false,
+                ValidateP = true,
+                ValidateQ = false,
+                ValidateTs = false,
+                ValidateU = false
+            };
+        }
+
+        private static SignedHttpRequestValidationContext CreateValidationContext(
+            SignedHttpRequestValidationParameters validationParameters)
+        {
+            return new SignedHttpRequestValidationContext(
+                CreateSignedHttpRequestWithPath("/Path1"),
+                CreateHttpRequestData(),
+                SignedHttpRequestTestUtils.DefaultTokenValidationParameters,
+                validationParameters);
+        }
+
+        private static HttpRequestData CreateHttpRequestData()
+        {
+            return new HttpRequestData
+            {
+                Method = "GET",
+                Uri = new Uri("https://www.contoso.com/path1")
+            };
+        }
+
+        private static string CreateSignedHttpRequestWithPath(string path)
+        {
+            return SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(
+                new JProperty(SignedHttpRequestClaimTypes.P, path)).EncodedToken;
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -319,7 +319,6 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         }
 
         [Theory, MemberData(nameof(ValidatePClaimTheoryData), DisableDiscoveryEnumeration = true)]
-        [ResetAppContextSwitches]
         public void ValidatePClaim(ValidateSignedHttpRequestTheoryData theoryData)
         {
             var context = TestUtilities.WriteHeader($"{this}.ValidatePClaim", theoryData);
@@ -339,42 +338,43 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         }
 
         [Fact]
-        [ResetAppContextSwitches]
-        public void ValidatePClaim_IsCaseInsensitive_WhenSwitchDisabled()
+        public void ValidatePClaim_IsCaseInsensitive_WhenConfigurationDisabled()
         {
-            // Arrange - request path and signed 'p' claim differ only by case; disable the switch to select the case-insensitive (OrdinalIgnoreCase) comparison, which is the default on the 8.x line.
-            AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, false);
+            // Arrange
             var handler = new SignedHttpRequestHandler();
             var theoryData = new ValidateSignedHttpRequestTheoryData
             {
                 HttpRequestUri = new Uri("https://www.contoso.com/path1"),
                 SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/Path1")),
             };
+            theoryData.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison = false;
             var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
 
-            // Act - with the switch disabled the comparison is case-insensitive (OrdinalIgnoreCase).
+            // Act
             var exception = Record.Exception(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
 
-            // Assert - the case-only mismatch is accepted.
+            // Assert
             Assert.Null(exception);
         }
 
         [Fact]
-        [ResetAppContextSwitches]
-        public void ValidatePClaim_IsCaseSensitive_WhenSwitchEnabled()
+        public void ValidatePClaim_IsCaseSensitive_WhenConfigurationEnabled()
         {
-            // Arrange - request path and signed 'p' claim differ only by case; enable the switch to opt in to the case-sensitive (Ordinal) comparison (not the default on the 8.x line).
-            AppContext.SetSwitch(AppContextSwitches.UseCaseSensitivePClaimComparisonSwitch, true);
+            // Arrange
             var handler = new SignedHttpRequestHandler();
             var theoryData = new ValidateSignedHttpRequestTheoryData
             {
                 HttpRequestUri = new Uri("https://www.contoso.com/path1"),
                 SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/Path1")),
             };
+            theoryData.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison = true;
             var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
 
-            // Act & Assert - with the switch enabled the comparison is ordinal (case-sensitive), so the case-only mismatch is rejected.
-            Assert.Throws<SignedHttpRequestInvalidPClaimException>(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
+            // Act
+            var exception = Assert.Throws<SignedHttpRequestInvalidPClaimException>(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
+
+            // Assert
+            Assert.Contains("IDX23011", exception.Message);
         }
 
         public static TheoryData<ValidateSignedHttpRequestTheoryData> ValidatePClaimTheoryData


### PR DESCRIPTION
Backports #3569 to 8.x.

Moves Signed HTTP Request `p` claim path-comparison configuration to `SignedHttpRequestValidationParameters` and removes the AppContext configuration path.

On 8.x, `UseCaseSensitivePClaimComparison` defaults to `false`, preserving case-insensitive comparison unless a caller explicitly opts into case-sensitive comparison.

Tests cover the 8.x default, both explicit comparison modes, and the public validation flow.