### PR TITLE
Avoid duplicate contextual logging

### DIFF
--- a/src/Microsoft.IdentityModel.Logging/LogHelper.cs
+++ b/src/Microsoft.IdentityModel.Logging/LogHelper.cs
@@ -316,10 +316,16 @@ namespace Microsoft.IdentityModel.Logging
             if (exception == null)
                 return null;
 
-            LogExceptionMessage(exception);
+            if (IdentityModelEventSource.Logger.IsEnabled(EventLevel.Error, EventKeywords.All))
+                IdentityModelEventSource.Logger.Write(EventLevel.Error, exception.InnerException, exception.Message);
 
             if (loggerContext?.Logger == null)
+            {
+                if (Logger.IsEnabled(EventLogLevel.Error))
+                    Logger.Log(WriteEntry(EventLogLevel.Error, exception.InnerException, exception.Message));
+
                 return exception;
+            }
 
             if (!loggerContext.Logger.IsEnabled(LogLevel.Error))
                 return exception;
@@ -366,10 +372,16 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void LogInformation(string message, LoggerContext loggerContext, params object[] args)
         {
-            LogInformation(message, args);
+            if (IdentityModelEventSource.Logger.IsEnabled(EventLevel.Informational, EventKeywords.All))
+                IdentityModelEventSource.Logger.WriteInformation(message, args);
 
             if (loggerContext?.Logger == null)
+            {
+                if (Logger.IsEnabled(EventLogLevel.Informational))
+                    Logger.Log(WriteEntry(EventLogLevel.Informational, null, message, null, args));
+
                 return;
+            }
 
             if (!loggerContext.Logger.IsEnabled(LogLevel.Information))
                 return;
@@ -406,10 +418,16 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void LogVerbose(string message, LoggerContext loggerContext, params object[] args)
         {
-            LogVerbose(message, args);
+            if (IdentityModelEventSource.Logger.IsEnabled(EventLevel.Verbose, EventKeywords.All))
+                IdentityModelEventSource.Logger.WriteVerbose(message, args);
 
             if (loggerContext?.Logger == null)
+            {
+                if (Logger.IsEnabled(EventLogLevel.Verbose))
+                    Logger.Log(WriteEntry(EventLogLevel.Verbose, null, message, null, args));
+
                 return;
+            }
 
             if (!loggerContext.Logger.IsEnabled(LogLevel.Debug))
                 return;
@@ -456,10 +474,16 @@ namespace Microsoft.IdentityModel.Logging
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         public static void LogWarning(string message, LoggerContext loggerContext, params object[] args)
         {
-            LogWarning(message, args);
+            if (IdentityModelEventSource.Logger.IsEnabled(EventLevel.Warning, EventKeywords.All))
+                IdentityModelEventSource.Logger.WriteWarning(message, args);
 
             if (loggerContext?.Logger == null)
+            {
+                if (Logger.IsEnabled(EventLogLevel.Warning))
+                    Logger.Log(WriteEntry(EventLogLevel.Warning, null, message, null, args));
+
                 return;
+            }
 
             if (!loggerContext.Logger.IsEnabled(LogLevel.Warning))
                 return;

--- a/test/Microsoft.IdentityModel.Logging.Tests/CorrelationLoggingTests.cs
+++ b/test/Microsoft.IdentityModel.Logging.Tests/CorrelationLoggingTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.IdentityModel.Abstractions;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -231,6 +232,98 @@ namespace Microsoft.IdentityModel.Logging.Tests
             // Assert
             Assert.NotEmpty(logger.Messages);
             Assert.All(logger.Messages, message => Assert.DoesNotContain("CorrelationId", message));
+        }
+
+        [Theory]
+        [InlineData(LoggingPath.Information)]
+        [InlineData(LoggingPath.Verbose)]
+        [InlineData(LoggingPath.Warning)]
+        [InlineData(LoggingPath.Exception)]
+        public void ContextLogger_IsAuthoritative_WhenProvided(LoggingPath loggingPath)
+        {
+            // Arrange
+            IIdentityLogger originalLogger = LogHelper.Logger;
+            bool originalHeaderWritten = LogHelper.HeaderWritten;
+            var staticLogger = new TestLogger();
+            var contextLogger = new CapturingLogger();
+            string message = $"IDXTEST: contextual {loggingPath} message.";
+
+            try
+            {
+                LogHelper.Logger = staticLogger;
+                LogHelper.HeaderWritten = true;
+
+                // Act
+                Log(loggingPath, message, new LoggerContext(contextLogger));
+
+                // Assert
+                Assert.Single(contextLogger.Messages);
+                Assert.Contains(message, contextLogger.Messages[0]);
+                Assert.False(staticLogger.ContainsLog(message));
+            }
+            finally
+            {
+                LogHelper.Logger = originalLogger;
+                LogHelper.HeaderWritten = originalHeaderWritten;
+            }
+        }
+
+        [Theory]
+        [InlineData(LoggingPath.Information)]
+        [InlineData(LoggingPath.Verbose)]
+        [InlineData(LoggingPath.Warning)]
+        [InlineData(LoggingPath.Exception)]
+        public void StaticLogger_IsFallback_WhenContextLoggerNotProvided(LoggingPath loggingPath)
+        {
+            // Arrange
+            IIdentityLogger originalLogger = LogHelper.Logger;
+            bool originalHeaderWritten = LogHelper.HeaderWritten;
+            var staticLogger = new TestLogger();
+            string message = $"IDXTEST: fallback {loggingPath} message.";
+
+            try
+            {
+                LogHelper.Logger = staticLogger;
+                LogHelper.HeaderWritten = true;
+
+                // Act
+                Log(loggingPath, message, new LoggerContext());
+
+                // Assert
+                Assert.True(staticLogger.ContainsLog(message));
+            }
+            finally
+            {
+                LogHelper.Logger = originalLogger;
+                LogHelper.HeaderWritten = originalHeaderWritten;
+            }
+        }
+
+        private static void Log(LoggingPath loggingPath, string message, LoggerContext context)
+        {
+            switch (loggingPath)
+            {
+                case LoggingPath.Information:
+                    LogHelper.LogInformation(message, context);
+                    break;
+                case LoggingPath.Verbose:
+                    LogHelper.LogVerbose(message, context);
+                    break;
+                case LoggingPath.Warning:
+                    LogHelper.LogWarning(message, context);
+                    break;
+                case LoggingPath.Exception:
+                    LogHelper.LogExceptionMessage(new InvalidOperationException(message), context);
+                    break;
+            }
+        }
+
+        public enum LoggingPath
+        {
+            Information,
+            Verbose,
+            Warning,
+            Exception,
         }
 
         // Exposes the protected LoggerContext copy constructor for testing.


### PR DESCRIPTION
Use the per-call ILogger as the authoritative sink when supplied, while preserving EventSource emission and IIdentityLogger fallback behavior.

# {PR title}
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the IdentityModel repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/Contributing.md) and [Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] If any gains or losses in performance are possible, you've included benchmarks for your changes. [More info](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/wiki/Benchmarking-in-Wilson)
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

{Detail}

Fixes #{bug number} (in this specific format)
