### PR TITLE
Port: Bound telemetry algorithm dimension cardinality (#3490)

### DIFF
--- a/src/Microsoft.IdentityModel.Tokens/Telemetry/CryptoTelemetry.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Telemetry/CryptoTelemetry.cs
@@ -206,6 +206,37 @@ public static class CryptoTelemetry
     }
 
     /// <summary>
+    /// Maps a raw algorithm string to a known algorithm family or "other" to prevent cardinality explosion.
+    /// </summary>
+    /// <param name="algorithm">The raw algorithm identifier.</param>
+    /// <returns>A bounded algorithm family string.</returns>
+    internal static string GetKnownAlgorithmFamilyOrOther(string algorithm)
+    {
+        if (string.IsNullOrEmpty(algorithm) ||
+            string.Equals(algorithm, SecurityAlgorithms.None, StringComparison.OrdinalIgnoreCase))
+        {
+            return TelemetryConstants.AlgorithmFamilies.None;
+        }
+
+        if (SupportedAlgorithms.RsaSigningAlgorithms.Contains(algorithm))
+            return TelemetryConstants.AlgorithmFamilies.RSA;
+
+        if (SupportedAlgorithms.RsaPssSigningAlgorithms.Contains(algorithm))
+            return TelemetryConstants.AlgorithmFamilies.RSAPSS;
+
+        if (SupportedAlgorithms.EcdsaSigningAlgorithms.Contains(algorithm))
+            return TelemetryConstants.AlgorithmFamilies.ECDSA;
+
+        if (SupportedAlgorithms.SymmetricSigningAlgorithms.Contains(algorithm))
+            return TelemetryConstants.AlgorithmFamilies.HMAC;
+
+        if (SupportedAlgorithms.MlDsaSigningAlgorithms.Contains(algorithm))
+            return TelemetryConstants.AlgorithmFamilies.MLDSA;
+
+        return TelemetryConstants.AlgorithmFamilies.Other;
+    }
+
+    /// <summary>
     /// Gets the issuer host for telemetry, returning "other" if not in the tracked issuers allowlist.
     /// </summary>
     /// <param name="issuer">The full issuer URI.</param>

--- a/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryClient.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryClient.cs
@@ -63,7 +63,7 @@ namespace Microsoft.IdentityModel.Telemetry
             var tagList = new TagList()
             {
                 { TelemetryConstants.IdentityModelVersionTag, ClientVer },
-                { TelemetryConstants.AlgorithmTag, algorithm },
+                { TelemetryConstants.AlgorithmTag, CryptoTelemetry.GetKnownAlgorithmFamilyOrOther(algorithm) },
                 { TelemetryConstants.KeyAlgorithmTag, CryptoTelemetry.GetKeyAlgorithmId(key) },
                 { TelemetryConstants.IssuerTag, CryptoTelemetry.GetTrackedIssuerOrOther(issuer) },
                 { TelemetryConstants.ErrorTag, errorType }

--- a/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryConstants.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Telemetry/TelemetryConstants.cs
@@ -129,6 +129,21 @@ namespace Microsoft.IdentityModel.Telemetry
         }
 
         /// <summary>
+        /// Algorithm family constants for telemetry. Raw algorithm strings are mapped to these
+        /// bounded values to prevent cardinality explosion in metric dimensions.
+        /// </summary>
+        public static class AlgorithmFamilies
+        {
+            public const string RSA = "RSA";
+            public const string RSAPSS = "RSA-PSS";
+            public const string ECDSA = "ECDSA";
+            public const string HMAC = "HMAC";
+            public const string MLDSA = "ML-DSA";
+            public const string None = "none";
+            public const string Other = "other";
+        }
+
+        /// <summary>
         /// Signature validation error constants. Kept limited to prevent cardinality explosion.
         /// </summary>
         public static class SignatureValidationErrors

--- a/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Telemetry/SamlSignatureValidationTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Saml.Tests/Telemetry/SamlSignatureValidationTelemetryTests.cs
@@ -60,7 +60,7 @@ public class SamlSignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.None },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, Default.AsymmetricSigningCredentials.Algorithm },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "RSA-2048" }
             });
     }
@@ -108,7 +108,7 @@ public class SamlSignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.SignatureVerificationFailed },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2.Algorithm },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "RSA-2048" }
             });
     }
@@ -148,7 +148,7 @@ public class SamlSignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.None },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, Default.AsymmetricSigningCredentials.Algorithm },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "RSA-2048" }
             });
     }
@@ -196,7 +196,7 @@ public class SamlSignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.SignatureVerificationFailed },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2.Algorithm },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "RSA-2048" }
             });
     }
@@ -236,7 +236,7 @@ public class SamlSignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.None },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, Default.SymmetricSigningCredentials.Algorithm },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.HMAC },
                 { TelemetryConstants.KeyAlgorithmTag, "SYM-256" }
             });
     }
@@ -276,7 +276,7 @@ public class SamlSignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.None },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, Default.SymmetricSigningCredentials.Algorithm },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.HMAC },
                 { TelemetryConstants.KeyAlgorithmTag, "SYM-256" }
             });
     }
@@ -316,7 +316,7 @@ public class SamlSignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.None },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, KeyingMaterial.DefaultX509SigningCreds_2048_RsaSha2_Sha2.Algorithm },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "RSA-2048" }
             });
     }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Telemetry/CryptoTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Telemetry/CryptoTelemetryTests.cs
@@ -343,6 +343,72 @@ public class CryptoTelemetryTests
         }
     }
 
+    [Theory]
+    [InlineData(SecurityAlgorithms.RsaSha256, "RSA")]
+    [InlineData(SecurityAlgorithms.RsaSha384, "RSA")]
+    [InlineData(SecurityAlgorithms.RsaSha512, "RSA")]
+    [InlineData(SecurityAlgorithms.RsaSha256Signature, "RSA")]
+    [InlineData(SecurityAlgorithms.RsaSha384Signature, "RSA")]
+    [InlineData(SecurityAlgorithms.RsaSha512Signature, "RSA")]
+    [InlineData(SecurityAlgorithms.RsaSsaPssSha256, "RSA-PSS")]
+    [InlineData(SecurityAlgorithms.RsaSsaPssSha384, "RSA-PSS")]
+    [InlineData(SecurityAlgorithms.RsaSsaPssSha512, "RSA-PSS")]
+    [InlineData(SecurityAlgorithms.RsaSsaPssSha256Signature, "RSA-PSS")]
+    [InlineData(SecurityAlgorithms.RsaSsaPssSha384Signature, "RSA-PSS")]
+    [InlineData(SecurityAlgorithms.RsaSsaPssSha512Signature, "RSA-PSS")]
+    [InlineData(SecurityAlgorithms.EcdsaSha256, "ECDSA")]
+    [InlineData(SecurityAlgorithms.EcdsaSha384, "ECDSA")]
+    [InlineData(SecurityAlgorithms.EcdsaSha512, "ECDSA")]
+    [InlineData(SecurityAlgorithms.EcdsaSha256Signature, "ECDSA")]
+    [InlineData(SecurityAlgorithms.EcdsaSha384Signature, "ECDSA")]
+    [InlineData(SecurityAlgorithms.EcdsaSha512Signature, "ECDSA")]
+    [InlineData(SecurityAlgorithms.HmacSha256, "HMAC")]
+    [InlineData(SecurityAlgorithms.HmacSha384, "HMAC")]
+    [InlineData(SecurityAlgorithms.HmacSha512, "HMAC")]
+    [InlineData(SecurityAlgorithms.HmacSha256Signature, "HMAC")]
+    [InlineData(SecurityAlgorithms.HmacSha384Signature, "HMAC")]
+    [InlineData(SecurityAlgorithms.HmacSha512Signature, "HMAC")]
+    [InlineData(SecurityAlgorithms.MlDsa44, "ML-DSA")]
+    [InlineData(SecurityAlgorithms.MlDsa65, "ML-DSA")]
+    [InlineData(SecurityAlgorithms.MlDsa87, "ML-DSA")]
+    public void GetKnownAlgorithmFamilyOrOther_KnownAlgorithms_ReturnsCorrectFamily(string algorithm, string expectedFamily)
+    {
+        // Act
+        var result = CryptoTelemetry.GetKnownAlgorithmFamilyOrOther(algorithm);
+
+        // Assert
+        Assert.Equal(expectedFamily, result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("none")]
+    [InlineData("NONE")]
+    public void GetKnownAlgorithmFamilyOrOther_NoAlgorithm_ReturnsNone(string algorithm)
+    {
+        // Act
+        var result = CryptoTelemetry.GetKnownAlgorithmFamilyOrOther(algorithm);
+
+        // Assert
+        Assert.Equal("none", result);
+    }
+
+    [Theory]
+    [InlineData("CUSTOM-ALG")]
+    [InlineData("RS-CUSTOM")]
+    [InlineData("ML-DSA-CUSTOM")]
+    [InlineData("http://example.com/custom-rsa-sha256")]
+    [InlineData(" ")]
+    public void GetKnownAlgorithmFamilyOrOther_UnknownAlgorithm_ReturnsOther(string algorithm)
+    {
+        // Act
+        var result = CryptoTelemetry.GetKnownAlgorithmFamilyOrOther(algorithm);
+
+        // Assert
+        Assert.Equal("other", result);
+    }
+
     /// <summary>
     /// Custom security key for testing unknown key type scenario
     /// </summary>

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Telemetry/SignatureValidationTelemetryTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Telemetry/SignatureValidationTelemetryTests.cs
@@ -63,7 +63,7 @@ public class SignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.None },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, SecurityAlgorithms.RsaSha256 },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "RSA-2048" }
             });
     }
@@ -104,7 +104,7 @@ public class SignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.None },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, SecurityAlgorithms.RsaSha256 },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "RSA-2048" }
             });
     }
@@ -142,7 +142,7 @@ public class SignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.None },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, SecurityAlgorithms.RsaSha256 },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "RSA-2048" }
             });
     }
@@ -187,7 +187,7 @@ public class SignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.SignatureProviderCreationFailed },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, SecurityAlgorithms.RsaSha256 },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "SYM-256" }
             });
     }
@@ -225,7 +225,7 @@ public class SignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.None },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, Default.SymmetricSigningCredentials.Algorithm },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.HMAC },
                 { TelemetryConstants.KeyAlgorithmTag, "SYM-256" }
             });
     }
@@ -269,7 +269,7 @@ public class SignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.None },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, SecurityAlgorithms.EcdsaSha256 },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.ECDSA },
                 { TelemetryConstants.KeyAlgorithmTag, "ECDSA-P256" }
             });
     }
@@ -312,7 +312,7 @@ public class SignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.None },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, SecurityAlgorithms.EcdsaSha384 },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.ECDSA },
                 { TelemetryConstants.KeyAlgorithmTag, "ECDSA-P384" }
             });
     }
@@ -355,7 +355,7 @@ public class SignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.None },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, SecurityAlgorithms.EcdsaSha512 },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.ECDSA },
                 { TelemetryConstants.KeyAlgorithmTag, "ECDSA-P521" }
             });
     }
@@ -396,7 +396,7 @@ public class SignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.AlgorithmNotSupported },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, SecurityAlgorithms.RsaSha256 },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "SYM-256" }
             });
     }
@@ -443,7 +443,7 @@ public class SignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.SignatureProviderCreationFailed },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, SecurityAlgorithms.RsaSha256 },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "SYM-256" }
             });
     }
@@ -483,7 +483,7 @@ public class SignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.SigningKeyNotFound },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, SecurityAlgorithms.RsaSha256 },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "NO-KEY" }
             });
     }
@@ -524,7 +524,7 @@ public class SignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.SigningKeyNotFound },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, SecurityAlgorithms.RsaSha256 },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "NO-KEY" }
             });
     }
@@ -571,7 +571,7 @@ public class SignatureValidationTelemetryTests
                 { TelemetryConstants.IdentityModelVersionTag, IdentityModelTelemetryUtil.ClientVer },
                 { TelemetryConstants.ErrorTag, TelemetryConstants.SignatureValidationErrors.SigningKeyNotFound },
                 { TelemetryConstants.IssuerTag, ExpectedIssuer },
-                { TelemetryConstants.AlgorithmTag, SecurityAlgorithms.RsaSha256 },
+                { TelemetryConstants.AlgorithmTag, TelemetryConstants.AlgorithmFamilies.RSA },
                 { TelemetryConstants.KeyAlgorithmTag, "NO-KEY" }
             });
     }


### PR DESCRIPTION
# Port: Bound telemetry algorithm dimension cardinality (#3490)

## Summary

Ports the signature-algorithm telemetry cardinality hardening from #3490 to `dev`.

Raw algorithm identifiers are mapped to bounded algorithm families before they are emitted as telemetry dimensions.

## Changes equivalent to the dev8x port

- Map signature algorithms to bounded `RSA`, `RSA-PSS`, `ECDSA`, `HMAC`, `none`, or `other` families.
- Normalize the algorithm dimension through `CryptoTelemetry.GetKnownAlgorithmFamilyOrOther`.
- Update JWT signature-validation telemetry tests for the bounded values.
- Keep the helper and taxonomy internal, with no API baseline changes.

## Required dev adaptations

- Add the `ML-DSA` family for the `ML-DSA-44`, `ML-DSA-65`, and `ML-DSA-87` algorithms already supported on `dev`.
- Use the current `SupportedAlgorithms` collections rather than prefix or substring matching. This aligns telemetry with the algorithms recognized by `dev` and prevents custom lookalike names from being classified as known algorithms.
- Preserve the newer bounded key-algorithm telemetry, including the existing ML-DSA key identifiers.
- Expand tests across all current JOSE and XML signature algorithm identifiers.

## Additional finding

The current `dev` SAML telemetry tests also consume the shared normalized telemetry path but still expected raw XML algorithm URIs. A separate commit updates those seven expectations to the bounded `RSA` and `HMAC` families.

## Validation-model review

The shared telemetry normalization covers:

- `TokenValidationParameters` and `TokenValidationResult` validation.
- Experimental `ValidationParameters` and result-based validation.
- Legacy `JwtSecurityTokenHandler`.
- Legacy and experimental SAML and SAML2 handlers.

No handler-specific production changes were required.

## Testing

- `CryptoTelemetryTests`: 76 passed on `net8.0`.
- `SignatureValidationTelemetryTests`: 13 passed on `net8.0`.
- `SamlSignatureValidationTelemetryTests`: 7 passed on `net8.0`.
- Total targeted tests: 96 passed.

