### PR TITLE
Fix Inconsistent Manual Request Refresh Throttling

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager_Blocking.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Configuration/ConfigurationManager_Blocking.cs
@@ -74,8 +74,6 @@ namespace Microsoft.IdentityModel.Protocols
                                 throw LogHelper.LogExceptionMessage(new InvalidConfigurationException(LogHelper.FormatInvariant(LogMessages.IDX20810, result.ErrorMessage)));
                         }
 
-                        _lastRequestRefresh = TimeProvider.GetUtcNow().UtcDateTime;
-
                         TelemetryForUpdateBlocking(TelemetryConstants.Protocols.ConfigurationSourceRetriever);
 
                         if (_refreshRequested)
@@ -157,12 +155,13 @@ namespace Microsoft.IdentityModel.Protocols
 
         private void RequestRefreshBlocking()
         {
-            DateTime now = TimeProvider.GetUtcNow().UtcDateTime;
+            DateTimeOffset now = TimeProvider.GetUtcNow();
 
             if (now >= DateTimeUtil.Add(_lastRequestRefresh.UtcDateTime, RefreshInterval) || _isFirstRefreshRequest)
             {
                 _refreshRequested = true;
                 _syncAfter = now;
+                _lastRequestRefresh = now;
                 _isFirstRefreshRequest = false;
             }
         }

--- a/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerBlockingEventHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.Protocols.OpenIdConnect.Tests/ConfigurationManagerBlockingEventHandlerTests.cs
@@ -495,6 +495,52 @@ public class ConfigurationManagerBlockingEventHandlerTests
     }
 
     [Fact]
+    public async Task Blocking_RequestRefresh_IsThrottledFromAcceptedRequest()
+    {
+        // Arrange
+        AppContext.SetSwitch(AppContextSwitches.UpdateConfigAsBlockingSwitch, true);
+
+        var timeProvider = new FakeTimeProvider();
+        var mockEventHandler = new MockConfigurationEventHandlerContextAware
+        {
+            ConfigurationToReturn = new OpenIdConnectConfiguration { Issuer = "https://test.issuer.com" },
+            RetrievalTimeToReturn = timeProvider.GetUtcNow()
+        };
+        var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+            "OpenIdConnectMetadata.json",
+            new OpenIdConnectConfigurationRetriever(),
+            new FileDocumentRetriever())
+        {
+            ConfigurationEventHandler = mockEventHandler,
+            TimeProvider = timeProvider
+        };
+
+        await configurationManager.GetConfigurationAsync();
+
+        // Act - consume the first accepted manual refresh.
+        configurationManager.RequestRefresh();
+        await configurationManager.GetConfigurationAsync();
+
+        mockEventHandler.ContextAwareBeforeRetrieveAsyncCalled = false;
+        mockEventHandler.LastContext = null;
+
+        // A second request inside RefreshInterval should be ignored.
+        configurationManager.RequestRefresh();
+        await configurationManager.GetConfigurationAsync();
+
+        // Assert
+        Assert.False(mockEventHandler.ContextAwareBeforeRetrieveAsyncCalled);
+
+        // A request after RefreshInterval should be accepted.
+        timeProvider.Advance(configurationManager.RefreshInterval + TimeSpan.FromSeconds(1));
+        configurationManager.RequestRefresh();
+        await configurationManager.GetConfigurationAsync();
+
+        Assert.True(mockEventHandler.ContextAwareBeforeRetrieveAsyncCalled);
+        Assert.True(mockEventHandler.LastContext?.BypassCache);
+    }
+
+    [Fact]
     public async Task Blocking_MultipleRequestRefresh_OnlyOneBypassTrueRefreshFires()
     {
         // Arrange


### PR DESCRIPTION
# Fix Inconsistent Manual Request Refresh Throttling

The field `_lastRequestRefresh` is used to throttle manual `RequestRefresh()` requests to the `BaseConfigurationManager.MinimumRefreshInterval` property (default is 1 second)

The documentation for this property states `Minimum time interval (1 second) that must pass before calling RequestRefresh() to obtain new configuration.`

Currently, in blocking mode,  `_lastRequestRefresh`  was updated after successful configuration retrieval rather than when a manual refresh request was accepted.

This caused inconsistent behavior depending on how configuration was retrieved:
• Successful retrieval through the regular configuration retriever updated ` _lastRequestRefresh` .
• Successful retrieval through `IConfigurationEventHandler`  returned before updating  `_lastRequestRefresh`, noticed [here](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3567#discussion_r3741313381)
• Automatic and initial retrievals through the regular retriever could update the field even though no manual refresh was requested.
• Consequently, repeated manual requests could bypass throttling when an event handler supplied the configuration.

This PR moves updates to `_lastRequestRefresh` to `RequestRefresh()` call sites instead of in the configuration retrieval paths, so automatic retrievals do not affect request throttling.