### PR TITLE
Fix vulenerability on ClientRuntime

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <JsonNetVersion>13.0.1</JsonNetVersion>
     <MicrosoftAzureKeyVaultVersion>3.0.0</MicrosoftAzureKeyVaultVersion>
+    <MicrosoftRestClientRuntimeVersion>2.3.24</MicrosoftRestClientRuntimeVersion>
     <MicrosoftAzureServicesAppAuthenticationVersion>1.0.3</MicrosoftAzureServicesAppAuthenticationVersion>
     <MicrosoftSourceLinkGitHubVersion>1.1.1</MicrosoftSourceLinkGitHubVersion>
     <NetStandardVersion>2.0.3</NetStandardVersion>

--- a/src/Microsoft.IdentityModel.JsonWebTokens/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Properties/AssemblyInfo.cs
@@ -30,10 +30,10 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyInformationalVersion("5.7.0")]
+[assembly: AssemblyFileVersion("5.7.0")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
+[assembly: AssemblyVersion("5.7.0")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
 

--- a/src/Microsoft.IdentityModel.KeyVaultExtensions/Microsoft.IdentityModel.KeyVaultExtensions.csproj
+++ b/src/Microsoft.IdentityModel.KeyVaultExtensions/Microsoft.IdentityModel.KeyVaultExtensions.csproj
@@ -20,8 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="$(MicrosoftAzureKeyVaultVersion)" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime"
-                  Version="[$(MicrosoftRestClientRuntimeVersion),3.0.0)" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntimeVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.IdentityModel.KeyVaultExtensions/Microsoft.IdentityModel.KeyVaultExtensions.csproj
+++ b/src/Microsoft.IdentityModel.KeyVaultExtensions/Microsoft.IdentityModel.KeyVaultExtensions.csproj
@@ -20,6 +20,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="$(MicrosoftAzureKeyVaultVersion)" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime"
+                  Version="[$(MicrosoftRestClientRuntimeVersion),3.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.IdentityModel.KeyVaultExtensions/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.KeyVaultExtensions/Properties/AssemblyInfo.cs
@@ -29,9 +29,9 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyInformationalVersion("5.7.0")]
+[assembly: AssemblyFileVersion("5.7.0")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
+[assembly: AssemblyVersion("5.7.0")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]

--- a/src/Microsoft.IdentityModel.Logging/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Logging/Properties/AssemblyInfo.cs
@@ -29,9 +29,9 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyInformationalVersion("5.7.0")]
+[assembly: AssemblyFileVersion("5.7.0")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
+[assembly: AssemblyVersion("5.7.0")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]

--- a/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.csproj
+++ b/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.csproj
@@ -21,8 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="$(MicrosoftAzureKeyVaultVersion)" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime"
-                  Version="[$(MicrosoftRestClientRuntimeVersion),3.0.0)" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="$(MicrosoftRestClientRuntimeVersion)" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="$(MicrosoftAzureServicesAppAuthenticationVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
   </ItemGroup>

--- a/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.csproj
+++ b/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey.csproj
@@ -21,6 +21,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="$(MicrosoftAzureKeyVaultVersion)" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime"
+                  Version="[$(MicrosoftRestClientRuntimeVersion),3.0.0)" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="$(MicrosoftAzureServicesAppAuthenticationVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
   </ItemGroup>

--- a/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Properties/AssemblyInfo.cs
@@ -29,9 +29,9 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyInformationalVersion("5.7.0")]
+[assembly: AssemblyFileVersion("5.7.0")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
+[assembly: AssemblyVersion("5.7.0")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Properties/AssemblyInfo.cs
@@ -29,9 +29,9 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyInformationalVersion("5.7.0")]
+[assembly: AssemblyFileVersion("5.7.0")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
+[assembly: AssemblyVersion("5.7.0")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/Properties/AssemblyInfo.cs
@@ -30,10 +30,10 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyInformationalVersion("5.7.0")]
+[assembly: AssemblyFileVersion("5.7.0")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
+[assembly: AssemblyVersion("5.7.0")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
 

--- a/src/Microsoft.IdentityModel.Protocols/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Properties/AssemblyInfo.cs
@@ -29,9 +29,9 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyInformationalVersion("5.7.0")]
+[assembly: AssemblyFileVersion("5.7.0")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
+[assembly: AssemblyVersion("5.7.0")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Properties/AssemblyInfo.cs
@@ -31,10 +31,10 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyInformationalVersion("5.7.0")]
+[assembly: AssemblyFileVersion("5.7.0")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
+[assembly: AssemblyVersion("5.7.0")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
 

--- a/src/Microsoft.IdentityModel.Tokens/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Properties/AssemblyInfo.cs
@@ -30,10 +30,10 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyInformationalVersion("5.7.0")]
+[assembly: AssemblyFileVersion("5.7.0")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
+[assembly: AssemblyVersion("5.7.0")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
 

--- a/src/Microsoft.IdentityModel.Xml/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Xml/Properties/AssemblyInfo.cs
@@ -30,10 +30,10 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyInformationalVersion("5.7.0")]
+[assembly: AssemblyFileVersion("5.7.0")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
+[assembly: AssemblyVersion("5.7.0")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
 

--- a/src/System.IdentityModel.Tokens.Jwt/Properties/AssemblyInfo.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/Properties/AssemblyInfo.cs
@@ -29,9 +29,9 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
+[assembly: AssemblyInformationalVersion("5.7.0")]
+[assembly: AssemblyFileVersion("5.7.0")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
+[assembly: AssemblyVersion("5.7.0")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]


### PR DESCRIPTION
# Fix vulenerability on ClientRuntime
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

The `dev5x` release and nightly pipelines fail during `dotnet restore` with `NU1902` because `Microsoft.Azure.KeyVault 3.0.0` resolves the vulnerable `Microsoft.Rest.ClientRuntime 2.3.11`.

Because warnings are treated as errors, Wilson tests and packaging never start. This also causes cascading failures in IdWeb, SAL, and MISE because the requested Wilson `5.7.2` packages are not produced.

## What

- Set `Microsoft.Rest.ClientRuntime 2.3.24` as the minimum supported version.
- Add a direct dependency to:
  - `Microsoft.IdentityModel.KeyVaultExtensions`
  - `Microsoft.IdentityModel.ManagedKeyVaultSecurityKey`
- Restrict the compatible range to `[2.3.24,3.0.0)`.

## Validation

- Restored and built `Wilson.sln` with NuGet audit enabled.
- Ran the full configured Wilson test suite successfully

