### PR TITLE
Deserialize the RFC 8693 act claim on the ValidationParameters pipeline

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/Experimental/JsonWebTokenHandler.ClaimsIdentity.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Experimental/JsonWebTokenHandler.ClaimsIdentity.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security.Claims;
+using System.Text.Json;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens.Experimental;
@@ -64,28 +65,17 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             _ = validationParameters ?? throw LogHelper.LogArgumentNullException(nameof(validationParameters));
 
             ClaimsIdentity identity = validationParameters.CreateClaimsIdentity(jwtToken, issuer);
+
+            // Actor resolution is order-independent: "act" (RFC 8693 object) wins whenever present, otherwise
+            // the legacy "actort" (nested-JWT string) is expanded. The raw "act"/"actort" claims are still
+            // added as ordinary claims by the loop below.
+            identity.Actor = ResolveActorClaimsIdentity(jwtToken, validationParameters, issuer);
+
             foreach (Claim jwtClaim in jwtToken.Claims)
             {
                 bool wasMapped = _inboundClaimTypeMap.TryGetValue(jwtClaim.Type, out string? type);
 
                 string claimType = type ?? jwtClaim.Type;
-
-                if (claimType == ClaimTypes.Actor)
-                {
-                    if (identity.Actor != null)
-                        throw LogHelper.LogExceptionMessage(
-                            new InvalidOperationException(
-                                LogHelper.FormatInvariant(
-                                    LogMessages.IDX14112,
-                                    LogHelper.MarkAsNonPII(JwtRegisteredClaimNames.Actort),
-                                    jwtClaim.Value)));
-
-                    if (CanReadToken(jwtClaim.Value))
-                    {
-                        JsonWebToken? actor = ReadToken(jwtClaim.Value) as JsonWebToken;
-                        identity.Actor = CreateClaimsIdentity(actor, validationParameters);
-                    }
-                }
 
                 if (wasMapped)
                 {
@@ -115,25 +105,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             _ = validationParameters ?? throw LogHelper.LogArgumentNullException(nameof(validationParameters));
 
             ClaimsIdentity identity = validationParameters.CreateClaimsIdentity(jwtToken, issuer);
+
+            // Actor resolution is order-independent: "act" (RFC 8693 object) wins whenever present, otherwise
+            // the legacy "actort" (nested-JWT string) is expanded. The raw "act"/"actort" claims are still
+            // added as ordinary claims by the loop below.
+            identity.Actor = ResolveActorClaimsIdentity(jwtToken, validationParameters, issuer);
+
             foreach (Claim jwtClaim in jwtToken.Claims)
             {
                 string claimType = jwtClaim.Type;
-                if (claimType == ClaimTypes.Actor)
-                {
-                    if (identity.Actor != null)
-                        throw LogHelper.LogExceptionMessage(
-                            new InvalidOperationException(
-                                LogHelper.FormatInvariant(
-                                    LogMessages.IDX14112,
-                                    LogHelper.MarkAsNonPII(JwtRegisteredClaimNames.Actort),
-                                    jwtClaim.Value)));
-
-                    if (CanReadToken(jwtClaim.Value))
-                    {
-                        JsonWebToken? actor = ReadToken(jwtClaim.Value) as JsonWebToken;
-                        identity.Actor = CreateClaimsIdentity(actor, validationParameters, issuer);
-                    }
-                }
 
                 if (jwtClaim.Properties.Count == 0)
                 {
@@ -151,6 +131,82 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             }
 
             return identity;
+        }
+
+        // Resolves ClaimsIdentity.Actor on the result-based (ValidationParameters) pipeline. The RFC 8693
+        // "act" (JSON object) claim takes precedence whenever present; otherwise the legacy "actort" (an
+        // unsigned nested-JWT string) is expanded for read back-compatibility. This handler only reads
+        // "actort" - it never writes it. Having both "act" and "actort" is not an error: "act" wins and no
+        // exception is thrown.
+        private ClaimsIdentity? ResolveActorClaimsIdentity(JsonWebToken jwtToken, ValidationParameters validationParameters, string issuer)
+        {
+            // "act" (RFC 8693) takes precedence whenever present, in ANY form, and suppresses "actort".
+            // TryGetPayloadValue<JsonElement> succeeds only for JSON objects/arrays (object -> expanded;
+            // array -> the helper warns IDX14314 and yields null).
+            if (jwtToken.TryGetPayloadValue<JsonElement>(ActClaimType, out JsonElement actClaim))
+                return CreateActorClaimsIdentity(actClaim, validationParameters, issuer);
+
+            // "act" present but a primitive (string/number/bool): it cannot be expanded but still wins -
+            // warn IDX14314 and suppress "actort". The raw "act" value is retained as a claim by the caller.
+            if (jwtToken.HasPayloadClaim(ActClaimType))
+            {
+                LogHelper.LogWarning(LogMessages.IDX14314);
+                return null;
+            }
+
+            // Legacy fallback: "actort" is an unsigned nested JWT (not validated here, matching the classic
+            // behavior). Its chain depth is not bounded by MaxActorChainLength (that bounds "act" only).
+            if (jwtToken.TryGetPayloadValue<string>(JwtRegisteredClaimNames.Actort, out string actorToken)
+                && CanReadToken(actorToken)
+                && ReadToken(actorToken) is JsonWebToken actor)
+            {
+                return CreateClaimsIdentity(actor, validationParameters, GetActualIssuer(actor));
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ClaimsIdentity"/> from the RFC 8693 "act" (actor) claim element on the
+        /// result-based (<see cref="ValidationParameters"/>) pipeline.
+        /// </summary>
+        /// <param name="actClaim">The "act" claim element already retrieved from the token payload.</param>
+        /// <param name="validationParameters">The validation parameters.</param>
+        /// <param name="issuer">The outer token's validated issuer, stamped on the actor claims.</param>
+        /// <returns>
+        /// A <see cref="ClaimsIdentity"/> representing the actor, or <see langword="null"/> when the "act"
+        /// claim cannot be expanded into an actor identity.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="validationParameters"/> is null.</exception>
+        private static ClaimsIdentity? CreateActorClaimsIdentity(
+            JsonElement actClaim,
+            ValidationParameters validationParameters,
+            string issuer)
+        {
+            if (validationParameters is null)
+                throw LogHelper.LogArgumentNullException(nameof(validationParameters));
+
+            // When a custom retriever is supplied it fully owns actor construction; it is invoked
+            // unconditionally (never gated by MaxActorChainLength) and its result is used as-is.
+            if (validationParameters.ActClaimRetriever is not null)
+            {
+                try
+                {
+                    return validationParameters.ActClaimRetriever(actClaim, validationParameters);
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception ex)
+                {
+                    // A failing retriever must not fail token validation. Warn (PII-scrubbed by default) and
+                    // leave Actor unset; the raw "act" claim is still retained on the identity.
+                    LogHelper.LogWarning(LogMessages.IDX14313, ex);
+                    return null;
+                }
+#pragma warning restore CA1031 // Do not catch general exception types
+            }
+
+            // Default expansion via the shared helper (bounded by MaxActorChainLength).
+            return CreateActorClaimsIdentityFromJsonElement(actClaim, issuer);
         }
     }
 }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/InternalAPI.Shipped.txt
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/InternalAPI.Shipped.txt
@@ -6,7 +6,6 @@ const Microsoft.IdentityModel.JsonWebTokens.LogMessages.IDX14101 = "IDX14101: Un
 const Microsoft.IdentityModel.JsonWebTokens.LogMessages.IDX14102 = "IDX14102: Unable to decode the header '{0}' as Base64Url encoded string." -> string
 const Microsoft.IdentityModel.JsonWebTokens.LogMessages.IDX14103 = "IDX14103: Failed to create the token encryption provider." -> string
 const Microsoft.IdentityModel.JsonWebTokens.LogMessages.IDX14107 = "IDX14107: Token string does not match the token formats: JWE (header.encryptedKey.iv.ciphertext.tag) or JWS (header.payload.signature)" -> string
-const Microsoft.IdentityModel.JsonWebTokens.LogMessages.IDX14112 = "IDX14112: Only a single 'Actor' is supported. Found second claim of type: '{0}'" -> string
 const Microsoft.IdentityModel.JsonWebTokens.LogMessages.IDX14113 = "IDX14113: A duplicate value for 'SecurityTokenDescriptor.{0}' exists in 'SecurityTokenDescriptor.Claims'. \nThe value of 'SecurityTokenDescriptor.{0}' is used." -> string
 const Microsoft.IdentityModel.JsonWebTokens.LogMessages.IDX14114 = "IDX14114: Both '{0}.{1}' and '{0}.{2}' are null or empty." -> string
 const Microsoft.IdentityModel.JsonWebTokens.LogMessages.IDX14116 = "IDX14116: '{0}' cannot contain the following claims: '{1}'. These values are added by default (if necessary) during security token creation." -> string

--- a/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/LogMessages.cs
@@ -23,7 +23,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
         // internal const string IDX14106 = "IDX14106:";
         internal const string IDX14107 = "IDX14107: Token string does not match the token formats: JWE (header.encryptedKey.iv.ciphertext.tag) or JWS (header.payload.signature)";
         //internal const string IDX14111 = "IDX14111: JWT: '{0}' must have three segments (JWS) or five segments (JWE).";
-        internal const string IDX14112 = "IDX14112: Only a single 'Actor' is supported. Found second claim of type: '{0}'";
+        //internal const string IDX14112 = "IDX14112: Only a single 'Actor' is supported. Found second claim of type: '{0}'"; // Retired: duplicate act/actort members now collapse in the payload, so the duplicate-actor throw is unreachable.
         internal const string IDX14113 = "IDX14113: A duplicate value for 'SecurityTokenDescriptor.{0}' exists in 'SecurityTokenDescriptor.Claims'. \nThe value of 'SecurityTokenDescriptor.{0}' is used.";
         internal const string IDX14114 = "IDX14114: Both '{0}.{1}' and '{0}.{2}' are null or empty.";
         // internal const string IDX14115 = "IDX14115:";

--- a/src/Microsoft.IdentityModel.Tokens/Experimental/Validation/ValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Experimental/Validation/ValidationParameters.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Security.Claims;
+using System.Text.Json;
 using System.Threading;
 using Microsoft.IdentityModel.Logging;
 
@@ -66,6 +67,7 @@ namespace Microsoft.IdentityModel.Tokens.Experimental
                 throw LogHelper.LogExceptionMessage(new ArgumentNullException(nameof(other)));
 
             ActorValidationParameters = other.ActorValidationParameters;
+            ActClaimRetriever = other.ActClaimRetriever;
             AlgorithmValidator = other.AlgorithmValidator;
             AudienceValidator = other.AudienceValidator;
             _authenticationType = other._authenticationType;
@@ -118,6 +120,19 @@ namespace Microsoft.IdentityModel.Tokens.Experimental
         /// Gets or sets <see cref="ValidationParameters"/>.
         /// </summary>
         public ValidationParameters? ActorValidationParameters { get; set; }
+
+        /// <summary>
+        /// Gets or sets a delegate that, when set, fully owns construction of the actor
+        /// <see cref="ClaimsIdentity"/> from the RFC 8693 "act" claim's <see cref="JsonElement"/>.
+        /// </summary>
+        /// <remarks>
+        /// When supplied, the delegate is invoked instead of the default "act" expansion and its result is
+        /// used as <see cref="ClaimsIdentity.Actor"/> as-is (it is not bounded by the handler's
+        /// MaxActorChainLength). A delegate that throws does not fail token validation: the failure is logged
+        /// (IDX14313, PII-scrubbed) and <see cref="ClaimsIdentity.Actor"/> is left null while the raw "act"
+        /// claim is retained.
+        /// </remarks>
+        public Func<JsonElement, ValidationParameters, ClaimsIdentity>? ActClaimRetriever { get; set; }
 
         /// <summary>
         /// Allows overriding the validator used to validate the cryptographic algorithm used.

--- a/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Tokens/PublicAPI.Unshipped.txt
@@ -110,6 +110,8 @@ Microsoft.IdentityModel.Tokens.Experimental.ValidationFailureType
 Microsoft.IdentityModel.Tokens.Experimental.ValidationFailureType.Name.get -> string!
 Microsoft.IdentityModel.Tokens.Experimental.ValidationFailureType.ValidationFailureType(string! name) -> void
 Microsoft.IdentityModel.Tokens.Experimental.ValidationParameters
+Microsoft.IdentityModel.Tokens.Experimental.ValidationParameters.ActClaimRetriever.get -> System.Func<System.Text.Json.JsonElement, Microsoft.IdentityModel.Tokens.Experimental.ValidationParameters!, System.Security.Claims.ClaimsIdentity!>?
+Microsoft.IdentityModel.Tokens.Experimental.ValidationParameters.ActClaimRetriever.set -> void
 Microsoft.IdentityModel.Tokens.Experimental.ValidationParameters.ActorValidationParameters.get -> Microsoft.IdentityModel.Tokens.Experimental.ValidationParameters?
 Microsoft.IdentityModel.Tokens.Experimental.ValidationParameters.ActorValidationParameters.set -> void
 Microsoft.IdentityModel.Tokens.Experimental.ValidationParameters.AlgorithmValidator.get -> Microsoft.IdentityModel.Tokens.Experimental.IAlgorithmValidator!

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/ActClaimTests/ActClaimExperimentalDeserializationTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/ActClaimTests/ActClaimExperimentalDeserializationTests.cs
@@ -1,0 +1,266 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Experimental;
+using Xunit;
+
+namespace Microsoft.IdentityModel.JsonWebTokens.Tests.ActClaimTests
+{
+    /// <summary>
+    /// Deserialization of the RFC 8693 "act" claim into <see cref="ClaimsIdentity.Actor"/> on the
+    /// result-based (<see cref="ValidationParameters"/>) validation pipeline - the companion of the
+    /// <see cref="ActClaimDeserializationTests"/> which cover the legacy TokenValidationParameters pipeline.
+    /// </summary>
+    [Collection("ActClaimTests")]
+    public class ActClaimExperimentalDeserializationTests : IDisposable
+    {
+        // Reset the process-wide MaxActorChainLength after every test for isolation.
+        public void Dispose() => JsonWebTokenHandler.MaxActorChainLength = 1;
+
+        private static ValidationParameters ValidationParameters =>
+            ValidationUtils.CreateValidationParameters(
+                audiences: [Default.Audience],
+                issuers: [Default.Issuer],
+                signingKeys: [Default.AsymmetricSigningKey]);
+
+        private static string CreateTokenWithClaims(ClaimsIdentity subject, IDictionary<string, object> extraClaims = null)
+        {
+            var descriptor = new SecurityTokenDescriptor
+            {
+                Subject = subject,
+                Issuer = Default.Issuer,
+                Audience = Default.Audience,
+                IssuedAt = DateTime.UtcNow.AddMinutes(-5),
+                NotBefore = DateTime.UtcNow.AddMinutes(-5),
+                Expires = DateTime.UtcNow.AddHours(1),
+                SigningCredentials = Default.AsymmetricSigningCredentials,
+            };
+
+            if (extraClaims is not null)
+                descriptor.Claims = extraClaims;
+
+            return new JsonWebTokenHandler().CreateToken(descriptor);
+        }
+
+        private static async Task<ValidationResult<ValidatedToken, ValidationError>> ValidateAsync(
+            string token, ValidationParameters validationParameters) =>
+            await ((IResultBasedValidation)new JsonWebTokenHandler())
+                .ValidateTokenAsync(token, validationParameters, new CallContext(), CancellationToken.None);
+
+        [Fact]
+        public async Task ValidateTokenAsync_ActObject_PopulatesActorFromAct()
+        {
+            // Arrange - an "act" (RFC 8693 JSON object) actor on the outgoing token.
+            var actor = new CaseSensitiveClaimsIdentity("ActorAuth");
+            actor.AddClaim(new Claim("sub", "actor-subject-id"));
+            actor.AddClaim(new Claim("name", "Actor Name"));
+
+            var main = new CaseSensitiveClaimsIdentity("Bearer");
+            main.AddClaim(new Claim("sub", "main-subject-id"));
+
+            string token = CreateTokenWithClaims(main, new Dictionary<string, object> { { "act", actor } });
+
+            // Act
+            ValidationResult<ValidatedToken, ValidationError> result = await ValidateAsync(token, ValidationParameters);
+
+            // Assert
+            Assert.True(result.Succeeded);
+            ClaimsIdentity actorIdentity = result.Result.ClaimsIdentity.Actor;
+            Assert.NotNull(actorIdentity);
+            Assert.Equal("actor-subject-id", actorIdentity.Claims.First(c => c.Type == "sub").Value);
+            Assert.Equal("Actor Name", actorIdentity.Claims.First(c => c.Type == "name").Value);
+        }
+
+        [Fact]
+        public async Task ValidateTokenAsync_NestedAct_ExpandsWithinMaxActorChainLength()
+        {
+            // Arrange - two actor levels require a chain length of 2.
+            JsonWebTokenHandler.MaxActorChainLength = 2;
+
+            var nested = new CaseSensitiveClaimsIdentity("NestedActorAuth");
+            nested.AddClaim(new Claim("sub", "nested-actor-id"));
+
+            var actor = new CaseSensitiveClaimsIdentity("ActorAuth");
+            actor.AddClaim(new Claim("sub", "actor-subject-id"));
+            actor.Actor = nested;
+
+            var main = new CaseSensitiveClaimsIdentity("Bearer");
+            main.AddClaim(new Claim("sub", "main-subject-id"));
+
+            string token = CreateTokenWithClaims(main, new Dictionary<string, object> { { "act", actor } });
+
+            // Act
+            ValidationResult<ValidatedToken, ValidationError> result = await ValidateAsync(token, ValidationParameters);
+
+            // Assert
+            Assert.True(result.Succeeded);
+            ClaimsIdentity actorIdentity = result.Result.ClaimsIdentity.Actor;
+            Assert.NotNull(actorIdentity);
+            Assert.Equal("actor-subject-id", actorIdentity.Claims.First(c => c.Type == "sub").Value);
+            Assert.NotNull(actorIdentity.Actor);
+            Assert.Equal("nested-actor-id", actorIdentity.Actor.Claims.First(c => c.Type == "sub").Value);
+        }
+
+        [Fact]
+        public async Task ValidateTokenAsync_CustomActClaimRetriever_OwnsActorConstruction()
+        {
+            // Arrange - a custom retriever fully owns actor construction from the raw JsonElement.
+            static ClaimsIdentity CustomRetriever(JsonElement element, ValidationParameters validationParameters)
+            {
+                var id = new CaseSensitiveClaimsIdentity("CustomActorAuth");
+                if (element.TryGetProperty("sub", out JsonElement sub))
+                    id.AddClaim(new Claim("sub", sub.GetString()));
+                return id;
+            }
+
+            var actor = new CaseSensitiveClaimsIdentity("ActorAuth");
+            actor.AddClaim(new Claim("sub", "actor-subject-id"));
+
+            var main = new CaseSensitiveClaimsIdentity("Bearer");
+            main.AddClaim(new Claim("sub", "main-subject-id"));
+
+            string token = CreateTokenWithClaims(main, new Dictionary<string, object> { { "act", actor } });
+
+            ValidationParameters validationParameters = ValidationParameters;
+            validationParameters.ActClaimRetriever = CustomRetriever;
+
+            // Act
+            ValidationResult<ValidatedToken, ValidationError> result = await ValidateAsync(token, validationParameters);
+
+            // Assert
+            Assert.True(result.Succeeded);
+            ClaimsIdentity actorIdentity = result.Result.ClaimsIdentity.Actor;
+            Assert.NotNull(actorIdentity);
+            Assert.Equal("CustomActorAuth", actorIdentity.AuthenticationType);
+            Assert.Equal("actor-subject-id", actorIdentity.Claims.First(c => c.Type == "sub").Value);
+        }
+
+        [Fact]
+        public async Task ValidateTokenAsync_FailingActClaimRetriever_WarnsAndLeavesActorNull()
+        {
+            // Arrange - a failing ActClaimRetriever must NOT fail token validation. It warns (IDX14313) and
+            // leaves Actor null; the raw "act" claim is still retained.
+            using var listener = SampleListener.CreateLoggerListener(EventLevel.Warning);
+
+            static ClaimsIdentity ThrowingRetriever(JsonElement element, ValidationParameters validationParameters) =>
+                throw new InvalidOperationException("retriever failure");
+
+            var actor = new CaseSensitiveClaimsIdentity("ActorAuth");
+            actor.AddClaim(new Claim("sub", "actor-subject-id"));
+
+            var main = new CaseSensitiveClaimsIdentity("Bearer");
+            main.AddClaim(new Claim("sub", "main-subject-id"));
+
+            string token = CreateTokenWithClaims(main, new Dictionary<string, object> { { "act", actor } });
+
+            ValidationParameters validationParameters = ValidationParameters;
+            validationParameters.ActClaimRetriever = ThrowingRetriever;
+
+            // Act
+            ValidationResult<ValidatedToken, ValidationError> result = await ValidateAsync(token, validationParameters);
+
+            // Assert - validation succeeds and the identity is accessible without throwing.
+            Assert.True(result.Succeeded);
+            ClaimsIdentity identity = result.Result.ClaimsIdentity;
+            Assert.Null(identity.Actor);
+            Assert.Contains(identity.Claims, c => c.Type == "act");
+            Assert.Contains("IDX14313", listener.TraceBuffer);
+        }
+
+        [Fact]
+        public async Task ValidateTokenAsync_PrimitiveAct_WarnsAndRetainsClaimWithoutActor()
+        {
+            // Arrange - a non-object "act" (a primitive) cannot be expanded; it warns (IDX14314), leaves
+            // Actor null, and is kept as an ordinary claim, and it still suppresses any legacy "actort".
+            using var listener = SampleListener.CreateLoggerListener(EventLevel.Warning);
+
+            var main = new CaseSensitiveClaimsIdentity("Bearer");
+            main.AddClaim(new Claim("sub", "main-subject-id"));
+
+            string token = CreateTokenWithClaims(main, new Dictionary<string, object> { { "act", "not-an-object" } });
+
+            // Act
+            ValidationResult<ValidatedToken, ValidationError> result = await ValidateAsync(token, ValidationParameters);
+
+            // Assert
+            Assert.True(result.Succeeded);
+            Assert.Null(result.Result.ClaimsIdentity.Actor);
+            Assert.Contains("IDX14314", listener.TraceBuffer);
+            Assert.Contains(result.Result.ClaimsIdentity.Claims, c => c.Type == "act" && c.Value == "not-an-object");
+        }
+
+        [Fact]
+        public async Task ValidateTokenAsync_WithBothActAndActort_OnlyActIsExpanded()
+        {
+            // Arrange - build a legacy "actort" JWT string with a distinguishable actor subject.
+            var actortActor = new CaseSensitiveClaimsIdentity("ActortAuth");
+            actortActor.AddClaim(new Claim("sub", "actort-actor-id"));
+            string actortJwt = new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+            {
+                Subject = actortActor,
+                Issuer = Default.Issuer,
+                Audience = Default.Audience,
+                SigningCredentials = Default.AsymmetricSigningCredentials,
+            });
+
+            var actActor = new CaseSensitiveClaimsIdentity("ActAuth");
+            actActor.AddClaim(new Claim("sub", "act-actor-id"));
+
+            var main = new CaseSensitiveClaimsIdentity("Bearer");
+            main.AddClaim(new Claim("sub", "main-subject-id"));
+
+            string token = CreateTokenWithClaims(main, new Dictionary<string, object>
+            {
+                { "act", actActor },
+                { "actort", actortJwt }
+            });
+
+            // Act
+            ValidationResult<ValidatedToken, ValidationError> result = await ValidateAsync(token, ValidationParameters);
+
+            // Assert - only "act" (JSON object) is expanded into Actor; "actort" is retained as a string claim.
+            Assert.True(result.Succeeded);
+            ClaimsIdentity actorIdentity = result.Result.ClaimsIdentity.Actor;
+            Assert.NotNull(actorIdentity);
+            Assert.Equal("act-actor-id", actorIdentity.Claims.First(c => c.Type == "sub").Value);
+            Assert.DoesNotContain(actorIdentity.Claims, c => c.Value == "actort-actor-id");
+            Assert.Contains(result.Result.ClaimsIdentity.Claims, c => c.Type == "actort" && c.Value == actortJwt);
+        }
+
+        [Fact]
+        public async Task ValidateTokenAsync_MapInboundClaimsTrue_PopulatesActorFromAct()
+        {
+            // Arrange - the MapInboundClaims path must also resolve "act" into Actor (detected via the raw
+            // "act" type, so inbound claim mapping cannot hide it).
+            var actor = new CaseSensitiveClaimsIdentity("ActorAuth");
+            actor.AddClaim(new Claim("sub", "actor-subject-id"));
+
+            var main = new CaseSensitiveClaimsIdentity("Bearer");
+            main.AddClaim(new Claim("sub", "main-subject-id"));
+
+            string token = CreateTokenWithClaims(main, new Dictionary<string, object> { { "act", actor } });
+
+            var handler = new JsonWebTokenHandler { MapInboundClaims = true };
+
+            // Act
+            ValidationResult<ValidatedToken, ValidationError> result = await ((IResultBasedValidation)handler)
+                .ValidateTokenAsync(token, ValidationParameters, new CallContext(), CancellationToken.None);
+
+            // Assert
+            Assert.True(result.Succeeded);
+            ClaimsIdentity actorIdentity = result.Result.ClaimsIdentity.Actor;
+            Assert.NotNull(actorIdentity);
+            Assert.Equal("actor-subject-id", actorIdentity.Claims.First(c => c.Type == "sub").Value);
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/ActClaimTests/ActClaimExperimentalDeserializationTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/ActClaimTests/ActClaimExperimentalDeserializationTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Tracing;
 using System.Linq;
 using System.Security.Claims;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,6 +28,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests.ActClaimTests
         // Reset the process-wide MaxActorChainLength after every test for isolation.
         public void Dispose() => JsonWebTokenHandler.MaxActorChainLength = 1;
 
+        // Expression-bodied (=>): returns a FRESH ValidationParameters instance on every access, so tests
+        // that mutate it (e.g. setting ActClaimRetriever) cannot contaminate one another.
         private static ValidationParameters ValidationParameters =>
             ValidationUtils.CreateValidationParameters(
                 audiences: [Default.Audience],
@@ -57,6 +60,15 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests.ActClaimTests
             await ((IResultBasedValidation)new JsonWebTokenHandler())
                 .ValidateTokenAsync(token, validationParameters, new CallContext(), CancellationToken.None);
 
+        // Decodes the payload of a signed JWT and returns the "act" member as a JsonElement.
+        // EnumerateObject preserves duplicate members, so CountMembers reflects real wire duplicates.
+        private static JsonElement ActClaimOf(string jwt) =>
+            JsonDocument.Parse(Encoding.UTF8.GetString(
+                Base64UrlEncoder.DecodeBytes(new JsonWebToken(jwt).EncodedPayload))).RootElement.GetProperty("act");
+
+        private static int CountMembers(JsonElement obj, string name) =>
+            obj.EnumerateObject().Count(p => p.Name == name);
+
         [Fact]
         public async Task ValidateTokenAsync_ActObject_PopulatesActorFromAct()
         {
@@ -79,6 +91,8 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests.ActClaimTests
             Assert.NotNull(actorIdentity);
             Assert.Equal("actor-subject-id", actorIdentity.Claims.First(c => c.Type == "sub").Value);
             Assert.Equal("Actor Name", actorIdentity.Claims.First(c => c.Type == "name").Value);
+            // "act"-derived actor claims carry the OUTER token's validated issuer.
+            Assert.Equal(Default.Issuer, actorIdentity.Claims.First(c => c.Type == "sub").Issuer);
         }
 
         [Fact]
@@ -178,16 +192,31 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests.ActClaimTests
         }
 
         [Fact]
-        public async Task ValidateTokenAsync_PrimitiveAct_WarnsAndRetainsClaimWithoutActor()
+        public async Task ValidateTokenAsync_PrimitiveAct_WarnsSuppressesActortAndRetainsClaim()
         {
             // Arrange - a non-object "act" (a primitive) cannot be expanded; it warns (IDX14314), leaves
-            // Actor null, and is kept as an ordinary claim, and it still suppresses any legacy "actort".
+            // Actor null, is kept as an ordinary claim, and STILL suppresses the legacy "actort" (act wins in
+            // any form). Include an "actort" to prove it is not expanded as a fallback.
             using var listener = SampleListener.CreateLoggerListener(EventLevel.Warning);
+
+            var actortActor = new CaseSensitiveClaimsIdentity("ActortAuth");
+            actortActor.AddClaim(new Claim("sub", "actort-actor-id"));
+            string actortJwt = new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+            {
+                Subject = actortActor,
+                Issuer = Default.Issuer,
+                Audience = Default.Audience,
+                SigningCredentials = Default.AsymmetricSigningCredentials,
+            });
 
             var main = new CaseSensitiveClaimsIdentity("Bearer");
             main.AddClaim(new Claim("sub", "main-subject-id"));
 
-            string token = CreateTokenWithClaims(main, new Dictionary<string, object> { { "act", "not-an-object" } });
+            string token = CreateTokenWithClaims(main, new Dictionary<string, object>
+            {
+                { "act", "not-an-object" },
+                { "actort", actortJwt }
+            });
 
             // Act
             ValidationResult<ValidatedToken, ValidationError> result = await ValidateAsync(token, ValidationParameters);
@@ -196,7 +225,190 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests.ActClaimTests
             Assert.True(result.Succeeded);
             Assert.Null(result.Result.ClaimsIdentity.Actor);
             Assert.Contains("IDX14314", listener.TraceBuffer);
+            // The raw primitive "act" is retained as an ordinary claim.
             Assert.Contains(result.Result.ClaimsIdentity.Claims, c => c.Type == "act" && c.Value == "not-an-object");
+            // "actort" is suppressed (never expanded) but retained verbatim as a string claim.
+            Assert.Contains(result.Result.ClaimsIdentity.Claims, c => c.Type == "actort" && c.Value == actortJwt);
+        }
+
+        [Fact]
+        public async Task ValidateTokenAsync_ArrayAct_WarnsSuppressesActortAndRetainsClaim()
+        {
+            // Arrange - an array "act" is a non-object value: it warns (IDX14314), leaves Actor null, is kept
+            // as a claim, and suppresses any legacy "actort". This drives the shared helper's non-object path
+            // through TryGetPayloadValue<JsonElement> in the result-based pipeline.
+            using var listener = SampleListener.CreateLoggerListener(EventLevel.Warning);
+
+            var actortActor = new CaseSensitiveClaimsIdentity("ActortAuth");
+            actortActor.AddClaim(new Claim("sub", "actort-actor-id"));
+            string actortJwt = new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+            {
+                Subject = actortActor,
+                Issuer = Default.Issuer,
+                Audience = Default.Audience,
+                SigningCredentials = Default.AsymmetricSigningCredentials,
+            });
+
+            var main = new CaseSensitiveClaimsIdentity("Bearer");
+            main.AddClaim(new Claim("sub", "main-subject-id"));
+
+            string token = CreateTokenWithClaims(main, new Dictionary<string, object>
+            {
+                { "act", new[] { "a", "b" } },
+                { "actort", actortJwt }
+            });
+
+            // Act
+            ValidationResult<ValidatedToken, ValidationError> result = await ValidateAsync(token, ValidationParameters);
+
+            // Assert
+            Assert.True(result.Succeeded);
+            Assert.Null(result.Result.ClaimsIdentity.Actor);
+            Assert.Contains("IDX14314", listener.TraceBuffer);
+            // "actort" is suppressed even though "act" could not be expanded (act wins in any form).
+            Assert.DoesNotContain(result.Result.ClaimsIdentity.Claims, c => c.Value == "actort-actor-id");
+            Assert.Contains(result.Result.ClaimsIdentity.Claims, c => c.Type == "actort" && c.Value == actortJwt);
+        }
+
+        [Fact]
+        public async Task ValidateTokenAsync_ActortOnly_PopulatesActorFromActortWithNestedIssuer()
+        {
+            // Arrange - no "act": the legacy "actort" (an unsigned nested JWT string) is expanded for read
+            // back-compatibility. Its actor claims carry the NESTED token's issuer (not the outer issuer).
+            const string actortIssuer = "https://actor.example.com";
+
+            var actortActor = new CaseSensitiveClaimsIdentity("ActortAuth");
+            actortActor.AddClaim(new Claim("sub", "actort-actor-id"));
+            string actortJwt = new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+            {
+                Subject = actortActor,
+                Issuer = actortIssuer,
+                Audience = Default.Audience,
+                SigningCredentials = Default.AsymmetricSigningCredentials,
+            });
+
+            var main = new CaseSensitiveClaimsIdentity("Bearer");
+            main.AddClaim(new Claim("sub", "main-subject-id"));
+
+            string token = CreateTokenWithClaims(main, new Dictionary<string, object> { { "actort", actortJwt } });
+
+            // Act
+            ValidationResult<ValidatedToken, ValidationError> result = await ValidateAsync(token, ValidationParameters);
+
+            // Assert
+            Assert.True(result.Succeeded);
+            ClaimsIdentity actorIdentity = result.Result.ClaimsIdentity.Actor;
+            Assert.NotNull(actorIdentity);
+            Claim actorSub = actorIdentity.Claims.First(c => c.Type == "sub");
+            Assert.Equal("actort-actor-id", actorSub.Value);
+            // "actort"-derived actor claims carry the nested JWT's issuer, distinct from the outer issuer.
+            Assert.Equal(actortIssuer, actorSub.Issuer);
+            Assert.NotEqual(Default.Issuer, actorSub.Issuer);
+        }
+
+        [Fact]
+        public async Task ValidateTokenAsync_NestedActBeyondMaxChainLength_RetainedAsClaimWithoutWarning()
+        {
+            // Arrange - default MaxActorChainLength = 1: the top actor expands, but its nested "act" is beyond
+            // the limit and must be kept as a claim (round-trippable) WITHOUT warning - depth degradation is
+            // expected, so IDX14314 is reserved for within-limit non-objects only.
+            using var listener = SampleListener.CreateLoggerListener(EventLevel.Warning);
+
+            var nested = new CaseSensitiveClaimsIdentity("NestedActorAuth");
+            nested.AddClaim(new Claim("sub", "nested-actor-id"));
+
+            var actor = new CaseSensitiveClaimsIdentity("ActorAuth");
+            actor.AddClaim(new Claim("sub", "actor-subject-id"));
+            actor.Actor = nested;
+
+            var main = new CaseSensitiveClaimsIdentity("Bearer");
+            main.AddClaim(new Claim("sub", "main-subject-id"));
+
+            string token = CreateTokenWithClaims(main, new Dictionary<string, object> { { "act", actor } });
+
+            // Act
+            ValidationResult<ValidatedToken, ValidationError> result = await ValidateAsync(token, ValidationParameters);
+
+            // Assert
+            Assert.True(result.Succeeded);
+            ClaimsIdentity actorIdentity = result.Result.ClaimsIdentity.Actor;
+            Assert.NotNull(actorIdentity);
+            Assert.Equal("actor-subject-id", actorIdentity.Claims.First(c => c.Type == "sub").Value);
+            // Beyond the limit: not expanded into a further Actor, kept as a claim, and NOT warned.
+            Assert.Null(actorIdentity.Actor);
+            Assert.Contains(actorIdentity.Claims, c => c.Type == "act");
+            Assert.DoesNotContain("IDX14314", listener.TraceBuffer);
+        }
+
+        [Fact]
+        public async Task ValidationParameters_Clone_PreservesActClaimRetriever()
+        {
+            // Arrange - a clone must carry the ActClaimRetriever and remain usable by the handler.
+            static ClaimsIdentity CustomRetriever(JsonElement element, ValidationParameters validationParameters)
+            {
+                var id = new CaseSensitiveClaimsIdentity("ClonedRetrieverAuth");
+                if (element.TryGetProperty("sub", out JsonElement sub))
+                    id.AddClaim(new Claim("sub", sub.GetString()));
+                return id;
+            }
+
+            ValidationParameters original = ValidationParameters;
+            original.ActClaimRetriever = CustomRetriever;
+
+            ValidationParameters clone = original.Clone();
+
+            // Assert - the delegate reference is preserved by the clone constructor.
+            Assert.Same(original.ActClaimRetriever, clone.ActClaimRetriever);
+
+            var actor = new CaseSensitiveClaimsIdentity("ActorAuth");
+            actor.AddClaim(new Claim("sub", "actor-subject-id"));
+            var main = new CaseSensitiveClaimsIdentity("Bearer");
+            main.AddClaim(new Claim("sub", "main-subject-id"));
+            string token = CreateTokenWithClaims(main, new Dictionary<string, object> { { "act", actor } });
+
+            // Act - validate with the CLONE.
+            ValidationResult<ValidatedToken, ValidationError> result = await ValidateAsync(token, clone);
+
+            // Assert - the cloned retriever owns actor construction.
+            Assert.True(result.Succeeded);
+            ClaimsIdentity actorIdentity = result.Result.ClaimsIdentity.Actor;
+            Assert.NotNull(actorIdentity);
+            Assert.Equal("ClonedRetrieverAuth", actorIdentity.AuthenticationType);
+            Assert.Equal("actor-subject-id", actorIdentity.Claims.First(c => c.Type == "sub").Value);
+        }
+
+        [Fact]
+        public async Task ReissuedToken_ValidatedIdentityUsedAsActor_EmitsExactlyOneActMember()
+        {
+            // Arrange - validate an "act" token through the result-based pipeline, then reuse the resulting
+            // ClaimsIdentity (which carries BOTH identity.Actor and a retained literal "act" claim) as the
+            // actor of a new token. The shared writer must emit exactly one nested "act" member.
+            var actor = new CaseSensitiveClaimsIdentity("ActorAuth");
+            actor.AddClaim(new Claim("sub", "actor-subject-id"));
+
+            var main = new CaseSensitiveClaimsIdentity("Bearer");
+            main.AddClaim(new Claim("sub", "main-subject-id"));
+
+            string inboundToken = CreateTokenWithClaims(main, new Dictionary<string, object> { { "act", actor } });
+
+            ValidationResult<ValidatedToken, ValidationError> result = await ValidateAsync(inboundToken, ValidationParameters);
+            Assert.True(result.Succeeded);
+
+            // Act - the validated identity becomes the actor of the outgoing token.
+            var downstream = new CaseSensitiveClaimsIdentity("Bearer");
+            downstream.AddClaim(new Claim("sub", "downstream"));
+            downstream.Actor = result.Result.ClaimsIdentity;
+            string reissuedToken = new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+            {
+                Subject = downstream,
+                Issuer = Default.Issuer,
+                Audience = Default.Audience,
+                SigningCredentials = Default.AsymmetricSigningCredentials,
+            });
+
+            // Assert - the signed "act" object contains exactly one nested "act" member (no duplicate).
+            JsonElement actObject = ActClaimOf(reissuedToken);
+            Assert.Equal(1, CountMembers(actObject, "act"));
         }
 
         [Fact]


### PR DESCRIPTION
# Deserialize the `act` claim on the ValidationParameters pipeline

## Summary of the changes (Less than 80 chars)

Deserialize the RFC 8693 `act` claim into `ClaimsIdentity.Actor` on `ValidationParameters`

## Why

Read-path companion for the new result-based **Experimental `ValidationParameters`** pipeline. It
brings the RFC 8693 `act` deserialization approved in #3571 (legacy `TokenValidationParameters`) to
`ValidationParameters`, so tokens validated through the new pipeline round-trip the actor the same way.
Serialization (#3560) needed no port — it lives in the shared `JsonWebTokenHandler.CreateToken` path
and already applies to both pipelines.

## What changed

- **`ValidationParameters` (Experimental)** gains `ActClaimRetriever`
  (`Func<JsonElement, ValidationParameters, ClaimsIdentity>?`), copied by the clone constructor and
  matching the `Func`-style retrievers already on the class. Public API updated.
- **`JsonWebTokenHandler` (Experimental)** — `CreateClaimsIdentityWithMapping` /
  `CreateClaimsIdentityPrivate` now set `ClaimsIdentity.Actor` via a new `ResolveActorClaimsIdentity`:
  the `act` (JSON object) claim **takes precedence**; a primitive `act` warns `IDX14314` and suppresses
  the legacy `actort`; `actort` (a nested-JWT string) is expanded only when `act` is absent. The old
  in-loop `actort` / `IDX14112` "single Actor" logic is **removed** — duplicate `act`/`actort` collapse
  in the dictionary-backed payload, so it was dead — aligning this pipeline with the legacy one.
- The default `act` expansion **reuses the shared, parameter-free**
  `CreateActorClaimsIdentityFromJsonElement` (bounded by `MaxActorChainLength`). A custom
  `ActClaimRetriever` fully owns actor construction; a throwing retriever warns `IDX14313` without
  failing validation.

## Notes

- No new public API beyond `ValidationParameters.ActClaimRetriever`.
- Tests: `ActClaimExperimentalDeserializationTests` covers `act`→`Actor`, nested `act`, custom
  retriever, a throwing retriever, primitive `act`, `act`-wins-over-`actort`, and the `MapInboundClaims`
  path.
- Completes the Experimental-pipeline alignment noted during #3571 review.
