### PR TITLE
Port: Tidy null handling in SAML conditions validation (#3491)

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml/SamlSecurityTokenHandler.cs
@@ -1275,8 +1275,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml
             ValidateConditions(samlToken, validationParameters);
             var issuer = ValidateIssuer(samlToken.Issuer, samlToken, validationParameters);
 
-            if (samlToken.Assertion.Conditions != null)
-                ValidateTokenReplay(samlToken.Assertion.Conditions.NotOnOrAfter, samlToken.Assertion.CanonicalString, validationParameters);
+            ValidateTokenReplay(samlToken.Assertion.Conditions?.NotOnOrAfter, samlToken.Assertion.CanonicalString, validationParameters);
 
             ValidateIssuerSecurityKey(samlToken.SigningKey, samlToken, validationParameters);
             validatedToken = samlToken;

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Saml2/Saml2SecurityTokenHandler.cs
@@ -274,8 +274,7 @@ namespace Microsoft.IdentityModel.Tokens.Saml2
             ValidateSubject(samlToken, validationParameters);
             var issuer = ValidateIssuer(samlToken.Issuer, samlToken, validationParameters);
 
-            if (samlToken.Assertion.Conditions != null)
-                ValidateTokenReplay(samlToken.Assertion.Conditions.NotOnOrAfter, samlToken.Assertion.CanonicalString, validationParameters);
+            ValidateTokenReplay(samlToken.Assertion.Conditions?.NotOnOrAfter, samlToken.Assertion.CanonicalString, validationParameters);
 
             ValidateIssuerSecurityKey(samlToken.SigningKey, samlToken, validationParameters);
             validatedToken = samlToken;

--- a/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidation/SamlConditionsHandlingTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/TokenValidation/SamlConditionsHandlingTests.cs
@@ -1,0 +1,198 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Tokens.Experimental;
+using Microsoft.IdentityModel.Tokens.Saml;
+using Microsoft.IdentityModel.Tokens.Saml2;
+using Xunit;
+
+#nullable enable
+namespace Microsoft.IdentityModel.Tokens.TokenValidation.Tests
+{
+    public class SamlConditionsHandlingTests
+    {
+        [Theory]
+        [InlineData(false, false, false)]
+        [InlineData(false, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(true, true, false)]
+        public async Task SamlConditionsHandling(
+            bool conditionsWithoutExpiration,
+            bool replayCachePresent,
+            bool expectNoExpirationError)
+        {
+            string token = conditionsWithoutExpiration
+                ? AddConditionsWithoutExpiration(
+                    ReferenceTokens.SamlToken_NoConditions_NoSignature,
+                    "<Conditions NotBefore=\"2017-08-25T21:17:29.554Z\"></Conditions>")
+                : ReferenceTokens.SamlToken_NoConditions_NoSignature;
+
+            Assert.Equal(conditionsWithoutExpiration, token.Contains("<Conditions "));
+
+            var handler = new SamlSecurityTokenHandler();
+            TrackingTokenReplayCache? tokenReplayCache = replayCachePresent ? new TrackingTokenReplayCache() : null;
+            TokenValidationParameters tokenValidationParameters = CreateTokenValidationParameters(tokenReplayCache);
+
+            if (expectNoExpirationError)
+            {
+                Assert.Throws<SecurityTokenNoExpirationException>(
+                    () => handler.ValidateToken(token, tokenValidationParameters, out _));
+            }
+            else
+            {
+                handler.ValidateToken(token, tokenValidationParameters, out _);
+            }
+
+            AssertCacheUsage(tokenReplayCache, conditionsWithoutExpiration && replayCachePresent);
+
+            await ValidateResultModelAsync(
+                new SamlSecurityTestingTokenHandler(),
+                token,
+                replayCachePresent,
+                expectNoExpirationError,
+                conditionsWithoutExpiration && replayCachePresent);
+        }
+
+        [Theory]
+        [InlineData(false, false, false)]
+        [InlineData(false, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(true, true, true)]
+        public async Task Saml2ConditionsHandling(
+            bool conditionsWithoutExpiration,
+            bool replayCachePresent,
+            bool expectNoExpirationError)
+        {
+            string token = conditionsWithoutExpiration
+                ? AddConditionsWithoutExpiration(
+                    ReferenceTokens.Saml2Token_NoConditions_NoSignature,
+                    "<Conditions NotBefore=\"2017-03-20T15:47:31.957Z\"></Conditions>")
+                : ReferenceTokens.Saml2Token_NoConditions_NoSignature;
+
+            Assert.Equal(conditionsWithoutExpiration, token.Contains("<Conditions "));
+
+            var handler = new Saml2SecurityTokenHandler();
+            TrackingTokenReplayCache? tokenReplayCache = replayCachePresent ? new TrackingTokenReplayCache() : null;
+            TokenValidationParameters tokenValidationParameters = CreateTokenValidationParameters(tokenReplayCache);
+
+            if (expectNoExpirationError)
+            {
+                Assert.Throws<SecurityTokenNoExpirationException>(
+                    () => handler.ValidateToken(token, tokenValidationParameters, out _));
+            }
+            else
+            {
+                handler.ValidateToken(token, tokenValidationParameters, out _);
+            }
+
+            AssertCacheUsage(tokenReplayCache, false);
+
+            await ValidateResultModelAsync(
+                new Saml2SecurityTestingTokenHandler(),
+                token,
+                replayCachePresent,
+                expectNoExpirationError,
+                false);
+        }
+
+        private static string AddConditionsWithoutExpiration(string token, string conditions)
+        {
+            return token.Replace("<AttributeStatement>", conditions + "<AttributeStatement>");
+        }
+
+        private static TokenValidationParameters CreateTokenValidationParameters(TrackingTokenReplayCache? tokenReplayCache)
+        {
+            return new TokenValidationParameters
+            {
+                RequireAudience = false,
+                RequireSignedTokens = false,
+                TokenReplayCache = tokenReplayCache,
+                ValidateAudience = false,
+                ValidateIssuer = false,
+                ValidateLifetime = false,
+                ValidateTokenReplay = true,
+            };
+        }
+
+        private static ValidationParameters CreateValidationParameters(TrackingTokenReplayCache? tokenReplayCache)
+        {
+            return new ValidationParameters
+            {
+                AlgorithmValidator = SkipValidationValidators.SkipAlgorithmValidation,
+                AudienceValidator = SkipValidationValidators.SkipAudienceValidation,
+                IssuerValidatorAsync = SkipValidationValidators.SkipIssuerValidation,
+                LifetimeValidator = SkipValidationValidators.SkipLifetimeValidation,
+                SignatureKeyValidator = SkipValidationValidators.SkipIssuerSigningKeyValidation,
+                SignatureValidator = SkipValidationValidators.SkipSignatureValidation,
+                TokenReplayCache = tokenReplayCache,
+            };
+        }
+
+        private static void AssertCacheUsage(TrackingTokenReplayCache? tokenReplayCache, bool expectedToAdd)
+        {
+            if (tokenReplayCache is null)
+                return;
+
+            Assert.Equal(expectedToAdd ? 1 : 0, tokenReplayCache.FindCount);
+            Assert.Equal(expectedToAdd ? 1 : 0, tokenReplayCache.AddCount);
+
+            if (expectedToAdd)
+                Assert.Equal(DateTime.MaxValue, tokenReplayCache.Expiration);
+        }
+
+        private static async Task ValidateResultModelAsync(
+            ITestingTokenHandler handler,
+            string token,
+            bool replayCachePresent,
+            bool expectNoExpirationError,
+            bool expectCacheAdd)
+        {
+            TrackingTokenReplayCache? tokenReplayCache = replayCachePresent ? new TrackingTokenReplayCache() : null;
+            ValidationResult<ValidatedToken, ValidationError> result = await handler.ValidateTokenAsync(
+                token,
+                CreateValidationParameters(tokenReplayCache),
+                new CallContext(),
+                CancellationToken.None);
+
+            if (expectNoExpirationError)
+            {
+                Assert.False(result.Succeeded);
+                TokenReplayValidationError error = Assert.IsType<TokenReplayValidationError>(result.Error);
+                Assert.Equal(TokenReplayValidationFailure.NoExpiration.Name, error.FailureType.Name);
+            }
+            else
+            {
+                Assert.True(result.Succeeded, result.Error?.Message);
+            }
+
+            AssertCacheUsage(tokenReplayCache, expectCacheAdd);
+        }
+
+        private sealed class TrackingTokenReplayCache : ITokenReplayCache
+        {
+            public int AddCount { get; private set; }
+
+            public DateTime Expiration { get; private set; }
+
+            public int FindCount { get; private set; }
+
+            public bool TryAdd(string securityToken, DateTime expiresOn)
+            {
+                AddCount++;
+                Expiration = expiresOn;
+                return true;
+            }
+
+            public bool TryFind(string securityToken)
+            {
+                FindCount++;
+                return false;
+            }
+        }
+    }
+}
+#nullable restore


### PR DESCRIPTION
# Port: Tidy null handling in SAML conditions validation (#3491)

## Summary

Ports the SAML conditions and token-replay validation correction from #3491 to `dev`.

The legacy SAML and SAML2 handlers now invoke replay validation consistently when the assertion does not contain a `Conditions` element. Missing conditions are passed to replay validation as a missing expiration rather than causing replay validation to be skipped.

## Changes equivalent to the dev8x port

- Call legacy SAML replay validation with `Conditions?.NotOnOrAfter`.
- Call legacy SAML2 replay validation with `Conditions?.NotOnOrAfter`.
- Preserve the existing behavior when replay validation is not configured.

## Required dev adaptations

- Place the regression matrix in the current unified token-validation tests rather than recreating the older dev8x test file.
- Exercise both `TokenValidationParameters` and experimental `ValidationParameters`.
- Preserve each API's error model:
  - Legacy handlers throw `SecurityTokenNoExpirationException`.
  - Newer handlers return `TokenReplayValidationError` with `TokenReplayValidationFailure.NoExpiration`.
- Build the no-expiration wire forms from existing fixtures to avoid adding duplicate full-token constants.

## Additional coverage

- Verify SAML 1.x and SAML2.
- Verify absent `Conditions` and `Conditions` without `NotOnOrAfter`.
- Verify replay-cache enabled and disabled behavior.
- Track replay-cache lookup and insertion so successful validation cannot hide a skipped replay check.

The experimental production handlers already use null-conditional conditions access, so no production change was needed in their result-based paths.

## Testing

- Focused TVP/VP and SAML/SAML2 matrix: 8 passed on `net8.0`.
- `Microsoft.IdentityModel.Tokens.Tests`: 2,446 passed on `net8.0`.
