### PR TITLE
Port: Disable automatic redirects for default SHR JKU retrieval (#3494)

### DIFF
--- a/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
+++ b/src/Microsoft.IdentityModel.Protocols.SignedHttpRequest/SignedHttpRequestHandler.cs
@@ -36,14 +36,21 @@ namespace Microsoft.IdentityModel.Protocols.SignedHttpRequest
         };
 
         private readonly Uri _baseUriHelper = new Uri("http://localhost", UriKind.Absolute);
-        internal readonly HttpClient _defaultHttpClient = new HttpClient();
+
+        // Redirects are disabled on the default client. Consumers who need
+        // different behavior can supply their own client via
+        // SignedHttpRequestValidationParameters.HttpClientProvider.
+        internal readonly HttpClient _defaultHttpClient = new HttpClient(
+            new HttpClientHandler { AllowAutoRedirect = false })
+        {
+            Timeout = TimeSpan.FromSeconds(10)
+        };
 
         /// <summary>
         /// Initializes a new instance of <see cref="SignedHttpRequestHandler"/>.
         /// </summary>
         public SignedHttpRequestHandler()
         {
-            _defaultHttpClient.Timeout = TimeSpan.FromSeconds(10);
         }
 
         #region SignedHttpRequest creation


### PR DESCRIPTION
# Port: Disable automatic redirects for default SHR JKU retrieval (#3494)

## Summary

Ports the `dev8x` JKU retrieval hardening from #3494 to `dev`.

The default internal `HttpClient` used by `SignedHttpRequestHandler` no longer follows HTTP redirects when retrieving a JWK set from a `jku` claim. Consumers that require different redirect behavior can continue to provide their own client through `SignedHttpRequestValidationParameters.HttpClientProvider`.

## Validation surface review

- `GetPopKeysFromJkuAsync` is the only production path that uses the default client for SHR JKU retrieval.
- The existing HTTPS requirement and allowed-domain validation remain unchanged.
- Caller-provided clients remain fully supported and retain control over their redirect policy.
- This change does not involve `TokenValidationParameters`, `ValidationParameters`, or their corresponding handler overloads.

## Testing

- `Microsoft.IdentityModel.Protocols.SignedHttpRequest.Tests.PopKeyResolvingTests`
- 71 passed on `net8.0`
