### PR TITLE
Add ILogger-aware LogHelper overloads and correlation-id support (#33…

### DIFF
--- a/benchmark/Microsoft.IdentityModel.Benchmarks/CorrelationLoggingBenchmarks.cs
+++ b/benchmark/Microsoft.IdentityModel.Benchmarks/CorrelationLoggingBenchmarks.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Toolchains.InProcess.Emit;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Logging;
+
+namespace Microsoft.IdentityModel.Benchmarks
+{
+    // dotnet run -c release -f net9.0 --no-restore /p:NuGetAudit=false --filter Microsoft.IdentityModel.Benchmarks.CorrelationLoggingBenchmarks*
+    //
+    // Isolates the correlation-id resolution cost on the ILogger warning path in LogHelper.
+    // Validates the engine change for issue #3361: the ActivityId->string fallback was removed and
+    // correlation logging is gated by LoggerContext.LogCorrelationId (default true, kill switch).
+    //
+    // Reliable signal is Allocated. Key comparisons:
+    //   New_Warning_ActivityIdOnly (real, fixed path)  vs  Old_Warning_ActivityIdOnly_Simulated (pre-fix cost)
+    //   => the delta is the per-log Guid->string + correlation string.Format the fix eliminates.
+    //
+    // Uses the in-process toolchain so BenchmarkDotNet does not generate/restore a child project
+    // (avoids offline NuGet audit failures).
+    [Config(typeof(Config))]
+    [MemoryDiagnoser]
+    public class CorrelationLoggingBenchmarks
+    {
+        private sealed class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddJob(Job.ShortRun.WithToolchain(InProcessEmitToolchain.Instance));
+            }
+        }
+
+        private const string Message = "IDX10233: ValidateAudience property on ValidationParameters is set to false. Exiting without validating the audience.";
+        private const string CorrelationId = "8fd7c1b2-3a4e-4c9d-9f2a-1b2c3d4e5f60";
+
+        private readonly ILogger _logger = new NullSinkLogger();
+
+        private LoggerContext _noCorrelation;
+        private LoggerContext _activityIdOnly;
+        private LoggerContext _correlationIdSet;
+        private LoggerContext _killSwitchOff;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            // Default: nothing supplied. Mirrors the dominant production case.
+            _noCorrelation = new LoggerContext(_logger);
+
+            // Only ActivityId set (ETW). Post-fix this must NOT be promoted into the ILogger message.
+            _activityIdOnly = new LoggerContext(_logger) { ActivityId = Guid.NewGuid() };
+
+            // Explicitly supplied correlation string (the supported opt-in path).
+            _correlationIdSet = new LoggerContext(_logger) { CorrelationId = CorrelationId };
+
+            // Kill switch: correlation supplied but LogCorrelationId disabled -> nothing appended.
+            _killSwitchOff = new LoggerContext(_logger) { CorrelationId = CorrelationId, LogCorrelationId = false };
+        }
+
+        // --- Real (fixed) LogHelper paths ---
+
+        [Benchmark(Baseline = true)]
+        public void New_Warning_NoCorrelation()
+        {
+            LogHelper.LogWarning(Message, _noCorrelation);
+        }
+
+        [Benchmark]
+        public void New_Warning_ActivityIdOnly()
+        {
+            LogHelper.LogWarning(Message, _activityIdOnly);
+        }
+
+        [Benchmark]
+        public void New_Warning_CorrelationIdSet()
+        {
+            LogHelper.LogWarning(Message, _correlationIdSet);
+        }
+
+        [Benchmark]
+        public void New_Warning_KillSwitchOff()
+        {
+            LogHelper.LogWarning(Message, _killSwitchOff);
+        }
+
+        // --- Control: reproduces the pre-fix ActivityId->string fallback cost per log ---
+
+        [Benchmark]
+        public void Old_Warning_ActivityIdOnly_Simulated()
+        {
+            // The removed behavior materialized ActivityId as a string and fed it as the correlation id,
+            // forcing a Guid->string allocation plus the correlation string.Format in WriteEntry on every log.
+            var ctx = new LoggerContext(_logger) { ActivityId = _activityIdOnly.ActivityId };
+            ctx.CorrelationId = ctx.ActivityId.ToString();
+            LogHelper.LogWarning(Message, ctx);
+        }
+
+        private sealed class NullSinkLogger : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                // Force the message to materialize (as a real sink would) without any extra sink-side cost.
+                _ = formatter(state, exception);
+            }
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+                public void Dispose() { }
+            }
+        }
+    }
+}

--- a/src/Microsoft.IdentityModel.Logging/InternalAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Logging/InternalAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.IdentityModel.Logging.LoggerContext.ResolveCorrelationId() -> string
+static Microsoft.IdentityModel.Logging.LogHelper.IsEnabled(Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.IdentityModel.Logging.LoggerContext loggerContext) -> bool
+static Microsoft.IdentityModel.Logging.LogHelper.IsEnabled(Microsoft.IdentityModel.Abstractions.EventLogLevel level, Microsoft.Extensions.Logging.LogLevel logLevel, Microsoft.IdentityModel.Logging.LoggerContext loggerContext) -> bool

--- a/src/Microsoft.IdentityModel.Logging/LogHelper.cs
+++ b/src/Microsoft.IdentityModel.Logging/LogHelper.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using System.Text;
 using Microsoft.IdentityModel.Abstractions;
 #if NET8_0_OR_GREATER
@@ -60,6 +61,17 @@ namespace Microsoft.IdentityModel.Logging
         {
             get { return _isHeaderWritten; }
             set { _isHeaderWritten = value; }
+        }
+
+        /// <summary>
+        /// Gets a boolean indicating whether logging is enabled at the specified LogLevel.
+        /// </summary>
+        /// <param name="logLevel">The log level</param>
+        /// <param name="loggerContext">A <see cref="LoggerContext"/> that contains logging control including <see cref="ILogger"/>.</param>
+        /// <returns><see langword="true"/> if logging is enabled at the specified level; otherwise, <see langword="false"/>.</returns>
+        internal static bool IsEnabled(LogLevel logLevel, LoggerContext loggerContext)
+        {
+            return loggerContext?.Logger?.IsEnabled(logLevel) ?? false;
         }
 
         /// <summary>
@@ -289,7 +301,45 @@ namespace Microsoft.IdentityModel.Logging
 
             EventLogLevel eventLogLevel = EventLevelToEventLogLevel(eventLevel);
             if (Logger.IsEnabled(eventLogLevel))
-                Logger.Log(WriteEntry(eventLogLevel, exception.InnerException, exception.Message, null));
+                Logger.Log(WriteEntry(eventLogLevel, exception.InnerException, exception.Message));
+
+            return exception;
+        }
+
+        /// <summary>
+        /// Logs an exception using the listeners that have been enabled.
+        /// </summary>
+        /// <param name="exception">The exception to log.</param>
+        /// <param name="loggerContext">The <see cref="LoggerContext"/> contains information useful for logging and debugging.</param>
+        public static Exception LogExceptionMessage(Exception exception, LoggerContext loggerContext)
+        {
+            if (exception == null)
+                return null;
+
+            LogExceptionMessage(exception);
+
+            if (loggerContext?.Logger == null)
+                return exception;
+
+            if (!loggerContext.Logger.IsEnabled(LogLevel.Error))
+                return exception;
+
+            // Correlation id is opt-in: only the explicitly supplied CorrelationId is logged, and only when
+            // LogCorrelationId is enabled (the default kill switch). ActivityId is never promoted into ILogger
+            // messages, avoiding a per-log Guid->string allocation for an all-zero ActivityId.
+            string correlationId = loggerContext.ResolveCorrelationId();
+
+            // Prototype: the ILogger exception path previously passed 'exception.Message' again as a
+            // format arg, forcing an object[] allocation + FormatInvariant (LINQ Select().ToArray() +
+            // string.Format) on every logged exception. The message is already complete, so pass no args.
+            LogEntry entry = WriteEntry(
+                EventLogLevel.Error,
+                exception.InnerException,
+                exception.Message,
+                correlationId,
+                (object[])null);
+
+            Log(entry, loggerContext.Logger);
 
             return exception;
         }
@@ -305,7 +355,33 @@ namespace Microsoft.IdentityModel.Logging
                 IdentityModelEventSource.Logger.WriteInformation(message, args);
 
             if (Logger.IsEnabled(EventLogLevel.Informational))
-                Logger.Log(WriteEntry(EventLogLevel.Informational, null, message, args));
+                Logger.Log(WriteEntry(EventLogLevel.Informational, null, message, null, args));
+        }
+
+        /// <summary>
+        /// Logs at the information level to the listeners that have been enabled.
+        /// </summary>
+        /// <param name="message">The log message.</param>
+        /// <param name="loggerContext">A <see cref="LoggerContext"/> that contains logging control including <see cref="ILogger"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogInformation(string message, LoggerContext loggerContext, params object[] args)
+        {
+            LogInformation(message, args);
+
+            if (loggerContext?.Logger == null)
+                return;
+
+            if (!loggerContext.Logger.IsEnabled(LogLevel.Information))
+                return;
+
+            LogEntry entry = WriteEntry(
+                EventLevelToEventLogLevel(EventLevel.Informational),
+                null,
+                message,
+                loggerContext.ResolveCorrelationId(),
+                null);
+
+            Log(entry, loggerContext.Logger);
         }
 
         /// <summary>
@@ -319,7 +395,33 @@ namespace Microsoft.IdentityModel.Logging
                 IdentityModelEventSource.Logger.WriteVerbose(message, args);
 
             if (Logger.IsEnabled(EventLogLevel.Verbose))
-                Logger.Log(WriteEntry(EventLogLevel.Verbose, null, message, args));
+                Logger.Log(WriteEntry(EventLogLevel.Verbose, null, message, null, args));
+        }
+
+        /// <summary>
+        /// Logs at the verbose level to the listeners that have been enabled.
+        /// </summary>
+        /// <param name="message">The log message.</param>
+        /// <param name="loggerContext">A <see cref="LoggerContext"/> that contains logging control including <see cref="ILogger"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogVerbose(string message, LoggerContext loggerContext, params object[] args)
+        {
+            LogVerbose(message, args);
+
+            if (loggerContext?.Logger == null)
+                return;
+
+            if (!loggerContext.Logger.IsEnabled(LogLevel.Debug))
+                return;
+
+            LogEntry entry = WriteEntry(
+                EventLogLevel.Verbose,
+                null,
+                message,
+                loggerContext.ResolveCorrelationId(),
+                null);
+
+            Log(entry, loggerContext.Logger);
         }
 
         /// <summary>
@@ -333,7 +435,43 @@ namespace Microsoft.IdentityModel.Logging
                 IdentityModelEventSource.Logger.WriteWarning(message, args);
 
             if (Logger.IsEnabled(EventLogLevel.Warning))
-                Logger.Log(WriteEntry(EventLogLevel.Warning, null, message, args));
+                Logger.Log(WriteEntry(EventLogLevel.Warning, null, message, null, args));
+        }
+
+        /// <summary>
+        /// Logs at the warning level to the listeners that have been enabled.
+        /// </summary>
+        /// <param name="message">The log message.</param>
+        /// <param name="loggerContext">A <see cref="LoggerContext"/> that contains logging control including <see cref="ILogger"/>.</param>
+        public static void LogWarning(string message, LoggerContext loggerContext)
+        {
+            LogWarning(message, loggerContext, null);
+        }
+
+        /// <summary>
+        /// Logs at the warning level to the listeners that have been enabled.
+        /// </summary>
+        /// <param name="message">The log message.</param>
+        /// <param name="loggerContext">A <see cref="LoggerContext"/> that contains logging control including <see cref="ILogger"/>.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        public static void LogWarning(string message, LoggerContext loggerContext, params object[] args)
+        {
+            LogWarning(message, args);
+
+            if (loggerContext?.Logger == null)
+                return;
+
+            if (!loggerContext.Logger.IsEnabled(LogLevel.Warning))
+                return;
+
+            LogEntry entry = WriteEntry(
+                EventLogLevel.Warning,
+                null,
+                message,
+                loggerContext.ResolveCorrelationId(),
+                null);
+
+            Log(entry, loggerContext.Logger);
         }
 
         /// <summary>
@@ -357,7 +495,7 @@ namespace Microsoft.IdentityModel.Logging
 
             EventLogLevel eventLogLevel = EventLevelToEventLogLevel(eventLevel);
             if (Logger.IsEnabled(eventLogLevel))
-                Logger.Log(WriteEntry(eventLogLevel, innerException, message, null));
+                Logger.Log(WriteEntry(eventLogLevel, innerException, message));
 
             if (innerException != null)
             {
@@ -459,7 +597,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="callback">A callback function to log the security artifact safely.</param>
         /// <returns>An argument marked as SecurityArtifact.</returns>
         /// <remarks>
-        /// Since even the payload may sometimes contain security artifacts, naïve disarm algorithms such as removing signatures
+        /// Since even the payload may sometimes contain security artifacts, naï¿½ve disarm algorithms such as removing signatures
         /// will not work. For now the <paramref name="callback"/> will only be leveraged if
         /// <see cref="IdentityModelEventSource.LogCompleteSecurityArtifact"/> is set and no unsafe callback is provided. Future changes
         /// may introduce a support for best effort disarm logging.
@@ -479,7 +617,7 @@ namespace Microsoft.IdentityModel.Logging
         /// <exception cref="ArgumentNullException">if <paramref name="callback"/> is null.</exception>
         /// <exception cref="ArgumentNullException">if <paramref name="callbackUnsafe"/> is null.</exception>
         /// <remarks>
-        /// Since even the payload may sometimes contain security artifacts, naïve disarm algorithms such as removing signatures
+        /// Since even the payload may sometimes contain security artifacts, naï¿½ve disarm algorithms such as removing signatures
         /// will not work. For now the <paramref name="callback"/> is currently unused. Future changes
         /// may introduce a support for best effort disarm logging which will leverage <paramref name="callback"/>.
         /// </remarks>
@@ -507,7 +645,29 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="innerException"><see cref="Exception"/></param>
         /// <param name="message">The log message.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
-        private static LogEntry WriteEntry(EventLogLevel eventLogLevel, Exception innerException, string message, params object[] args)
+        private static LogEntry WriteEntry(
+            EventLogLevel eventLogLevel,
+            Exception innerException,
+            string message,
+            params object[] args)
+        {
+            return WriteEntry(eventLogLevel, innerException, message, (string)null, args);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="LogEntry"/> by using the provided event level, exception argument, string argument and arguments list.
+        /// </summary>
+        /// <param name="eventLogLevel"><see cref="EventLogLevel"/></param>
+        /// <param name="innerException"><see cref="Exception"/></param>
+        /// <param name="message">The log message.</param>
+        /// <param name="correlationId">The CorrelationId is set by caller to coordinate logs between services.</param>
+        /// <param name="args">An object array that contains zero or more objects to format.</param>
+        private static LogEntry WriteEntry(
+            EventLogLevel eventLogLevel,
+            Exception innerException,
+            string message,
+            string correlationId,
+            params object[] args)
         {
             if (string.IsNullOrEmpty(message))
                 return null;
@@ -525,23 +685,72 @@ namespace Microsoft.IdentityModel.Logging
 
             LogEntry entry = new LogEntry();
             entry.EventLogLevel = eventLogLevel;
+            entry.CorrelationId = correlationId;
 
             // Prefix header (library version, DateTime, whether PII is ON/OFF) to the first message logged by Wilson.
             if (!_isHeaderWritten)
             {
-                string headerMessage = string.Format(CultureInfo.InvariantCulture, "Microsoft.IdentityModel Version: {0}. Date {1}. {2}",
-                    typeof(IdentityModelEventSource).Assembly.GetName().Version.ToString(),
-                    DateTime.UtcNow,
-                    IdentityModelEventSource.ShowPII ? _piiOnLogMessage : _piiOffLogMessage);
-
-                entry.Message = headerMessage + Environment.NewLine + message;
+                entry.Message = (correlationId == null) ?
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Microsoft.IdentityModel Version: {0}. Date {1}. {2}  Message: {3}",
+                        typeof(IdentityModelEventSource).Assembly.GetName().Version.ToString(),
+                        DateTime.UtcNow,
+                        IdentityModelEventSource.ShowPII ? _piiOnLogMessage : _piiOffLogMessage,
+                        Environment.NewLine + message) :
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Microsoft.IdentityModel Version: {0}. Date {1}. {2} Message: {3}, CorrelationId: {4}.",
+                        typeof(IdentityModelEventSource).Assembly.GetName().Version.ToString(),
+                        DateTime.UtcNow,
+                        IdentityModelEventSource.ShowPII ? _piiOnLogMessage : _piiOffLogMessage,
+                        Environment.NewLine + message,
+                        correlationId);
 
                 _isHeaderWritten = true;
             }
             else
-                entry.Message = message;
+                entry.Message = (correlationId == null) ?
+                    message :
+                    string.Format(CultureInfo.InvariantCulture, "{0}, CorrelationId: {1}.", message, correlationId);
 
             return entry;
+        }
+
+        private static void Log(LogEntry entry, ILogger logger)
+        {
+            if (entry != null)
+            {
+                switch (entry.EventLogLevel)
+                {
+                    case EventLogLevel.Critical:
+                        logger.LogCritical(entry.Message);
+                        break;
+
+                    case EventLogLevel.Error:
+                        logger.LogError(entry.Message);
+                        break;
+
+                    case EventLogLevel.Warning:
+                        logger.LogWarning(entry.Message);
+                        break;
+
+                    case EventLogLevel.Informational:
+                        logger.LogInformation(entry.Message);
+                        break;
+
+                    case EventLogLevel.Verbose:
+                        logger.LogDebug(entry.Message);
+                        break;
+
+                    case EventLogLevel.LogAlways:
+                        logger.LogTrace(entry.Message);
+                        break;
+
+                    default:
+                        break;
+                }
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.IdentityModel.Logging/LogHelper.cs
+++ b/src/Microsoft.IdentityModel.Logging/LogHelper.cs
@@ -379,7 +379,7 @@ namespace Microsoft.IdentityModel.Logging
                 null,
                 message,
                 loggerContext.ResolveCorrelationId(),
-                null);
+                args);
 
             Log(entry, loggerContext.Logger);
         }
@@ -419,7 +419,7 @@ namespace Microsoft.IdentityModel.Logging
                 null,
                 message,
                 loggerContext.ResolveCorrelationId(),
-                null);
+                args);
 
             Log(entry, loggerContext.Logger);
         }
@@ -469,7 +469,7 @@ namespace Microsoft.IdentityModel.Logging
                 null,
                 message,
                 loggerContext.ResolveCorrelationId(),
-                null);
+                args);
 
             Log(entry, loggerContext.Logger);
         }

--- a/src/Microsoft.IdentityModel.Logging/LogHelper.cs
+++ b/src/Microsoft.IdentityModel.Logging/LogHelper.cs
@@ -316,10 +316,16 @@ namespace Microsoft.IdentityModel.Logging
             if (exception == null)
                 return null;
 
-            LogExceptionMessage(exception);
+            if (IdentityModelEventSource.Logger.IsEnabled(EventLevel.Error, EventKeywords.All))
+                IdentityModelEventSource.Logger.Write(EventLevel.Error, exception.InnerException, exception.Message);
 
             if (loggerContext?.Logger == null)
+            {
+                if (Logger.IsEnabled(EventLogLevel.Error))
+                    Logger.Log(WriteEntry(EventLogLevel.Error, exception.InnerException, exception.Message));
+
                 return exception;
+            }
 
             if (!loggerContext.Logger.IsEnabled(LogLevel.Error))
                 return exception;
@@ -366,10 +372,16 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void LogInformation(string message, LoggerContext loggerContext, params object[] args)
         {
-            LogInformation(message, args);
+            if (IdentityModelEventSource.Logger.IsEnabled(EventLevel.Informational, EventKeywords.All))
+                IdentityModelEventSource.Logger.WriteInformation(message, args);
 
             if (loggerContext?.Logger == null)
+            {
+                if (Logger.IsEnabled(EventLogLevel.Informational))
+                    Logger.Log(WriteEntry(EventLogLevel.Informational, null, message, null, args));
+
                 return;
+            }
 
             if (!loggerContext.Logger.IsEnabled(LogLevel.Information))
                 return;
@@ -406,10 +418,16 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void LogVerbose(string message, LoggerContext loggerContext, params object[] args)
         {
-            LogVerbose(message, args);
+            if (IdentityModelEventSource.Logger.IsEnabled(EventLevel.Verbose, EventKeywords.All))
+                IdentityModelEventSource.Logger.WriteVerbose(message, args);
 
             if (loggerContext?.Logger == null)
+            {
+                if (Logger.IsEnabled(EventLogLevel.Verbose))
+                    Logger.Log(WriteEntry(EventLogLevel.Verbose, null, message, null, args));
+
                 return;
+            }
 
             if (!loggerContext.Logger.IsEnabled(LogLevel.Debug))
                 return;
@@ -456,10 +474,16 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void LogWarning(string message, LoggerContext loggerContext, params object[] args)
         {
-            LogWarning(message, args);
+            if (IdentityModelEventSource.Logger.IsEnabled(EventLevel.Warning, EventKeywords.All))
+                IdentityModelEventSource.Logger.WriteWarning(message, args);
 
             if (loggerContext?.Logger == null)
+            {
+                if (Logger.IsEnabled(EventLogLevel.Warning))
+                    Logger.Log(WriteEntry(EventLogLevel.Warning, null, message, null, args));
+
                 return;
+            }
 
             if (!loggerContext.Logger.IsEnabled(LogLevel.Warning))
                 return;

--- a/src/Microsoft.IdentityModel.Logging/LoggerContext.cs
+++ b/src/Microsoft.IdentityModel.Logging/LoggerContext.cs
@@ -11,6 +11,10 @@ namespace Microsoft.IdentityModel.Logging
     /// <summary>
     /// A context class that can be used to store work per request to aid with debugging.
     /// </summary>
+    /// <remarks>
+    /// A <see cref="LoggerContext"/> represents a single logical call and is not thread-safe. Its mutable
+    /// properties must not be written on one thread while it is being used to log on another.
+    /// </remarks>
     public class LoggerContext
     {
         /// <summary>
@@ -97,7 +101,8 @@ namespace Microsoft.IdentityModel.Logging
         /// Gets or sets a <see cref="string"/> correlation id that is written to logs emitted through <see cref="ILogger"/>
         /// when <see cref="LogCorrelationId"/> is <see langword="true"/> (the default). Supplying a value is the opt-in.
         /// </summary>
-        /// <remarks>Only this explicitly supplied value is logged; <see cref="ActivityId"/> is never promoted into ILogger messages.</remarks>
+        /// <remarks>Only this explicitly supplied value is logged; <see cref="ActivityId"/> is never promoted into ILogger messages.
+        /// It is treated as a non-PII correlation token and is emitted verbatim (not redacted when PII display is off), so callers must not place PII in it.</remarks>
         public string CorrelationId { get; set; }
 
         /// <summary>
@@ -136,9 +141,9 @@ namespace Microsoft.IdentityModel.Logging
 
         /// <summary>
         /// Resolves the correlation id to write to an <see cref="ILogger"/> message: the explicitly supplied
-        /// <see cref="CorrelationId"/> when <see cref="LogCorrelationId"/> is enabled; otherwise <see langword="null"/>.
-        /// <see cref="ActivityId"/> is intentionally never used here.
+        /// <see cref="CorrelationId"/> when <see cref="LogCorrelationId"/> is enabled and the value is non-empty;
+        /// otherwise <see langword="null"/>. <see cref="ActivityId"/> is intentionally never used here.
         /// </summary>
-        internal string ResolveCorrelationId() => LogCorrelationId ? CorrelationId : null;
+        internal string ResolveCorrelationId() => LogCorrelationId && !string.IsNullOrEmpty(CorrelationId) ? CorrelationId : null;
     }
 }

--- a/src/Microsoft.IdentityModel.Logging/LoggerContext.cs
+++ b/src/Microsoft.IdentityModel.Logging/LoggerContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.IdentityModel.Logging
 {
@@ -28,9 +29,88 @@ namespace Microsoft.IdentityModel.Logging
             ActivityId = activityId;
         }
 
+#pragma warning disable CS3001 // ILogger is not CLSCompliant
+#pragma warning disable CS3003 // ILogger is not CLSCompliant
+        /// <summary>
+        /// Instantiates a new <see cref="LoggerContext"/>.
+        /// </summary>
+        /// <param name="logger"><see cref="ILogger"/> to record logs.</param>
+        /// <exception cref="ArgumentNullException">if <paramref name="logger"/> is null.</exception>
+        public LoggerContext(ILogger logger)
+        {
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// Instantiates a new <see cref="LoggerContext"/> with an activity identifier.
+        /// </summary>
+        /// <param name="logger"><see cref="ILogger"/> to record logs.</param>
+        /// <param name="activityId">activity id to include in logs.</param>
+        /// <exception cref="ArgumentNullException">if <paramref name="logger"/> is null.</exception>
+        public LoggerContext(ILogger logger, Guid activityId)
+        {
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            ActivityId = activityId;
+        }
+
+        /// <summary>
+        /// Instantiates a new <see cref="LoggerContext"/> with a correlation identifier.
+        /// </summary>
+        /// <param name="logger"><see cref="ILogger"/> to record logs.</param>
+        /// <param name="correlationId">correlation id to include in logs.</param>
+        /// <exception cref="ArgumentNullException">if <paramref name="logger"/> is null.</exception>
+        public LoggerContext(ILogger logger, string correlationId)
+        {
+            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            CorrelationId = correlationId;
+        }
+
+        /// <summary>
+        /// Instantiates a new <see cref="LoggerContext"/> by copying the logging state (logger, correlation id,
+        /// <see cref="LogCorrelationId"/>, activity id, and <see cref="CaptureLogs"/>) from another context.
+        /// The mutable <see cref="Logs"/> buffer and <see cref="PropertyBag"/> are intentionally not shared so a
+        /// derived or nested context does not cross-contaminate the originating context.
+        /// </summary>
+        /// <param name="other">The context to copy logging state from.</param>
+        /// <exception cref="ArgumentNullException">if <paramref name="other"/> is null.</exception>
+        protected LoggerContext(LoggerContext other)
+        {
+            if (other is null)
+                throw new ArgumentNullException(nameof(other));
+
+            Logger = other.Logger;
+            CorrelationId = other.CorrelationId;
+            LogCorrelationId = other.LogCorrelationId;
+            ActivityId = other.ActivityId;
+            CaptureLogs = other.CaptureLogs;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ILogger"/> that will be used to log messages.
+        /// </summary>
+        public ILogger Logger { get; }
+
+#pragma warning restore CS3001 // ILogger is not CLSCompliant
+#pragma warning restore CS3003 // ILogger is not CLSCompliant
+
+        /// <summary>
+        /// Gets or sets a <see cref="string"/> correlation id that is written to logs emitted through <see cref="ILogger"/>
+        /// when <see cref="LogCorrelationId"/> is <see langword="true"/> (the default). Supplying a value is the opt-in.
+        /// </summary>
+        /// <remarks>Only this explicitly supplied value is logged; <see cref="ActivityId"/> is never promoted into ILogger messages.</remarks>
+        public string CorrelationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean that controls whether <see cref="CorrelationId"/> is written to logs emitted through <see cref="ILogger"/>.
+        /// Defaults to <see langword="true"/>. Set to <see langword="false"/> as a kill switch to suppress correlation-id logging and restore the prior behavior.
+        /// </summary>
+        /// <remarks>This flag gates only the explicitly supplied <see cref="CorrelationId"/> string. It has no effect on <see cref="ActivityId"/>.</remarks>
+        public bool LogCorrelationId { get; set; } = true;
+
         /// <summary>
         /// Gets or set a <see cref="Guid"/> that will be used in the call to EventSource.SetCurrentThreadActivityId before logging.
         /// </summary>
+        /// <remarks><see cref="ActivityId"/> is used only for EventSource/ETW correlation and is not written to <see cref="ILogger"/> messages.</remarks>
         public Guid ActivityId { get; set; } = Guid.Empty;
 
         /// <summary>
@@ -53,5 +133,12 @@ namespace Microsoft.IdentityModel.Logging
         /// Gets or sets an <see cref="IDictionary{String, Object}"/> that enables custom extensibility scenarios.
         /// </summary>
         public IDictionary<string, object> PropertyBag { get; set; }
+
+        /// <summary>
+        /// Resolves the correlation id to write to an <see cref="ILogger"/> message: the explicitly supplied
+        /// <see cref="CorrelationId"/> when <see cref="LogCorrelationId"/> is enabled; otherwise <see langword="null"/>.
+        /// <see cref="ActivityId"/> is intentionally never used here.
+        /// </summary>
+        internal string ResolveCorrelationId() => LogCorrelationId ? CorrelationId : null;
     }
 }

--- a/src/Microsoft.IdentityModel.Logging/Microsoft.IdentityModel.Logging.csproj
+++ b/src/Microsoft.IdentityModel.Logging/Microsoft.IdentityModel.Logging.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\build\common.props" />
 
@@ -34,6 +34,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.IdentityModel.Abstractions\Microsoft.IdentityModel.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.IdentityModel.Logging/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.IdentityModel.Logging/PublicAPI.Unshipped.txt
@@ -1,0 +1,14 @@
+Microsoft.IdentityModel.Logging.LoggerContext.CorrelationId.get -> string
+Microsoft.IdentityModel.Logging.LoggerContext.CorrelationId.set -> void
+Microsoft.IdentityModel.Logging.LoggerContext.LogCorrelationId.get -> bool
+Microsoft.IdentityModel.Logging.LoggerContext.LogCorrelationId.set -> void
+Microsoft.IdentityModel.Logging.LoggerContext.Logger.get -> Microsoft.Extensions.Logging.ILogger
+Microsoft.IdentityModel.Logging.LoggerContext.LoggerContext(Microsoft.Extensions.Logging.ILogger logger) -> void
+Microsoft.IdentityModel.Logging.LoggerContext.LoggerContext(Microsoft.Extensions.Logging.ILogger logger, string correlationId) -> void
+Microsoft.IdentityModel.Logging.LoggerContext.LoggerContext(Microsoft.Extensions.Logging.ILogger logger, System.Guid activityId) -> void
+Microsoft.IdentityModel.Logging.LoggerContext.LoggerContext(Microsoft.IdentityModel.Logging.LoggerContext other) -> void
+static Microsoft.IdentityModel.Logging.LogHelper.LogExceptionMessage(System.Exception exception, Microsoft.IdentityModel.Logging.LoggerContext loggerContext) -> System.Exception
+static Microsoft.IdentityModel.Logging.LogHelper.LogInformation(string message, Microsoft.IdentityModel.Logging.LoggerContext loggerContext, params object[] args) -> void
+static Microsoft.IdentityModel.Logging.LogHelper.LogVerbose(string message, Microsoft.IdentityModel.Logging.LoggerContext loggerContext, params object[] args) -> void
+static Microsoft.IdentityModel.Logging.LogHelper.LogWarning(string message, Microsoft.IdentityModel.Logging.LoggerContext loggerContext) -> void
+static Microsoft.IdentityModel.Logging.LogHelper.LogWarning(string message, Microsoft.IdentityModel.Logging.LoggerContext loggerContext, params object[] args) -> void

--- a/test/Microsoft.IdentityModel.Logging.Tests/CorrelationLoggingTests.cs
+++ b/test/Microsoft.IdentityModel.Logging.Tests/CorrelationLoggingTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.IdentityModel.Logging.Tests
+{
+    // Covers the #3361 logging-engine correlation behavior:
+    //   - correlation id is opt-in and gated by LoggerContext.LogCorrelationId (default true, kill switch)
+    //   - ActivityId is never promoted into ILogger messages
+    //   - the protected LoggerContext copy constructor carries logging state
+    [Collection("Relying on ShowPII and LogCompleteSecurityArtifact")]
+    public class CorrelationLoggingTests
+    {
+        [Fact]
+        public void LogCorrelationId_DefaultsToTrue()
+        {
+            // Arrange & Act
+            var context = new LoggerContext();
+
+            // Assert
+            Assert.True(context.LogCorrelationId);
+        }
+
+        [Fact]
+        public void ResolveCorrelationId_ReturnsCorrelationId_WhenSet()
+        {
+            // Arrange
+            var context = new LoggerContext { CorrelationId = "corr-123" };
+
+            // Act & Assert
+            Assert.Equal("corr-123", context.ResolveCorrelationId());
+        }
+
+        [Fact]
+        public void ResolveCorrelationId_ReturnsNull_WhenNotSet()
+        {
+            // Arrange
+            var context = new LoggerContext();
+
+            // Act & Assert
+            Assert.Null(context.ResolveCorrelationId());
+        }
+
+        [Fact]
+        public void ResolveCorrelationId_ReturnsNull_WhenKillSwitchOff()
+        {
+            // Arrange
+            var context = new LoggerContext { CorrelationId = "corr-123", LogCorrelationId = false };
+
+            // Act & Assert
+            Assert.Null(context.ResolveCorrelationId());
+        }
+
+        [Fact]
+        public void ResolveCorrelationId_DoesNotPromoteActivityId()
+        {
+            // Arrange: ActivityId set but no CorrelationId - must not be promoted.
+            var context = new LoggerContext { ActivityId = Guid.NewGuid() };
+
+            // Act & Assert
+            Assert.Null(context.ResolveCorrelationId());
+        }
+
+        [Fact]
+        public void CopyConstructor_Throws_WhenOtherIsNull()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new DerivedLoggerContext(null));
+        }
+
+        [Fact]
+        public void CopyConstructor_CarriesLoggingState()
+        {
+            // Arrange
+            var logger = new CapturingLogger();
+            var activityId = Guid.NewGuid();
+            var source = new LoggerContext(logger)
+            {
+                CorrelationId = "corr-123",
+                LogCorrelationId = false,
+                ActivityId = activityId,
+                CaptureLogs = true,
+            };
+
+            // Act
+            var copy = new DerivedLoggerContext(source);
+
+            // Assert: logging state carried over.
+            Assert.Same(logger, copy.Logger);
+            Assert.Equal("corr-123", copy.CorrelationId);
+            Assert.False(copy.LogCorrelationId);
+            Assert.Equal(activityId, copy.ActivityId);
+            Assert.True(copy.CaptureLogs);
+
+            // Assert: the mutable Logs buffer is not shared (avoids cross-contamination).
+            Assert.NotSame(source.Logs, copy.Logs);
+        }
+
+        [Fact]
+        public void LogWarning_WritesCorrelationId_WhenSet()
+        {
+            // Arrange
+            var logger = new CapturingLogger();
+            var context = new LoggerContext(logger) { CorrelationId = "corr-123" };
+
+            // Act
+            LogHelper.LogWarning("IDXTEST: correlation test.", context);
+
+            // Assert
+            Assert.NotEmpty(logger.Messages);
+            Assert.Contains(logger.Messages, message => message.Contains("CorrelationId: corr-123"));
+        }
+
+        [Fact]
+        public void LogWarning_OmitsCorrelationId_WhenKillSwitchOff()
+        {
+            // Arrange
+            var logger = new CapturingLogger();
+            var context = new LoggerContext(logger) { CorrelationId = "corr-123", LogCorrelationId = false };
+
+            // Act
+            LogHelper.LogWarning("IDXTEST: correlation test.", context);
+
+            // Assert
+            Assert.NotEmpty(logger.Messages);
+            Assert.All(logger.Messages, message => Assert.DoesNotContain("CorrelationId", message));
+        }
+
+        [Fact]
+        public void LogWarning_DoesNotPromoteActivityId()
+        {
+            // Arrange: ActivityId set but no CorrelationId.
+            var logger = new CapturingLogger();
+            var context = new LoggerContext(logger) { ActivityId = Guid.NewGuid() };
+
+            // Act
+            LogHelper.LogWarning("IDXTEST: correlation test.", context);
+
+            // Assert
+            Assert.NotEmpty(logger.Messages);
+            Assert.All(logger.Messages, message => Assert.DoesNotContain("CorrelationId", message));
+        }
+
+        [Fact]
+        public void LogWarning_OmitsCorrelationId_ByDefault()
+        {
+            // Arrange: nothing supplied.
+            var logger = new CapturingLogger();
+            var context = new LoggerContext(logger);
+
+            // Act
+            LogHelper.LogWarning("IDXTEST: correlation test.", context);
+
+            // Assert
+            Assert.NotEmpty(logger.Messages);
+            Assert.All(logger.Messages, message => Assert.DoesNotContain("CorrelationId", message));
+        }
+
+        // Exposes the protected LoggerContext copy constructor for testing.
+        private sealed class DerivedLoggerContext : LoggerContext
+        {
+            public DerivedLoggerContext(LoggerContext other) : base(other)
+            {
+            }
+        }
+
+        // Minimal ILogger that captures the rendered message text.
+        private sealed class CapturingLogger : ILogger
+        {
+            public List<string> Messages { get; } = new List<string>();
+
+            public bool Enabled { get; set; } = true;
+
+            public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => Enabled;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                Messages.Add(formatter(state, exception));
+            }
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+
+                public void Dispose()
+                {
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.Logging.Tests/CorrelationLoggingTests.cs
+++ b/test/Microsoft.IdentityModel.Logging.Tests/CorrelationLoggingTests.cs
@@ -65,6 +65,18 @@ namespace Microsoft.IdentityModel.Logging.Tests
             Assert.Null(context.ResolveCorrelationId());
         }
 
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void ResolveCorrelationId_ReturnsNull_WhenCorrelationIdNullOrEmpty(string correlationId)
+        {
+            // Arrange: an empty/null correlation id must not produce a trailing "CorrelationId: ." fragment.
+            var context = new LoggerContext { CorrelationId = correlationId };
+
+            // Act & Assert
+            Assert.Null(context.ResolveCorrelationId());
+        }
+
         [Fact]
         public void CopyConstructor_Throws_WhenOtherIsNull()
         {
@@ -154,6 +166,67 @@ namespace Microsoft.IdentityModel.Logging.Tests
 
             // Act
             LogHelper.LogWarning("IDXTEST: correlation test.", context);
+
+            // Assert
+            Assert.NotEmpty(logger.Messages);
+            Assert.All(logger.Messages, message => Assert.DoesNotContain("CorrelationId", message));
+        }
+
+        [Fact]
+        public void LogWarning_OmitsCorrelationId_WhenCorrelationIdEmpty()
+        {
+            // Arrange: an empty correlation id must not append a "CorrelationId: ." fragment.
+            var logger = new CapturingLogger();
+            var context = new LoggerContext(logger) { CorrelationId = string.Empty };
+
+            // Act
+            LogHelper.LogWarning("IDXTEST: correlation test.", context);
+
+            // Assert
+            Assert.NotEmpty(logger.Messages);
+            Assert.All(logger.Messages, message => Assert.DoesNotContain("CorrelationId", message));
+        }
+
+        [Fact]
+        public void LogWarning_AppendsCorrelationId_AfterFormattingArgs()
+        {
+            // Arrange: correlation id is appended after the message is formatted with its args.
+            var logger = new CapturingLogger();
+            var context = new LoggerContext(logger) { CorrelationId = "corr-123" };
+
+            // Act
+            LogHelper.LogWarning("IDXTEST: value is {0}.", context, LogHelper.MarkAsNonPII("formatted-arg"));
+
+            // Assert
+            Assert.Contains(logger.Messages, message => message.Contains("formatted-arg") && message.Contains("CorrelationId: corr-123"));
+        }
+
+        [Fact]
+        public void LogExceptionMessage_WritesCorrelationId_WhenSet()
+        {
+            // Arrange
+            var logger = new CapturingLogger();
+            var context = new LoggerContext(logger) { CorrelationId = "corr-123" };
+            var exception = new InvalidOperationException("IDXTEST: exception path.");
+
+            // Act
+            LogHelper.LogExceptionMessage(exception, context);
+
+            // Assert
+            Assert.NotEmpty(logger.Messages);
+            Assert.Contains(logger.Messages, message => message.Contains("CorrelationId: corr-123"));
+        }
+
+        [Fact]
+        public void LogExceptionMessage_OmitsCorrelationId_WhenKillSwitchOff()
+        {
+            // Arrange
+            var logger = new CapturingLogger();
+            var context = new LoggerContext(logger) { CorrelationId = "corr-123", LogCorrelationId = false };
+            var exception = new InvalidOperationException("IDXTEST: exception path.");
+
+            // Act
+            LogHelper.LogExceptionMessage(exception, context);
 
             // Assert
             Assert.NotEmpty(logger.Messages);

--- a/test/Microsoft.IdentityModel.Logging.Tests/CorrelationLoggingTests.cs
+++ b/test/Microsoft.IdentityModel.Logging.Tests/CorrelationLoggingTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.IdentityModel.Abstractions;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -231,6 +232,98 @@ namespace Microsoft.IdentityModel.Logging.Tests
             // Assert
             Assert.NotEmpty(logger.Messages);
             Assert.All(logger.Messages, message => Assert.DoesNotContain("CorrelationId", message));
+        }
+
+        [Theory]
+        [InlineData(LoggingPath.Information)]
+        [InlineData(LoggingPath.Verbose)]
+        [InlineData(LoggingPath.Warning)]
+        [InlineData(LoggingPath.Exception)]
+        public void ContextLogger_IsAuthoritative_WhenProvided(LoggingPath loggingPath)
+        {
+            // Arrange
+            IIdentityLogger originalLogger = LogHelper.Logger;
+            bool originalHeaderWritten = LogHelper.HeaderWritten;
+            var staticLogger = new TestLogger();
+            var contextLogger = new CapturingLogger();
+            string message = $"IDXTEST: contextual {loggingPath} message.";
+
+            try
+            {
+                LogHelper.Logger = staticLogger;
+                LogHelper.HeaderWritten = true;
+
+                // Act
+                Log(loggingPath, message, new LoggerContext(contextLogger));
+
+                // Assert
+                Assert.Single(contextLogger.Messages);
+                Assert.Contains(message, contextLogger.Messages[0]);
+                Assert.False(staticLogger.ContainsLog(message));
+            }
+            finally
+            {
+                LogHelper.Logger = originalLogger;
+                LogHelper.HeaderWritten = originalHeaderWritten;
+            }
+        }
+
+        [Theory]
+        [InlineData(LoggingPath.Information)]
+        [InlineData(LoggingPath.Verbose)]
+        [InlineData(LoggingPath.Warning)]
+        [InlineData(LoggingPath.Exception)]
+        public void StaticLogger_IsFallback_WhenContextLoggerNotProvided(LoggingPath loggingPath)
+        {
+            // Arrange
+            IIdentityLogger originalLogger = LogHelper.Logger;
+            bool originalHeaderWritten = LogHelper.HeaderWritten;
+            var staticLogger = new TestLogger();
+            string message = $"IDXTEST: fallback {loggingPath} message.";
+
+            try
+            {
+                LogHelper.Logger = staticLogger;
+                LogHelper.HeaderWritten = true;
+
+                // Act
+                Log(loggingPath, message, new LoggerContext());
+
+                // Assert
+                Assert.True(staticLogger.ContainsLog(message));
+            }
+            finally
+            {
+                LogHelper.Logger = originalLogger;
+                LogHelper.HeaderWritten = originalHeaderWritten;
+            }
+        }
+
+        private static void Log(LoggingPath loggingPath, string message, LoggerContext context)
+        {
+            switch (loggingPath)
+            {
+                case LoggingPath.Information:
+                    LogHelper.LogInformation(message, context);
+                    break;
+                case LoggingPath.Verbose:
+                    LogHelper.LogVerbose(message, context);
+                    break;
+                case LoggingPath.Warning:
+                    LogHelper.LogWarning(message, context);
+                    break;
+                case LoggingPath.Exception:
+                    LogHelper.LogExceptionMessage(new InvalidOperationException(message), context);
+                    break;
+            }
+        }
+
+        public enum LoggingPath
+        {
+            Information,
+            Verbose,
+            Warning,
+            Exception,
         }
 
         // Exposes the protected LoggerContext copy constructor for testing.


### PR DESCRIPTION
**Logging engine: ILogger-aware overloads + opt-in correlation id (#3361)**

✓ You've read the Contributor Guide and Code of Conduct.
• You've included unit or integration tests for your change, where applicable. 
✓ You've included inline docs for your change, where applicable.
✓ If any gains or losses in performance are possible, you've included benchmarks for your changes.
✓ There's an open issue for the PR that you are making.

Foundational logging engine for the high-performance logging rollout.

**Description**

This is the engine PR of the high-performance logging effort (#3361), scoped to  Microsoft.IdentityModel.Logging  only. It adds the substrate that consumers and the per-project PRs build on: an  ILogger -aware  LogHelper , an opt-in correlation id, and a kill switch.

**What changed**

•  LoggerContext 
• Adds  CorrelationId  ( string ) — an explicitly supplied correlation id written to  ILogger  logs.
• Adds  LogCorrelationId  ( bool , default  true ) — a kill switch; set  false  to suppress correlation logging and restore prior behavior.
• Adds a  protected LoggerContext(LoggerContext other)  copy constructor that carries  Logger ,  CorrelationId ,  LogCorrelationId ,  ActivityId , and  CaptureLogs  (the  Logs  buffer and  PropertyBag  are intentionally not shared, to avoid cross-contaminating nested/derived contexts).
•  LogHelper 
• Adds  LoggerContext -aware  LogInformation  /  LogVerbose  /  LogWarning  /  LogExceptionMessage  overloads that emit through a consumer-supplied  ILogger .
• Centralizes correlation resolution in one place ( ResolveCorrelationId() ), removing duplicated inline logic across the overloads.
• Correlation is opt-in and gated by  LogCorrelationId . The previous  CorrelationId ?? ActivityId.ToString()  fallback is removed, so  ActivityId  stays ETW-only and is never promoted into  ILogger  text — no  Guid  is materialized on the default path.
• Takes a minimal dependency on  Microsoft.Extensions.Logging.Abstractions .

**Behavior**
<img width="575" height="161" alt="image" src="https://github.com/user-attachments/assets/63775679-53c4-42eb-8497-54d60e7879c0" />

 ActivityId  behavior is unchanged by this PR.

**Benchmarks**

 CorrelationLoggingBenchmarks  (net9.0, in-process, MemoryDiagnoser — Allocated is the reliable signal):
<img width="932" height="372" alt="image" src="https://github.com/user-attachments/assets/a57a76da-74ea-47ff-bd52-80dadec6e848" />


Removing the fallback saves ~600 B/log (94%) and ~6.5× latency on the common ETW- ActivityId  case; the kill switch restores prior behavior exactly.

**API surface**

New public/internal members recorded in  PublicAPI.Unshipped.txt  /  InternalAPI.Unshipped.txt :  LoggerContext.CorrelationId ,  LoggerContext.LogCorrelationId ,  LoggerContext(LoggerContext) , the  ILogger  ctors, the  LogHelper   LoggerContext  overloads, and  LoggerContext.ResolveCorrelationId() .

**Notes / decisions**

• Builds clean on  net472 ,  netstandard2.0 ,  net9.0 .
• Chose  Microsoft.Extensions.Logging.Abstractions  (minimal) over the full  Microsoft.Extensions.Logging  package — only  ILogger / LogLevel  are used.
• The copy constructor is the base for the Experimental  CallContext(CallContext other)  propagation coming in the Tokens PR (also closes the  ValidatedToken  fresh-context correlation-loss review comment).

**Out of scope (follow-up PRs, one per project)**

 ILogger  threading +  [LoggerMessage]  hot-path conversion in Tokens, JsonWebTokens, Saml/Saml2, Protocols, OpenIdConnect, SignedHttpRequest, WsFederation, Validators, Xml.