### PR TITLE
Propagate caller cancellation when retrieving OIDC configuration

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager.cs
@@ -25,11 +25,13 @@ namespace Microsoft.IdentityModel.Protocols
         private DateTimeOffset _lastRequestRefresh = DateTimeOffset.MinValue;
         private bool _isFirstRefreshRequest = true;
         private readonly SemaphoreSlim _configurationNullLock = new SemaphoreSlim(1);
+        private readonly object _configurationTaskLock = new object();
 
         private readonly IDocumentRetriever _docRetriever;
         private readonly IConfigurationRetriever<T> _configRetriever;
         private readonly IConfigurationValidator<T> _configValidator;
         private T _currentConfiguration;
+        private Task<T> _configurationTask;
 
         // Tracks the most recent fetch failure for the blocking path. Promoted from a local in
         // GetConfigurationWithBlockingAsync so the original exception (e.g. an IOException carrying
@@ -188,6 +190,10 @@ namespace Microsoft.IdentityModel.Protocols
         /// <returns>Configuration of type <typeparamref name="T"/>.</returns>
         /// <remarks>
         /// <para>
+        /// Cancellation stops this caller from waiting for configuration. It does not cancel an in-progress
+        /// retrieval because the retrieved configuration is shared by all callers.
+        /// </para>
+        /// <para>
         /// If the time since the last call is less than <see cref="BaseConfigurationManager.AutomaticRefreshInterval"/>
         /// then <see cref="IConfigurationRetriever{T}.GetConfigurationAsync"/> is not called and the current Configuration is returned.
         /// By default, this method blocks until the configuration is retrieved the first time. After the configuration was retrieved once,
@@ -211,13 +217,61 @@ namespace Microsoft.IdentityModel.Protocols
             if (_currentConfiguration != null && _syncAfter > TimeProvider.GetUtcNow())
                 return _currentConfiguration;
 
-            if (AppContextSwitches.UpdateConfigAsBlocking)
-                return await GetConfigurationWithBlockingAsync(cancel).ConfigureAwait(false);
-            else
-                return await GetConfigurationNonBlockingAsync(cancel).ConfigureAwait(false);
+            Task<T> configurationTask;
+            lock (_configurationTaskLock)
+            {
+                if (_currentConfiguration != null && _syncAfter > TimeProvider.GetUtcNow())
+                    return _currentConfiguration;
+
+                if (_configurationTask == null || _configurationTask.IsCompleted)
+                {
+                    _configurationTask = AppContextSwitches.UpdateConfigAsBlocking
+                        ? GetConfigurationWithBlockingAsync()
+                        : GetConfigurationNonBlockingAsync();
+
+                    _ = _configurationTask.ContinueWith(
+                        static task => _ = task.Exception,
+                        CancellationToken.None,
+                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
+                }
+
+                configurationTask = _configurationTask;
+            }
+
+            return await WaitForConfigurationAsync(configurationTask, cancel).ConfigureAwait(false);
         }
 
-        private async Task<T> GetConfigurationNonBlockingAsync(CancellationToken cancel)
+        // VSTHRD003: WaitForConfigurationAsync intentionally awaits the shared, coalesced
+        // _configurationTask that was started by another caller. This is by design — the fetch is
+        // shared across all callers — and every await uses ConfigureAwait(false), so the deadlock
+        // scenario the analyzer guards against does not apply.
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+        private static async Task<T> WaitForConfigurationAsync(
+            Task<T> configurationTask,
+            CancellationToken cancellationToken)
+        {
+            if (!cancellationToken.CanBeCanceled || configurationTask.IsCompleted)
+                return await configurationTask.ConfigureAwait(false);
+
+            var cancellationCompletion = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            using (cancellationToken.Register(
+                state => ((TaskCompletionSource<bool>)state).TrySetResult(true),
+                cancellationCompletion))
+            {
+                await Task.WhenAny(configurationTask, cancellationCompletion.Task).ConfigureAwait(false);
+            }
+
+            if (configurationTask.IsCompleted)
+                return await configurationTask.ConfigureAwait(false);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return await configurationTask.ConfigureAwait(false);
+        }
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+
+        private async Task<T> GetConfigurationNonBlockingAsync()
         {
             Exception fetchMetadataFailure = null;
 
@@ -230,7 +284,7 @@ namespace Microsoft.IdentityModel.Protocols
             //   else kick off task to update current configuration
             if (_currentConfiguration == null)
             {
-                await _configurationNullLock.WaitAsync(cancel).ConfigureAwait(false);
+                await _configurationNullLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
                 if (_currentConfiguration != null)
                 {
                     _configurationNullLock.Release();
@@ -245,7 +299,9 @@ namespace Microsoft.IdentityModel.Protocols
                     // If provided configuration is valid, skip regular retriaval process and update current configuration.
                     if (ConfigurationEventHandler != null)
                     {
-                        var configurationRetrieved = await HandleBeforeRetrieveAsync(retrievalContext, cancel).ConfigureAwait(false);
+                        var configurationRetrieved = await HandleBeforeRetrieveAsync(
+                            retrievalContext,
+                            CancellationToken.None).ConfigureAwait(false);
 
                         // replicate the behavior of successful retrieval from endpoint
                         if (configurationRetrieved != null && configurationRetrieved.Configuration != null)
@@ -260,8 +316,8 @@ namespace Microsoft.IdentityModel.Protocols
                         }
                     }
 
-                    // Don't use the individual CT here, this is a shared operation that shouldn't be affected by an individual's cancellation.
-                    // The transport should have its own timeouts, etc.
+                    // This fetch populates shared state and must outlive any individual caller.
+                    // Callers apply cancellation while awaiting the shared task.
                     T configuration = await _configRetriever.GetConfigurationAsync(
                         MetadataAddress,
                         _docRetriever,

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager_Blocking.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager_Blocking.cs
@@ -21,9 +21,9 @@ namespace Microsoft.IdentityModel.Protocols
         /// </summary>
         private bool _refreshRequested;
 
-        private async Task<T> GetConfigurationWithBlockingAsync(CancellationToken cancel)
+        private async Task<T> GetConfigurationWithBlockingAsync()
         {
-            await _refreshLock.WaitAsync(cancel).ConfigureAwait(false);
+            await _refreshLock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
 
             long startTimestamp = TimeProvider.GetTimestamp();
 
@@ -39,7 +39,9 @@ namespace Microsoft.IdentityModel.Protocols
                         if (ConfigurationEventHandler != null)
                         {
                             ConfigurationEventHandlerResult<T> configurationRetrieved =
-                                await HandleBeforeRetrieveAsync(retrievalContext, cancel).ConfigureAwait(false);
+                                await HandleBeforeRetrieveAsync(
+                                    retrievalContext,
+                                    CancellationToken.None).ConfigureAwait(false);
 
                             // replicate the behavior of successful retrieval from endpoint
                             if (configurationRetrieved != null && configurationRetrieved.Configuration != null)
@@ -57,9 +59,12 @@ namespace Microsoft.IdentityModel.Protocols
                             }
                         }
 
-                        // Don't use the individual CT here, this is a shared operation that shouldn't be affected by an individual's cancellation.
-                        // The transport should have it's own timeouts, etc..
-                        var configuration = await _configRetriever.GetConfigurationAsync(MetadataAddress, _docRetriever, CancellationToken.None).ConfigureAwait(false);
+                        // This fetch populates shared state and must outlive any individual caller.
+                        // Callers apply cancellation while awaiting the shared task.
+                        var configuration = await _configRetriever.GetConfigurationAsync(
+                            MetadataAddress,
+                            _docRetriever,
+                            CancellationToken.None).ConfigureAwait(false);
 
                         var elapsedTime = TimeProvider.GetElapsedTime(startTimestamp);
                         TelemetryClient.LogConfigurationRetrievalDuration(

--- a/src/Microsoft.IdentityModel.Protocols/Configuration/HttpDocumentRetriever.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/HttpDocumentRetriever.cs
@@ -126,7 +126,7 @@ namespace Microsoft.IdentityModel.Protocols
 
                 var httpClient = _httpClient ?? _defaultHttpClient;
                 var uri = new Uri(address, UriKind.RelativeOrAbsolute);
-                response = await SendAndRetryOnNetworkErrorAsync(httpClient, uri).ConfigureAwait(false);
+                response = await SendAndRetryOnNetworkErrorAsync(httpClient, uri, cancel).ConfigureAwait(false);
 
                 var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 if (response.IsSuccessStatusCode)
@@ -141,6 +141,10 @@ namespace Microsoft.IdentityModel.Protocols
 
                 unsuccessfulHttpResponseException.Data.Add(StatusCode, response.StatusCode);
                 unsuccessfulHttpResponseException.Data.Add(ResponseContent, responseContent);
+            }
+            catch (OperationCanceledException) when (cancel.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -179,7 +183,10 @@ namespace Microsoft.IdentityModel.Protocols
 #endif
         }
 
-        private async Task<HttpResponseMessage> SendAndRetryOnNetworkErrorAsync(HttpClient httpClient, Uri uri)
+        private async Task<HttpResponseMessage> SendAndRetryOnNetworkErrorAsync(
+            HttpClient httpClient,
+            Uri uri,
+            CancellationToken cancellationToken)
         {
             int maxAttempt = 2;
             HttpResponseMessage response = null;
@@ -193,7 +200,7 @@ namespace Microsoft.IdentityModel.Protocols
                     if (SendAdditionalHeaderData)
                         IdentityModelTelemetryUtil.SetTelemetryData(message, AdditionalHeaderData);
 
-                    response = await httpClient.SendAsync(message).ConfigureAwait(false);
+                    response = await httpClient.SendAsync(message, cancellationToken).ConfigureAwait(false);
                     if (response.IsSuccessStatusCode)
                         return response;
 

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerTests.cs
@@ -174,6 +174,127 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             Assert.Equal(ConfigurationManager<OpenIdConnectConfiguration>.MinimumRefreshInterval, new TimeSpan(0, 0, 0, 1));
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task CallerCancellationDoesNotCancelSharedInitialRetrieval(bool blocking)
+        {
+            // Arrange
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, blocking);
+            var configurationRetriever = new CancelableConfigurationRetriever();
+            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                "https://example.com/.well-known/openid-configuration",
+                configurationRetriever,
+                new FileDocumentRetriever());
+            using var cancellationTokenSource = new CancellationTokenSource();
+
+            // Act
+            Task<OpenIdConnectConfiguration> canceledCallerTask =
+                configurationManager.GetConfigurationAsync(cancellationTokenSource.Token);
+            Assert.Equal(1, configurationRetriever.CallCount);
+            cancellationTokenSource.Cancel();
+
+            try
+            {
+                Task completedTask = await Task.WhenAny(
+                    canceledCallerTask,
+                    Task.Delay(TimeSpan.FromSeconds(5)));
+
+                Assert.Same(canceledCallerTask, completedTask);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledCallerTask);
+
+                Task<OpenIdConnectConfiguration> secondCallerTask =
+                    configurationManager.GetConfigurationAsync(CancellationToken.None);
+
+                Assert.Equal(1, configurationRetriever.CallCount);
+
+                configurationRetriever.Release();
+                OpenIdConnectConfiguration configuration = await secondCallerTask;
+
+                // Assert
+                Assert.NotNull(configuration);
+                Assert.Equal(1, configurationRetriever.CallCount);
+                Assert.False(configurationRetriever.CancellationCanBeCanceled);
+            }
+            finally
+            {
+                configurationRetriever.Release();
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task OriginatingCallerCancellationDoesNotDisruptConcurrentSharedAwaiter(bool blocking)
+        {
+            // Arrange
+            AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, blocking);
+            var configurationRetriever = new CancelableConfigurationRetriever();
+            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                "https://example.com/.well-known/openid-configuration",
+                configurationRetriever,
+                new FileDocumentRetriever());
+            using var cancellationTokenSource = new CancellationTokenSource();
+
+            // Act - the originating caller kicks off (but does not own) the shared fetch.
+            Task<OpenIdConnectConfiguration> originatingCallerTask =
+                configurationManager.GetConfigurationAsync(cancellationTokenSource.Token);
+            Assert.Equal(1, configurationRetriever.CallCount);
+
+            // A second caller joins the SAME in-flight fetch before any cancellation occurs.
+            Task<OpenIdConnectConfiguration> concurrentCallerTask =
+                configurationManager.GetConfigurationAsync(CancellationToken.None);
+            Assert.Equal(1, configurationRetriever.CallCount);
+
+            // The originator cancels while the shared fetch is still running.
+            cancellationTokenSource.Cancel();
+
+            try
+            {
+                Task completedTask = await Task.WhenAny(
+                    originatingCallerTask,
+                    Task.Delay(TimeSpan.FromSeconds(5)));
+
+                // The originator returns promptly, observing only its own cancellation...
+                Assert.Same(originatingCallerTask, completedTask);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(() => originatingCallerTask);
+
+                // ...while the concurrent co-awaiter is unaffected and still awaiting the shared fetch.
+                Assert.False(concurrentCallerTask.IsCompleted);
+                Assert.Equal(1, configurationRetriever.CallCount);
+
+                // Completing the shared fetch serves the surviving co-awaiter with the shared result.
+                configurationRetriever.Release();
+                OpenIdConnectConfiguration configuration = await concurrentCallerTask;
+
+                // Assert
+                Assert.NotNull(configuration);
+                Assert.Equal(1, configurationRetriever.CallCount);
+                Assert.False(configurationRetriever.CancellationCanBeCanceled);
+            }
+            finally
+            {
+                configurationRetriever.Release();
+            }
+        }
+
+        [Fact]
+        public async Task InitialConfigurationTransportTimeoutIsHandledAsRetrievalFailure()
+        {
+            // Arrange
+            var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                "https://example.com/.well-known/openid-configuration",
+                new TransportTimeoutConfigurationRetriever(),
+                new FileDocumentRetriever());
+
+            // Act
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => configurationManager.GetConfigurationAsync(CancellationToken.None));
+
+            // Assert
+            Assert.IsType<TaskCanceledException>(exception.InnerException);
+        }
+
         [Fact]
         public async Task FetchMetadataFailureTest()
         {
@@ -1090,6 +1211,50 @@ namespace Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests
             }
 
             return false;
+        }
+
+        private sealed class CancelableConfigurationRetriever : IConfigurationRetriever<OpenIdConnectConfiguration>
+        {
+            private readonly TaskCompletionSource<object> _release =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private int _callCount;
+
+            public bool CancellationCanBeCanceled { get; private set; }
+
+            public int CallCount => Volatile.Read(ref _callCount);
+
+            public async Task<OpenIdConnectConfiguration> GetConfigurationAsync(
+                string address,
+                IDocumentRetriever retriever,
+                CancellationToken cancel)
+            {
+                Interlocked.Increment(ref _callCount);
+                CancellationCanBeCanceled = cancel.CanBeCanceled;
+
+                await Task.WhenAny(
+                    Task.Delay(Timeout.Infinite, cancel),
+                    _release.Task);
+
+                cancel.ThrowIfCancellationRequested();
+                return new OpenIdConnectConfiguration();
+            }
+
+            public void Release()
+            {
+                _release.TrySetResult(null);
+            }
+        }
+
+        private sealed class TransportTimeoutConfigurationRetriever : IConfigurationRetriever<OpenIdConnectConfiguration>
+        {
+            public Task<OpenIdConnectConfiguration> GetConfigurationAsync(
+                string address,
+                IDocumentRetriever retriever,
+                CancellationToken cancel)
+            {
+                return Task.FromException<OpenIdConnectConfiguration>(
+                    new TaskCanceledException("The HTTP transport timed out."));
+            }
         }
 
         public static TheoryData<ConfigurationManagerTheoryData<OpenIdConnectConfiguration>> ValidateOpenIdConnectConfigurationTestCases

--- a/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.Tests/HttpDocumentRetrieverTests.cs
@@ -34,6 +34,68 @@ namespace Microsoft.IdentityModel.Protocols.Tests
         }
 
         [Fact]
+        public async Task GetDocumentAsyncHonorsCancellation()
+        {
+            // Arrange
+            var release = new TaskCompletionSource<HttpResponseMessage>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var callback = new Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>(
+                async (_, cancellationToken) =>
+                {
+                    await Task.WhenAny(
+                        Task.Delay(Timeout.Infinite, cancellationToken),
+                        release.Task);
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return await release.Task;
+                });
+
+            using var httpClient = new HttpClient(new DelegateHttpMessageHandler(callback));
+            var documentRetriever = new HttpDocumentRetriever(httpClient);
+            using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+            // Act
+            Task<string> retrievalTask = documentRetriever.GetDocumentAsync(
+                "https://localhost",
+                cancellationTokenSource.Token);
+            Task completedTask;
+            try
+            {
+                completedTask = await Task.WhenAny(retrievalTask, Task.Delay(TimeSpan.FromSeconds(5)));
+            }
+            finally
+            {
+                release.TrySetResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(string.Empty)
+                });
+            }
+
+            // Assert
+            Assert.Same(retrievalTask, completedTask);
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => retrievalTask);
+        }
+
+        [Fact]
+        public async Task GetDocumentAsyncWrapsTransportTimeout()
+        {
+            // Arrange
+            var callback = new Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>(
+                (_, _) => Task.FromException<HttpResponseMessage>(
+                    new TaskCanceledException("The HTTP transport timed out.")));
+
+            using var httpClient = new HttpClient(new DelegateHttpMessageHandler(callback));
+            var documentRetriever = new HttpDocumentRetriever(httpClient);
+
+            // Act
+            IOException exception = await Assert.ThrowsAsync<IOException>(
+                () => documentRetriever.GetDocumentAsync("https://localhost", CancellationToken.None));
+
+            // Assert
+            Assert.IsType<TaskCanceledException>(exception.InnerException);
+        }
+
+        [Fact]
         public void GetSets()
         {
             HttpDocumentRetriever docRetriever = new HttpDocumentRetriever();


### PR DESCRIPTION
## Problem

`ConfigurationManager<T>.GetConfigurationAsync(cancel)` dropped the caller's `CancellationToken` to `CancellationToken.None` for the shared initial retrieval, so the token had no effect. A caller that supplied a cancelable token (e.g. one with a deadline) could never abort a slow or hung metadata fetch - it would hang until the underlying request completed on its own, regardless of the token.

## Fix

Separate *who is waiting* from *the shared work*:

- Concurrent callers are coalesced onto a single shared `_configurationTask` under a lightweight lock (behind a lock-free fast path; no I/O held under the lock).
- Callers await via `WaitForConfigurationAsync(task, cancel)`, which honors each caller's token (`Task.WhenAny` + `CancellationToken.Register`) and then `ThrowIfCancellationRequested()`.
- The shared fetch still runs with `CancellationToken.None`, so it outlives any individual caller — one caller cancelling never disrupts the fetch or other awaiters.
- `HttpDocumentRetriever` now re-throws only caller-requested cancellation; transport/`HttpClient` timeouts are still wrapped as `IOException`.

Not a breaking change to the shared-fetch contract; both blocking and non-blocking paths are covered.

## Tests

- Caller cancellation does not cancel the shared retrieval (blocking + non-blocking).
- The originating caller cancels promptly while a concurrent co-awaiter still gets the config.
- Shared fetch is invoked with a non-cancelable token.
- `HttpDocumentRetriever` re-throws caller cancellation instead of wrapping as `IOException`.