### PR TITLE
Clarify intended Audience and Audiences behavior in JsonWebTokenHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ See the [releases](https://github.com/AzureAD/azure-activedirectory-identitymode
 ## New Features
 - Add `SignedHttpRequestValidationParameters.UseCaseSensitivePClaimComparison` to configure Signed HTTP Request `p` claim path comparison per validation. The default is case-sensitive; set the property to `false` for case-insensitive comparison. The previous `Switch.Microsoft.IdentityModel.SignedHttpRequest.UseCaseSensitivePClaimComparison` AppContext key is no longer honored. Applications upgrading from 8.22.0 that set the key to `false` must set this property to `false` instead. See [PR #3569](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/pull/3569).
 
+## Documentation
+- Correct the `SecurityTokenDescriptor.Audience` and `SecurityTokenDescriptor.Audiences` documentation to describe the actual token creation behavior. The previous text stated that these members are combined with the `aud` claims in `Claims` or `Subject`, which only describes the legacy `JwtSecurityTokenHandler`. `JsonWebTokenHandler` intentionally uses `Audience`/`Audiences` as the only source for `aud` when either is set, so that a token's audiences can be overridden with a smaller subset than the claims it is created from. Applications migrating from `JwtSecurityTokenHandler` that set `aud` in more than one place should consolidate all intended audiences into `Audiences`. See [issue #3535](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/3535).
+
 8.22.0
 ====
 ## New Features

--- a/src/Microsoft.IdentityModel.Tokens/SecurityTokenDescriptor.cs
+++ b/src/Microsoft.IdentityModel.Tokens/SecurityTokenDescriptor.cs
@@ -17,15 +17,38 @@ namespace Microsoft.IdentityModel.Tokens
         private List<string> _audiences;
 
         /// <summary>
-        /// Gets or sets the value of the {"": audience} claim. Will be combined with <see cref="Audiences"/> and any "Aud" claims in
-        /// <see cref="Claims"/> or <see cref="Subject"/> when creating a token.
+        /// Gets or sets the value of the {"": audience} claim. Will be combined with <see cref="Audiences"/> when creating a token.
         /// </summary>
+        /// <remarks>
+        /// When <see cref="Audience"/> and/or <see cref="Audiences"/> is set, <c>JsonWebTokenHandler</c>
+        /// uses them as the only source for the token's 'aud' claim and ignores any "Aud" claims in <see cref="Claims"/> or <see cref="Subject"/>.
+        /// This allows the audiences of a token to be overridden with a smaller subset than the claims it is created from.
+        /// When neither is set, the 'aud' claim is taken from <see cref="Claims"/> if present, otherwise from <see cref="Subject"/>.
+        /// <para>
+        /// The legacy <c>JwtSecurityTokenHandler</c> instead combines <see cref="Audience"/> and <see cref="Audiences"/> with the "Aud"
+        /// claims found in <see cref="Claims"/> or <see cref="Subject"/>. Applications migrating to
+        /// <c>JsonWebTokenHandler</c> that set "Aud" claims in more than one place should
+        /// consolidate all intended audiences into <see cref="Audiences"/>.
+        /// </para>
+        /// </remarks>
         public string Audience { get; set; }
 
         /// <summary>
-        /// Gets the list audiences to include in the token's 'Aud' claim. Will be combined with <see cref="Audiences"/> and any
-        /// "Aud" claims in <see cref="Claims"/> or <see cref="Subject"/> when creating a token.
+        /// Gets the list audiences to include in the token's 'Aud' claim. Will be combined with <see cref="Audience"/> when creating a token.
         /// </summary>
+        /// <remarks>
+        /// When <see cref="Audiences"/> and/or <see cref="Audience"/> is set, <c>JsonWebTokenHandler</c>
+        /// uses them as the only source for the token's 'aud' claim and ignores any "Aud" claims in <see cref="Claims"/> or <see cref="Subject"/>.
+        /// This allows the audiences of a token to be overridden with a smaller subset than the claims it is created from.
+        /// When neither is set, the 'aud' claim is taken from <see cref="Claims"/> if present, otherwise from <see cref="Subject"/>.
+        /// Duplicate values are not removed; each entry is written to the token as provided.
+        /// <para>
+        /// The legacy <c>JwtSecurityTokenHandler</c> instead combines <see cref="Audiences"/> and <see cref="Audience"/> with the "Aud"
+        /// claims found in <see cref="Claims"/> or <see cref="Subject"/>. Applications migrating to
+        /// <c>JsonWebTokenHandler</c> that set "Aud" claims in more than one place should
+        /// consolidate all intended audiences into <see cref="Audiences"/>.
+        /// </para>
+        /// </remarks>
         public IList<string> Audiences => _audiences ?? Interlocked.CompareExchange(ref _audiences, [], null) ?? _audiences;
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -1391,6 +1391,113 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
+        // Locks in the intended 'aud' resolution for JsonWebTokenHandler: when SecurityTokenDescriptor.Audience and/or
+        // Audiences is set they are the only source for the 'aud' claim, so that a token's audiences can be overridden
+        // with a smaller subset than the claims it is created from. This intentionally differs from JwtSecurityTokenHandler,
+        // which combines the descriptor audiences with the 'aud' claims in Claims or Subject.
+        [Theory, MemberData(nameof(CreateTokenAudienceResolutionTheoryData), DisableDiscoveryEnumeration = true)]
+        public void CreateTokenAudienceResolution(CreateTokenTheoryData theoryData)
+        {
+            var context = TestUtilities.WriteHeader($"{this}.CreateTokenAudienceResolution", theoryData);
+
+            // Act
+            var jsonWebToken = new JsonWebToken(new JsonWebTokenHandler().CreateToken(theoryData.TokenDescriptor));
+
+            // Assert
+            IdentityComparer.AreEqual(theoryData.ExpectedClaims["aud"], jsonWebToken.Audiences, context);
+
+            TestUtilities.AssertFailIfErrors(context);
+        }
+
+        public static TheoryData<CreateTokenTheoryData> CreateTokenAudienceResolutionTheoryData
+        {
+            get
+            {
+                TheoryData<CreateTokenTheoryData> theoryData = new TheoryData<CreateTokenTheoryData>();
+
+                static ClaimsIdentity Subject(params string[] audiences)
+                {
+                    ClaimsIdentity identity = new CaseSensitiveClaimsIdentity();
+                    foreach (string audience in audiences)
+                        identity.AddClaim(new Claim(JwtRegisteredClaimNames.Aud, audience));
+
+                    return identity;
+                }
+
+                static CreateTokenTheoryData Data(string testId, SecurityTokenDescriptor descriptor, params string[] expected)
+                {
+                    descriptor.SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials;
+                    return new CreateTokenTheoryData(testId)
+                    {
+                        TokenDescriptor = descriptor,
+                        ExpectedClaims = new Dictionary<string, object> { { "aud", new List<string>(expected) } }
+                    };
+                }
+
+                // Audiences wins over Subject. This is the scenario reported in issue #3535 and is by design.
+                SecurityTokenDescriptor audiencesAndSubject = new SecurityTokenDescriptor { Subject = Subject("aud-from-subject") };
+                audiencesAndSubject.Audiences.Add("aud-from-descriptor");
+                theoryData.Add(Data("AudiencesWinsOverSubject", audiencesAndSubject, "aud-from-descriptor"));
+
+                theoryData.Add(Data(
+                    "AudienceWinsOverSubject",
+                    new SecurityTokenDescriptor { Audience = "aud-from-descriptor", Subject = Subject("aud-from-subject") },
+                    "aud-from-descriptor"));
+
+                theoryData.Add(Data(
+                    "AudienceWinsOverClaims",
+                    new SecurityTokenDescriptor
+                    {
+                        Audience = "aud-from-descriptor",
+                        Claims = new Dictionary<string, object> { { JwtRegisteredClaimNames.Aud, "aud-from-claims" } }
+                    },
+                    "aud-from-descriptor"));
+
+                // The descriptor members allow narrowing the audiences to a subset of those in Subject.
+                SecurityTokenDescriptor narrowing = new SecurityTokenDescriptor { Subject = Subject("aud1", "aud2", "aud3") };
+                narrowing.Audiences.Add("aud2");
+                theoryData.Add(Data("AudiencesNarrowsSubjectAudiences", narrowing, "aud2"));
+
+                // Claims takes precedence over Subject when no descriptor audience is set.
+                theoryData.Add(Data(
+                    "ClaimsWinsOverSubjectWhenNoDescriptorAudience",
+                    new SecurityTokenDescriptor
+                    {
+                        Claims = new Dictionary<string, object> { { JwtRegisteredClaimNames.Aud, "aud-from-claims" } },
+                        Subject = Subject("aud-from-subject")
+                    },
+                    "aud-from-claims"));
+
+                theoryData.Add(Data(
+                    "SubjectUsedWhenNoDescriptorAudienceOrClaims",
+                    new SecurityTokenDescriptor { Subject = Subject("aud-from-subject1", "aud-from-subject2") },
+                    "aud-from-subject1", "aud-from-subject2"));
+
+                // Audience and Audiences are always combined with each other.
+                SecurityTokenDescriptor audienceAndAudiences = new SecurityTokenDescriptor { Audience = "aud-from-audience" };
+                audienceAndAudiences.Audiences.Add("aud-from-audiences1");
+                audienceAndAudiences.Audiences.Add("aud-from-audiences2");
+                theoryData.Add(Data(
+                    "AudienceCombinedWithAudiences",
+                    audienceAndAudiences,
+                    "aud-from-audiences1", "aud-from-audiences2", "aud-from-audience"));
+
+                // Audience and Audiences are combined even when Subject also defines an 'aud' claim.
+                SecurityTokenDescriptor audienceAndAudiencesWithSubject = new SecurityTokenDescriptor
+                {
+                    Audience = "aud-from-audience",
+                    Subject = Subject("aud-from-subject")
+                };
+                audienceAndAudiencesWithSubject.Audiences.Add("aud-from-audiences");
+                theoryData.Add(Data(
+                    "AudienceCombinedWithAudiencesAndSubjectIgnored",
+                    audienceAndAudiencesWithSubject,
+                    "aud-from-audiences", "aud-from-audience"));
+
+                return theoryData;
+            }
+        }
+
         // This test checks to make sure that SecurityTokenDescriptor.Audience, Expires, IssuedAt, NotBefore, Issuer have priority over SecurityTokenDescriptor.Claims.
         [Theory, MemberData(nameof(CreateJWSWithSecurityTokenDescriptorClaimsTheoryData), DisableDiscoveryEnumeration = true)]
         public void CreateJWSWithSecurityTokenDescriptorClaims(CreateTokenTheoryData theoryData)

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandlerTests.cs
@@ -1391,7 +1391,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
             }
         }
 
-        // Locks in the intended 'aud' resolution for JsonWebTokenHandler: when SecurityTokenDescriptor.Audience and/or
+        // Tests the intended 'aud' resolution for JsonWebTokenHandler: when SecurityTokenDescriptor.Audience and/or
         // Audiences is set they are the only source for the 'aud' claim, so that a token's audiences can be overridden
         // with a smaller subset than the claims it is created from. This intentionally differs from JwtSecurityTokenHandler,
         // which combines the descriptor audiences with the 'aud' claims in Claims or Subject.


### PR DESCRIPTION
Clarifies intended behavior of audience and audiences when using the JsonWebTokenHandler through documentation on the relevant members and tests to ensure we notice if the behavior changes.