### PR TITLE
Backport SHR p-claim percent-encoding hex case handling to dev8x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See the [releases](https://github.com/AzureAD/azure-activedirectory-identitymode
   See PR [#2377](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/2377) for details.
 
 ## Bug Fixes
+- Normalize hexadecimal letter casing inside percent-encoded triplets during Signed HTTP Request `p` claim validation. Literal path-letter comparison remains controlled by `UseCaseSensitivePClaimComparison`, and `p` claim creation output is unchanged.
 - **Sanitize logs to avoid leaking sensitive data**  
   Updated logging to sanitize sensitive values, reducing the risk of inadvertently exposing secrets or PII in logs.  
   See PR [#3316](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3316) for details.

--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -825,16 +825,27 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
             if (!signedHttpRequest.TryGetPayloadValue(SignedHttpRequestClaimTypes.P, out string pClaimValue) || pClaimValue == null)
                 throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(LogMessages.IDX23003, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P))));
 
-            // relax comparison by trimming start and ending forward slashes
-            pClaimValue = pClaimValue.Trim('/');
-            var expectedPClaimValue = httpRequestUri.AbsolutePath.Trim('/');
+            // Relax comparison by trimming start and ending forward slashes without allocating new strings.
+            ReadOnlySpan<char> pClaimValueSpan = pClaimValue.AsSpan().Trim('/');
+            ReadOnlySpan<char> expectedPClaimValueSpan = httpRequestUri.AbsolutePath.AsSpan().Trim('/');
 
             // URI path components are case-sensitive per RFC 3986 section 3.3. On the 8.x line this stricter comparison is opt-in.
             var comparison = signedHttpRequestValidationContext.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison
                 ? StringComparison.Ordinal
                 : StringComparison.OrdinalIgnoreCase;
-            if (!string.Equals(expectedPClaimValue, pClaimValue, comparison))
-                throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(LogMessages.IDX23011, LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P), expectedPClaimValue, pClaimValue)));
+            if (expectedPClaimValueSpan.Equals(pClaimValueSpan, comparison))
+                return;
+
+            // RFC 3986 requires an additional check because ordinal comparison distinguishes equivalent percent-encoded hexadecimal casing.
+            if (comparison == StringComparison.Ordinal &&
+                ArePClaimValuesEqual(expectedPClaimValueSpan, pClaimValueSpan))
+                return;
+
+            throw LogHelper.LogExceptionMessage(new SignedHttpRequestInvalidPClaimException(LogHelper.FormatInvariant(
+                LogMessages.IDX23011,
+                LogHelper.MarkAsNonPII(SignedHttpRequestClaimTypes.P),
+                expectedPClaimValueSpan.ToString(),
+                pClaimValueSpan.ToString())));
         }
 
         /// <summary>
@@ -1290,6 +1301,52 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
 #endif
 
             return Base64UrlEncoder.Encode(hashedBytes);
+        }
+
+        // Compares p-claim path values ordinally while ignoring hexadecimal letter casing
+        // only within aligned, valid percent-encoded triplets. The triplets are not decoded:
+        // "foo%2Fbar" equals "foo%2fbar", but "foo%2Fbar" does not equal "foo/bar",
+        // and malformed "foo%2Gbar" does not equal "foo%2gbar".
+        private static bool ArePClaimValuesEqual(ReadOnlySpan<char> expectedValue, ReadOnlySpan<char> actualValue)
+        {
+            if (expectedValue.Length != actualValue.Length)
+                return false;
+
+            for (int i = 0; i < expectedValue.Length; i++)
+            {
+                if (expectedValue[i] == '%' &&
+                    actualValue[i] == '%' &&
+                    i + 2 < expectedValue.Length)
+                {
+                    char expectedFirstHexCharacter = expectedValue[i + 1];
+                    char expectedSecondHexCharacter = expectedValue[i + 2];
+                    char actualFirstHexCharacter = actualValue[i + 1];
+                    char actualSecondHexCharacter = actualValue[i + 2];
+
+                    if (Uri.IsHexDigit(expectedFirstHexCharacter) &&
+                        Uri.IsHexDigit(expectedSecondHexCharacter) &&
+                        Uri.IsHexDigit(actualFirstHexCharacter) &&
+                        Uri.IsHexDigit(actualSecondHexCharacter))
+                    {
+                        // RFC 3986 section 6.2.2.1 defines uppercase hexadecimal letters as the canonical form for percent-encoded triplets.
+                        if (char.ToUpperInvariant(expectedFirstHexCharacter) != char.ToUpperInvariant(actualFirstHexCharacter) ||
+                            char.ToUpperInvariant(expectedSecondHexCharacter) != char.ToUpperInvariant(actualSecondHexCharacter))
+                        {
+                            return false;
+                        }
+
+                        i += 2;
+                        continue;
+                    }
+                }
+
+                if (expectedValue[i] != actualValue[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestCreationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestCreationTests.cs
@@ -449,6 +449,24 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                         ExpectedClaimValue = $@"{{""p"":""/pa%20th1""}}",
                         HttpRequestUri = new Uri("http://www.contoso.com:81/pa th1")
                     },
+                    new CreateSignedHttpRequestTheoryData("ValidPLowerHexPreserved")
+                    {
+                        ExpectedClaim = SignedHttpRequestClaimTypes.P,
+                        ExpectedClaimValue = $@"{{""p"":""/foo%2fbar""}}",
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2fbar")
+                    },
+                    new CreateSignedHttpRequestTheoryData("ValidPUpperHexPreserved")
+                    {
+                        ExpectedClaim = SignedHttpRequestClaimTypes.P,
+                        ExpectedClaimValue = $@"{{""p"":""/foo%2Fbar""}}",
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar")
+                    },
+                    new CreateSignedHttpRequestTheoryData("ValidPDoubleEncodingPreserved")
+                    {
+                        ExpectedClaim = SignedHttpRequestClaimTypes.P,
+                        ExpectedClaimValue = $@"{{""p"":""/foo%252Fbar""}}",
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%252Fbar")
+                    },
                     new CreateSignedHttpRequestTheoryData("NoPath")
                     {
                         ExpectedClaim = SignedHttpRequestClaimTypes.P,

--- a/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests/SignedHttpRequestValidationTests.cs
@@ -340,12 +340,12 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         [Fact]
         public void ValidatePClaim_IsCaseInsensitive_WhenConfigurationDisabled()
         {
-            // Arrange
+            // Arrange - request path and signed 'p' claim differ by literal case and percent-triplet hex case.
             var handler = new SignedHttpRequestHandler();
             var theoryData = new ValidateSignedHttpRequestTheoryData
             {
-                HttpRequestUri = new Uri("https://www.contoso.com/path1"),
-                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/Path1")),
+                HttpRequestUri = new Uri("https://www.contoso.com/Foo%2Fbar"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
             };
             theoryData.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison = false;
             var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
@@ -360,12 +360,12 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
         [Fact]
         public void ValidatePClaim_IsCaseSensitive_WhenConfigurationEnabled()
         {
-            // Arrange
+            // Arrange - request path and signed 'p' claim differ by literal case and percent-triplet hex case.
             var handler = new SignedHttpRequestHandler();
             var theoryData = new ValidateSignedHttpRequestTheoryData
             {
-                HttpRequestUri = new Uri("https://www.contoso.com/path1"),
-                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/Path1")),
+                HttpRequestUri = new Uri("https://www.contoso.com/Foo%2Fbar"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
             };
             theoryData.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison = true;
             var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
@@ -375,6 +375,76 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
 
             // Assert
             Assert.Contains("IDX23011", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("/path", "/path", true, true)]
+        [InlineData("/path", "/path", false, true)]
+        [InlineData("/foo%2Fbar", "/foo%2Fbar", true, true)]
+        [InlineData("/foo%2Fbar", "/foo%2fbar", true, true)]
+        [InlineData("/foo%2Fbar", "/foo%3Fbar", true, false)]
+        [InlineData("/foo%2Fbar%ABbaz", "/foo%2fbar%abbaz", true, true)]
+        [InlineData("/foo%2fbar", "/foo%2fbar", false, true)]
+        [InlineData("/caf%C3%A9", "/caf%c3%a9", true, true)]
+        [InlineData("/caf%C3%A9", "/caf%c3%a9", false, true)]
+        [InlineData("/Path", "/path", true, false)]
+        [InlineData("/Path", "/path", false, true)]
+        [InlineData("/path", "/paths", true, false)]
+        [InlineData("/foo%25", "/foo%", true, false)]
+        [InlineData("/foo%25X", "/foo%X", false, false)]
+        [InlineData("/foo%252G", "/foo%2G", true, false)]
+        [InlineData("/foo%252Gbar", "/foo%252gbar", true, false)]
+        [InlineData("/foo%252Gbar", "/foo%252gbar", false, true)]
+        [InlineData("/foo%BAr", "/foo%bar", true, true)]
+        [InlineData("/foo%25bar", "/foo%bar", true, false)]
+        [InlineData("/foo%2Fbar", "/foo/bar", true, false)]
+        [InlineData("/fooABC", "/fooAB%", false, false)]
+        [InlineData("/fooABCD", "/fooAB%2", false, false)]
+        public void ValidatePClaim_ComparisonMatrix(string requestPath, string pClaim, bool useCaseSensitiveComparison, bool expectedValid)
+        {
+            // Arrange
+            var handler = new SignedHttpRequestHandler();
+            var theoryData = new ValidateSignedHttpRequestTheoryData
+            {
+                HttpRequestUri = new Uri($"https://www.contoso.com{requestPath}"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, pClaim)),
+            };
+            theoryData.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison = useCaseSensitiveComparison;
+            var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
+
+            // Act
+            var exception = Record.Exception(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
+
+            // Assert
+            if (expectedValid)
+                Assert.Null(exception);
+            else
+                Assert.IsType<SignedHttpRequestInvalidPClaimException>(exception);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ValidatePClaim_PreservesPercentEncodingHexCaseInException(bool useCaseSensitiveComparison)
+        {
+            // Arrange
+            var handler = new SignedHttpRequestHandler();
+            var theoryData = new ValidateSignedHttpRequestTheoryData
+            {
+                HttpRequestUri = new Uri("https://www.contoso.com/Expected%2fPath"),
+                SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/Actual%2aPath")),
+            };
+            theoryData.SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison = useCaseSensitiveComparison;
+            var signedHttpRequestValidationContext = theoryData.BuildSignedHttpRequestValidationContext();
+
+            // Act
+            var exception = Assert.Throws<SignedHttpRequestInvalidPClaimException>(() => handler.ValidatePClaim(theoryData.SignedHttpRequestToken, signedHttpRequestValidationContext));
+
+            // Assert
+            Assert.Contains("Expected%2fPath", exception.Message);
+            Assert.Contains("Actual%2aPath", exception.Message);
+            Assert.DoesNotContain("Expected%2FPath", exception.Message);
+            Assert.DoesNotContain("Actual%2APath", exception.Message);
         }
 
         public static TheoryData<ValidateSignedHttpRequestTheoryData> ValidatePClaimTheoryData
@@ -447,10 +517,107 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests
                     },
                     new ValidateSignedHttpRequestTheoryData
                     {
-                        // Percent-encoding hex case is preserved by Uri.AbsolutePath; equal hex case validates under the ordinal comparison.
+                        // Percent-encoding hex case is preserved by Uri.AbsolutePath; equal hex case validates directly.
                         HttpRequestUri = new Uri("https://www.contoso.com/foo%2fbar"),
                         SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
-                        TestId = "ValidPHexCaseMatch",
+                        TestId = "ValidPHexCaseMatchLower",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2fbar")),
+                        TestId = "ValidPHexCaseMismatchUpperRequest",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2Fbar")),
+                        TestId = "ValidPHexCaseMismatchLowerRequest",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%ABbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%aBbar")),
+                        TestId = "ValidPMixedHexCase",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar%2Fbaz"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2Fbar%2fbaz")),
+                        TestId = "ValidPMultipleTripletsMixedHexCase",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%2Fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo/bar")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPEncodedSlashVsLiteralSlash",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo/bar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2Fbar")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPLiteralSlashVsEncodedSlash",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%25bar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%25bar")),
+                        TestId = "ValidPEncodedPercent",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%252Fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%252Fbar")),
+                        TestId = "ValidPDoubleEncodedSlash",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%252Fbar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2Fbar")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPDoubleEncodedVsSingleEncoded",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%25"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPTrailingPercent",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%252"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%2")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPTruncatedTriplet",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%25zz"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%zz")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPNonHexTriplet",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/foo%25bar"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/foo%bar")),
+                        ExpectedException = new ExpectedException(typeof(SignedHttpRequestInvalidPClaimException), "IDX23011"),
+                        TestId = "InvalidPValidLowerHexDifferentOctet",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, "/")),
+                        TestId = "ValidPRootSlash",
+                    },
+                    new ValidateSignedHttpRequestTheoryData
+                    {
+                        HttpRequestUri = new Uri("https://www.contoso.com/"),
+                        SignedHttpRequestToken = SignedHttpRequestTestUtils.ReplaceOrAddPropertyAndCreateDefaultSignedHttpRequest(new JProperty(SignedHttpRequestClaimTypes.P, string.Empty)),
+                        TestId = "ValidPRootEmptyClaim",
                     },
                     new ValidateSignedHttpRequestTheoryData
                     {


### PR DESCRIPTION
## Summary

Backports #3561 to the dev8x branch.

- treats hexadecimal letters inside valid percent-encoded triplets as case-insensitive during SHR p claim validation
- preserves the 8.x default for literal path casing through UseCaseSensitivePClaimComparison
- keeps encoded characters distinct from literal delimiters and preserves p claim creation output
- includes the corresponding validation and creation tests

Replaces the fork-based PR #3578.

## Testing

- Targeted ValidatePClaim and CreatePClaim tests pass on .NET 8 and 10 (66 tests per target)
- .NET 6 and 9 require CI because those runtimes are not installed locally
- .NET Framework targets require an environment configured for delay-signed assembly verification