### PR TITLE
Port: Defensive validation collections and pooled buffer handling (#3492, #3493)

### DIFF
--- a/src/Microsoft.IdentityModel.JsonWebTokens/Experimental/JsonWebTokenHandler.DecryptToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Experimental/JsonWebTokenHandler.DecryptToken.cs
@@ -123,12 +123,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                         configurationKeys = configuration.TokenDecryptionKeys.ToList();
 
                     if (keys != null)
-                    {
-                        if (keys is List<SecurityKey> keysList)
-                            keysList.AddRange(configurationKeys);
-                        else
-                            keys = keys.Concat(configurationKeys).ToList();
-                    }
+                        keys = keys.Concat(configurationKeys).ToList();
                     else
                         keys = configurationKeys;
                 }

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebToken.cs
@@ -744,7 +744,7 @@ namespace Microsoft.IdentityModel.JsonWebTokens
             const int MaxStackallocThreshold = 256;
             Span<byte> output = outputSize <= MaxStackallocThreshold
                 ? stackalloc byte[outputSize]
-                : (rented = ArrayPool<byte>.Shared.Rent(outputSize));
+                : (rented = ArrayPool<byte>.Shared.Rent(outputSize)).AsSpan(0, outputSize);
 
             try
             {

--- a/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/JsonWebTokenHandler.CreateToken.cs
@@ -266,13 +266,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 finally
                 {
                     if (encodedChars is not null)
-                        ArrayPool<char>.Shared.Return(encodedChars);
+                        ArrayPool<char>.Shared.Return(encodedChars, clearArray: true);
 #if NET6_0_OR_GREATER
                     if (signatureBytes is not null)
-                        ArrayPool<byte>.Shared.Return(signatureBytes);
+                        ArrayPool<byte>.Shared.Return(signatureBytes, clearArray: true);
 #endif
                     if (asciiBytes is not null)
-                        ArrayPool<byte>.Shared.Return(asciiBytes);
+                        ArrayPool<byte>.Shared.Return(asciiBytes, clearArray: true);
 
                     writer?.Dispose();
                 }
@@ -608,16 +608,16 @@ namespace Microsoft.IdentityModel.JsonWebTokens
                 finally
                 {
                     if (encodedChars is not null)
-                        ArrayPool<char>.Shared.Return(encodedChars);
+                        ArrayPool<char>.Shared.Return(encodedChars, clearArray: true);
 #if NET6_0_OR_GREATER
                     if (signatureBytes is not null)
-                        ArrayPool<byte>.Shared.Return(signatureBytes);
+                        ArrayPool<byte>.Shared.Return(signatureBytes, clearArray: true);
 #endif
                     if (asciiBytes is not null)
-                        ArrayPool<byte>.Shared.Return(asciiBytes);
+                        ArrayPool<byte>.Shared.Return(asciiBytes, clearArray: true);
 
                     if (payloadBytes is not null)
-                        ArrayPool<byte>.Shared.Return(payloadBytes);
+                        ArrayPool<byte>.Shared.Return(payloadBytes, clearArray: true);
 
                     writer?.Dispose();
                 }

--- a/src/Microsoft.IdentityModel.Tokens/DeflateCompressionProvider.cs
+++ b/src/Microsoft.IdentityModel.Tokens/DeflateCompressionProvider.cs
@@ -104,7 +104,7 @@ namespace Microsoft.IdentityModel.Tokens
             finally
             {
                 if (chars != null)
-                    ArrayPool<char>.Shared.Return(chars);
+                    ArrayPool<char>.Shared.Return(chars, clearArray: true);
             }
         }
 

--- a/src/Microsoft.IdentityModel.Tokens/EncodingUtils.cs
+++ b/src/Microsoft.IdentityModel.Tokens/EncodingUtils.cs
@@ -64,7 +64,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
             finally
             {
-                ArrayPool<byte>.Shared.Return(bytes);
+                ArrayPool<byte>.Shared.Return(bytes, clearArray: true);
             }
         }
 
@@ -108,7 +108,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
             finally
             {
-                ArrayPool<byte>.Shared.Return(bytes);
+                ArrayPool<byte>.Shared.Return(bytes, clearArray: true);
             }
         }
 
@@ -171,7 +171,7 @@ namespace Microsoft.IdentityModel.Tokens
             }
             finally
             {
-                ArrayPool<byte>.Shared.Return(bytes);
+                ArrayPool<byte>.Shared.Return(bytes, clearArray: true);
             }
         }
     }

--- a/src/Microsoft.IdentityModel.Tokens/Experimental/Validation/ValidationParameters.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Experimental/Validation/ValidationParameters.cs
@@ -77,7 +77,7 @@ namespace Microsoft.IdentityModel.Tokens.Experimental
             IgnoreTrailingSlashWhenValidatingAudience = other.IgnoreTrailingSlashWhenValidatingAudience;
             IgnoreCaseWhenValidatingAudience = other.IgnoreCaseWhenValidatingAudience;
             SignatureKeyResolver = other.SignatureKeyResolver;
-            _signingKeys = other.SigningKeys;
+            _signingKeys = new List<SecurityKey>(other.SigningKeys);
             SignatureKeyValidator = other.SignatureKeyValidator;
             IssuerValidatorAsync = other.IssuerValidatorAsync;
             LifetimeValidator = other.LifetimeValidator;
@@ -96,16 +96,16 @@ namespace Microsoft.IdentityModel.Tokens.Experimental
             TryAllDecryptionKeys = other.TryAllDecryptionKeys;
             TryAllSigningKeys = other.TryAllSigningKeys;
             DecryptionKeyResolver = other.DecryptionKeyResolver;
-            _decryptionKeys = other.DecryptionKeys;
+            _decryptionKeys = new List<SecurityKey>(other.DecryptionKeys);
             TokenReplayCache = other.TokenReplayCache;
             TokenReplayValidator = other.TokenReplayValidator;
             TokenTypeValidator = other.TokenTypeValidator;
             ValidateActor = other.ValidateActor;
             ValidateWithLKG = other.ValidateWithLKG;
-            _validIssuers = other.ValidIssuers;
-            _validAudiences = other.ValidAudiences;
-            _validAlgorithms = other.ValidAlgorithms;
-            _validTokenTypes = other.ValidTypes;
+            _validIssuers = new List<string>(other.ValidIssuers);
+            _validAudiences = new List<string>(other.ValidAudiences);
+            _validAlgorithms = new List<string>(other.ValidAlgorithms);
+            _validTokenTypes = new List<string>(other.ValidTypes);
         }
 
         /// <summary>

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/ClaimSetBufferHandlingTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/ClaimSetBufferHandlingTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Microsoft.IdentityModel.JsonWebTokens.Tests
+{
+    public class ClaimSetBufferHandlingTests
+    {
+        [Fact]
+        public void LargeHeaderAndPayload_PooledBufferPath_ClaimsRoundTrip()
+        {
+            // Arrange
+            string largeHeaderValue = new('H', 300);
+            string largePayloadValue = new('P', 300);
+            var descriptor = new SecurityTokenDescriptor
+            {
+                AdditionalHeaderClaims = new Dictionary<string, object>
+                {
+                    ["large-header"] = largeHeaderValue
+                },
+                Claims = new Dictionary<string, object>
+                {
+                    ["large-payload"] = largePayloadValue
+                }
+            };
+
+            // Act
+            string encodedToken = new JsonWebTokenHandler().CreateToken(descriptor);
+            var token = new JsonWebToken(encodedToken);
+
+            // Assert
+            Assert.Equal(largeHeaderValue, token.GetHeaderValue<string>("large-header"));
+            Assert.Equal(largePayloadValue, token.GetPayloadValue<string>("large-payload"));
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.DecryptToken.DecryptionKeysTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.DecryptToken.DecryptionKeysTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.IdentityModel.TestUtils;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Tokens.Experimental;
+using Xunit;
+
+namespace Microsoft.IdentityModel.JsonWebTokens.Tests
+{
+    public class JsonWebTokenHandlerDecryptTokenDecryptionKeysTests
+    {
+        [Fact]
+        public void GetContentEncryptionKeys_CombiningConfigurationKeys_DoesNotMutateValidationParameters()
+        {
+            // Arrange
+            var handler = new JsonWebTokenHandler();
+            var encryptingCredentials = new EncryptingCredentials(
+                KeyingMaterial.RsaSecurityKey_2048,
+                SecurityAlgorithms.RsaPKCS1,
+                SecurityAlgorithms.Aes128CbcHmacSha256);
+            string token = handler.CreateToken(new SecurityTokenDescriptor
+            {
+                SigningCredentials = KeyingMaterial.JsonWebKeyRsa256SigningCredentials,
+                EncryptingCredentials = encryptingCredentials,
+                Claims = Default.PayloadDictionary
+            });
+
+            var validationParameters = new ValidationParameters();
+            validationParameters.DecryptionKeys.Add(
+                new SymmetricSecurityKey(KeyingMaterial.DefaultSymmetricKeyBytes_256)
+                {
+                    KeyId = "UnmatchedKeyId"
+                });
+
+            var configuration = new OpenIdConnectConfiguration();
+            configuration.TokenDecryptionKeys.Add(
+                new SymmetricSecurityKey(KeyingMaterial.DefaultSymmetricKeyBytes_512)
+                {
+                    KeyId = "ConfigurationKeyId"
+                });
+
+            // Act
+            handler.GetContentEncryptionKeys(
+                new JsonWebToken(token),
+                validationParameters,
+                configuration,
+                callContext: null);
+
+            // Assert
+            Assert.Single(validationParameters.DecryptionKeys);
+            Assert.Equal("UnmatchedKeyId", validationParameters.DecryptionKeys[0].KeyId);
+        }
+    }
+}

--- a/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.DecryptToken.DecryptionKeysTests.cs
+++ b/test/Microsoft.IdentityModel.JsonWebTokens.Tests/JsonWebTokenHandler.DecryptToken.DecryptionKeysTests.cs
@@ -12,12 +12,13 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
     public class JsonWebTokenHandlerDecryptTokenDecryptionKeysTests
     {
         [Fact]
-        public void GetContentEncryptionKeys_CombiningConfigurationKeys_DoesNotMutateValidationParameters()
+        public void DecryptToken_ConfigurationKeyIncludedWithoutMutatingValidationParameters()
         {
             // Arrange
             var handler = new JsonWebTokenHandler();
+            var encryptionKey = KeyingMaterial.RsaSecurityKey_2048;
             var encryptingCredentials = new EncryptingCredentials(
-                KeyingMaterial.RsaSecurityKey_2048,
+                encryptionKey,
                 SecurityAlgorithms.RsaPKCS1,
                 SecurityAlgorithms.Aes128CbcHmacSha256);
             string token = handler.CreateToken(new SecurityTokenDescriptor
@@ -36,19 +37,21 @@ namespace Microsoft.IdentityModel.JsonWebTokens.Tests
 
             var configuration = new OpenIdConnectConfiguration();
             configuration.TokenDecryptionKeys.Add(
-                new SymmetricSecurityKey(KeyingMaterial.DefaultSymmetricKeyBytes_512)
+                new RsaSecurityKey(encryptionKey.Parameters)
                 {
                     KeyId = "ConfigurationKeyId"
                 });
 
             // Act
-            handler.GetContentEncryptionKeys(
+            ValidationResult<string, ValidationError> result = handler.DecryptToken(
                 new JsonWebToken(token),
                 validationParameters,
                 configuration,
                 callContext: null);
 
             // Assert
+            Assert.True(result.Succeeded);
+            Assert.NotEmpty(result.Result);
             Assert.Single(validationParameters.DecryptionKeys);
             Assert.Equal("UnmatchedKeyId", validationParameters.DecryptionKeys[0].KeyId);
         }

--- a/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationParametersTests.cs
+++ b/test/Microsoft.IdentityModel.Tokens.Tests/Validation/ValidationParametersTests.cs
@@ -83,6 +83,37 @@ namespace Microsoft.IdentityModel.Tokens.Validation.Tests
         }
 
         [Fact]
+        public void CopyConstructor_CreatesIndependentCollections()
+        {
+            // Arrange
+            var original = new ValidationParameters();
+            var originalKey = new SymmetricSecurityKey(new byte[32]);
+            original.SigningKeys.Add(originalKey);
+            original.DecryptionKeys.Add(originalKey);
+            original.ValidIssuers.Add("issuer");
+            original.ValidAudiences.Add("audience");
+            original.ValidAlgorithms.Add("algorithm");
+            original.ValidTypes.Add("type");
+
+            // Act
+            var copy = new CopyConstructibleValidationParameters(original);
+            copy.SigningKeys.Add(new SymmetricSecurityKey(new byte[32]));
+            copy.DecryptionKeys.Add(new SymmetricSecurityKey(new byte[32]));
+            copy.ValidIssuers.Add("copy-issuer");
+            copy.ValidAudiences.Add("copy-audience");
+            copy.ValidAlgorithms.Add("copy-algorithm");
+            copy.ValidTypes.Add("copy-type");
+
+            // Assert
+            Assert.Single(original.SigningKeys);
+            Assert.Single(original.DecryptionKeys);
+            Assert.Single(original.ValidIssuers);
+            Assert.Single(original.ValidAudiences);
+            Assert.Single(original.ValidAlgorithms);
+            Assert.Single(original.ValidTypes);
+        }
+
+        [Fact]
         public void SetValidators_NullValue_ThrowsArgumentNullException()
         {
             var validationParameters = new ValidationParameters();


### PR DESCRIPTION
# Port: Defensive validation collections and pooled buffer handling (#3492, #3493)

## Summary

Combines the closely related collection-ownership fix from #3492 and pooled-buffer safety fixes from #3493 for `dev`.

The work remains separated into logical commits so each original port can be reviewed independently.

## Commit 1: ValidationParameters collection ownership

### Changes equivalent to #3492

- Copy `SigningKeys`, `DecryptionKeys`, `ValidIssuers`, `ValidAudiences`, `ValidAlgorithms`, and `ValidTypes` into independent list instances.
- Combine validation and configuration decryption keys without mutating the caller-owned `ValidationParameters.DecryptionKeys` collection.

### Required dev adaptations

- Preserve the newer `IgnoreCaseWhenValidatingAudience` copy behavior.
- Preserve the #3602 `TryAllSigningKeys` copy behavior and its `true` default.
- Add ownership assertions alongside the current `ValidationParameters` copy-constructor tests.
- Use the current non-null lazy collection getters rather than retaining obsolete null checks.

### Additional test strengthening

The regression test decrypts successfully using a configuration-only RSA key with a deliberately mismatched key identifier. This forces the `TryAllDecryptionKeys` combination path while proving:

- Configuration keys remain usable.
- The caller's decryption-key collection is not modified.

## Commit 2: Pooled buffer safety

### Changes equivalent to #3493

- Slice a rented `JsonWebToken` decoding buffer to the requested output size.
- Clear rented character and byte arrays returned by token creation.
- Clear rented arrays returned by compression and encoding helpers.

### Required dev adaptations

- `dev` already cleared the main `JsonWebToken` rented byte array, so only the missing span slice is changed there.
- A focused large-header and large-payload test covers both the original pooled payload path and the newer header-replacement surface on `dev`.

## Validation-model review

- `TokenValidationParameters` already owns independent copies of its mutable collections.
- This port restores equivalent collection ownership in `ValidationParameters`.
- Existing intentional differences remain unchanged:
  - `TokenValidationParameters` recursively clones actor parameters.
  - `ValidationParameters` retains the actor-parameter reference.
  - Newer handler paths continue to return `ValidationResult` and `ValidationError`.

## Testing

- Collection and configuration-key tests: 9 passed on `net8.0`.
- Claim parsing, creation, signature, and compression tests: 37 passed on `net8.0`.
- Review-driven configuration-only decryption regression: 1 passed on `net8.0`.
- Total targeted executions: 47 passed.
