### PR TITLE
Refactor PropertyBag assignment

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/TokenValidationParameters.cs
@@ -73,7 +73,12 @@ namespace Microsoft.IdentityModel.Tokens
             LogValidationExceptions = other.LogValidationExceptions;
             NameClaimType = other.NameClaimType;
             NameClaimTypeRetriever = other.NameClaimTypeRetriever;
-            PropertyBag = other.PropertyBag is not null ? new Dictionary<string, object>(other.PropertyBag) : null;
+            PropertyBag = other.PropertyBag switch
+            {
+                null => null,
+                Dictionary<string, object> dictionary => new Dictionary<string, object>(dictionary, dictionary.Comparer),
+                _ => new Dictionary<string, object>(other.PropertyBag)
+            };
             TryReadJwtClaim = other.TryReadJwtClaim;
             RefreshBeforeValidation = other.RefreshBeforeValidation;
             RequireAudience = other.RequireAudience;


### PR DESCRIPTION
Preserve the source dictionary's  IEqualityComparer  when  TokenValidationParameters.Clone()  deep-copies  PropertyBag , matching the 8.x implementation, so a bag created with a custom comparer (for example  StringComparer.OrdinalIgnoreCase ) no longer silently reverts to the default comparer on the clone.

