### PR TITLE
Fix dev5x assembly version generation

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -10,9 +10,9 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Company>Microsoft Corporation.</Company>
     <DelaySign>true</DelaySign>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
     <OutputTypeEx>library</OutputTypeEx>
     <Product>Microsoft IdentityModel</Product>
     <RepositoryType>git</RepositoryType>

--- a/build/common.props
+++ b/build/common.props
@@ -10,9 +10,6 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <Company>Microsoft Corporation.</Company>
     <DelaySign>true</DelaySign>
-    <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
     <OutputTypeEx>library</OutputTypeEx>
     <Product>Microsoft IdentityModel</Product>
     <RepositoryType>git</RepositoryType>

--- a/build/version.props
+++ b/build/version.props
@@ -9,9 +9,6 @@
     <Version Condition="'$(MicrosoftIdentityModelVersion)' != ''">$(MicrosoftIdentityModelVersion)</Version>
     <VersionSuffix Condition="'$(MicrosoftIdentityModelVersion)' == ''">$(PreviewVersionSuffix)</VersionSuffix>
     <VersionPrefix Condition="'$(MicrosoftIdentityModelVersion)' == ''">$(MicrosoftIdentityModelCurrentVersion)</VersionPrefix>
-    <IdentityModelBaseVersion Condition="'$(MicrosoftIdentityModelVersion)' != ''">$([System.Text.RegularExpressions.Regex]::Match('$(MicrosoftIdentityModelVersion)', '^\d+\.\d+').Value)</IdentityModelBaseVersion>
-    <IdentityModelBaseVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(MicrosoftIdentityModelCurrentVersion)', '^\d+\.\d+').Value)</IdentityModelBaseVersion>
-    <AssemblyVersion>$(IdentityModelBaseVersion).0.0</AssemblyVersion>
     <FileVersion Condition="'$(MicrosoftIdentityModelVersion)' != '' and '$(IsCustomPreview)' != 'true' ">$(MicrosoftIdentityModelVersion).$([System.DateTime]::Now.ToString("yy"))$([System.DateTime]::Now.DayOfYear.ToString("000"))</FileVersion>
     <FileVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">$(MicrosoftIdentityModelCurrentVersion).$([System.DateTime]::Now.ToString("yy"))$([System.DateTime]::Now.DayOfYear.ToString("000"))</FileVersion>
   </PropertyGroup>

--- a/build/version.props
+++ b/build/version.props
@@ -9,6 +9,9 @@
     <Version Condition="'$(MicrosoftIdentityModelVersion)' != ''">$(MicrosoftIdentityModelVersion)</Version>
     <VersionSuffix Condition="'$(MicrosoftIdentityModelVersion)' == ''">$(PreviewVersionSuffix)</VersionSuffix>
     <VersionPrefix Condition="'$(MicrosoftIdentityModelVersion)' == ''">$(MicrosoftIdentityModelCurrentVersion)</VersionPrefix>
+    <IdentityModelBaseVersion Condition="'$(MicrosoftIdentityModelVersion)' != ''">$([System.Text.RegularExpressions.Regex]::Match('$(MicrosoftIdentityModelVersion)', '^\d+\.\d+').Value)</IdentityModelBaseVersion>
+    <IdentityModelBaseVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">$([System.Text.RegularExpressions.Regex]::Match('$(MicrosoftIdentityModelCurrentVersion)', '^\d+\.\d+').Value)</IdentityModelBaseVersion>
+    <AssemblyVersion>$(IdentityModelBaseVersion).0.0</AssemblyVersion>
     <FileVersion Condition="'$(MicrosoftIdentityModelVersion)' != '' and '$(IsCustomPreview)' != 'true' ">$(MicrosoftIdentityModelVersion).$([System.DateTime]::Now.ToString("yy"))$([System.DateTime]::Now.DayOfYear.ToString("000"))</FileVersion>
     <FileVersion Condition="'$(MicrosoftIdentityModelVersion)' == ''">$(MicrosoftIdentityModelCurrentVersion).$([System.DateTime]::Now.ToString("yy"))$([System.DateTime]::Now.DayOfYear.ToString("000"))</FileVersion>
   </PropertyGroup>

--- a/src/Microsoft.IdentityModel.JsonWebTokens/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.JsonWebTokens/Properties/AssemblyInfo.cs
@@ -30,10 +30,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
 

--- a/src/Microsoft.IdentityModel.KeyVaultExtensions/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.KeyVaultExtensions/Properties/AssemblyInfo.cs
@@ -29,9 +29,6 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]

--- a/src/Microsoft.IdentityModel.Logging/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Logging/Properties/AssemblyInfo.cs
@@ -29,9 +29,6 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]

--- a/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.ManagedKeyVaultSecurityKey/Properties/AssemblyInfo.cs
@@ -29,9 +29,6 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]

--- a/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Protocols.OpenIdConnect/Properties/AssemblyInfo.cs
@@ -29,9 +29,6 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]

--- a/src/Microsoft.IdentityModel.Protocols.WsFederation/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Protocols.WsFederation/Properties/AssemblyInfo.cs
@@ -30,10 +30,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
 

--- a/src/Microsoft.IdentityModel.Protocols/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Protocols/Properties/AssemblyInfo.cs
@@ -29,9 +29,6 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]

--- a/src/Microsoft.IdentityModel.Tokens.Saml/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Tokens.Saml/Properties/AssemblyInfo.cs
@@ -31,10 +31,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
 

--- a/src/Microsoft.IdentityModel.Tokens/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Tokens/Properties/AssemblyInfo.cs
@@ -30,10 +30,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
 

--- a/src/Microsoft.IdentityModel.Xml/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Xml/Properties/AssemblyInfo.cs
@@ -30,10 +30,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
 

--- a/src/System.IdentityModel.Tokens.Jwt/Properties/AssemblyInfo.cs
+++ b/src/System.IdentityModel.Tokens.Jwt/Properties/AssemblyInfo.cs
@@ -29,9 +29,6 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyInformationalVersion("0.0.1")]
-[assembly: AssemblyFileVersion("0.0.1")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
-[assembly: AssemblyVersion("0.0.1")]
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]


### PR DESCRIPTION
# Align dev5x assembly-version generation with dev

## Description

The dev5x production `AssemblyInfo.cs` files contain hard-coded `0.0.1` assembly, file, and informational version attributes.

The legacy build replaced these placeholders through `updateAssemblyInfo.ps1`. The unified `dotnet` build does not run that script, allowing packages to retain an incorrect `0.0.1.0` assembly identity.

This PR aligns dev5x with the SDK-driven version-generation convention used by `dev`.

## Changes

- Remove hard-coded `AssemblyVersion`, `AssemblyFileVersion`, and `AssemblyInformationalVersion` attributes from affected production `AssemblyInfo.cs` files.
- Preserve assembly metadata, CLS compliance, COM visibility, and friend-assembly declarations.
- Continue supplying `Version`, `VersionPrefix`/`VersionSuffix`, and `FileVersion` centrally through `build/version.props`.
- Leave `AssemblyVersion` and the `GenerateAssembly*Attribute` properties at their SDK defaults.
- Allow the SDK to generate assembly, file, and informational version attributes.

No target frameworks, dependencies, public APIs, or runtime behavior are changed.

## Final version behavior

For a release build with:

```text
MicrosoftIdentityModelVersion=5.7.2

the SDK generates:

┌───────────────────────────────┬──────────────────────────┐
│ Metadata                      │ Value                    │
├───────────────────────────────┼──────────────────────────┤
│ NuGet package version         │ 5.7.2                    │
├───────────────────────────────┼──────────────────────────┤
│ Assembly version              │ 5.7.2.0                  │
├───────────────────────────────┼──────────────────────────┤
│ File version                  │ 5.7.2.<build-date stamp> │
├───────────────────────────────┼──────────────────────────┤
│ Informational/product version │ 5.7.2+<commit>           │
└───────────────────────────────┴──────────────────────────┘
```
This is the same generation convention used by  dev , with the dev5x version supplied as input.

**Compatibility decision**

The original implementation explicitly generated:

AssemblyVersion=5.7.0.0

for all 5.7.x packages.

Follow-up PR #3631 removed that compatibility override to match  dev . Assembly version now follows the complete package version:

Package 5.7.1 -> AssemblyVersion 5.7.1.0
Package 5.7.2 -> AssemblyVersion 5.7.2.0

This means patch releases no longer share a fixed  5.7.0.0  assembly identity. Consumers of strong-named assemblies on .NET Framework may require binding redirects when moving between patch versions. This is an intentional consequence of matching the  dev  SDK convention.

**Validation**

The final branch should be validated using the same version input as the release pipeline:

dotnet build Wilson.sln ` -c Release ` -p:MicrosoftIdentityModelVersion=5.7.2 ` -p:NuGetAudit=false ` --source https://packagefeedproxy.microsoft.io/nuget/v3/index.json

Then pack a representative package and inspect a DLL from the generated  .nupkg .

**Expected metadata:**

PackageVersion=5.7.2
AssemblyVersion=5.7.2.0
FileVersion=5.7.2.<build-date stamp>
InformationalVersion=5.7.2+<commit>

The validation should also confirm that no production assembly retains the legacy  0.0.1  version attributes.

**Related PR**

• #3631 — aligns the implementation with  dev  by removing the explicit  5.7.0.0  assembly-version override.